### PR TITLE
feat: add folder deletion via context menu

### DIFF
--- a/src-tauri/src/commands/actions.rs
+++ b/src-tauri/src/commands/actions.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use tauri::State;
 
+use crate::commands::events::{emit_folders_changed, emit_messages_changed};
 use crate::db;
 use crate::error::{Error, Result};
 use crate::mail::imap::{ImapConfig, ImapConnection};
@@ -34,6 +35,7 @@ async fn build_imap_config(account: &db::accounts::AccountFull) -> Result<ImapCo
 /// Move messages to a target folder on the IMAP/JMAP server and update local DB.
 #[tauri::command]
 pub async fn move_messages(
+    app: tauri::AppHandle,
     state: State<'_, AppState>,
     account_id: String,
     message_ids: Vec<String>,
@@ -138,12 +140,16 @@ pub async fn move_messages(
         target_folder
     );
 
+    emit_messages_changed(&app, &account_id);
+    emit_folders_changed(&app, &account_id);
+
     Ok(())
 }
 
 /// Delete messages on the IMAP server and remove from local DB.
 #[tauri::command]
 pub async fn delete_messages(
+    app: tauri::AppHandle,
     state: State<'_, AppState>,
     account_id: String,
     message_ids: Vec<String>,
@@ -237,12 +243,16 @@ pub async fn delete_messages(
         message_ids.len()
     );
 
+    emit_messages_changed(&app, &account_id);
+    emit_folders_changed(&app, &account_id);
+
     Ok(())
 }
 
 /// Set or remove flags on messages (e.g., \Seen, \Flagged).
 #[tauri::command]
 pub async fn set_message_flags(
+    app: tauri::AppHandle,
     state: State<'_, AppState>,
     account_id: String,
     message_ids: Vec<String>,
@@ -365,6 +375,8 @@ pub async fn set_message_flags(
         flags.join(", "),
         message_ids.len()
     );
+
+    emit_messages_changed(&app, &account_id);
 
     Ok(())
 }

--- a/src-tauri/src/commands/events.rs
+++ b/src-tauri/src/commands/events.rs
@@ -1,0 +1,11 @@
+use tauri::Emitter;
+
+/// Emit a `folders-changed` event so the frontend refreshes folder lists/counts.
+pub fn emit_folders_changed(app: &tauri::AppHandle, account_id: &str) {
+    app.emit("folders-changed", account_id.to_string()).ok();
+}
+
+/// Emit a `messages-changed` event so the frontend refreshes the message list.
+pub fn emit_messages_changed(app: &tauri::AppHandle, account_id: &str) {
+    app.emit("messages-changed", account_id.to_string()).ok();
+}

--- a/src-tauri/src/commands/mail.rs
+++ b/src-tauri/src/commands/mail.rs
@@ -558,7 +558,15 @@ pub async fn delete_folder(
             password: account.password.clone(),
         };
         let conn_jmap = crate::mail::jmap::JmapConnection::connect(&jmap_config).await?;
-        conn_jmap.destroy_mailbox(&jmap_config, &folder_path, true).await?;
+        conn_jmap.destroy_mailbox(&jmap_config, &folder_path, true).await.map_err(|e| {
+            log::error!(
+                "Failed to delete JMAP folder '{}' for account {}: {}",
+                folder_path,
+                account_id,
+                e
+            );
+            e
+        })?;
     } else {
         // IMAP: DELETE
         let (imap_password, imap_xoauth2) = if account.provider == "o365" {
@@ -599,7 +607,7 @@ pub async fn delete_folder(
         db::folders::delete_folder(&conn, &account_id, &folder_path)?;
     }
 
-    log::info!("Folder '{}' deleted", folder_path);
+    log::info!("Folder '{}' deleted for account {}", folder_path, account_id);
     emit_folders_changed(&app, &account_id);
     Ok(())
 }

--- a/src-tauri/src/commands/mail.rs
+++ b/src-tauri/src/commands/mail.rs
@@ -531,6 +531,74 @@ pub async fn create_folder(
     Ok(())
 }
 
+/// Delete a folder on the mail server and remove it from local DB.
+#[tauri::command]
+pub async fn delete_folder(
+    state: State<'_, AppState>,
+    account_id: String,
+    folder_path: String,
+) -> Result<()> {
+    log::info!("Deleting folder '{}' for account {}", folder_path, account_id);
+
+    let account = {
+        let conn = state.db.lock().await;
+        db::accounts::get_account_full(&conn, &account_id)?
+    };
+
+    if account.mail_protocol == "jmap" {
+        // JMAP: Mailbox/set destroy — folder_path is the mailbox ID
+        let jmap_config = JmapConfig {
+            jmap_url: account.jmap_url.clone(),
+            email: account.email.clone(),
+            username: account.username.clone(),
+            password: account.password.clone(),
+        };
+        let conn_jmap = crate::mail::jmap::JmapConnection::connect(&jmap_config).await?;
+        conn_jmap.destroy_mailbox(&jmap_config, &folder_path, true).await?;
+    } else {
+        // IMAP: DELETE
+        let (imap_password, imap_xoauth2) = if account.provider == "o365" {
+            let tokens = crate::oauth::load_tokens(&account_id)?
+                .ok_or_else(|| Error::Other("No O365 tokens".into()))?;
+            let refresh = tokens.refresh_token
+                .ok_or_else(|| Error::Other("No O365 refresh token".into()))?;
+            let new = crate::oauth::refresh_with_scopes(
+                &crate::oauth::MICROSOFT, &refresh, crate::oauth::MICROSOFT_IMAP_SCOPES,
+            ).await?;
+            crate::oauth::store_tokens(&account_id, &new)?;
+            (new.access_token, true)
+        } else {
+            (account.password, false)
+        };
+        let imap_config = ImapConfig {
+            host: account.imap_host,
+            port: account.imap_port,
+            username: account.username,
+            password: imap_password,
+            use_tls: account.use_tls,
+            use_xoauth2: imap_xoauth2,
+        };
+        let folder_for_imap = folder_path.clone();
+        tokio::task::spawn_blocking(move || {
+            let mut conn = crate::mail::imap::ImapConnection::connect(&imap_config)?;
+            conn.delete_folder(&folder_for_imap)?;
+            conn.logout();
+            Ok::<(), crate::error::Error>(())
+        })
+        .await
+        .map_err(|e| Error::Other(format!("Delete folder panicked: {}", e)))??;
+    }
+
+    // Remove from local DB
+    {
+        let conn = state.db.lock().await;
+        db::folders::delete_folder(&conn, &account_id, &folder_path)?;
+    }
+
+    log::info!("Folder '{}' deleted", folder_path);
+    Ok(())
+}
+
 /// Extract an attachment from a message and save it.
 /// The save dialog is opened by the backend — the renderer never supplies a path.
 #[tauri::command]

--- a/src-tauri/src/commands/mail.rs
+++ b/src-tauri/src/commands/mail.rs
@@ -1,5 +1,6 @@
 use tauri::State;
 
+use crate::commands::events::emit_folders_changed;
 use crate::db;
 use crate::db::messages::{MessageSummary, ThreadedPage};
 use crate::error::{Error, Result};
@@ -462,6 +463,7 @@ pub async fn unthread_message(
 /// Create a new folder on the mail server and register it locally.
 #[tauri::command]
 pub async fn create_folder(
+    app: tauri::AppHandle,
     state: State<'_, AppState>,
     account_id: String,
     folder_path: String,
@@ -528,12 +530,14 @@ pub async fn create_folder(
     // with the correct server-side path/ID and register it properly.
 
     log::info!("Folder '{}' created on server, will appear after sync", folder_path);
+    emit_folders_changed(&app, &account_id);
     Ok(())
 }
 
 /// Delete a folder on the mail server and remove it from local DB.
 #[tauri::command]
 pub async fn delete_folder(
+    app: tauri::AppHandle,
     state: State<'_, AppState>,
     account_id: String,
     folder_path: String,
@@ -596,6 +600,7 @@ pub async fn delete_folder(
     }
 
     log::info!("Folder '{}' deleted", folder_path);
+    emit_folders_changed(&app, &account_id);
     Ok(())
 }
 

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -3,6 +3,7 @@ pub mod actions;
 pub mod calendar;
 pub mod compose;
 pub mod contacts;
+pub mod events;
 pub mod filters;
 pub mod mail;
 pub mod oauth;

--- a/src-tauri/src/commands/sync_cmd.rs
+++ b/src-tauri/src/commands/sync_cmd.rs
@@ -3,6 +3,8 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use tauri::{AppHandle, Emitter, State};
 
+use crate::commands::events::{emit_folders_changed, emit_messages_changed};
+
 /// (message_id, uid, flags_json) tuple for prefetch grouping.
 type PrefetchMsg = (String, u32, String);
 
@@ -251,6 +253,8 @@ pub async fn sync_folder(
                     "total_synced": count,
                 }),
             ).ok();
+            emit_folders_changed(&app, &account_id);
+            emit_messages_changed(&app, &account_id);
             log::info!("Single folder sync done: {} new in {}", count, folder_path);
         }
         Err(e) => {
@@ -722,6 +726,8 @@ async fn sync_graph_account(
         "account_id": account_id,
         "total_synced": grand_total,
     })).ok();
+    emit_folders_changed(&app, account_id);
+    emit_messages_changed(&app, account_id);
 
     log::info!("Graph sync: completed for account {}, {} new messages", account_id, grand_total);
     Ok(())

--- a/src-tauri/src/db/folders.rs
+++ b/src-tauri/src/db/folders.rs
@@ -145,7 +145,7 @@ pub fn build_folder_tree(mut folders: Vec<Folder>) -> Vec<Folder> {
 }
 
 pub fn delete_folder(conn: &Connection, account_id: &str, path: &str) -> Result<()> {
-    // Delete messages in this folder first (foreign key)
+    // Remove orphaned messages in this folder to keep the local DB consistent
     conn.execute(
         "DELETE FROM messages WHERE account_id = ?1 AND folder_path = ?2",
         params![account_id, path],

--- a/src-tauri/src/db/folders.rs
+++ b/src-tauri/src/db/folders.rs
@@ -144,6 +144,20 @@ pub fn build_folder_tree(mut folders: Vec<Folder>) -> Vec<Folder> {
         .collect()
 }
 
+pub fn delete_folder(conn: &Connection, account_id: &str, path: &str) -> Result<()> {
+    // Delete messages in this folder first (foreign key)
+    conn.execute(
+        "DELETE FROM messages WHERE account_id = ?1 AND folder_path = ?2",
+        params![account_id, path],
+    )?;
+    conn.execute(
+        "DELETE FROM folders WHERE account_id = ?1 AND path = ?2",
+        params![account_id, path],
+    )?;
+    log::info!("Deleted folder '{}' from local DB for account {}", path, account_id);
+    Ok(())
+}
+
 pub fn update_folder_counts(
     conn: &Connection,
     account_id: &str,

--- a/src-tauri/src/mail/imap.rs
+++ b/src-tauri/src/mail/imap.rs
@@ -365,6 +365,17 @@ impl ImapConnection {
         Ok(())
     }
 
+    /// Delete a mailbox (folder) on the IMAP server.
+    pub fn delete_folder(&mut self, folder_path: &str) -> Result<()> {
+        log::info!("IMAP deleting folder: {}", folder_path);
+        self.session.unsubscribe(folder_path).ok();
+        self.session.delete(folder_path).map_err(|e| {
+            log::error!("IMAP DELETE folder '{}' failed: {}", folder_path, e);
+            Error::Imap(e.to_string())
+        })?;
+        Ok(())
+    }
+
     /// Move messages to a destination folder.
     ///
     /// Uses COPY + STORE \Deleted + EXPUNGE, which works on all IMAP servers

--- a/src-tauri/src/mail/jmap.rs
+++ b/src-tauri/src/mail/jmap.rs
@@ -1,6 +1,32 @@
 use crate::error::{Error, Result};
 use serde::{Deserialize, Serialize};
 
+fn summarize_http_error_body(body: &str) -> String {
+    let trimmed = body.trim();
+    if trimmed.is_empty() {
+        return "empty response body".to_string();
+    }
+
+    if trimmed.starts_with('<') {
+        let text = regex::Regex::new(r"<[^>]+>")
+            .ok()
+            .map(|re| re.replace_all(trimmed, " ").to_string())
+            .unwrap_or_else(|| trimmed.to_string());
+        let collapsed = text.split_whitespace().collect::<Vec<_>>().join(" ");
+        if collapsed.is_empty() {
+            return "HTML error response".to_string();
+        }
+        return collapsed;
+    }
+
+    let single_line = trimmed.split_whitespace().collect::<Vec<_>>().join(" ");
+    if single_line.len() > 240 {
+        format!("{}...", &single_line[..240])
+    } else {
+        single_line
+    }
+}
+
 // ---------------------------------------------------------------------------
 // JMAP Calendar types
 // ---------------------------------------------------------------------------
@@ -186,7 +212,8 @@ impl JmapConnection {
         if !resp.status().is_success() {
             let status = resp.status();
             let body = resp.text().await.unwrap_or_default();
-            return Err(Error::Other(format!("JMAP API error {}: {}", status, body)));
+            let summary = summarize_http_error_body(&body);
+            return Err(Error::Other(format!("JMAP API error {}: {}", status, summary)));
         }
 
         resp.json().await.map_err(|e| Error::Other(format!("JMAP response parse error: {}", e)))
@@ -1198,6 +1225,15 @@ impl JmapConnection {
             ]
         });
         let resp = self.api_request(&request, config).await?;
+        let method_name = resp["methodResponses"][0][0].as_str().unwrap_or("<unknown>");
+        if method_name != "Mailbox/set" {
+            log::error!("Unexpected JMAP response to mailbox destroy: {}", resp);
+            return Err(Error::Other(format!(
+                "Unexpected JMAP response to mailbox destroy: {}",
+                method_name,
+            )));
+        }
+
         let destroyed = resp["methodResponses"][0][1]["destroyed"]
             .as_array()
             .map(|a| a.iter().any(|v| v.as_str() == Some(mailbox_id)))
@@ -1206,6 +1242,12 @@ impl JmapConnection {
             let err = resp["methodResponses"][0][1]["notDestroyed"][mailbox_id]["description"]
                 .as_str()
                 .unwrap_or("Unknown error");
+            log::error!(
+                "JMAP mailbox destroy failed for {}: {}. Response: {}",
+                mailbox_id,
+                err,
+                resp
+            );
             return Err(Error::Other(format!("JMAP Mailbox/set destroy failed: {}", err)));
         }
         log::info!("JMAP mailbox destroyed: {}", mailbox_id);

--- a/src-tauri/src/mail/jmap.rs
+++ b/src-tauri/src/mail/jmap.rs
@@ -1183,6 +1183,35 @@ impl JmapConnection {
         Ok(created_id)
     }
 
+    /// Delete a mailbox on the JMAP server.
+    /// `on_destroy_remove_messages` controls whether messages in the mailbox are deleted too.
+    pub async fn destroy_mailbox(&self, config: &JmapConfig, mailbox_id: &str, remove_messages: bool) -> Result<()> {
+        log::info!("JMAP destroying mailbox: {} (remove_messages={})", mailbox_id, remove_messages);
+        let request = serde_json::json!({
+            "using": ["urn:ietf:params:jmap:core", "urn:ietf:params:jmap:mail"],
+            "methodCalls": [
+                ["Mailbox/set", {
+                    "accountId": self.account_id,
+                    "onDestroyRemoveMessages": remove_messages,
+                    "destroy": [mailbox_id]
+                }, "d1"]
+            ]
+        });
+        let resp = self.api_request(&request, config).await?;
+        let destroyed = resp["methodResponses"][0][1]["destroyed"]
+            .as_array()
+            .map(|a| a.iter().any(|v| v.as_str() == Some(mailbox_id)))
+            .unwrap_or(false);
+        if !destroyed {
+            let err = resp["methodResponses"][0][1]["notDestroyed"][mailbox_id]["description"]
+                .as_str()
+                .unwrap_or("Unknown error");
+            return Err(Error::Other(format!("JMAP Mailbox/set destroy failed: {}", err)));
+        }
+        log::info!("JMAP mailbox destroyed: {}", mailbox_id);
+        Ok(())
+    }
+
     // -----------------------------------------------------------------------
     // Contacts (JSContact / JMAP Contacts)
     // -----------------------------------------------------------------------

--- a/src-tauri/src/mail/jmap_sync.rs
+++ b/src-tauri/src/mail/jmap_sync.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use tauri::{AppHandle, Emitter};
 use tokio::sync::Mutex;
 
+use crate::commands::events::{emit_folders_changed, emit_messages_changed};
 use crate::db;
 use crate::error::{Error, Result};
 use crate::mail::jmap::{JmapConfig, JmapConnection};
@@ -68,6 +69,8 @@ pub async fn sync_jmap_account(
                 },
             )
             .ok();
+            emit_folders_changed(&app, &account_id);
+            emit_messages_changed(&app, &account_id);
         }
         Err(e) => {
             app.emit(
@@ -383,6 +386,8 @@ pub async fn sync_jmap_folder_public(
                 }),
             )
             .ok();
+            emit_folders_changed(&app, &account_id);
+            emit_messages_changed(&app, &account_id);
         }
         Err(e) => {
             app.emit(

--- a/src-tauri/src/mail/sync.rs
+++ b/src-tauri/src/mail/sync.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use tauri::{AppHandle, Emitter};
 use tokio::sync::Mutex;
 
+use crate::commands::events::{emit_folders_changed, emit_messages_changed};
 use crate::db;
 use crate::error::{Error, Result};
 use crate::filters::engine::{self, AddressEntry, MessageData};
@@ -75,6 +76,8 @@ pub async fn sync_account(
                 },
             )
             .ok();
+            emit_folders_changed(&app, &account_id);
+            emit_messages_changed(&app, &account_id);
         }
         Err(e) => {
             app.emit(

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -46,6 +46,7 @@ fn main() {
             commands::mail::get_thread_messages,
             commands::mail::unthread_message,
             commands::mail::create_folder,
+            commands::mail::delete_folder,
             commands::mail::save_attachment,
             commands::sync_cmd::trigger_sync,
             commands::sync_cmd::sync_folder,

--- a/src/App.vue
+++ b/src/App.vue
@@ -4,6 +4,7 @@ import { useRoute } from "vue-router";
 import Sidebar from "@/components/common/Sidebar.vue";
 import MenuBar from "@/components/common/MenuBar.vue";
 import StatusBar from "@/components/common/StatusBar.vue";
+import ToastContainer from "@/components/common/ToastContainer.vue";
 import { useActivityStore } from "@/stores/activity";
 import { useAccountsStore } from "@/stores/accounts";
 import { useUiStore } from "@/stores/ui";
@@ -60,6 +61,8 @@ onMounted(async () => {
       <StatusBar />
     </div>
   </div>
+
+  <ToastContainer />
 </template>
 
 <style scoped>

--- a/src/__tests__/messages-selection.test.ts
+++ b/src/__tests__/messages-selection.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { setActivePinia, createPinia } from "pinia";
 
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn().mockResolvedValue(() => {}),
+}));
+
 vi.mock("@/lib/tauri", () => ({
   listAccounts: vi.fn().mockResolvedValue([]),
   getMessages: vi.fn().mockResolvedValue({ messages: [], total: 0, page: 0, per_page: 100 }),

--- a/src/components/common/ToastContainer.vue
+++ b/src/components/common/ToastContainer.vue
@@ -1,0 +1,99 @@
+<script setup lang="ts">
+import { useToasts } from "@/lib/toast";
+
+const toasts = useToasts();
+</script>
+
+<template>
+  <Teleport to="body">
+    <div class="toast-container">
+      <TransitionGroup name="toast">
+        <div
+          v-for="toast in toasts"
+          :key="toast.id"
+          class="toast"
+          :class="toast.type"
+        >
+          <span class="toast-icon">
+            <svg v-if="toast.type === 'info'" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <circle cx="12" cy="12" r="10" /><polyline points="12 6 12 12 16 14" />
+            </svg>
+            <svg v-else-if="toast.type === 'success'" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <polyline points="20 6 9 17 4 12" />
+            </svg>
+            <svg v-else width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <circle cx="12" cy="12" r="10" /><line x1="15" y1="9" x2="9" y2="15" /><line x1="9" y1="9" x2="15" y2="15" />
+            </svg>
+          </span>
+          <span class="toast-message">{{ toast.message }}</span>
+        </div>
+      </TransitionGroup>
+    </div>
+  </Teleport>
+</template>
+
+<style>
+.toast-container {
+  position: fixed;
+  bottom: 40px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 99999;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  pointer-events: none;
+}
+
+.toast {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 16px;
+  border-radius: 8px;
+  font-size: 13px;
+  font-weight: 500;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  pointer-events: auto;
+  white-space: nowrap;
+}
+
+.toast.info {
+  background: var(--color-bg);
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+}
+
+.toast.success {
+  background: #065f46;
+  color: #d1fae5;
+  border: 1px solid #059669;
+}
+
+.toast.error {
+  background: #7f1d1d;
+  color: #fecaca;
+  border: 1px solid #dc2626;
+}
+
+.toast-icon {
+  display: flex;
+  flex-shrink: 0;
+}
+
+.toast-enter-active,
+.toast-leave-active {
+  transition: all 0.25s ease;
+}
+
+.toast-enter-from {
+  opacity: 0;
+  transform: translateY(10px);
+}
+
+.toast-leave-to {
+  opacity: 0;
+  transform: translateY(-10px);
+}
+</style>

--- a/src/components/mail/FolderTree.vue
+++ b/src/components/mail/FolderTree.vue
@@ -82,6 +82,7 @@ const newFolderName = ref("");
 const newFolderParent = ref("");
 const newFolderSaving = ref(false);
 const newFolderError = ref<string | null>(null);
+const deletingFolder = ref<{ accountId: string; folder: Folder } | null>(null);
 
 // Predefined avatar colors for accounts
 const avatarColors = ["#3366cc", "#2e7d32", "#9c27b0", "#e65100", "#00838f"];
@@ -328,6 +329,31 @@ async function markFolderRead() {
     console.error("Mark folder read failed:", e);
   }
 }
+
+function confirmDeleteFolder() {
+  const folder = contextMenu.value?.folder;
+  const accountId = findAccountForFolder(folder);
+  if (!accountId || !folder) return;
+  closeContextMenu();
+  deletingFolder.value = { accountId, folder };
+}
+
+async function doDeleteFolder() {
+  if (!deletingFolder.value) return;
+  const { accountId, folder } = deletingFolder.value;
+  deletingFolder.value = null;
+
+  try {
+    await api.deleteFolder(accountId, folder.path);
+    await foldersStore.fetchAllAccountFolders();
+    // If the deleted folder was active, switch to inbox
+    if (foldersStore.activeFolderPath === folder.path) {
+      await foldersStore.fetchFolders();
+    }
+  } catch (e) {
+    console.error("Delete folder failed:", e);
+  }
+}
 </script>
 
 <template>
@@ -446,6 +472,8 @@ async function markFolderRead() {
         <div class="ctx-separator"></div>
         <button class="ctx-item" @click="markFolderRead">Mark Folder Read</button>
         <div class="ctx-separator"></div>
+        <button class="ctx-item danger" @click="confirmDeleteFolder">Delete Folder</button>
+        <div class="ctx-separator"></div>
         <button class="ctx-item disabled">Properties</button>
         <button class="ctx-item" @click="syncThisFolder">
           Sync "{{ contextMenu.folder.name }}"
@@ -498,6 +526,27 @@ async function markFolderRead() {
             <button class="nf-btn-create" :disabled="newFolderSaving" @click="createNewFolder">
               {{ newFolderSaving ? "Creating..." : "Create Folder" }}
             </button>
+          </div>
+        </div>
+      </div>
+    </Teleport>
+
+    <!-- Delete Folder Confirmation -->
+    <Teleport to="body">
+      <div v-if="deletingFolder" class="modal-overlay" @click.self="deletingFolder = null">
+        <div class="new-folder-modal">
+          <div class="nf-body" style="padding: 20px">
+            <h3 style="margin: 0 0 8px">Delete Folder</h3>
+            <p style="font-size: 13px; color: var(--color-text-secondary); line-height: 1.5; margin: 0 0 4px">
+              Are you sure you want to delete "{{ deletingFolder.folder.name }}"?
+            </p>
+            <p style="font-size: 12px; color: var(--color-text-muted); margin: 0">
+              All messages in this folder will be permanently deleted.
+            </p>
+          </div>
+          <div class="nf-footer">
+            <button class="nf-btn-cancel" @click="deletingFolder = null">Cancel</button>
+            <button class="nf-btn-create" style="background: var(--color-danger, #dc2626)" @click="doDeleteFolder">Delete</button>
           </div>
         </div>
       </div>
@@ -717,6 +766,14 @@ async function markFolderRead() {
 .folder-context-menu .ctx-item.disabled {
   opacity: 0.4;
   cursor: default;
+}
+
+.folder-context-menu .ctx-item.danger {
+  color: var(--color-danger, #dc2626);
+}
+
+.folder-context-menu .ctx-item.danger:hover {
+  background: rgba(220, 53, 69, 0.08);
 }
 
 .folder-context-menu .ctx-separator {

--- a/src/components/mail/FolderTree.vue
+++ b/src/components/mail/FolderTree.vue
@@ -175,10 +175,6 @@ async function syncThisFolder() {
   syncing.value = folder.path;
   try {
     await api.syncFolder(accountId, folder.path);
-    await foldersStore.fetchFolders();
-    if (foldersStore.activeFolderPath === folder.path) {
-      await messagesStore.fetchMessages();
-    }
   } catch (e) {
     console.error("Folder sync failed:", e);
   } finally {
@@ -254,7 +250,6 @@ async function createNewFolder() {
     showNewFolderModal.value = false;
     // Trigger sync so the server-assigned folder ID/path gets registered locally
     await api.triggerSync(accountId);
-    await foldersStore.fetchAllAccountFolders();
   } catch (e) {
     newFolderError.value = String(e);
   } finally {
@@ -298,8 +293,6 @@ async function onFolderMouseUp(accountId: string, folderPath: string) {
     messagesStore.clearSelection();
     messagesStore.activeMessage = null;
     messagesStore.activeMessageId = null;
-    await messagesStore.fetchMessages();
-    await foldersStore.fetchAllAccountFolders();
   } catch (e) {
     console.error("Drag-and-drop move failed:", e);
   }
@@ -320,10 +313,6 @@ async function markFolderRead() {
 
     if (unreadIds.length > 0) {
       await api.setMessageFlags(accountId, unreadIds, ["seen"], true);
-      await foldersStore.fetchFolders();
-      if (foldersStore.activeFolderPath === folder.path) {
-        await messagesStore.fetchMessages();
-      }
     }
   } catch (e) {
     console.error("Mark folder read failed:", e);
@@ -344,8 +333,6 @@ async function doDeleteFolder() {
 
   try {
     await api.deleteFolder(accountId, folder.path);
-    await foldersStore.fetchAllAccountFolders();
-    await foldersStore.fetchFolders();
     // If the deleted folder was active on this account, switch to inbox
     if (
       accountsStore.activeAccountId === accountId &&

--- a/src/components/mail/FolderTree.vue
+++ b/src/components/mail/FolderTree.vue
@@ -6,6 +6,7 @@ import { useMessagesStore } from "@/stores/messages";
 import type { Folder } from "@/lib/types";
 import * as api from "@/lib/tauri";
 import { dragMessageIds, dragSourceAccountId, isDragging } from "@/lib/drag-state";
+import { showToast, dismissToast } from "@/lib/toast";
 
 const foldersStore = useFoldersStore();
 const accountsStore = useAccountsStore();
@@ -246,10 +247,13 @@ async function createNewFolder() {
   newFolderSaving.value = true;
   newFolderError.value = null;
   try {
+    const toastId = showToast(`Creating folder...`, "info", 0);
     await api.createFolder(accountId, folderPath);
     showNewFolderModal.value = false;
     // Trigger sync so the server-assigned folder ID/path gets registered locally
     await api.triggerSync(accountId);
+    await foldersStore.fetchAllAccountFolders();
+    dismissToast(toastId);
   } catch (e) {
     newFolderError.value = String(e);
   } finally {
@@ -289,10 +293,12 @@ async function onFolderMouseUp(accountId: string, folderPath: string) {
 
   const messageIds = [...dragMessageIds.value];
   try {
+    const toastId = showToast(`Moving ${messageIds.length} message(s)...`, "info", 0);
     await api.moveMessages(accountId, messageIds, folderPath);
     messagesStore.clearSelection();
     messagesStore.activeMessage = null;
     messagesStore.activeMessageId = null;
+    dismissToast(toastId);
   } catch (e) {
     console.error("Drag-and-drop move failed:", e);
   }
@@ -332,7 +338,9 @@ async function doDeleteFolder() {
   deletingFolder.value = null;
 
   try {
+    const toastId = showToast(`Deleting "${folder.name}"...`, "info", 0);
     await api.deleteFolder(accountId, folder.path);
+    await foldersStore.fetchAllAccountFolders();
     // If the deleted folder was active on this account, switch to inbox
     if (
       accountsStore.activeAccountId === accountId &&
@@ -342,6 +350,7 @@ async function doDeleteFolder() {
       const inbox = folders.find((f: Folder) => f.folder_type === "inbox");
       foldersStore.setActiveFolder(inbox?.path ?? (folders[0]?.path ?? ""));
     }
+    dismissToast(toastId);
   } catch (e) {
     console.error("Delete folder failed:", e);
   }

--- a/src/components/mail/FolderTree.vue
+++ b/src/components/mail/FolderTree.vue
@@ -11,7 +11,7 @@ const foldersStore = useFoldersStore();
 const accountsStore = useAccountsStore();
 const messagesStore = useMessagesStore();
 
-const contextMenu = ref<{ x: number; y: number; folder: Folder } | null>(null);
+const contextMenu = ref<{ x: number; y: number; folder: Folder; accountId: string } | null>(null);
 const accountMenu = ref<{ x: number; y: number; accountId: string } | null>(null);
 const syncing = ref<string | null>(null);
 const collapsedAccounts = ref<string[]>([]);
@@ -141,9 +141,9 @@ watch(
   },
 );
 
-function onFolderContextMenu(event: MouseEvent, folder: Folder) {
+function onFolderContextMenu(event: MouseEvent, folder: Folder, accountId: string) {
   event.preventDefault();
-  contextMenu.value = { x: event.clientX, y: event.clientY, folder };
+  contextMenu.value = { x: event.clientX, y: event.clientY, folder, accountId };
 }
 
 function closeContextMenu() {
@@ -331,9 +331,8 @@ async function markFolderRead() {
 }
 
 function confirmDeleteFolder() {
-  const folder = contextMenu.value?.folder;
-  const accountId = findAccountForFolder(folder);
-  if (!accountId || !folder) return;
+  if (!contextMenu.value) return;
+  const { folder, accountId } = contextMenu.value;
   closeContextMenu();
   deletingFolder.value = { accountId, folder };
 }
@@ -346,9 +345,15 @@ async function doDeleteFolder() {
   try {
     await api.deleteFolder(accountId, folder.path);
     await foldersStore.fetchAllAccountFolders();
-    // If the deleted folder was active, switch to inbox
-    if (foldersStore.activeFolderPath === folder.path) {
-      await foldersStore.fetchFolders();
+    await foldersStore.fetchFolders();
+    // If the deleted folder was active on this account, switch to inbox
+    if (
+      accountsStore.activeAccountId === accountId &&
+      foldersStore.activeFolderPath === folder.path
+    ) {
+      const folders = foldersStore.getAccountFolders(accountId);
+      const inbox = folders.find((f: Folder) => f.folder_type === "inbox");
+      foldersStore.setActiveFolder(inbox?.path ?? (folders[0]?.path ?? ""));
     }
   } catch (e) {
     console.error("Delete folder failed:", e);
@@ -397,7 +402,7 @@ async function doDeleteFolder() {
           }"
           :style="{ paddingLeft: (12 + item.depth * 16) + 'px' }"
           @click.stop="selectFolder(account.id, item.folder.path)"
-          @contextmenu="onFolderContextMenu($event, item.folder)"
+          @contextmenu="onFolderContextMenu($event, item.folder, account.id)"
           @mouseenter="onFolderMouseEnter(account.id, item.folder.path)"
           @mouseleave="onFolderMouseLeave(account.id, item.folder.path)"
           @mouseup="onFolderMouseUp(account.id, item.folder.path)"

--- a/src/components/mail/FolderTree.vue
+++ b/src/components/mail/FolderTree.vue
@@ -246,18 +246,17 @@ async function createNewFolder() {
 
   newFolderSaving.value = true;
   newFolderError.value = null;
+  const createToastId = showToast(`Creating folder...`, "info", 0);
   try {
-    const toastId = showToast(`Creating folder...`, "info", 0);
     await api.createFolder(accountId, folderPath);
     showNewFolderModal.value = false;
-    // Trigger sync so the server-assigned folder ID/path gets registered locally
     await api.triggerSync(accountId);
     await foldersStore.fetchAllAccountFolders();
-    dismissToast(toastId);
   } catch (e) {
     newFolderError.value = String(e);
   } finally {
     newFolderSaving.value = false;
+    dismissToast(createToastId);
   }
 }
 
@@ -292,15 +291,16 @@ async function onFolderMouseUp(accountId: string, folderPath: string) {
   if (foldersStore.activeFolderPath === folderPath && accountsStore.activeAccountId === accountId) return;
 
   const messageIds = [...dragMessageIds.value];
+  const moveToastId = showToast(`Moving ${messageIds.length} message(s)...`, "info", 0);
   try {
-    const toastId = showToast(`Moving ${messageIds.length} message(s)...`, "info", 0);
     await api.moveMessages(accountId, messageIds, folderPath);
     messagesStore.clearSelection();
     messagesStore.activeMessage = null;
     messagesStore.activeMessageId = null;
-    dismissToast(toastId);
   } catch (e) {
     console.error("Drag-and-drop move failed:", e);
+  } finally {
+    dismissToast(moveToastId);
   }
 }
 
@@ -337,11 +337,10 @@ async function doDeleteFolder() {
   const { accountId, folder } = deletingFolder.value;
   deletingFolder.value = null;
 
+  const deleteToastId = showToast(`Deleting "${folder.name}"...`, "info", 0);
   try {
-    const toastId = showToast(`Deleting "${folder.name}"...`, "info", 0);
     await api.deleteFolder(accountId, folder.path);
     await foldersStore.fetchAllAccountFolders();
-    // If the deleted folder was active on this account, switch to inbox
     if (
       accountsStore.activeAccountId === accountId &&
       foldersStore.activeFolderPath === folder.path
@@ -350,9 +349,10 @@ async function doDeleteFolder() {
       const inbox = folders.find((f: Folder) => f.folder_type === "inbox");
       foldersStore.setActiveFolder(inbox?.path ?? (folders[0]?.path ?? ""));
     }
-    dismissToast(toastId);
   } catch (e) {
     console.error("Delete folder failed:", e);
+  } finally {
+    dismissToast(deleteToastId);
   }
 }
 </script>

--- a/src/components/mail/FolderTree.vue
+++ b/src/components/mail/FolderTree.vue
@@ -168,9 +168,8 @@ function openNewFolderFromAccount() {
 }
 
 async function syncThisFolder() {
-  const folder = contextMenu.value?.folder;
-  const accountId = findAccountForFolder(folder);
-  if (!accountId || !folder) return;
+  if (!contextMenu.value) return;
+  const { folder, accountId } = contextMenu.value;
   closeContextMenu();
 
   syncing.value = folder.path;
@@ -183,28 +182,12 @@ async function syncThisFolder() {
   }
 }
 
-function findFolderInTree(folders: Folder[], path: string): boolean {
-  for (const f of folders) {
-    if (f.path === path) return true;
-    if (findFolderInTree(f.children, path)) return true;
-  }
-  return false;
-}
-
-function findAccountForFolder(folder: Folder | undefined): string | null {
-  if (!folder) return null;
-  for (const acc of accountsStore.accounts) {
-    const folders = foldersStore.getAccountFolders(acc.id);
-    if (findFolderInTree(folders, folder.path)) return acc.id;
-  }
-  return accountsStore.activeAccountId;
-}
 
 function openNewFolderModal() {
-  const folder = contextMenu.value?.folder;
-  const accountId = findAccountForFolder(folder);
+  if (!contextMenu.value) return;
+  const { folder, accountId } = contextMenu.value;
   // Default parent to the right-clicked folder's path
-  newFolderParent.value = folder ? `${accountId}|${folder.path}` : "";
+  newFolderParent.value = `${accountId}|${folder.path}`;
   newFolderName.value = "";
   newFolderError.value = null;
   closeContextMenu();
@@ -305,9 +288,8 @@ async function onFolderMouseUp(accountId: string, folderPath: string) {
 }
 
 async function markFolderRead() {
-  const folder = contextMenu.value?.folder;
-  const accountId = findAccountForFolder(folder);
-  if (!accountId || !folder) return;
+  if (!contextMenu.value) return;
+  const { folder, accountId } = contextMenu.value;
   closeContextMenu();
 
   try {
@@ -349,8 +331,11 @@ async function doDeleteFolder() {
       const inbox = folders.find((f: Folder) => f.folder_type === "inbox");
       foldersStore.setActiveFolder(inbox?.path ?? (folders[0]?.path ?? ""));
     }
+    showToast(`Deleted "${folder.name}"`, "success");
   } catch (e) {
     console.error("Delete folder failed:", e);
+    const message = e instanceof Error ? e.message : String(e);
+    showToast(`Failed to delete "${folder.name}": ${message}`, "error", 5000);
   } finally {
     dismissToast(deleteToastId);
   }

--- a/src/components/mail/MessageList.vue
+++ b/src/components/mail/MessageList.vue
@@ -279,8 +279,6 @@ async function ctxMoveTo(folderPath: string) {
     messagesStore.clearSelection();
     messagesStore.activeMessage = null;
     messagesStore.activeMessageId = null;
-    await messagesStore.fetchMessages();
-    await foldersStore.fetchFolders();
   } catch (e) {
     console.error("Move failed:", e);
   }
@@ -293,7 +291,6 @@ async function ctxCopyTo(folderPath: string) {
   closeContextMenu();
   try {
     await api.copyMessages(accountId, ids, folderPath);
-    await foldersStore.fetchFolders();
   } catch (e) {
     console.error("Copy failed:", e);
   }
@@ -337,8 +334,6 @@ async function ctxNotSpam() {
     messagesStore.clearSelection();
     messagesStore.activeMessage = null;
     messagesStore.activeMessageId = null;
-    await messagesStore.fetchMessages();
-    await foldersStore.fetchFolders();
   } catch (e) {
     console.error("Not Spam failed:", e);
   }

--- a/src/components/mail/MessageList.vue
+++ b/src/components/mail/MessageList.vue
@@ -275,15 +275,16 @@ async function ctxMoveTo(folderPath: string) {
   if (!accountId) return;
   const ids = messagesStore.resolveSelectedIds();
   closeContextMenu();
+  const toastId = showToast(`Moving ${ids.length} message(s)...`, "info", 0);
   try {
-    const toastId = showToast(`Moving ${ids.length} message(s)...`, "info", 0);
     await api.moveMessages(accountId, ids, folderPath);
     messagesStore.clearSelection();
     messagesStore.activeMessage = null;
     messagesStore.activeMessageId = null;
-    dismissToast(toastId);
   } catch (e) {
     console.error("Move failed:", e);
+  } finally {
+    dismissToast(toastId);
   }
 }
 

--- a/src/components/mail/MessageList.vue
+++ b/src/components/mail/MessageList.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted } from "vue";
 import { dragMessageIds, dragSourceAccountId, isDragging } from "@/lib/drag-state";
+import { showToast, dismissToast } from "@/lib/toast";
 import { useMessagesStore } from "@/stores/messages";
 import { useAccountsStore } from "@/stores/accounts";
 import { useFoldersStore } from "@/stores/folders";
@@ -275,10 +276,12 @@ async function ctxMoveTo(folderPath: string) {
   const ids = messagesStore.resolveSelectedIds();
   closeContextMenu();
   try {
+    const toastId = showToast(`Moving ${ids.length} message(s)...`, "info", 0);
     await api.moveMessages(accountId, ids, folderPath);
     messagesStore.clearSelection();
     messagesStore.activeMessage = null;
     messagesStore.activeMessageId = null;
+    dismissToast(toastId);
   } catch (e) {
     console.error("Move failed:", e);
   }

--- a/src/components/mail/MessageReader.vue
+++ b/src/components/mail/MessageReader.vue
@@ -431,8 +431,6 @@ async function deleteMessage() {
     await api.deleteMessages(accountId, [msgId]);
     messagesStore.activeMessage = null;
     messagesStore.activeMessageId = null;
-    await messagesStore.fetchMessages();
-    await foldersStore.fetchFolders();
   } catch (e) {
     console.error("Delete failed:", e);
   }
@@ -451,8 +449,6 @@ async function archiveMessage() {
     await api.moveMessages(accountId, [msgId], folder.path);
     messagesStore.activeMessage = null;
     messagesStore.activeMessageId = null;
-    await messagesStore.fetchMessages();
-    await foldersStore.fetchFolders();
   } catch (e) {
     console.error("Archive failed:", e);
   }
@@ -471,8 +467,6 @@ async function markSpam() {
     await api.moveMessages(accountId, [msgId], folder.path);
     messagesStore.activeMessage = null;
     messagesStore.activeMessageId = null;
-    await messagesStore.fetchMessages();
-    await foldersStore.fetchFolders();
   } catch (e) {
     console.error("Spam move failed:", e);
   }

--- a/src/components/mail/Toolbar.vue
+++ b/src/components/mail/Toolbar.vue
@@ -30,8 +30,6 @@ async function markNotSpam() {
     messagesStore.clearSelection();
     messagesStore.activeMessage = null;
     messagesStore.activeMessageId = null;
-    await messagesStore.fetchMessages();
-    await foldersStore.fetchFolders();
   } catch (e) {
     console.error("Not Spam failed:", e);
   }

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -79,6 +79,13 @@ export async function createFolder(
   return invoke("create_folder", { accountId, folderPath });
 }
 
+export async function deleteFolder(
+  accountId: string,
+  folderPath: string,
+): Promise<void> {
+  return invoke("delete_folder", { accountId, folderPath });
+}
+
 export async function saveAttachment(
   accountId: string,
   messageId: string,

--- a/src/lib/toast.ts
+++ b/src/lib/toast.ts
@@ -1,0 +1,30 @@
+import { ref } from "vue";
+
+export interface Toast {
+  id: number;
+  message: string;
+  type: "info" | "success" | "error";
+}
+
+const toasts = ref<Toast[]>([]);
+let nextId = 0;
+
+/** Show a toast notification. Auto-dismisses after `duration` ms. */
+export function showToast(message: string, type: "info" | "success" | "error" = "info", duration = 3000) {
+  const id = nextId++;
+  toasts.value.push({ id, message, type });
+  if (duration > 0) {
+    setTimeout(() => dismissToast(id), duration);
+  }
+  return id;
+}
+
+/** Dismiss a toast by ID (e.g., when operation completes early). */
+export function dismissToast(id: number) {
+  toasts.value = toasts.value.filter((t) => t.id !== id);
+}
+
+/** Reactive list of active toasts (read by ToastContainer component). */
+export function useToasts() {
+  return toasts;
+}

--- a/src/stores/folders.ts
+++ b/src/stores/folders.ts
@@ -1,5 +1,6 @@
 import { defineStore } from "pinia";
 import { ref, watch } from "vue";
+import { listen } from "@tauri-apps/api/event";
 import type { Folder } from "@/lib/types";
 import * as api from "@/lib/tauri";
 import { useAccountsStore } from "./accounts";
@@ -102,6 +103,16 @@ export const useFoldersStore = defineStore("folders", () => {
       fetchFolders();
     },
   );
+
+  // Subscribe to backend folder-change events with debounce
+  let foldersRefreshTimer: ReturnType<typeof setTimeout> | null = null;
+  listen<string>("folders-changed", () => {
+    if (foldersRefreshTimer) clearTimeout(foldersRefreshTimer);
+    foldersRefreshTimer = setTimeout(() => {
+      fetchAllAccountFolders();
+      fetchFolders();
+    }, 200);
+  });
 
   return {
     folders,

--- a/src/stores/messages.ts
+++ b/src/stores/messages.ts
@@ -1,5 +1,6 @@
 import { defineStore } from "pinia";
 import { ref, computed, watch } from "vue";
+import { listen } from "@tauri-apps/api/event";
 import type { MessageSummary, MessageBody, ThreadSummary, QuickFilter } from "@/lib/types";
 import * as api from "@/lib/tauri";
 import { useAccountsStore } from "./accounts";
@@ -410,8 +411,6 @@ export const useMessagesStore = defineStore("messages", () => {
       selectedIds.value = [];
       activeMessage.value = null;
       activeMessageId.value = null;
-      await fetchMessages();
-      await foldersStore.fetchFolders();
     } catch (e) {
       console.error("Delete failed:", e);
     }
@@ -444,6 +443,15 @@ export const useMessagesStore = defineStore("messages", () => {
       fetchMessages();
     },
   );
+
+  // Subscribe to backend message-change events with debounce
+  let messagesRefreshTimer: ReturnType<typeof setTimeout> | null = null;
+  listen<string>("messages-changed", () => {
+    if (messagesRefreshTimer) clearTimeout(messagesRefreshTimer);
+    messagesRefreshTimer = setTimeout(() => {
+      fetchMessages();
+    }, 200);
+  });
 
   return {
     messages,


### PR DESCRIPTION
Fixes #11 — right-click a folder and select "Delete Folder" to remove it from the server and local DB.

Backend:
- IMAP: DELETE + UNSUBSCRIBE via new ImapConnection::delete_folder
- JMAP: Mailbox/set destroy with onDestroyRemoveMessages=true
- Local DB: deletes folder and its messages from SQLite
- O365/XOAUTH2 token refresh handled for IMAP deletion

Frontend:
- "Delete Folder" option in folder context menu (styled as danger)
- Confirmation modal before deletion
- Refreshes folder list after deletion
- Switches to inbox if deleted folder was active