### PR TITLE
feat: JMAP OIDC authentication via Device Authorization Grant

### DIFF
--- a/src-tauri/src/commands/accounts.rs
+++ b/src-tauri/src/commands/accounts.rs
@@ -86,6 +86,9 @@ pub async fn get_account_config(
         password: String::new(),
         use_tls: full.use_tls,
         signature: full.signature,
+        jmap_auth_method: full.jmap_auth_method,
+        oidc_token_endpoint: full.oidc_token_endpoint,
+        oidc_client_id: full.oidc_client_id,
     })
 }
 

--- a/src-tauri/src/commands/actions.rs
+++ b/src-tauri/src/commands/actions.rs
@@ -64,12 +64,7 @@ pub async fn move_messages(
         }
     } else if account.mail_protocol == "jmap" {
         // JMAP path: extract JMAP email IDs and source mailbox, then move via JMAP API
-        let jmap_config = crate::mail::jmap::JmapConfig {
-            jmap_url: account.jmap_url.clone(),
-            email: account.email.clone(),
-            username: account.username.clone(),
-            password: account.password.clone(),
-        };
+        let jmap_config = crate::commands::sync_cmd::build_jmap_config(&account).await?;
 
         // Extract JMAP IDs and group by source folder
         let mut by_folder: HashMap<String, Vec<String>> = HashMap::new();
@@ -170,12 +165,7 @@ pub async fn delete_messages(
         }
     } else if account.mail_protocol == "jmap" {
         // JMAP path: extract JMAP email IDs and delete via Email/set destroy
-        let jmap_config = crate::mail::jmap::JmapConfig {
-            jmap_url: account.jmap_url.clone(),
-            email: account.email.clone(),
-            username: account.username.clone(),
-            password: account.password.clone(),
-        };
+        let jmap_config = crate::commands::sync_cmd::build_jmap_config(&account).await?;
 
         // Extract JMAP email IDs from composite message IDs
         // Format: {account_id}_{folder}_{jmap_email_id}
@@ -275,12 +265,7 @@ pub async fn set_message_flags(
         }
     } else if account.mail_protocol == "jmap" {
         // JMAP path: extract JMAP email IDs and set flags via JMAP API
-        let jmap_config = crate::mail::jmap::JmapConfig {
-            jmap_url: account.jmap_url.clone(),
-            email: account.email.clone(),
-            username: account.username.clone(),
-            password: account.password.clone(),
-        };
+        let jmap_config = crate::commands::sync_cmd::build_jmap_config(&account).await?;
 
         // Extract JMAP email IDs from composite message IDs
         let jmap_ids: Vec<String> = message_ids.iter().map(|mid| {

--- a/src-tauri/src/commands/calendar.rs
+++ b/src-tauri/src/commands/calendar.rs
@@ -317,12 +317,7 @@ pub async fn create_event(
                 log::warn!("create_event: no remote calendar ID for local calendar '{}'", cal_event.calendar_id);
             }
             drop(conn); // Release lock before async call
-            let jmap_config = crate::mail::jmap::JmapConfig {
-                jmap_url: account.jmap_url,
-                email: account.email,
-                username: account.username,
-                password: account.password,
-            };
+            let jmap_config = crate::commands::sync_cmd::build_jmap_config(&account).await?;
             let jmap_event = crate::mail::jmap::JmapCalendarEvent {
                 id: String::new(),
                 calendar_id: remote_cal_id,
@@ -536,12 +531,7 @@ pub async fn delete_event(
                     Err(e) => log::warn!("delete_event: no Graph token, skipping server delete: {}", e),
                 }
             } else if account.mail_protocol == "jmap" {
-                let jmap_config = crate::mail::jmap::JmapConfig {
-                    jmap_url: account.jmap_url.clone(),
-                    email: account.email.clone(),
-                    username: account.username.clone(),
-                    password: account.password.clone(),
-                };
+                let jmap_config = crate::commands::sync_cmd::build_jmap_config(&account).await?;
                 match crate::mail::jmap::JmapConnection::connect(&jmap_config).await {
                     Ok(conn_jmap) => {
                         if let Err(e) = conn_jmap.delete_calendar_event(&jmap_config, remote_id).await {
@@ -626,12 +616,7 @@ async fn sync_calendars_jmap(
     account_id: &str,
     account: &db::accounts::AccountFull,
 ) -> Result<()> {
-    let jmap_config = crate::mail::jmap::JmapConfig {
-        jmap_url: account.jmap_url.clone(),
-        email: account.email.clone(),
-        username: account.username.clone(),
-        password: account.password.clone(),
-    };
+    let jmap_config = crate::commands::sync_cmd::build_jmap_config(account).await?;
 
     let jmap_conn = crate::mail::jmap::JmapConnection::connect(&jmap_config).await?;
 
@@ -1385,12 +1370,7 @@ pub async fn respond_to_invite(
 
         if account.mail_protocol == "jmap" {
             log::info!("respond_to_invite: sending reply via JMAP");
-            let jmap_config = crate::mail::jmap::JmapConfig {
-                jmap_url: account.jmap_url.clone(),
-                email: account.email.clone(),
-                username: account.username.clone(),
-                password: account.password.clone(),
-            };
+            let jmap_config = crate::commands::sync_cmd::build_jmap_config(&account).await?;
 
             let raw_message = build_calendar_reply_message(
                 &account.email,
@@ -1849,12 +1829,7 @@ pub async fn send_invites(
         }
 
         if account.mail_protocol == "jmap" {
-            let jmap_config = crate::mail::jmap::JmapConfig {
-                jmap_url: account.jmap_url.clone(),
-                email: account.email.clone(),
-                username: account.username.clone(),
-                password: account.password.clone(),
-            };
+            let jmap_config = crate::commands::sync_cmd::build_jmap_config(&account).await?;
             let conn_jmap = crate::mail::jmap::JmapConnection::connect(&jmap_config).await?;
             conn_jmap.send_email(&jmap_config, &raw).await?;
         } else {
@@ -1954,12 +1929,7 @@ pub async fn process_invite_reply(
             // Update on JMAP server if applicable
             if account.mail_protocol == "jmap" {
                 if let Some(ref remote_id) = event.remote_id {
-                    let jmap_config = crate::mail::jmap::JmapConfig {
-                        jmap_url: account.jmap_url.clone(),
-                        email: account.email.clone(),
-                        username: account.username.clone(),
-                        password: account.password.clone(),
-                    };
+                    let jmap_config = crate::commands::sync_cmd::build_jmap_config(&account).await?;
                     // Find participant key by matching email
                     // We need to fetch the event to find the right participant key
                     drop(conn);

--- a/src-tauri/src/commands/compose.rs
+++ b/src-tauri/src/commands/compose.rs
@@ -3,7 +3,7 @@ use tauri::State;
 
 use crate::db;
 use crate::error::{Error, Result};
-use crate::mail::jmap::{JmapConfig, JmapConnection};
+use crate::mail::jmap::JmapConnection;
 use crate::mail::smtp;
 use crate::state::AppState;
 
@@ -58,12 +58,7 @@ pub async fn send_message(
     } else if account.mail_protocol == "jmap" {
         log::info!("Sending via JMAP for account {}", account.email);
 
-        let jmap_config = JmapConfig {
-            jmap_url: account.jmap_url.clone(),
-            email: account.email.clone(),
-            username: account.username.clone(),
-            password: account.password.clone(),
-        };
+        let jmap_config = crate::commands::sync_cmd::build_jmap_config(&account).await?;
 
         // Build raw RFC5322 message using lettre's builder, then send via JMAP
         let attachment_data = read_attachments(&message.attachments)?;
@@ -186,12 +181,7 @@ pub async fn save_draft(
     )?;
 
     if account.mail_protocol == "jmap" {
-        let jmap_config = JmapConfig {
-            jmap_url: account.jmap_url.clone(),
-            email: account.email.clone(),
-            username: account.username.clone(),
-            password: account.password.clone(),
-        };
+        let jmap_config = crate::commands::sync_cmd::build_jmap_config(&account).await?;
         let conn_jmap = JmapConnection::connect(&jmap_config).await?;
         conn_jmap.save_draft(&jmap_config, &raw_message).await?;
     } else {

--- a/src-tauri/src/commands/contacts.rs
+++ b/src-tauri/src/commands/contacts.rs
@@ -293,12 +293,7 @@ pub async fn update_contact(
                         let conn = state.db.lock().await;
                         db::accounts::get_account_full(&conn, &account_id)?
                     };
-                    let jmap_config = crate::mail::jmap::JmapConfig {
-                        jmap_url: account.jmap_url,
-                        email: account.email,
-                        username: account.username,
-                        password: account.password,
-                    };
+                    let jmap_config = crate::commands::sync_cmd::build_jmap_config(&account).await?;
                     match crate::mail::jmap::JmapConnection::connect(&jmap_config).await {
                         Ok(conn_jmap) => {
                             match conn_jmap.update_contact_card(
@@ -403,12 +398,7 @@ pub async fn delete_contact(
                 let conn = state.db.lock().await;
                 db::accounts::get_account_full(&conn, &account_id)?
             };
-            let jmap_config = crate::mail::jmap::JmapConfig {
-                jmap_url: account.jmap_url,
-                email: account.email,
-                username: account.username,
-                password: account.password,
-            };
+            let jmap_config = crate::commands::sync_cmd::build_jmap_config(&account).await?;
             match crate::mail::jmap::JmapConnection::connect(&jmap_config).await {
                 Ok(conn_jmap) => {
                     match conn_jmap.delete_contact_card(&jmap_config, &remote_id).await {
@@ -644,14 +634,9 @@ async fn sync_contacts_jmap(
     account_id: &str,
     account: &db::accounts::AccountFull,
 ) -> Result<()> {
-    use crate::mail::jmap::{JmapConfig, JmapConnection};
+    use crate::mail::jmap::JmapConnection;
 
-    let jmap_config = JmapConfig {
-        jmap_url: account.jmap_url.clone(),
-        email: account.email.clone(),
-        username: account.username.clone(),
-        password: account.password.clone(),
-    };
+    let jmap_config = crate::commands::sync_cmd::build_jmap_config(account).await?;
 
     let jmap_conn = JmapConnection::connect(&jmap_config).await?;
 

--- a/src-tauri/src/commands/mail.rs
+++ b/src-tauri/src/commands/mail.rs
@@ -4,7 +4,6 @@ use crate::db;
 use crate::db::messages::{MessageSummary, ThreadedPage};
 use crate::error::{Error, Result};
 use crate::mail::imap::ImapConfig;
-use crate::mail::jmap::JmapConfig;
 use crate::mail::jmap_sync;
 use crate::mail::parser;
 use crate::mail::sync as mail_sync;
@@ -158,12 +157,7 @@ pub async fn get_message_body(
         let relative_path = if account.mail_protocol == "jmap" {
             log::info!("Body not on disk for {}, fetching from JMAP", message_id);
 
-            let jmap_config = JmapConfig {
-                jmap_url: account.jmap_url.clone(),
-                email: account.email.clone(),
-                username: account.username.clone(),
-                password: account.password.clone(),
-            };
+            let jmap_config = crate::commands::sync_cmd::build_jmap_config(&account).await?;
 
             // Extract the JMAP email ID from our composite message ID
             // Format: {account_id}_{folder_path}_{jmap_email_id}
@@ -475,12 +469,7 @@ pub async fn create_folder(
 
     if account.mail_protocol == "jmap" {
         // JMAP: Mailbox/set create
-        let jmap_config = JmapConfig {
-            jmap_url: account.jmap_url.clone(),
-            email: account.email.clone(),
-            username: account.username.clone(),
-            password: account.password.clone(),
-        };
+        let jmap_config = crate::commands::sync_cmd::build_jmap_config(&account).await?;
         let conn_jmap = crate::mail::jmap::JmapConnection::connect(&jmap_config).await?;
         // For JMAP, folder_path is "parentId/name" (built by the frontend).
         // Split to get the parent mailbox ID and the new folder name.

--- a/src-tauri/src/commands/oauth.rs
+++ b/src-tauri/src/commands/oauth.rs
@@ -160,3 +160,119 @@ pub struct MsProfile {
     /// The Microsoft login identity (e.g., kushaldas@gmail.com) — used for IMAP XOAUTH2
     pub login_email: String,
 }
+
+/// Start the JMAP OIDC device flow. Performs OIDC discovery, requests a device code,
+/// and returns the user code + verification URL for the user to complete in their browser.
+#[tauri::command]
+pub async fn jmap_oidc_start(
+    jmap_url: String,
+    email: String,
+    client_id: String,
+) -> Result<JmapOidcStartResult> {
+    // Derive base URL from jmap_url or email domain (with auto-discovery)
+    let base_url = if !jmap_url.is_empty() {
+        jmap_url.trim_end_matches('/').to_string()
+    } else {
+        let domain = email.rsplit_once('@')
+            .map(|(_, d)| d)
+            .ok_or_else(|| Error::Other(format!("Cannot extract domain from '{}'", email)))?;
+        // Try the same candidates as JMAP auto-discovery
+        let candidates = [
+            format!("https://{}", domain),
+            format!("https://mail.{}", domain),
+            format!("https://jmap.{}", domain),
+        ];
+        let http = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(5))
+            .build().map_err(|e| Error::Other(format!("HTTP client error: {}", e)))?;
+        let mut found = None;
+        for c in &candidates {
+            let url = format!("{}/.well-known/openid-configuration", c);
+            if let Ok(resp) = http.get(&url).send().await {
+                if resp.status().is_success() {
+                    found = Some(c.clone());
+                    break;
+                }
+            }
+        }
+        found.ok_or_else(|| Error::Other(format!(
+            "OIDC auto-discovery failed for {} (tried {}, mail.{}, jmap.{})",
+            domain, domain, domain, domain
+        )))?
+    };
+
+    // Discover OIDC endpoints
+    let endpoints = crate::oauth::discover_oidc(&base_url).await?;
+
+    let device_auth_endpoint = endpoints.device_authorization_endpoint
+        .ok_or_else(|| Error::Other(
+            "Server does not support device authorization flow (no device_authorization_endpoint in OIDC discovery)".into()
+        ))?;
+
+    // Use provided client_id, or register a new one via RFC 7591
+    let effective_client_id = if !client_id.trim().is_empty() {
+        log::info!("JMAP OIDC: reusing existing client_id");
+        client_id.trim().to_string()
+    } else if let Some(ref reg_endpoint) = endpoints.registration_endpoint {
+        crate::oauth::register_oidc_client(reg_endpoint).await?
+    } else {
+        return Err(Error::Other(
+            "OIDC requires a client_id but none was provided and the server does not support dynamic client registration. \
+             Register a client in your identity provider and enter its client_id.".into()
+        ));
+    };
+
+    // Request device code
+    let device_resp = crate::oauth::device_auth_start(&device_auth_endpoint, &effective_client_id).await?;
+
+    log::info!("JMAP OIDC device flow: verification_uri={}, client_id={}",
+        device_resp.verification_uri, effective_client_id);
+
+    Ok(JmapOidcStartResult {
+        verification_uri: device_resp.verification_uri.clone(),
+        verification_uri_complete: device_resp.verification_uri_complete.clone(),
+        user_code: device_resp.user_code.clone(),
+        device_code: device_resp.device_code.clone(),
+        interval: device_resp.interval,
+        expires_in: device_resp.expires_in,
+        token_endpoint: endpoints.token_endpoint,
+        client_id: effective_client_id,
+    })
+}
+
+#[derive(serde::Serialize)]
+pub struct JmapOidcStartResult {
+    pub verification_uri: String,
+    pub verification_uri_complete: Option<String>,
+    pub user_code: String,
+    pub device_code: String,
+    pub interval: u64,
+    pub expires_in: u64,
+    pub token_endpoint: String,
+    pub client_id: String,
+}
+
+/// Poll the token endpoint until the user completes device authorization.
+#[tauri::command]
+pub async fn jmap_oidc_complete(
+    device_code: String,
+    token_endpoint: String,
+    interval: u64,
+    expires_in: u64,
+    account_id: String,
+    client_id: String,
+) -> Result<()> {
+    let tokens = crate::oauth::device_auth_poll(
+        &token_endpoint,
+        &device_code,
+        interval,
+        expires_in,
+        &client_id,
+    ).await?;
+
+    // Store tokens in keyring
+    crate::oauth::store_tokens(&account_id, &tokens)?;
+
+    log::info!("JMAP OIDC: device flow completed for account {}", account_id);
+    Ok(())
+}

--- a/src-tauri/src/commands/sync_cmd.rs
+++ b/src-tauri/src/commands/sync_cmd.rs
@@ -65,6 +65,41 @@ pub async fn get_jmap_oidc_token(account: &crate::db::accounts::AccountFull) -> 
     Ok(Some(new_tokens.access_token))
 }
 
+/// Refresh an OIDC access token using the account_id and OIDC metadata.
+/// Used by the push loop to refresh tokens on reconnect without DB access.
+pub async fn refresh_jmap_oidc_token(
+    account_id: &str,
+    oidc_token_endpoint: &str,
+    oidc_client_id: &str,
+) -> crate::error::Result<Option<String>> {
+    let tokens = match crate::oauth::load_tokens(account_id)? {
+        Some(t) => t,
+        None => return Ok(None),
+    };
+
+    if !tokens.is_expired() {
+        return Ok(Some(tokens.access_token));
+    }
+
+    let refresh_token = match tokens.refresh_token {
+        Some(rt) => rt,
+        None => return Ok(Some(tokens.access_token)), // can't refresh, return stale
+    };
+
+    if oidc_token_endpoint.is_empty() || oidc_client_id.is_empty() {
+        return Ok(Some(tokens.access_token)); // can't refresh without metadata
+    }
+
+    let new_tokens = crate::oauth::refresh_token_dynamic(
+        oidc_token_endpoint,
+        &refresh_token,
+        oidc_client_id,
+    ).await?;
+    crate::oauth::store_tokens(account_id, &new_tokens)?;
+
+    Ok(Some(new_tokens.access_token))
+}
+
 /// Build a JmapConfig from an AccountFull, with OIDC token if applicable.
 pub async fn build_jmap_config(account: &crate::db::accounts::AccountFull) -> crate::error::Result<crate::mail::jmap::JmapConfig> {
     let access_token = get_jmap_oidc_token(account).await?;
@@ -74,6 +109,8 @@ pub async fn build_jmap_config(account: &crate::db::accounts::AccountFull) -> cr
         username: account.username.clone(),
         password: account.password.clone(),
         access_token,
+        oidc_token_endpoint: account.oidc_token_endpoint.clone(),
+        oidc_client_id: account.oidc_client_id.clone(),
     })
 }
 

--- a/src-tauri/src/commands/sync_cmd.rs
+++ b/src-tauri/src/commands/sync_cmd.rs
@@ -22,6 +22,61 @@ use crate::mail::jmap_sync;
 use crate::mail::sync as mail_sync;
 use crate::state::AppState;
 
+/// Get a valid OIDC access token for a JMAP account, refreshing if needed.
+/// Returns `None` if the account doesn't use OIDC.
+pub async fn get_jmap_oidc_token(account: &crate::db::accounts::AccountFull) -> crate::error::Result<Option<String>> {
+    if account.jmap_auth_method != "oidc" {
+        return Ok(None);
+    }
+
+    let tokens = crate::oauth::load_tokens(&account.id)?
+        .ok_or_else(|| crate::error::Error::Other(
+            "No OIDC tokens found. Please sign in again.".into()
+        ))?;
+
+    if !tokens.is_expired() {
+        return Ok(Some(tokens.access_token));
+    }
+
+    // Need to refresh
+    let refresh_token = tokens.refresh_token
+        .ok_or_else(|| crate::error::Error::Other(
+            "No refresh token. Please sign in again.".into()
+        ))?;
+
+    if account.oidc_token_endpoint.is_empty() {
+        return Err(crate::error::Error::Other(
+            "OIDC token endpoint not configured. Please sign in again.".into()
+        ));
+    }
+    if account.oidc_client_id.is_empty() {
+        return Err(crate::error::Error::Other(
+            "OIDC client_id not configured. Please sign in again.".into()
+        ));
+    }
+
+    let new_tokens = crate::oauth::refresh_token_dynamic(
+        &account.oidc_token_endpoint,
+        &refresh_token,
+        &account.oidc_client_id,
+    ).await?;
+    crate::oauth::store_tokens(&account.id, &new_tokens)?;
+
+    Ok(Some(new_tokens.access_token))
+}
+
+/// Build a JmapConfig from an AccountFull, with OIDC token if applicable.
+pub async fn build_jmap_config(account: &crate::db::accounts::AccountFull) -> crate::error::Result<crate::mail::jmap::JmapConfig> {
+    let access_token = get_jmap_oidc_token(account).await?;
+    Ok(crate::mail::jmap::JmapConfig {
+        jmap_url: account.jmap_url.clone(),
+        email: account.email.clone(),
+        username: account.username.clone(),
+        password: account.password.clone(),
+        access_token,
+    })
+}
+
 #[tauri::command]
 pub async fn trigger_sync(
     app: AppHandle,
@@ -74,12 +129,7 @@ pub async fn trigger_sync(
             account.jmap_url
         );
 
-        let jmap_config = JmapConfig {
-            jmap_url: account.jmap_url.clone(),
-            email: account.email.clone(),
-            username: account.username.clone(),
-            password: account.password.clone(),
-        };
+        let jmap_config = build_jmap_config(&account).await?;
 
         if let Err(e) = jmap_sync::sync_jmap_account(
             app.clone(),
@@ -173,12 +223,7 @@ pub async fn sync_folder(
     };
 
     if account.mail_protocol == "jmap" {
-        let jmap_config = JmapConfig {
-            jmap_url: account.jmap_url.clone(),
-            email: account.email.clone(),
-            username: account.username.clone(),
-            password: account.password.clone(),
-        };
+        let jmap_config = build_jmap_config(&account).await?;
 
         return jmap_sync::sync_jmap_folder_public(
             app,
@@ -855,12 +900,7 @@ async fn start_jmap_push(
         db::accounts::get_account_full(&conn, &account.id)?
     };
 
-    let jmap_config = JmapConfig {
-        jmap_url: full_account.jmap_url.clone(),
-        email: full_account.email.clone(),
-        username: full_account.username.clone(),
-        password: full_account.password.clone(),
-    };
+    let jmap_config = build_jmap_config(&full_account).await?;
 
     let account_id = account.id.clone();
     let stop_flag = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));

--- a/src-tauri/src/db/accounts.rs
+++ b/src-tauri/src/db/accounts.rs
@@ -163,9 +163,11 @@ pub fn insert_account(conn: &Connection, id: &str, config: &AccountConfig) -> Re
 }
 
 pub fn update_account(conn: &Connection, id: &str, config: &AccountConfig) -> Result<()> {
-    // Only update keyring if a new password was provided (non-empty).
-    // Empty means "keep existing" — the frontend never receives the stored password.
-    if !config.password.is_empty() {
+    // Only update keyring if a real password was provided; skip OIDC accounts and oauth2 markers.
+    if !config.password.is_empty()
+        && config.jmap_auth_method != "oidc"
+        && !config.password.starts_with("oauth2:")
+    {
         crate::keyring::set_password(id, &config.password)?;
     }
 

--- a/src-tauri/src/db/accounts.rs
+++ b/src-tauri/src/db/accounts.rs
@@ -30,6 +30,16 @@ pub struct AccountConfig {
     pub use_tls: bool,
     #[serde(default)]
     pub signature: String,
+    #[serde(default = "default_basic")]
+    pub jmap_auth_method: String,
+    #[serde(default)]
+    pub oidc_token_endpoint: String,
+    #[serde(default)]
+    pub oidc_client_id: String,
+}
+
+fn default_basic() -> String {
+    "basic".to_string()
 }
 
 #[derive(Debug, Clone)]
@@ -50,6 +60,9 @@ pub struct AccountFull {
     pub use_tls: bool,
     pub enabled: bool,
     pub signature: String,
+    pub jmap_auth_method: String,
+    pub oidc_token_endpoint: String,
+    pub oidc_client_id: String,
 }
 
 pub fn list_accounts(conn: &Connection) -> Result<Vec<Account>> {
@@ -73,7 +86,7 @@ pub fn list_accounts(conn: &Connection) -> Result<Vec<Account>> {
 
 pub fn get_account_full(conn: &Connection, id: &str) -> Result<AccountFull> {
     let mut account = conn.query_row(
-        "SELECT id, display_name, email, provider, mail_protocol, imap_host, imap_port, smtp_host, smtp_port, jmap_url, caldav_url, username, use_tls, enabled, signature FROM accounts WHERE id = ?1",
+        "SELECT id, display_name, email, provider, mail_protocol, imap_host, imap_port, smtp_host, smtp_port, jmap_url, caldav_url, username, use_tls, enabled, signature, jmap_auth_method, oidc_token_endpoint, oidc_client_id FROM accounts WHERE id = ?1",
         params![id],
         |row| {
             Ok(AccountFull {
@@ -93,6 +106,9 @@ pub fn get_account_full(conn: &Connection, id: &str) -> Result<AccountFull> {
                 use_tls: row.get(12)?,
                 enabled: row.get(13)?,
                 signature: row.get(14)?,
+                jmap_auth_method: row.get(15)?,
+                oidc_token_endpoint: row.get(16)?,
+                oidc_client_id: row.get(17)?,
             })
         },
     ).map_err(|e| match e {
@@ -112,12 +128,17 @@ pub fn get_account_full(conn: &Connection, id: &str) -> Result<AccountFull> {
 }
 
 pub fn insert_account(conn: &Connection, id: &str, config: &AccountConfig) -> Result<()> {
-    // Store password in system keyring
-    crate::keyring::set_password(id, &config.password)?;
+    // Store real passwords in system keyring; skip OIDC accounts and oauth2 migration markers
+    if !config.password.is_empty()
+        && config.jmap_auth_method != "oidc"
+        && !config.password.starts_with("oauth2:")
+    {
+        crate::keyring::set_password(id, &config.password)?;
+    }
 
     conn.execute(
-        "INSERT INTO accounts (id, display_name, email, provider, mail_protocol, imap_host, imap_port, smtp_host, smtp_port, jmap_url, caldav_url, username, use_tls, signature)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
+        "INSERT INTO accounts (id, display_name, email, provider, mail_protocol, imap_host, imap_port, smtp_host, smtp_port, jmap_url, caldav_url, username, use_tls, signature, jmap_auth_method, oidc_token_endpoint, oidc_client_id)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17)",
         params![
             id,
             config.display_name,
@@ -133,6 +154,9 @@ pub fn insert_account(conn: &Connection, id: &str, config: &AccountConfig) -> Re
             config.username,
             config.use_tls,
             config.signature,
+            config.jmap_auth_method,
+            config.oidc_token_endpoint,
+            config.oidc_client_id,
         ],
     )?;
     Ok(())
@@ -148,8 +172,10 @@ pub fn update_account(conn: &Connection, id: &str, config: &AccountConfig) -> Re
     let rows = conn.execute(
         "UPDATE accounts SET display_name=?1, email=?2, provider=?3, mail_protocol=?4,
          imap_host=?5, imap_port=?6, smtp_host=?7, smtp_port=?8, jmap_url=?9,
-         caldav_url=?10, username=?11, use_tls=?12, signature=?13, updated_at=CURRENT_TIMESTAMP
-         WHERE id=?14",
+         caldav_url=?10, username=?11, use_tls=?12, signature=?13,
+         jmap_auth_method=?14, oidc_token_endpoint=?15, oidc_client_id=?16,
+         updated_at=CURRENT_TIMESTAMP
+         WHERE id=?17",
         params![
             config.display_name,
             config.email,
@@ -164,6 +190,9 @@ pub fn update_account(conn: &Connection, id: &str, config: &AccountConfig) -> Re
             config.username,
             config.use_tls,
             config.signature,
+            config.jmap_auth_method,
+            config.oidc_token_endpoint,
+            config.oidc_client_id,
             id,
         ],
     )?;
@@ -208,6 +237,9 @@ mod tests {
                 use_tls INTEGER NOT NULL DEFAULT 1,
                 enabled INTEGER NOT NULL DEFAULT 1,
                 signature TEXT NOT NULL DEFAULT '',
+                jmap_auth_method TEXT NOT NULL DEFAULT 'basic',
+                oidc_token_endpoint TEXT NOT NULL DEFAULT '',
+                oidc_client_id TEXT NOT NULL DEFAULT '',
                 created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
                 updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
             );
@@ -237,6 +269,9 @@ mod tests {
             password: "secret123".to_string(),
             use_tls: true,
             signature: String::new(),
+            jmap_auth_method: "basic".to_string(),
+            oidc_token_endpoint: String::new(),
+            oidc_client_id: String::new(),
         }
     }
 

--- a/src-tauri/src/db/schema.rs
+++ b/src-tauri/src/db/schema.rs
@@ -244,14 +244,36 @@ fn run_migrations(conn: &Connection) -> Result<()> {
         )?;
     }
 
-    // Add parent_id column to folders if it doesn't exist (for JMAP hierarchy)
-    let has_parent_id: bool = conn
-        .prepare("SELECT parent_id FROM folders LIMIT 0")
+    // Add jmap_auth_method column if it doesn't exist
+    let has_jmap_auth_method: bool = conn
+        .prepare("SELECT jmap_auth_method FROM accounts LIMIT 0")
         .is_ok();
-    if !has_parent_id {
-        log::info!("Migration: adding parent_id column to folders table");
+    if !has_jmap_auth_method {
+        log::info!("Migration: adding jmap_auth_method column to accounts table");
         conn.execute_batch(
-            "ALTER TABLE folders ADD COLUMN parent_id TEXT;",
+            "ALTER TABLE accounts ADD COLUMN jmap_auth_method TEXT NOT NULL DEFAULT 'basic';",
+        )?;
+    }
+
+    // Add oidc_token_endpoint column if it doesn't exist
+    let has_oidc_token_endpoint: bool = conn
+        .prepare("SELECT oidc_token_endpoint FROM accounts LIMIT 0")
+        .is_ok();
+    if !has_oidc_token_endpoint {
+        log::info!("Migration: adding oidc_token_endpoint column to accounts table");
+        conn.execute_batch(
+            "ALTER TABLE accounts ADD COLUMN oidc_token_endpoint TEXT NOT NULL DEFAULT '';",
+        )?;
+    }
+
+    // Add oidc_client_id column if it doesn't exist
+    let has_oidc_client_id: bool = conn
+        .prepare("SELECT oidc_client_id FROM accounts LIMIT 0")
+        .is_ok();
+    if !has_oidc_client_id {
+        log::info!("Migration: adding oidc_client_id column to accounts table");
+        conn.execute_batch(
+            "ALTER TABLE accounts ADD COLUMN oidc_client_id TEXT NOT NULL DEFAULT '';",
         )?;
     }
 

--- a/src-tauri/src/mail/jmap.rs
+++ b/src-tauri/src/mail/jmap.rs
@@ -35,6 +35,19 @@ pub struct JmapConfig {
     pub email: String,
     pub username: String,
     pub password: String,
+    pub access_token: Option<String>,
+}
+
+impl JmapConfig {
+    /// Apply authentication to a reqwest RequestBuilder.
+    /// Uses Bearer auth if access_token is set, otherwise Basic auth.
+    fn apply_auth(&self, req: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+        if let Some(ref token) = self.access_token {
+            req.bearer_auth(token)
+        } else {
+            req.basic_auth(&self.username, Some(&self.password))
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -119,8 +132,7 @@ impl JmapConnection {
 
         // Fetch session with authentication
         let well_known = format!("{}/.well-known/jmap", base_url);
-        let resp = http.get(&well_known)
-            .basic_auth(&config.username, Some(&config.password))
+        let resp = config.apply_auth(http.get(&well_known))
             .send().await
             .map_err(|e| Error::Other(format!("JMAP session fetch failed: {}", e)))?;
 
@@ -177,8 +189,7 @@ impl JmapConnection {
 
     /// Send a JMAP API request and return the response JSON.
     async fn api_request(&self, body: &serde_json::Value, config: &JmapConfig) -> Result<serde_json::Value> {
-        let resp = self.http.post(&self.api_url)
-            .basic_auth(&config.username, Some(&config.password))
+        let resp = config.apply_auth(self.http.post(&self.api_url))
             .json(body)
             .send().await
             .map_err(|e| Error::Other(format!("JMAP request failed: {}", e)))?;
@@ -387,8 +398,7 @@ impl JmapConnection {
             .replace("{type}", "application/octet-stream");
 
         log::debug!("JMAP downloading blob from {}", download_url);
-        let resp = self.http.get(&download_url)
-            .basic_auth(&config.username, Some(&config.password))
+        let resp = config.apply_auth(self.http.get(&download_url))
             .send().await
             .map_err(|e| Error::Other(format!("JMAP download failed: {}", e)))?;
 
@@ -486,8 +496,7 @@ impl JmapConnection {
             .replace("{accountId}", &self.account_id);
         log::debug!("JMAP uploading blob to {}", upload_url);
 
-        let resp = self.http.post(&upload_url)
-            .basic_auth(&config.username, Some(&config.password))
+        let resp = config.apply_auth(self.http.post(&upload_url))
             .header("Content-Type", "message/rfc822")
             .body(raw_message.to_vec())
             .send().await
@@ -612,8 +621,7 @@ impl JmapConnection {
         let upload_url = self.upload_url_template
             .replace("{accountId}", &self.account_id);
 
-        let resp = self.http.post(&upload_url)
-            .basic_auth(&config.username, Some(&config.password))
+        let resp = config.apply_auth(self.http.post(&upload_url))
             .header("Content-Type", "message/rfc822")
             .body(raw_message.to_vec())
             .send().await

--- a/src-tauri/src/mail/jmap.rs
+++ b/src-tauri/src/mail/jmap.rs
@@ -36,6 +36,9 @@ pub struct JmapConfig {
     pub username: String,
     pub password: String,
     pub access_token: Option<String>,
+    /// OIDC metadata for token refresh (used by push loop on reconnect)
+    pub oidc_token_endpoint: String,
+    pub oidc_client_id: String,
 }
 
 impl JmapConfig {

--- a/src-tauri/src/mail/jmap_push.rs
+++ b/src-tauri/src/mail/jmap_push.rs
@@ -126,10 +126,22 @@ pub async fn run_push_loop(
     log::info!("JMAP push loop stopped for account {}", account_id);
 }
 
-/// Holds Basic Auth credentials for the SSE connection.
+/// Holds auth credentials for the SSE connection.
 struct HttpAuth {
     username: String,
     password: String,
+    access_token: Option<String>,
+}
+
+impl HttpAuth {
+    /// Apply authentication to a reqwest RequestBuilder.
+    fn apply_auth(&self, req: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+        if let Some(ref token) = self.access_token {
+            req.bearer_auth(token)
+        } else {
+            req.basic_auth(&self.username, Some(&self.password))
+        }
+    }
 }
 
 /// Connect to the JMAP server, fetch session, and return the EventSource URL.
@@ -138,7 +150,6 @@ async fn connect_and_get_url(config: &JmapConfig) -> Result<(String, HttpAuth), 
         .await
         .map_err(|e| format!("JMAP connect failed: {}", e))?;
 
-    // Request all state change types: *, which covers Email, Mailbox, etc.
     let url = conn
         .event_source_url("*", PING_INTERVAL_SECS)
         .ok_or_else(|| "Server does not advertise eventSourceUrl".to_string())?;
@@ -148,6 +159,7 @@ async fn connect_and_get_url(config: &JmapConfig) -> Result<(String, HttpAuth), 
         HttpAuth {
             username: config.username.clone(),
             password: config.password.clone(),
+            access_token: config.access_token.clone(),
         },
     ))
 }
@@ -171,9 +183,7 @@ async fn stream_events(
         .build()
         .map_err(|e| format!("HTTP client build error: {}", e))?;
 
-    let response = client
-        .get(url)
-        .basic_auth(&auth.username, Some(&auth.password))
+    let response = auth.apply_auth(client.get(url))
         .header("Accept", "text/event-stream")
         // Prevent reverse proxies (nginx) from buffering SSE responses.
         .header("Cache-Control", "no-cache")

--- a/src-tauri/src/mail/jmap_push.rs
+++ b/src-tauri/src/mail/jmap_push.rs
@@ -42,7 +42,7 @@ pub enum PushEvent {
 /// This function runs indefinitely in an async task — cancel it via
 /// the `stop` flag or by aborting the task.
 pub async fn run_push_loop(
-    config: JmapConfig,
+    mut config: JmapConfig,
     account_id: String,
     stop: Arc<AtomicBool>,
     on_event: Arc<dyn Fn(PushEvent) + Send + Sync>,
@@ -53,6 +53,20 @@ pub async fn run_push_loop(
     let mut was_disconnected = false;
 
     while !stop.load(Ordering::Relaxed) {
+        // For OIDC accounts, refresh the access token before each connect attempt
+        // so reconnects after token expiry don't keep using a stale token.
+        if config.access_token.is_some() {
+            match crate::commands::sync_cmd::refresh_jmap_oidc_token(
+                &account_id,
+                &config.oidc_token_endpoint,
+                &config.oidc_client_id,
+            ).await {
+                Ok(Some(new_token)) => config.access_token = Some(new_token),
+                Ok(None) => {}
+                Err(e) => log::warn!("JMAP push: token refresh failed for {}: {}", account_id, e),
+            }
+        }
+
         // Connect and get the EventSource URL
         let (event_source_url, http_auth) = match connect_and_get_url(&config).await {
             Ok(v) => v,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -69,6 +69,8 @@ fn main() {
             commands::oauth::oauth_get_token,
             commands::oauth::oauth_has_tokens,
             commands::oauth::oauth_get_ms_profile,
+            commands::oauth::jmap_oidc_start,
+            commands::oauth::jmap_oidc_complete,
             commands::actions::move_messages,
             commands::actions::delete_messages,
             commands::actions::set_message_flags,

--- a/src-tauri/src/oauth.rs
+++ b/src-tauri/src/oauth.rs
@@ -411,13 +411,35 @@ pub async fn discover_oidc(base_url: &str) -> Result<OidcEndpoints> {
         .ok_or_else(|| Error::Other("OIDC: no token_endpoint in discovery".into()))?
         .to_string();
 
+    if !token_endpoint.starts_with("https://") {
+        return Err(Error::Other(format!(
+            "OIDC: token_endpoint must use HTTPS, got: {}", token_endpoint
+        )));
+    }
+
     let device_authorization_endpoint = config["device_authorization_endpoint"]
         .as_str()
         .map(|s| s.to_string());
 
+    if let Some(ref ep) = device_authorization_endpoint {
+        if !ep.starts_with("https://") {
+            return Err(Error::Other(format!(
+                "OIDC: device_authorization_endpoint must use HTTPS, got: {}", ep
+            )));
+        }
+    }
+
     let registration_endpoint = config["registration_endpoint"]
         .as_str()
         .map(|s| s.to_string());
+
+    if let Some(ref ep) = registration_endpoint {
+        if !ep.starts_with("https://") {
+            return Err(Error::Other(format!(
+                "OIDC: registration_endpoint must use HTTPS, got: {}", ep
+            )));
+        }
+    }
 
     log::info!("OIDC: discovered token={}, device_auth={:?}, registration={:?}",
         token_endpoint, device_authorization_endpoint, registration_endpoint);

--- a/src-tauri/src/oauth.rs
+++ b/src-tauri/src/oauth.rs
@@ -551,16 +551,26 @@ pub async fn device_auth_poll(
     expires_in: u64,
     client_id: &str,
 ) -> Result<OAuthTokens> {
-    let client = reqwest::Client::new();
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .build()
+        .map_err(|e| Error::Other(format!("HTTP client error: {}", e)))?;
+
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(expires_in);
-    let poll_interval = std::time::Duration::from_secs(interval);
+    let mut current_interval = std::time::Duration::from_secs(interval);
+    let mut first_poll = true;
 
     loop {
         if std::time::Instant::now() >= deadline {
             return Err(Error::Other("Device authorization timed out — user did not complete sign-in".into()));
         }
 
-        tokio::time::sleep(poll_interval).await;
+        // Sleep before polling (skip on first attempt per RFC 8628 §3.5)
+        if first_poll {
+            first_poll = false;
+        } else {
+            tokio::time::sleep(current_interval).await;
+        }
 
         let mut params = HashMap::new();
         params.insert("grant_type", "urn:ietf:params:oauth:grant-type:device_code".to_string());
@@ -611,8 +621,9 @@ pub async fn device_auth_poll(
                 continue;
             }
             "slow_down" => {
-                log::debug!("OIDC device flow: slow_down, increasing interval");
-                tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                // RFC 8628 §3.5: increase interval by 5 seconds
+                current_interval += std::time::Duration::from_secs(5);
+                log::debug!("OIDC device flow: slow_down, interval now {}s", current_interval.as_secs());
                 continue;
             }
             "access_denied" => {
@@ -641,7 +652,10 @@ pub async fn refresh_token_dynamic(
     params.insert("refresh_token", refresh_token.to_string());
     params.insert("grant_type", "refresh_token".to_string());
 
-    let client = reqwest::Client::new();
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .build()
+        .map_err(|e| Error::Other(format!("HTTP client error: {}", e)))?;
     let resp = client
         .post(token_url)
         .form(&params)

--- a/src-tauri/src/oauth.rs
+++ b/src-tauri/src/oauth.rs
@@ -372,6 +372,315 @@ pub async fn refresh_with_scopes(
 }
 
 // ---------------------------------------------------------------------------
+// OIDC discovery for JMAP
+// ---------------------------------------------------------------------------
+
+/// Discovered OIDC endpoints from .well-known/openid-configuration.
+pub struct OidcEndpoints {
+    pub token_endpoint: String,
+    pub device_authorization_endpoint: Option<String>,
+    pub registration_endpoint: Option<String>,
+}
+
+/// Discover OIDC endpoints from a JMAP server's .well-known/openid-configuration.
+/// `base_url` should be like "https://mail.example.com".
+pub async fn discover_oidc(base_url: &str) -> Result<OidcEndpoints> {
+    let url = format!("{}/.well-known/openid-configuration", base_url.trim_end_matches('/'));
+    log::info!("OIDC: discovering endpoints from {}", url);
+
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(10))
+        .build()
+        .map_err(|e| Error::Other(format!("HTTP client build error: {}", e)))?;
+
+    let resp = client.get(&url).send().await
+        .map_err(|e| Error::Other(format!("OIDC discovery failed: {}", e)))?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        return Err(Error::Other(format!(
+            "OIDC discovery returned {}: server may not support OIDC", status
+        )));
+    }
+
+    let config: serde_json::Value = resp.json().await
+        .map_err(|e| Error::Other(format!("OIDC discovery parse error: {}", e)))?;
+
+    let token_endpoint = config["token_endpoint"]
+        .as_str()
+        .ok_or_else(|| Error::Other("OIDC: no token_endpoint in discovery".into()))?
+        .to_string();
+
+    let device_authorization_endpoint = config["device_authorization_endpoint"]
+        .as_str()
+        .map(|s| s.to_string());
+
+    let registration_endpoint = config["registration_endpoint"]
+        .as_str()
+        .map(|s| s.to_string());
+
+    log::info!("OIDC: discovered token={}, device_auth={:?}, registration={:?}",
+        token_endpoint, device_authorization_endpoint, registration_endpoint);
+
+    Ok(OidcEndpoints {
+        token_endpoint,
+        device_authorization_endpoint,
+        registration_endpoint,
+    })
+}
+
+/// Register a client dynamically via RFC 7591.
+/// Returns the assigned `client_id`.
+pub async fn register_oidc_client(registration_endpoint: &str) -> Result<String> {
+    let body = serde_json::json!({
+        "client_name": "Chithi Mail",
+        "redirect_uris": [],
+        "grant_types": ["urn:ietf:params:oauth:grant-type:device_code", "refresh_token"],
+        "response_types": [],
+        "token_endpoint_auth_method": "none",
+    });
+
+    log::info!("OIDC: registering client at {}", registration_endpoint);
+
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(10))
+        .build()
+        .map_err(|e| Error::Other(format!("HTTP client error: {}", e)))?;
+
+    let resp = client
+        .post(registration_endpoint)
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| Error::Other(format!("OIDC client registration failed: {}", e)))?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let resp_body = resp.text().await.unwrap_or_default();
+        return Err(Error::Other(format!(
+            "OIDC client registration returned {}: {}", status, resp_body
+        )));
+    }
+
+    let reg_resp: serde_json::Value = resp.json().await
+        .map_err(|e| Error::Other(format!("OIDC registration parse error: {}", e)))?;
+
+    let client_id = reg_resp["client_id"]
+        .as_str()
+        .ok_or_else(|| Error::Other("OIDC: no client_id in registration response".into()))?
+        .to_string();
+
+    log::info!("OIDC: registered client_id={}", client_id);
+
+    Ok(client_id)
+}
+
+// ---------------------------------------------------------------------------
+// OAuth2 Device Authorization Grant (RFC 8628) for JMAP OIDC
+// ---------------------------------------------------------------------------
+
+/// Response from the device authorization endpoint.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeviceAuthResponse {
+    pub device_code: String,
+    pub user_code: String,
+    pub verification_uri: String,
+    #[serde(default)]
+    pub verification_uri_complete: Option<String>,
+    /// Polling interval in seconds (default 5).
+    #[serde(default = "default_interval")]
+    pub interval: u64,
+    /// Lifetime of the device code in seconds.
+    #[serde(default = "default_expires_in")]
+    pub expires_in: u64,
+}
+
+fn default_interval() -> u64 { 5 }
+fn default_expires_in() -> u64 { 600 }
+
+/// Start the device authorization flow — POST to the device authorization endpoint.
+/// Returns the device code, user code, and verification URL to show to the user.
+pub async fn device_auth_start(
+    device_auth_endpoint: &str,
+    client_id: &str,
+) -> Result<DeviceAuthResponse> {
+    if client_id.trim().is_empty() {
+        return Err(Error::Other("Device authorization requires a client_id".into()));
+    }
+
+    log::info!("OIDC device flow: requesting device code from {}", device_auth_endpoint);
+
+    let mut params = HashMap::new();
+    params.insert("client_id", client_id.to_string());
+
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(10))
+        .build()
+        .map_err(|e| Error::Other(format!("HTTP client error: {}", e)))?;
+
+    let resp = client
+        .post(device_auth_endpoint)
+        .form(&params)
+        .send()
+        .await
+        .map_err(|e| Error::Other(format!("Device auth request failed: {}", e)))?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        return Err(Error::Other(format!(
+            "Device auth endpoint returned {}: {}", status, body
+        )));
+    }
+
+    let auth_resp: DeviceAuthResponse = resp.json().await
+        .map_err(|e| Error::Other(format!("Device auth response parse error: {}", e)))?;
+
+    log::info!("OIDC device flow: received user_code, verification_uri={}",
+        auth_resp.verification_uri);
+
+    Ok(auth_resp)
+}
+
+/// Poll the token endpoint until the user completes device authorization.
+/// Returns tokens on success, or errors on expiry/denial.
+pub async fn device_auth_poll(
+    token_endpoint: &str,
+    device_code: &str,
+    interval: u64,
+    expires_in: u64,
+    client_id: &str,
+) -> Result<OAuthTokens> {
+    let client = reqwest::Client::new();
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(expires_in);
+    let poll_interval = std::time::Duration::from_secs(interval);
+
+    loop {
+        if std::time::Instant::now() >= deadline {
+            return Err(Error::Other("Device authorization timed out — user did not complete sign-in".into()));
+        }
+
+        tokio::time::sleep(poll_interval).await;
+
+        let mut params = HashMap::new();
+        params.insert("grant_type", "urn:ietf:params:oauth:grant-type:device_code".to_string());
+        params.insert("device_code", device_code.to_string());
+        if !client_id.is_empty() {
+            params.insert("client_id", client_id.to_string());
+        }
+
+        let resp = client
+            .post(token_endpoint)
+            .form(&params)
+            .send()
+            .await
+            .map_err(|e| Error::Other(format!("Device token poll failed: {}", e)))?;
+
+        if resp.status().is_success() {
+            let token_resp: serde_json::Value = resp.json().await
+                .map_err(|e| Error::Other(format!("Device token parse failed: {}", e)))?;
+
+            let access_token = token_resp["access_token"]
+                .as_str()
+                .ok_or_else(|| Error::Other("No access_token in device token response".into()))?
+                .to_string();
+
+            let refresh_token = token_resp["refresh_token"]
+                .as_str()
+                .map(|s| s.to_string());
+
+            let expires_in = token_resp["expires_in"].as_i64().unwrap_or(3600);
+            let expires_at = chrono::Utc::now().timestamp() + expires_in;
+
+            log::info!("OIDC device flow: authorization complete, expires in {}s", expires_in);
+
+            return Ok(OAuthTokens {
+                access_token,
+                refresh_token,
+                expires_at: Some(expires_at),
+            });
+        }
+
+        // Check error response
+        let body: serde_json::Value = resp.json().await.unwrap_or_default();
+        let error = body["error"].as_str().unwrap_or("");
+
+        match error {
+            "authorization_pending" => {
+                log::debug!("OIDC device flow: authorization pending, polling again...");
+                continue;
+            }
+            "slow_down" => {
+                log::debug!("OIDC device flow: slow_down, increasing interval");
+                tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                continue;
+            }
+            "access_denied" => {
+                return Err(Error::Other("Device authorization denied by user".into()));
+            }
+            "expired_token" => {
+                return Err(Error::Other("Device code expired — please try again".into()));
+            }
+            _ => {
+                let desc = body["error_description"].as_str().unwrap_or("");
+                return Err(Error::Other(format!("Device auth error: {} {}", error, desc)));
+            }
+        }
+    }
+}
+
+/// Refresh an access token using a dynamically discovered token endpoint.
+/// Used for JMAP OIDC where there is no static OAuthProvider.
+pub async fn refresh_token_dynamic(
+    token_url: &str,
+    refresh_token: &str,
+    client_id: &str,
+) -> Result<OAuthTokens> {
+    let mut params = HashMap::new();
+    params.insert("client_id", client_id.to_string());
+    params.insert("refresh_token", refresh_token.to_string());
+    params.insert("grant_type", "refresh_token".to_string());
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(token_url)
+        .form(&params)
+        .send()
+        .await
+        .map_err(|e| Error::Other(format!("OIDC token refresh failed: {}", e)))?;
+
+    if !resp.status().is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        return Err(Error::Other(format!("OIDC token refresh error: {}", body)));
+    }
+
+    let token_resp: serde_json::Value = resp.json().await
+        .map_err(|e| Error::Other(format!("OIDC token refresh parse failed: {}", e)))?;
+
+    let access_token = token_resp["access_token"]
+        .as_str()
+        .ok_or_else(|| Error::Other("No access_token in OIDC refresh response".into()))?
+        .to_string();
+
+    let expires_in = token_resp["expires_in"].as_i64().unwrap_or(3600);
+    let expires_at = chrono::Utc::now().timestamp() + expires_in;
+
+    // IdP may rotate the refresh token
+    let new_refresh = token_resp["refresh_token"]
+        .as_str()
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| refresh_token.to_string());
+
+    log::info!("OIDC: token refreshed, expires in {}s", expires_in);
+
+    Ok(OAuthTokens {
+        access_token,
+        refresh_token: Some(new_refresh),
+        expires_at: Some(expires_at),
+    })
+}
+
+// ---------------------------------------------------------------------------
 // Keyring storage for OAuth tokens
 // ---------------------------------------------------------------------------
 
@@ -520,5 +829,17 @@ mod tests {
         assert!(MICROSOFT_GRAPH_SCOPES.contains("User.Read"));
         assert!(MICROSOFT_GRAPH_SCOPES.contains("Calendars.ReadWrite"));
         assert!(MICROSOFT_GRAPH_SCOPES.contains("Contacts.ReadWrite"));
+    }
+
+    #[test]
+    fn test_device_auth_response_defaults() {
+        let json = r#"{"device_code":"dc","user_code":"UC","verification_uri":"https://example.com/device"}"#;
+        let resp: DeviceAuthResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.device_code, "dc");
+        assert_eq!(resp.user_code, "UC");
+        assert_eq!(resp.verification_uri, "https://example.com/device");
+        assert_eq!(resp.interval, 5); // default
+        assert_eq!(resp.expires_in, 600); // default
+        assert!(resp.verification_uri_complete.is_none());
     }
 }

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -421,3 +421,39 @@ export async function searchCollectedContacts(
 ): Promise<import("./types").CollectedContact[]> {
   return invoke("search_collected_contacts", { query });
 }
+
+// JMAP OIDC (Device Authorization Flow)
+export async function jmapOidcStart(
+  jmapUrl: string,
+  email: string,
+  clientId: string,
+): Promise<{
+  verification_uri: string;
+  verification_uri_complete: string | null;
+  user_code: string;
+  device_code: string;
+  interval: number;
+  expires_in: number;
+  token_endpoint: string;
+  client_id: string;
+}> {
+  return invoke("jmap_oidc_start", { jmapUrl, email, clientId });
+}
+
+export async function jmapOidcComplete(
+  deviceCode: string,
+  tokenEndpoint: string,
+  interval: number,
+  expiresIn: number,
+  accountId: string,
+  clientId: string,
+): Promise<void> {
+  return invoke("jmap_oidc_complete", {
+    deviceCode,
+    tokenEndpoint,
+    interval,
+    expiresIn,
+    accountId,
+    clientId,
+  });
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -117,6 +117,9 @@ export interface AccountConfig {
   password: string;
   use_tls: boolean;
   signature: string;
+  jmap_auth_method: "basic" | "oidc";
+  oidc_token_endpoint: string;
+  oidc_client_id: string;
 }
 
 export interface FilterRule {

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -17,7 +17,6 @@ const error = ref<string | null>(null);
 const editingAccountId = ref<string | null>(null);
 const oauthStatus = ref<string | null>(null);
 const oauthInProgress = ref(false);
-const jmapOidcTokenEndpoint = ref("");
 
 const avatarColors = ["#3366cc", "#2e7d32", "#9c27b0", "#e65100", "#00838f"];
 
@@ -286,6 +285,9 @@ async function startJmapOidc() {
     // Show the user code and open browser to verification URL
     oidcUserCode.value = result.user_code;
     const openUrl = result.verification_uri_complete ?? result.verification_uri;
+    if (!openUrl.startsWith("https://") && !openUrl.startsWith("http://")) {
+      throw new Error(`Unexpected verification URL scheme: ${openUrl}`);
+    }
     await shellOpen(openUrl);
 
     // Poll until user completes authorization (this blocks)
@@ -298,8 +300,11 @@ async function startJmapOidc() {
       result.client_id,
     );
 
-    // Mark password field so add_account migrates the tokens
-    form.value.password = `oauth2:${tempAccountId}`;
+    // Only set oauth2: marker for new accounts (triggers token migration in add_account).
+    // On re-auth of existing accounts, keep password empty so save doesn't overwrite keyring.
+    if (!editingAccountId.value) {
+      form.value.password = `oauth2:${tempAccountId}`;
+    }
     form.value.jmap_auth_method = "oidc";
     oidcUserCode.value = null;
     oauthStatus.value = "Signed in via OIDC";

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -17,6 +17,7 @@ const error = ref<string | null>(null);
 const editingAccountId = ref<string | null>(null);
 const oauthStatus = ref<string | null>(null);
 const oauthInProgress = ref(false);
+const jmapOidcTokenEndpoint = ref("");
 
 const avatarColors = ["#3366cc", "#2e7d32", "#9c27b0", "#e65100", "#00838f"];
 
@@ -45,6 +46,9 @@ const defaultForm = (): AccountConfig => ({
   password: "",
   use_tls: true,
   signature: "",
+  jmap_auth_method: "basic",
+  oidc_token_endpoint: "",
+  oidc_client_id: "",
 });
 
 const form = ref<AccountConfig>(defaultForm());
@@ -141,6 +145,16 @@ async function openEditForm(id: string) {
       } catch { oauthStatus.value = null; }
     } else if (config.mail_protocol === "jmap") {
       accountType.value = "jmap";
+      if (config.jmap_auth_method === "oidc") {
+        try {
+          const hasTokens = await api.oauthHasTokens(id);
+          if (hasTokens) {
+            oauthStatus.value = "Signed in via OIDC";
+          } else {
+            oauthStatus.value = null;
+          }
+        } catch { oauthStatus.value = null; }
+      }
     } else if (config.caldav_url && !config.imap_host) {
       accountType.value = "caldav";
     } else {
@@ -247,6 +261,56 @@ async function startMicrosoftOAuth() {
   }
 }
 
+const oidcUserCode = ref<string | null>(null);
+
+async function startJmapOidc() {
+  oauthInProgress.value = true;
+  oauthStatus.value = null;
+  oidcUserCode.value = null;
+  error.value = null;
+
+  try {
+    const tempAccountId = editingAccountId.value ?? `jmap-oidc-pending-${Date.now()}`;
+
+    // Start device flow — passes existing client_id (empty for first-time setup)
+    const result = await api.jmapOidcStart(
+      form.value.jmap_url,
+      form.value.email,
+      form.value.oidc_client_id,
+    );
+
+    // Save token endpoint and client_id for account creation
+    form.value.oidc_token_endpoint = result.token_endpoint;
+    form.value.oidc_client_id = result.client_id;
+
+    // Show the user code and open browser to verification URL
+    oidcUserCode.value = result.user_code;
+    const openUrl = result.verification_uri_complete ?? result.verification_uri;
+    await shellOpen(openUrl);
+
+    // Poll until user completes authorization (this blocks)
+    await api.jmapOidcComplete(
+      result.device_code,
+      result.token_endpoint,
+      result.interval,
+      result.expires_in,
+      tempAccountId,
+      result.client_id,
+    );
+
+    // Mark password field so add_account migrates the tokens
+    form.value.password = `oauth2:${tempAccountId}`;
+    form.value.jmap_auth_method = "oidc";
+    oidcUserCode.value = null;
+    oauthStatus.value = "Signed in via OIDC";
+  } catch (e) {
+    error.value = `OIDC sign-in failed: ${e}`;
+    oidcUserCode.value = null;
+  } finally {
+    oauthInProgress.value = false;
+  }
+}
+
 async function doDelete() {
   if (deletingAccountId.value) {
     await accountsStore.deleteAccount(deletingAccountId.value);
@@ -333,7 +397,7 @@ async function doDelete() {
               <label>Email Address</label>
               <input v-model="form.email" type="email" placeholder="user@example.com" />
             </div>
-            <div v-if="accountType !== 'o365'" class="form-group">
+            <div v-if="accountType !== 'o365' && !(accountType === 'jmap' && form.jmap_auth_method === 'oidc')" class="form-group">
               <label>{{ accountType === 'gmail' ? 'App Password' : 'Password' }}</label>
               <PasswordInput
                 v-model="form.password"
@@ -423,10 +487,56 @@ async function doDelete() {
 
             <template v-if="accountType === 'jmap'">
               <div class="form-group">
+                <label>Authentication</label>
+                <div class="type-selector">
+                  <button
+                    class="type-btn"
+                    :class="{ active: form.jmap_auth_method === 'basic' }"
+                    :disabled="!!editingAccountId"
+                    @click="form.jmap_auth_method = 'basic'; oauthStatus = null"
+                  >Password</button>
+                  <button
+                    class="type-btn"
+                    :class="{ active: form.jmap_auth_method === 'oidc' }"
+                    :disabled="!!editingAccountId"
+                    @click="form.jmap_auth_method = 'oidc'"
+                  >OIDC</button>
+                </div>
+              </div>
+              <div class="form-group">
                 <label>JMAP URL</label>
                 <input v-model="form.jmap_url" type="url" placeholder="https://mail.example.com" />
                 <span class="field-hint">Leave blank for auto-discovery via .well-known/jmap</span>
               </div>
+              <template v-if="form.jmap_auth_method === 'oidc'">
+                <div class="form-group">
+                  <label>OIDC Sign In</label>
+                  <div v-if="oauthStatus" class="oauth-row">
+                    <div class="oauth-status">
+                      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#00a63e" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12" /></svg>
+                      {{ oauthStatus }}
+                    </div>
+                    <button class="btn-reauth" @click="oauthStatus = null">Sign in again</button>
+                  </div>
+                  <div v-else-if="oidcUserCode" class="oidc-device-code">
+                    <p class="device-code-label">Enter this code in your browser:</p>
+                    <p class="device-code-value">{{ oidcUserCode }}</p>
+                    <p class="device-code-hint">Waiting for authorization...</p>
+                  </div>
+                  <button
+                    v-else
+                    class="btn-oauth"
+                    :disabled="oauthInProgress || !form.email"
+                    @click="startJmapOidc"
+                  >
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+                      <rect x="3" y="11" width="18" height="11" rx="2" ry="2" /><path d="M7 11V7a5 5 0 0 1 10 0v4" />
+                    </svg>
+                    {{ oauthInProgress ? "Starting..." : "Sign in with OIDC" }}
+                  </button>
+                  <span class="field-hint">Opens your browser to authenticate with your identity provider.</span>
+                </div>
+              </template>
             </template>
 
             <template v-if="accountType === 'imap' || accountType === 'caldav'">
@@ -918,5 +1028,33 @@ async function doDelete() {
   font-size: 13px;
   color: var(--color-text-secondary);
   line-height: 1.5;
+}
+
+.oidc-device-code {
+  text-align: center;
+  padding: 16px;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  background: var(--color-bg-secondary);
+}
+
+.device-code-label {
+  font-size: 13px;
+  color: var(--color-text-secondary);
+  margin-bottom: 8px;
+}
+
+.device-code-value {
+  font-size: 28px;
+  font-weight: 700;
+  font-family: 'Liberation Mono', monospace;
+  letter-spacing: 4px;
+  color: var(--color-accent);
+  margin-bottom: 8px;
+}
+
+.device-code-hint {
+  font-size: 12px;
+  color: var(--color-text-muted);
 }
 </style>

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -153,6 +153,8 @@ async function openEditForm(id: string) {
             oauthStatus.value = null;
           }
         } catch { oauthStatus.value = null; }
+      } else {
+        oauthStatus.value = null;
       }
     } else if (config.caldav_url && !config.imap_host) {
       accountType.value = "caldav";
@@ -498,7 +500,7 @@ async function doDelete() {
                     class="type-btn"
                     :class="{ active: form.jmap_auth_method === 'basic' }"
                     :disabled="!!editingAccountId"
-                    @click="form.jmap_auth_method = 'basic'; oauthStatus = null"
+                    @click="form.jmap_auth_method = 'basic'; oauthStatus.value = null"
                   >Password</button>
                   <button
                     class="type-btn"
@@ -521,7 +523,7 @@ async function doDelete() {
                       <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#00a63e" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12" /></svg>
                       {{ oauthStatus }}
                     </div>
-                    <button class="btn-reauth" @click="oauthStatus = null">Sign in again</button>
+                    <button class="btn-reauth" @click="oauthStatus.value = null">Sign in again</button>
                   </div>
                   <div v-else-if="oidcUserCode" class="oidc-device-code">
                     <p class="device-code-label">Enter this code in your browser:</p>


### PR DESCRIPTION
Add optional OIDC login for JMAP accounts (e.g., Stalwart) using the OAuth2 Device Authorization Grant (RFC 8628) with dynamic client registration (RFC 7591).

Flow:
1. OIDC discovery from JMAP server domain (.well-known/openid-configuration)
2. Dynamic client registration if no client_id exists yet
3. Device authorization — user gets a code, opens browser to verify
4. Chithi polls token endpoint until authorization completes
5. Bearer auth for all JMAP requests (session, API, blobs, EventSource)
6. Automatic token refresh using stored client_id and token_endpoint

Backend:
- discover_oidc, register_oidc_client, device_auth_start, device_auth_poll in oauth.rs
- jmap_oidc_start / jmap_oidc_complete Tauri commands
- JmapConfig.access_token + apply_auth helper for Bearer/Basic branching
- build_jmap_config helper wires OIDC tokens through all 19 call sites
- DB migration: jmap_auth_method, oidc_token_endpoint, oidc_client_id

Frontend:
- Password/OIDC toggle in JMAP account form
- Device code display with verification URL
- Stores client_id for reuse on re-auth

Note:
- There is currently a bug in Stalwart, that does not allow redirect_uri to be set to plain http:// but requires https:// making http://localhost not viable, so device flow was choosen instead. Can be changed once: https://github.com/stalwartlabs/stalwart/issues/2959 is fixed.

fixes: #4