### PR TITLE
fix: decode IMAP Modified UTF-7 folder names to UTF-8

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -600,6 +600,7 @@ dependencies = [
  "uppsala",
  "url",
  "urlencoding",
+ "utf7-imap",
  "uuid",
 ]
 
@@ -6053,6 +6054,17 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf7-imap"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e326365261fc2761f0809dfb6032810534a0427bbd8f0edf546f6afeef89f5d"
+dependencies = [
+ "base64 0.13.1",
+ "encoding_rs",
+ "regex",
+]
 
 [[package]]
 name = "utf8-ranges"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -41,6 +41,7 @@ urlencoding = "2"
 sha2 = "0.10"
 base64 = "0.22"
 rand = "0.9"
+utf7-imap = "0.3.2"
 
 [build-dependencies]
 tauri-build = { version = "2", features = [] }

--- a/src-tauri/src/mail/imap.rs
+++ b/src-tauri/src/mail/imap.rs
@@ -133,13 +133,16 @@ impl ImapConnection {
 
         let mut folders = Vec::new();
         for mb in mailboxes.iter() {
-            let name = mb.name().to_string();
+            let path = mb.name().to_string();
             let delimiter = mb.delimiter().unwrap_or("/");
-            let display_name = name
+            // Decode IMAP Modified UTF-7 (RFC 3501 §5.1.3) to UTF-8 for display.
+            // The raw path is kept for IMAP commands (SELECT, etc.).
+            let decoded = utf7_imap::decode_utf7_imap(path.clone());
+            let display_name = decoded
                 .rsplit_once(delimiter)
                 .map(|(_, last)| last.to_string())
-                .unwrap_or_else(|| name.clone());
-            folders.push((display_name, name));
+                .unwrap_or_else(|| decoded.clone());
+            folders.push((display_name, path));
         }
         log::info!("IMAP found {} folders", folders.len());
         for (display, path) in &folders {
@@ -355,13 +358,15 @@ impl ImapConnection {
 
     /// Create a new mailbox (folder) on the IMAP server.
     pub fn create_folder(&mut self, folder_path: &str) -> Result<()> {
-        log::info!("IMAP creating folder: {}", folder_path);
-        self.session.create(folder_path).map_err(|e| {
+        // Encode UTF-8 folder name to IMAP Modified UTF-7 (RFC 3501 §5.1.3)
+        let encoded = utf7_imap::encode_utf7_imap(folder_path.to_string());
+        log::info!("IMAP creating folder: {} (encoded: {})", folder_path, encoded);
+        self.session.create(&encoded).map_err(|e| {
             log::error!("IMAP CREATE folder '{}' failed: {}", folder_path, e);
             Error::Imap(e.to_string())
         })?;
         // Subscribe so it shows in LIST
-        self.session.subscribe(folder_path).ok();
+        self.session.subscribe(&encoded).ok();
         Ok(())
     }
 
@@ -631,4 +636,27 @@ fn addresses_to_json(addrs: Option<&[imap_proto::types::Address<'_>]>) -> String
         })
         .collect();
     serde_json::to_string(&list).unwrap_or_else(|_| "[]".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_utf7_imap_decode() {
+        let decoded = utf7_imap::decode_utf7_imap("Komih&AOU-g".to_string());
+        assert_eq!(decoded, "Komihåg");
+    }
+
+    #[test]
+    fn test_utf7_imap_roundtrip() {
+        let original = "Komihåg";
+        let encoded = utf7_imap::encode_utf7_imap(original.to_string());
+        let decoded = utf7_imap::decode_utf7_imap(encoded);
+        assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn test_utf7_imap_ascii_passthrough() {
+        let decoded = utf7_imap::decode_utf7_imap("INBOX".to_string());
+        assert_eq!(decoded, "INBOX");
+    }
 }


### PR DESCRIPTION
Fixes #3 — folder names with non-ASCII characters (e.g., "Komihåg") were displayed in raw Modified UTF-7 encoding ("Komih&AOU-g").

- Decode folder display names from Modified UTF-7 (RFC 3501 §5.1.3) to UTF-8 using utf7-imap crate
- Keep raw encoded path for IMAP commands (SELECT, FETCH, etc.)
- Encode UTF-8 folder names back to Modified UTF-7 when creating new folders via IMAP CREATE