### PR TITLE
feat: display folders as collapsible tree structure

### DIFF
--- a/src-tauri/src/commands/mail.rs
+++ b/src-tauri/src/commands/mail.rs
@@ -467,7 +467,14 @@ pub async fn create_folder(
             password: account.password.clone(),
         };
         let conn_jmap = crate::mail::jmap::JmapConnection::connect(&jmap_config).await?;
-        conn_jmap.create_mailbox(&jmap_config, &folder_path).await?;
+        // For JMAP, folder_path is "parentId/name" (built by the frontend).
+        // Split to get the parent mailbox ID and the new folder name.
+        let (parent_id, mailbox_name) = if let Some((parent, name)) = folder_path.rsplit_once('/') {
+            (if parent.is_empty() { None } else { Some(parent) }, name)
+        } else {
+            (None, folder_path.as_str())
+        };
+        conn_jmap.create_mailbox(&jmap_config, mailbox_name, parent_id).await?;
     } else {
         // IMAP: CREATE
         let imap_config = ImapConfig {

--- a/src-tauri/src/commands/mail.rs
+++ b/src-tauri/src/commands/mail.rs
@@ -38,9 +38,10 @@ pub async fn list_folders(
 ) -> Result<Vec<db::folders::Folder>> {
     log::debug!("Listing folders for account {}", account_id);
     let conn = state.db.lock().await;
-    let folders = db::folders::list_folders(&conn, &account_id)?;
-    log::debug!("Found {} folders for account {}", folders.len(), account_id);
-    Ok(folders)
+    let flat_folders = db::folders::list_folders(&conn, &account_id)?;
+    log::debug!("Found {} folders for account {}", flat_folders.len(), account_id);
+    let tree = db::folders::build_folder_tree(flat_folders);
+    Ok(tree)
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/sync_cmd.rs
+++ b/src-tauri/src/commands/sync_cmd.rs
@@ -628,7 +628,7 @@ async fn sync_graph_account(
         let conn = db_arc.lock().await;
         for gf in &graph_folders {
             let folder_type = graph::guess_folder_type(&gf.display_name);
-            db::folders::upsert_folder(&conn, account_id, &gf.display_name, &gf.id, folder_type)?;
+            db::folders::upsert_folder(&conn, account_id, &gf.display_name, &gf.id, folder_type, None)?;
             db::folders::update_folder_counts(&conn, account_id, &gf.id, gf.unread_count, gf.total_count)?;
         }
     }

--- a/src-tauri/src/db/folders.rs
+++ b/src-tauri/src/db/folders.rs
@@ -101,11 +101,17 @@ pub fn build_folder_tree(mut folders: Vec<Folder>) -> Vec<Folder> {
     // For IMAP (path-based), use '/' count as depth proxy.
     let mut parent_paths: Vec<String> = children_map.keys().cloned().collect();
     if has_parent_ids {
-        // Compute depth for each folder by following parent_id chain
+        // Compute depth for each folder by following parent_id chain.
+        // Guard against cycles with a visited set.
         let depth_of = |path: &str| -> usize {
             let mut depth = 0usize;
             let mut current = path.to_string();
+            let mut visited = std::collections::HashSet::new();
             while let Some(idx) = by_path.get(&current) {
+                if !visited.insert(current.clone()) {
+                    log::warn!("Cycle detected in folder parent_id chain at {}", current);
+                    break;
+                }
                 if let Some(ref pid) = folders[*idx].parent_id {
                     depth += 1;
                     current = pid.clone();

--- a/src-tauri/src/db/folders.rs
+++ b/src-tauri/src/db/folders.rs
@@ -11,6 +11,8 @@ pub struct Folder {
     pub unread_count: i64,
     pub total_count: i64,
     pub children: Vec<Folder>,
+    #[serde(skip_serializing)]
+    pub parent_id: Option<String>,
 }
 
 pub fn upsert_folder(
@@ -19,19 +21,20 @@ pub fn upsert_folder(
     name: &str,
     path: &str,
     folder_type: Option<&str>,
+    parent_id: Option<&str>,
 ) -> Result<()> {
     conn.execute(
-        "INSERT INTO folders (account_id, name, path, folder_type)
-         VALUES (?1, ?2, ?3, ?4)
-         ON CONFLICT(account_id, path) DO UPDATE SET name = ?2, folder_type = ?4",
-        params![account_id, name, path, folder_type],
+        "INSERT INTO folders (account_id, name, path, folder_type, parent_id)
+         VALUES (?1, ?2, ?3, ?4, ?5)
+         ON CONFLICT(account_id, path) DO UPDATE SET name = ?2, folder_type = ?4, parent_id = ?5",
+        params![account_id, name, path, folder_type, parent_id],
     )?;
     Ok(())
 }
 
 pub fn list_folders(conn: &Connection, account_id: &str) -> Result<Vec<Folder>> {
     let mut stmt = conn.prepare(
-        "SELECT name, path, folder_type, unread_count, total_count
+        "SELECT name, path, folder_type, unread_count, total_count, parent_id
          FROM folders WHERE account_id = ?1 ORDER BY
          CASE folder_type
            WHEN 'inbox' THEN 0
@@ -52,10 +55,87 @@ pub fn list_folders(conn: &Connection, account_id: &str) -> Result<Vec<Folder>> 
                 unread_count: row.get(3)?,
                 total_count: row.get(4)?,
                 children: vec![],
+                parent_id: row.get(5)?,
             })
         })?
         .collect::<std::result::Result<Vec<_>, _>>()?;
     Ok(folders)
+}
+
+/// Build a nested folder tree from a flat list of folders.
+/// IMAP folders use `/` in their path to denote hierarchy (e.g., "INBOX/IETF/123").
+/// JMAP folders use `parent_id` to reference the parent mailbox's path/id.
+/// Top-level folders (no parent, or parent not in list) become roots.
+pub fn build_folder_tree(mut folders: Vec<Folder>) -> Vec<Folder> {
+    use std::collections::HashMap;
+
+    let has_parent_ids = folders.iter().any(|f| f.parent_id.is_some());
+
+    let mut by_path: HashMap<String, usize> = HashMap::new();
+    for (i, f) in folders.iter().enumerate() {
+        by_path.insert(f.path.clone(), i);
+    }
+
+    let mut children_map: HashMap<String, Vec<usize>> = HashMap::new();
+    let mut is_child = vec![false; folders.len()];
+
+    for i in 0..folders.len() {
+        let parent_path = if has_parent_ids {
+            // JMAP: parent_id references another mailbox's path/id
+            folders[i].parent_id.clone()
+        } else {
+            // IMAP: derive parent from path hierarchy
+            folders[i].path.rsplit_once('/').map(|(p, _)| p.to_string())
+        };
+
+        if let Some(pp) = parent_path {
+            if by_path.contains_key(&pp) {
+                children_map.entry(pp).or_default().push(i);
+                is_child[i] = true;
+            }
+        }
+    }
+
+    // Process deepest parents first so children are fully built before attaching.
+    // For JMAP (parent_id), compute depth by counting hops to root.
+    // For IMAP (path-based), use '/' count as depth proxy.
+    let mut parent_paths: Vec<String> = children_map.keys().cloned().collect();
+    if has_parent_ids {
+        // Compute depth for each folder by following parent_id chain
+        let depth_of = |path: &str| -> usize {
+            let mut depth = 0usize;
+            let mut current = path.to_string();
+            while let Some(idx) = by_path.get(&current) {
+                if let Some(ref pid) = folders[*idx].parent_id {
+                    depth += 1;
+                    current = pid.clone();
+                } else {
+                    break;
+                }
+            }
+            depth
+        };
+        parent_paths.sort_by(|a, b| depth_of(b).cmp(&depth_of(a)));
+    } else {
+        parent_paths.sort_by(|a, b| b.matches('/').count().cmp(&a.matches('/').count()));
+    }
+
+    for parent_path in parent_paths {
+        if let Some(child_indices) = children_map.remove(&parent_path) {
+            let children: Vec<Folder> = child_indices.iter()
+                .map(|&i| folders[i].clone())
+                .collect();
+            if let Some(&parent_idx) = by_path.get(&parent_path) {
+                folders[parent_idx].children = children;
+            }
+        }
+    }
+
+    folders.into_iter()
+        .enumerate()
+        .filter(|(i, _)| !is_child[*i])
+        .map(|(_, f)| f)
+        .collect()
 }
 
 pub fn update_folder_counts(
@@ -158,5 +238,142 @@ pub fn guess_folder_type(name: &str) -> Option<&'static str> {
         "junk" | "spam" | "bulk mail" => Some("junk"),
         "archive" | "all mail" | "all" => Some("archive"),
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_folder(name: &str, path: &str, folder_type: Option<&str>) -> Folder {
+        Folder {
+            name: name.to_string(),
+            path: path.to_string(),
+            folder_type: folder_type.map(|s| s.to_string()),
+            unread_count: 0,
+            total_count: 0,
+            children: vec![],
+            parent_id: None,
+        }
+    }
+
+    #[test]
+    fn test_flat_folders_stay_flat() {
+        let folders = vec![
+            make_folder("Inbox", "INBOX", Some("inbox")),
+            make_folder("Sent", "Sent", Some("sent")),
+            make_folder("Drafts", "Drafts", Some("drafts")),
+        ];
+        let tree = build_folder_tree(folders);
+        assert_eq!(tree.len(), 3);
+        assert!(tree.iter().all(|f| f.children.is_empty()));
+    }
+
+    #[test]
+    fn test_one_level_nesting() {
+        let folders = vec![
+            make_folder("Inbox", "INBOX", Some("inbox")),
+            make_folder("IETF", "INBOX/IETF", None),
+            make_folder("Infra", "INBOX/Infra", None),
+        ];
+        let tree = build_folder_tree(folders);
+        assert_eq!(tree.len(), 1);
+        assert_eq!(tree[0].children.len(), 2);
+    }
+
+    #[test]
+    fn test_deep_nesting() {
+        let folders = vec![
+            make_folder("Inbox", "INBOX", Some("inbox")),
+            make_folder("IETF", "INBOX/IETF", None),
+            make_folder("123", "INBOX/IETF/123", None),
+            make_folder("456", "INBOX/IETF/456", None),
+        ];
+        let tree = build_folder_tree(folders);
+        assert_eq!(tree.len(), 1);
+        assert_eq!(tree[0].children.len(), 1);
+        assert_eq!(tree[0].children[0].children.len(), 2);
+    }
+
+    #[test]
+    fn test_orphan_stays_at_root() {
+        let folders = vec![
+            make_folder("123", "INBOX/IETF/123", None),
+            make_folder("Sent", "Sent", Some("sent")),
+        ];
+        let tree = build_folder_tree(folders);
+        assert_eq!(tree.len(), 2);
+    }
+
+    #[test]
+    fn test_jmap_parent_id_nesting() {
+        let folders = vec![
+            Folder {
+                name: "Inbox".to_string(),
+                path: "m1".to_string(),
+                folder_type: Some("inbox".to_string()),
+                unread_count: 3,
+                total_count: 10,
+                children: vec![],
+                parent_id: None,
+            },
+            Folder {
+                name: "IETF".to_string(),
+                path: "m2".to_string(),
+                folder_type: None,
+                unread_count: 0,
+                total_count: 5,
+                children: vec![],
+                parent_id: Some("m1".to_string()),
+            },
+            Folder {
+                name: "123".to_string(),
+                path: "m3".to_string(),
+                folder_type: None,
+                unread_count: 0,
+                total_count: 2,
+                children: vec![],
+                parent_id: Some("m2".to_string()),
+            },
+            Folder {
+                name: "Sent".to_string(),
+                path: "m4".to_string(),
+                folder_type: Some("sent".to_string()),
+                unread_count: 0,
+                total_count: 0,
+                children: vec![],
+                parent_id: None,
+            },
+        ];
+        let tree = build_folder_tree(folders);
+        assert_eq!(tree.len(), 2); // Inbox, Sent
+
+        let inbox = tree.iter().find(|f| f.path == "m1").unwrap();
+        assert_eq!(inbox.children.len(), 1); // IETF
+        assert_eq!(inbox.children[0].children.len(), 1); // 123
+    }
+
+    #[test]
+    fn test_mixed_hierarchy() {
+        let folders = vec![
+            make_folder("Inbox", "INBOX", Some("inbox")),
+            make_folder("IETF", "INBOX/IETF", None),
+            make_folder("123", "INBOX/IETF/123", None),
+            make_folder("Infra", "INBOX/Infra", None),
+            make_folder("Mastodon", "INBOX/Infra/Mastodon", None),
+            make_folder("Sent", "Sent", Some("sent")),
+            make_folder("Drafts", "Drafts", Some("drafts")),
+        ];
+        let tree = build_folder_tree(folders);
+        assert_eq!(tree.len(), 3);
+
+        let inbox = tree.iter().find(|f| f.path == "INBOX").unwrap();
+        assert_eq!(inbox.children.len(), 2);
+
+        let ietf = inbox.children.iter().find(|f| f.path == "INBOX/IETF").unwrap();
+        assert_eq!(ietf.children.len(), 1);
+
+        let infra = inbox.children.iter().find(|f| f.path == "INBOX/Infra").unwrap();
+        assert_eq!(infra.children.len(), 1);
     }
 }

--- a/src-tauri/src/db/schema.rs
+++ b/src-tauri/src/db/schema.rs
@@ -244,6 +244,17 @@ fn run_migrations(conn: &Connection) -> Result<()> {
         )?;
     }
 
+    // Add parent_id column to folders if it doesn't exist (for JMAP hierarchy)
+    let has_parent_id: bool = conn
+        .prepare("SELECT parent_id FROM folders LIMIT 0")
+        .is_ok();
+    if !has_parent_id {
+        log::info!("Migration: adding parent_id column to folders table");
+        conn.execute_batch(
+            "ALTER TABLE folders ADD COLUMN parent_id TEXT;",
+        )?;
+    }
+
     // Populate FTS index for existing messages (one-time migration)
     if !has_migration(conn, "fts5_initial_populate") {
         log::info!("Migration: populating FTS5 index for existing messages");

--- a/src-tauri/src/mail/jmap.rs
+++ b/src-tauri/src/mail/jmap.rs
@@ -192,14 +192,14 @@ impl JmapConnection {
         resp.json().await.map_err(|e| Error::Other(format!("JMAP response parse error: {}", e)))
     }
 
-    pub async fn list_folders(&self, config: &JmapConfig) -> Result<Vec<(String, String, Option<&'static str>)>> {
+    pub async fn list_folders(&self, config: &JmapConfig) -> Result<Vec<(String, String, Option<&'static str>, Option<String>)>> {
         log::debug!("JMAP listing mailboxes");
         let request = serde_json::json!({
             "using": ["urn:ietf:params:jmap:core", "urn:ietf:params:jmap:mail"],
             "methodCalls": [
                 ["Mailbox/get", {
                     "accountId": self.account_id,
-                    "properties": ["id", "name", "role", "totalEmails", "unreadEmails"]
+                    "properties": ["id", "name", "role", "totalEmails", "unreadEmails", "parentId"]
                 }, "m1"]
             ]
         });
@@ -224,8 +224,9 @@ impl JmapConnection {
                 Some("archive") => Some("archive"),
                 _ => None,
             };
-            log::debug!("  mailbox: {} ({}) role={:?}", name, id, role);
-            folders.push((name, id, folder_type));
+            let parent_id = mb["parentId"].as_str().map(|s| s.to_string());
+            log::debug!("  mailbox: {} ({}) role={:?} parentId={:?}", name, id, role, parent_id);
+            folders.push((name, id, folder_type, parent_id));
         }
         log::info!("JMAP found {} mailboxes", folders.len());
         Ok(folders)

--- a/src-tauri/src/mail/jmap.rs
+++ b/src-tauri/src/mail/jmap.rs
@@ -1150,18 +1150,20 @@ impl JmapConnection {
         Ok(None)
     }
     /// Create a new mailbox on the JMAP server.
-    pub async fn create_mailbox(&self, config: &JmapConfig, name: &str) -> Result<String> {
-        log::info!("JMAP creating mailbox: {}", name);
+    pub async fn create_mailbox(&self, config: &JmapConfig, name: &str, parent_id: Option<&str>) -> Result<String> {
+        log::info!("JMAP creating mailbox: {} (parent={:?})", name, parent_id);
         let create_id = "new-folder";
+        let mut mailbox = serde_json::json!({ "name": name });
+        if let Some(pid) = parent_id {
+            mailbox["parentId"] = serde_json::json!(pid);
+        }
         let request = serde_json::json!({
             "using": ["urn:ietf:params:jmap:core", "urn:ietf:params:jmap:mail"],
             "methodCalls": [
                 ["Mailbox/set", {
                     "accountId": self.account_id,
                     "create": {
-                        create_id: {
-                            "name": name
-                        }
+                        create_id: mailbox
                     }
                 }, "c1"]
             ]

--- a/src-tauri/src/mail/jmap_sync.rs
+++ b/src-tauri/src/mail/jmap_sync.rs
@@ -97,7 +97,7 @@ async fn sync_jmap_account_inner(
     let jmap_folders = conn_jmap.list_folders(jmap_config).await?;
     {
         let conn = db.lock().await;
-        for (display_name, mailbox_id, folder_type) in &jmap_folders {
+        for (display_name, mailbox_id, folder_type, parent_id) in &jmap_folders {
             // For JMAP, we store the mailbox_id in the `path` column
             db::folders::upsert_folder(
                 &conn,
@@ -105,6 +105,7 @@ async fn sync_jmap_account_inner(
                 display_name,
                 mailbox_id,
                 *folder_type,
+                parent_id.as_deref(),
             )?;
         }
     }
@@ -112,7 +113,7 @@ async fn sync_jmap_account_inner(
     // Determine sync order: current folder first, then Inbox, then rest
     let mut priority: Vec<(&str, &str)> = Vec::new();
     let mut others: Vec<(&str, &str)> = Vec::new();
-    for (name, mailbox_id, folder_type) in &jmap_folders {
+    for (name, mailbox_id, folder_type, _parent_id) in &jmap_folders {
         if current_folder
             .map(|cf| cf == mailbox_id.as_str())
             .unwrap_or(false)

--- a/src-tauri/src/mail/sync.rs
+++ b/src-tauri/src/mail/sync.rs
@@ -113,7 +113,7 @@ fn sync_account_blocking(
         for (display_name, path) in &imap_folders {
             let folder_type = db::folders::guess_folder_type(display_name)
                 .or_else(|| db::folders::guess_folder_type(path));
-            db::folders::upsert_folder(&conn, account_id, display_name, path, folder_type)?;
+            db::folders::upsert_folder(&conn, account_id, display_name, path, folder_type, None)?;
         }
     }
 

--- a/src/components/mail/FolderTree.vue
+++ b/src/components/mail/FolderTree.vue
@@ -14,6 +14,60 @@ const contextMenu = ref<{ x: number; y: number; folder: Folder } | null>(null);
 const accountMenu = ref<{ x: number; y: number; accountId: string } | null>(null);
 const syncing = ref<string | null>(null);
 const collapsedAccounts = ref<string[]>([]);
+
+// Folder expand/collapse state, persisted per account in localStorage
+const collapsedFolders = ref<Record<string, string[]>>(loadCollapsedFolders());
+
+function loadCollapsedFolders(): Record<string, string[]> {
+  try {
+    const stored = localStorage.getItem("chithi-collapsed-folders");
+    return stored ? JSON.parse(stored) : {};
+  } catch {
+    return {};
+  }
+}
+
+function saveCollapsedFolders() {
+  localStorage.setItem("chithi-collapsed-folders", JSON.stringify(collapsedFolders.value));
+}
+
+function isFolderCollapsed(accountId: string, folderPath: string): boolean {
+  return collapsedFolders.value[accountId]?.includes(folderPath) ?? false;
+}
+
+function toggleFolderCollapse(accountId: string, folderPath: string) {
+  const current = collapsedFolders.value[accountId] ?? [];
+  if (current.includes(folderPath)) {
+    collapsedFolders.value = {
+      ...collapsedFolders.value,
+      [accountId]: current.filter(p => p !== folderPath),
+    };
+  } else {
+    collapsedFolders.value = {
+      ...collapsedFolders.value,
+      [accountId]: [...current, folderPath],
+    };
+  }
+  saveCollapsedFolders();
+}
+
+interface FlatFolder {
+  folder: Folder;
+  depth: number;
+  hasChildren: boolean;
+}
+
+function flattenTree(folders: Folder[], depth: number, accountId: string): FlatFolder[] {
+  const result: FlatFolder[] = [];
+  for (const folder of folders) {
+    result.push({ folder, depth, hasChildren: folder.children.length > 0 });
+    if (folder.children.length > 0 && !isFolderCollapsed(accountId, folder.path)) {
+      result.push(...flattenTree(folder.children, depth + 1, accountId));
+    }
+  }
+  return result;
+}
+
 const showNewFolderModal = ref(false);
 const newFolderName = ref("");
 const newFolderParent = ref("");
@@ -122,11 +176,19 @@ async function syncThisFolder() {
   }
 }
 
+function findFolderInTree(folders: Folder[], path: string): boolean {
+  for (const f of folders) {
+    if (f.path === path) return true;
+    if (findFolderInTree(f.children, path)) return true;
+  }
+  return false;
+}
+
 function findAccountForFolder(folder: Folder | undefined): string | null {
   if (!folder) return null;
   for (const acc of accountsStore.accounts) {
     const folders = foldersStore.getAccountFolders(acc.id);
-    if (folders.some(f => f.path === folder.path)) return acc.id;
+    if (findFolderInTree(folders, folder.path)) return acc.id;
   }
   return accountsStore.activeAccountId;
 }
@@ -144,12 +206,18 @@ function openNewFolderModal() {
 
 function buildParentOptions(): { label: string; value: string }[] {
   const options: { label: string; value: string }[] = [];
-  for (const acc of accountsStore.accounts) {
-    // Account root level
-    options.push({ label: `${acc.display_name} (root)`, value: `${acc.id}|` });
-    for (const folder of foldersStore.getAccountFolders(acc.id)) {
-      options.push({ label: `${folder.name} on ${acc.email}`, value: `${acc.id}|${folder.path}` });
+
+  function addFolders(folders: Folder[], accountId: string, accountEmail: string, prefix: string) {
+    for (const folder of folders) {
+      const label = prefix ? `${prefix}/${folder.name}` : folder.name;
+      options.push({ label: `${label} on ${accountEmail}`, value: `${accountId}|${folder.path}` });
+      addFolders(folder.children, accountId, accountEmail, label);
     }
+  }
+
+  for (const acc of accountsStore.accounts) {
+    options.push({ label: `${acc.display_name} (root)`, value: `${acc.id}|` });
+    addFolders(foldersStore.getAccountFolders(acc.id), acc.id, acc.email, "");
   }
   return options;
 }
@@ -241,46 +309,62 @@ async function markFolderRead() {
 
       <div v-if="!collapsedAccounts.includes(account.id)" class="folder-list">
         <button
-          v-for="folder in foldersStore.getAccountFolders(account.id)"
-          :key="account.id + '/' + folder.path"
+          v-for="item in flattenTree(foldersStore.getAccountFolders(account.id), 0, account.id)"
+          :key="account.id + '/' + item.folder.path"
           class="folder-item"
           :class="{
-            active: accountsStore.activeAccountId === account.id && foldersStore.activeFolderPath === folder.path,
-            syncing: syncing === folder.path,
+            active: accountsStore.activeAccountId === account.id && foldersStore.activeFolderPath === item.folder.path,
+            syncing: syncing === item.folder.path,
           }"
-          @click.stop="selectFolder(account.id, folder.path)"
-          @contextmenu="onFolderContextMenu($event, folder)"
+          :style="{ paddingLeft: (12 + item.depth * 16) + 'px' }"
+          @click.stop="selectFolder(account.id, item.folder.path)"
+          @contextmenu="onFolderContextMenu($event, item.folder)"
         >
+          <span
+            v-if="item.hasChildren"
+            class="folder-toggle"
+            @click.stop="toggleFolderCollapse(account.id, item.folder.path)"
+          >
+            <svg
+              width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+              stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+              :style="{ transform: isFolderCollapsed(account.id, item.folder.path) ? 'rotate(-90deg)' : '', transition: 'transform 0.15s' }"
+            >
+              <path d="M6 9l6 6 6-6" />
+            </svg>
+          </span>
+          <span v-else class="folder-toggle-spacer"></span>
+
           <!-- Folder icons as SVG -->
-          <svg v-if="folderIcon(folder) === 'inbox'" class="folder-svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+          <svg v-if="folderIcon(item.folder) === 'inbox'" class="folder-svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
             <polyline points="22 12 16 12 14 15 10 15 8 12 2 12" />
             <path d="M5.45 5.11L2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-6.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11z" />
           </svg>
-          <svg v-else-if="folderIcon(folder) === 'sent'" class="folder-svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+          <svg v-else-if="folderIcon(item.folder) === 'sent'" class="folder-svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
             <path d="M9 18l6-6-6-6" />
           </svg>
-          <svg v-else-if="folderIcon(folder) === 'drafts'" class="folder-svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+          <svg v-else-if="folderIcon(item.folder) === 'drafts'" class="folder-svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
             <path d="M12 20h9M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z" />
           </svg>
-          <svg v-else-if="folderIcon(folder) === 'trash'" class="folder-svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+          <svg v-else-if="folderIcon(item.folder) === 'trash'" class="folder-svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
             <polyline points="3 6 5 6 21 6" /><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
           </svg>
-          <svg v-else-if="folderIcon(folder) === 'spam'" class="folder-svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+          <svg v-else-if="folderIcon(item.folder) === 'spam'" class="folder-svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
             <circle cx="12" cy="12" r="10" /><line x1="4.93" y1="4.93" x2="19.07" y2="19.07" />
           </svg>
-          <svg v-else-if="folderIcon(folder) === 'archive'" class="folder-svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+          <svg v-else-if="folderIcon(item.folder) === 'archive'" class="folder-svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
             <polyline points="21 8 21 21 3 21 3 8" /><rect x="1" y="3" width="22" height="5" /><line x1="10" y1="12" x2="14" y2="12" />
           </svg>
-          <svg v-else-if="folderIcon(folder) === 'starred'" class="folder-svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+          <svg v-else-if="folderIcon(item.folder) === 'starred'" class="folder-svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
             <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
           </svg>
           <svg v-else class="folder-svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
             <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z" />
           </svg>
 
-          <span class="folder-name">{{ folder.name }}</span>
-          <span v-if="syncing === folder.path" class="sync-spinner"></span>
-          <span v-else-if="folder.unread_count > 0" class="unread-badge">{{ folder.unread_count }}</span>
+          <span class="folder-name">{{ item.folder.name }}</span>
+          <span v-if="syncing === item.folder.path" class="sync-spinner"></span>
+          <span v-else-if="item.folder.unread_count > 0" class="unread-badge">{{ item.folder.unread_count }}</span>
         </button>
       </div>
     </div>
@@ -467,6 +551,27 @@ async function markFolderRead() {
 
 .folder-item.syncing {
   opacity: 0.6;
+}
+
+.folder-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  border-radius: 3px;
+}
+
+.folder-toggle:hover {
+  background: var(--color-bg-hover);
+}
+
+.folder-toggle-spacer {
+  width: 16px;
+  flex-shrink: 0;
 }
 
 .folder-svg {

--- a/src/components/mail/FolderTree.vue
+++ b/src/components/mail/FolderTree.vue
@@ -21,7 +21,14 @@ const collapsedFolders = ref<Record<string, string[]>>(loadCollapsedFolders());
 function loadCollapsedFolders(): Record<string, string[]> {
   try {
     const stored = localStorage.getItem("chithi-collapsed-folders");
-    return stored ? JSON.parse(stored) : {};
+    if (!stored) return {};
+    const parsed: unknown = JSON.parse(stored);
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return {};
+    // Validate all values are string arrays
+    for (const v of Object.values(parsed as Record<string, unknown>)) {
+      if (!Array.isArray(v) || !v.every((item) => typeof item === "string")) return {};
+    }
+    return parsed as Record<string, string[]>;
   } catch {
     return {};
   }
@@ -323,7 +330,12 @@ async function markFolderRead() {
           <span
             v-if="item.hasChildren"
             class="folder-toggle"
+            role="button"
+            tabindex="0"
+            :aria-expanded="!isFolderCollapsed(account.id, item.folder.path)"
             @click.stop="toggleFolderCollapse(account.id, item.folder.path)"
+            @keydown.enter.stop="toggleFolderCollapse(account.id, item.folder.path)"
+            @keydown.space.stop.prevent="toggleFolderCollapse(account.id, item.folder.path)"
           >
             <svg
               width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor"

--- a/src/components/mail/MessageList.vue
+++ b/src/components/mail/MessageList.vue
@@ -462,7 +462,7 @@ const displayedCount = () => {
           </button>
           <div v-if="subMenu === 'move'" class="ctx-submenu">
             <button
-              v-for="folder in foldersStore.folders"
+              v-for="folder in foldersStore.getFlatFolders()"
               :key="folder.path"
               class="ctx-item"
               :class="{ disabled: folder.path === foldersStore.activeFolderPath }"
@@ -479,7 +479,7 @@ const displayedCount = () => {
           </button>
           <div v-if="subMenu === 'copy'" class="ctx-submenu">
             <button
-              v-for="folder in foldersStore.folders"
+              v-for="folder in foldersStore.getFlatFolders()"
               :key="folder.path"
               class="ctx-item"
               @click="ctxCopyTo(folder.path)"

--- a/src/stores/folders.ts
+++ b/src/stores/folders.ts
@@ -34,8 +34,9 @@ export const useFoldersStore = defineStore("folders", () => {
       if (folders.value.length > 0) {
         // If no folder is selected, or the selected folder doesn't exist
         // in this account, default to Inbox.
-        const currentValid = activeFolderPath.value &&
-          findFolderInTree(folders.value, activeFolderPath.value);
+        const active = activeFolderPath.value;
+        const currentValid = active !== null &&
+          findFolderInTree(folders.value, active) !== undefined;
         if (!currentValid) {
           const inbox = folders.value.find((f) => f.folder_type === "inbox");
           activeFolderPath.value = inbox?.path ?? folders.value[0].path;
@@ -78,6 +79,23 @@ export const useFoldersStore = defineStore("folders", () => {
     return foldersByAccount.value[accountId] ?? [];
   }
 
+  /** Flatten a folder tree into a flat list (for dropdowns, filters, move targets). */
+  function flattenFolders(tree: Folder[]): Folder[] {
+    const result: Folder[] = [];
+    for (const f of tree) {
+      result.push(f);
+      if (f.children.length > 0) {
+        result.push(...flattenFolders(f.children));
+      }
+    }
+    return result;
+  }
+
+  /** All folders for the active account as a flat list (for dropdowns/selects). */
+  function getFlatFolders(): Folder[] {
+    return flattenFolders(folders.value);
+  }
+
   watch(
     () => accountsStore.activeAccountId,
     () => {
@@ -94,5 +112,6 @@ export const useFoldersStore = defineStore("folders", () => {
     fetchAllAccountFolders,
     setActiveFolder,
     getAccountFolders,
+    getFlatFolders,
   };
 });

--- a/src/stores/folders.ts
+++ b/src/stores/folders.ts
@@ -12,6 +12,15 @@ export const useFoldersStore = defineStore("folders", () => {
 
   const accountsStore = useAccountsStore();
 
+  function findFolderInTree(folders: Folder[], path: string): Folder | undefined {
+    for (const f of folders) {
+      if (f.path === path) return f;
+      const found = findFolderInTree(f.children, path);
+      if (found) return found;
+    }
+    return undefined;
+  }
+
   async function fetchFolders() {
     const accountId = accountsStore.activeAccountId;
     if (!accountId) {
@@ -26,7 +35,7 @@ export const useFoldersStore = defineStore("folders", () => {
         // If no folder is selected, or the selected folder doesn't exist
         // in this account, default to Inbox.
         const currentValid = activeFolderPath.value &&
-          folders.value.some((f) => f.path === activeFolderPath.value);
+          findFolderInTree(folders.value, activeFolderPath.value);
         if (!currentValid) {
           const inbox = folders.value.find((f) => f.folder_type === "inbox");
           activeFolderPath.value = inbox?.path ?? folders.value[0].path;

--- a/src/views/FiltersView.vue
+++ b/src/views/FiltersView.vue
@@ -224,7 +224,7 @@ const opLabels: Record<string, string> = {
         <label class="apply-label">Apply filters to folder</label>
         <select v-model="applyingFolder" class="apply-select">
           <option :value="null" disabled>Select folder...</option>
-          <option v-for="f in foldersStore.folders" :key="f.path" :value="f.path">
+          <option v-for="f in foldersStore.getFlatFolders()" :key="f.path" :value="f.path">
             {{ f.name }}
           </option>
         </select>
@@ -331,7 +331,7 @@ const opLabels: Record<string, string> = {
             @change="setActionTarget(i, ($event.target as HTMLSelectElement).value)"
           >
             <option value="" disabled>Select folder...</option>
-            <option v-for="f in foldersStore.folders" :key="f.path" :value="f.path">
+            <option v-for="f in foldersStore.getFlatFolders()" :key="f.path" :value="f.path">
               {{ f.name }}
             </option>
           </select>


### PR DESCRIPTION
Fixes #6 — subfolders were displayed as a flat list instead of a proper nested tree with expand/collapse.

Backend:
- build_folder_tree assembles nested Folder structs from flat DB rows
- IMAP: splits paths on "/" to determine hierarchy
- JMAP: fetches parentId from Mailbox/get to determine hierarchy
- Unified tree builder auto-detects which mode to use
- list_folders command returns nested tree instead of flat list
- DB migration adds parent_id column to folders table

Frontend:
- flattenTree helper converts nested tree to depth-annotated list
- Expand/collapse triangle on folders with children
- 16px indentation per nesting level
- Collapse state persisted in localStorage per account
- All folders expanded by default on first load
- Recursive folder search for active folder validation