### PR TITLE
feat: drag-and-drop messages to folders

### DIFF
--- a/src/assets/styles/main.css
+++ b/src/assets/styles/main.css
@@ -130,6 +130,13 @@ button {
   font: inherit;
 }
 
+body.dragging-messages,
+body.dragging-messages * {
+  -webkit-user-select: none !important;
+  user-select: none !important;
+  cursor: grabbing !important;
+}
+
 input,
 textarea,
 select {

--- a/src/components/mail/FolderTree.vue
+++ b/src/components/mail/FolderTree.vue
@@ -5,6 +5,7 @@ import { useAccountsStore } from "@/stores/accounts";
 import { useMessagesStore } from "@/stores/messages";
 import type { Folder } from "@/lib/types";
 import * as api from "@/lib/tauri";
+import { dragMessageIds, dragSourceAccountId, isDragging } from "@/lib/drag-state";
 
 const foldersStore = useFoldersStore();
 const accountsStore = useAccountsStore();
@@ -14,6 +15,7 @@ const contextMenu = ref<{ x: number; y: number; folder: Folder } | null>(null);
 const accountMenu = ref<{ x: number; y: number; accountId: string } | null>(null);
 const syncing = ref<string | null>(null);
 const collapsedAccounts = ref<string[]>([]);
+const dropTarget = ref<string | null>(null);
 
 // Folder expand/collapse state, persisted per account in localStorage
 const collapsedFolders = ref<Record<string, string[]>>(loadCollapsedFolders());
@@ -259,6 +261,49 @@ async function createNewFolder() {
   }
 }
 
+let dragExpandTimer: ReturnType<typeof setTimeout> | null = null;
+
+function onFolderMouseEnter(accountId: string, folderPath: string) {
+  if (!isDragging.value) return;
+  if (dragSourceAccountId.value !== accountId) return;
+  if (foldersStore.activeFolderPath === folderPath && accountsStore.activeAccountId === accountId) return;
+  dropTarget.value = `${accountId}:${folderPath}`;
+  if (isFolderCollapsed(accountId, folderPath)) {
+    dragExpandTimer = setTimeout(() => {
+      toggleFolderCollapse(accountId, folderPath);
+    }, 600);
+  }
+}
+
+function onFolderMouseLeave(accountId: string, folderPath: string) {
+  if (dropTarget.value === `${accountId}:${folderPath}`) {
+    dropTarget.value = null;
+  }
+  if (dragExpandTimer) {
+    clearTimeout(dragExpandTimer);
+    dragExpandTimer = null;
+  }
+}
+
+async function onFolderMouseUp(accountId: string, folderPath: string) {
+  if (!isDragging.value || dragMessageIds.value.length === 0) return;
+  dropTarget.value = null;
+  if (dragSourceAccountId.value !== accountId) return;
+  if (foldersStore.activeFolderPath === folderPath && accountsStore.activeAccountId === accountId) return;
+
+  const messageIds = [...dragMessageIds.value];
+  try {
+    await api.moveMessages(accountId, messageIds, folderPath);
+    messagesStore.clearSelection();
+    messagesStore.activeMessage = null;
+    messagesStore.activeMessageId = null;
+    await messagesStore.fetchMessages();
+    await foldersStore.fetchAllAccountFolders();
+  } catch (e) {
+    console.error("Drag-and-drop move failed:", e);
+  }
+}
+
 async function markFolderRead() {
   const folder = contextMenu.value?.folder;
   const accountId = findAccountForFolder(folder);
@@ -322,10 +367,14 @@ async function markFolderRead() {
           :class="{
             active: accountsStore.activeAccountId === account.id && foldersStore.activeFolderPath === item.folder.path,
             syncing: syncing === item.folder.path,
+            'drop-target': dropTarget === `${account.id}:${item.folder.path}`,
           }"
           :style="{ paddingLeft: (12 + item.depth * 16) + 'px' }"
           @click.stop="selectFolder(account.id, item.folder.path)"
           @contextmenu="onFolderContextMenu($event, item.folder)"
+          @mouseenter="onFolderMouseEnter(account.id, item.folder.path)"
+          @mouseleave="onFolderMouseLeave(account.id, item.folder.path)"
+          @mouseup="onFolderMouseUp(account.id, item.folder.path)"
         >
           <span
             v-if="item.hasChildren"
@@ -563,6 +612,12 @@ async function markFolderRead() {
 
 .folder-item.syncing {
   opacity: 0.6;
+}
+
+.folder-item.drop-target {
+  background: var(--color-accent-light);
+  outline: 1.5px solid var(--color-accent);
+  outline-offset: -1.5px;
 }
 
 .folder-toggle {

--- a/src/components/mail/MessageList.vue
+++ b/src/components/mail/MessageList.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted } from "vue";
+import { dragMessageIds, dragSourceAccountId, isDragging } from "@/lib/drag-state";
 import { useMessagesStore } from "@/stores/messages";
 import { useAccountsStore } from "@/stores/accounts";
 import { useFoldersStore } from "@/stores/folders";
@@ -88,6 +89,76 @@ function onSelect(messageId: string, event?: MouseEvent) {
     ctrlKey: isCtrl,
     metaKey: false,
   });
+}
+
+// Custom drag-and-drop via mouse events (WebKitGTK doesn't support HTML5 DnD)
+const dragStartPos = ref<{ x: number; y: number } | null>(null);
+const dragSourceId = ref<string | null>(null);
+const dragGhost = ref<HTMLElement | null>(null);
+const DRAG_THRESHOLD = 5; // pixels before drag starts
+
+function onDragMouseDown(event: MouseEvent, messageId: string) {
+  if (event.button !== 0) return;
+  if ((event.target as HTMLElement).closest(".row-checkbox")) return;
+  dragStartPos.value = { x: event.clientX, y: event.clientY };
+  dragSourceId.value = messageId;
+
+  const handleMove = (e: MouseEvent) => {
+    if (!dragStartPos.value || !dragSourceId.value) return;
+
+    const dx = e.clientX - dragStartPos.value.x;
+    const dy = e.clientY - dragStartPos.value.y;
+    if (!isDragging.value && Math.sqrt(dx * dx + dy * dy) < DRAG_THRESHOLD) return;
+
+    if (!isDragging.value) {
+      // Select for drag without triggering read/open side effects
+      if (!messagesStore.isSelected(dragSourceId.value)) {
+        messagesStore.selectedIds = [dragSourceId.value];
+      }
+      dragMessageIds.value = messagesStore.resolveSelectedIds();
+      dragSourceAccountId.value = accountsStore.activeAccountId;
+      isDragging.value = true;
+
+      // Ghost badge showing drag count — positioned away from cursor
+      // so it doesn't intercept mouse events on drop targets
+      const ghost = document.createElement("div");
+      ghost.textContent = `${dragMessageIds.value.length} message(s)`;
+      ghost.style.cssText = "position:fixed;z-index:99999;padding:4px 10px;background:#3366cc;color:white;border-radius:4px;font-size:12px;font-weight:500;white-space:nowrap;pointer-events:none;";
+      document.body.appendChild(ghost);
+      dragGhost.value = ghost;
+      // Test: also change body cursor
+      document.body.style.cursor = "grabbing";
+      document.body.classList.add("dragging-messages");
+    }
+
+    if (dragGhost.value) {
+      dragGhost.value.style.left = e.clientX + 12 + "px";
+      dragGhost.value.style.top = e.clientY + 12 + "px";
+    }
+  };
+
+  const handleUp = () => {
+    document.body.style.cursor = "";
+    document.body.classList.remove("dragging-messages");
+    if (isDragging.value) {
+      setTimeout(() => {
+        isDragging.value = false;
+        dragMessageIds.value = [];
+        dragSourceAccountId.value = null;
+        if (dragGhost.value) {
+          dragGhost.value.remove();
+          dragGhost.value = null;
+        }
+      }, 0);
+    }
+    dragStartPos.value = null;
+    dragSourceId.value = null;
+    document.removeEventListener("mousemove", handleMove);
+    document.removeEventListener("mouseup", handleUp);
+  };
+
+  document.addEventListener("mousemove", handleMove);
+  document.addEventListener("mouseup", handleUp);
 }
 
 function onOpen(messageId: string) {
@@ -366,6 +437,7 @@ const displayedCount = () => {
         <div
           @click="onThreadSelect(thread, $event)"
           @contextmenu.prevent="onRowRightClick($event,thread.message_ids[0])"
+          @mousedown="onDragMouseDown($event, thread.message_ids[0])"
         >
           <ThreadRow
             :thread="thread"
@@ -385,6 +457,7 @@ const displayedCount = () => {
             class="thread-child"
             @click.stop="onChildSelect(msg.id)"
             @contextmenu.prevent.stop="onRowRightClick($event, msg.id)"
+            @mousedown="onDragMouseDown($event, msg.id)"
           >
             <MessageListItem
               :message="msg"
@@ -406,6 +479,7 @@ const displayedCount = () => {
         :key="msg.id"
         @click="onSelect(msg.id, $event)"
         @contextmenu.prevent="onRowRightClick($event,msg.id)"
+        @mousedown="onDragMouseDown($event, msg.id)"
       >
         <MessageListItem
           :message="msg"

--- a/src/lib/drag-state.ts
+++ b/src/lib/drag-state.ts
@@ -1,0 +1,6 @@
+import { ref } from "vue";
+
+/** Shared reactive state for custom drag-and-drop (WebKitGTK doesn't support HTML5 DnD). */
+export const dragMessageIds = ref<string[]>([]);
+export const dragSourceAccountId = ref<string | null>(null);
+export const isDragging = ref(false);


### PR DESCRIPTION
Fixes #12 — drag messages from the message list and drop them onto a folder in the sidebar to move them.

- Message rows are draggable (uses selected messages, or just the dragged message if not part of selection)
- Folder items are drop targets with visual highlight on dragover
- Drop calls moveMessages (same backend as right-click Move To)
- Refreshes folder counts and message list after move