### PR TITLE
feat: cross-account message move via drag-and-drop

### DIFF
--- a/src-tauri/src/commands/actions.rs
+++ b/src-tauri/src/commands/actions.rs
@@ -297,17 +297,14 @@ pub async fn move_messages_cross_account(
         )));
     }
 
-    // Read raw bytes from disk using async I/O to avoid blocking the runtime.
-    // Validate each path: skip non-disk entries (graph: prefix) and reject
-    // absolute paths or ".." segments that could escape the data directory.
+    // Resolve and validate all maildir paths before starting the transfer.
+    // Rejects non-disk entries (graph: prefix), absolute paths, and ".." segments.
     let data_dir = state.data_dir.clone();
-    let paths_clone = maildir_paths.clone();
-    let raw_messages: Vec<Vec<u8>> = tokio::task::spawn_blocking(move || -> Result<Vec<Vec<u8>>> {
+    let validated_paths: Vec<std::path::PathBuf> = {
         let canonical_data_dir = std::fs::canonicalize(&data_dir)
             .unwrap_or_else(|_| data_dir.clone());
-        let mut messages = Vec::with_capacity(paths_clone.len());
-        for (msg_id, maildir_path) in &paths_clone {
-            // Skip non-disk entries (e.g. Graph API messages with "graph:" prefix)
+        let mut paths = Vec::with_capacity(maildir_paths.len());
+        for (msg_id, maildir_path) in &maildir_paths {
             if maildir_path.starts_with("graph:") {
                 return Err(Error::Other(format!(
                     "Message {} is not stored on disk (Graph API). \
@@ -334,28 +331,25 @@ pub async fn move_messages_cross_account(
                     "Path traversal detected for message {}", msg_id
                 )));
             }
-            let bytes = std::fs::read(&canonical).map_err(|e| {
-                Error::Other(format!(
-                    "Failed to read maildir file {}: {}",
-                    full_path.display(), e
-                ))
-            })?;
-            messages.push(bytes);
+            paths.push(canonical);
         }
-        Ok(messages)
-    })
-    .await
-    .map_err(|e| Error::Other(format!("Read task panicked: {}", e)))??;
+        paths
+    };
 
-    // Append to destination
+    // Append to destination — stream one message at a time to avoid
+    // loading all message bodies into memory simultaneously.
     match target_account.mail_protocol.as_str() {
         "imap" => {
+            // IMAP: read and append in a single blocking task (one connection)
             let imap_config = build_imap_config(&target_account).await?;
             let target_folder_clone = target_folder.clone();
             tokio::task::spawn_blocking(move || -> Result<()> {
                 let mut conn = ImapConnection::connect(&imap_config)?;
-                for bytes in &raw_messages {
-                    conn.append_message_raw(&target_folder_clone, bytes)?;
+                for path in &validated_paths {
+                    let bytes = std::fs::read(path).map_err(|e| {
+                        Error::Other(format!("Failed to read {}: {}", path.display(), e))
+                    })?;
+                    conn.append_message_raw(&target_folder_clone, &bytes)?;
                 }
                 conn.logout();
                 Ok(())
@@ -364,12 +358,20 @@ pub async fn move_messages_cross_account(
             .map_err(|e| Error::Other(format!("IMAP append task panicked: {}", e)))??;
         }
         "jmap" => {
+            // JMAP: read each message in a blocking task, then import async
             let jmap_config =
                 crate::commands::sync_cmd::build_jmap_config(&target_account).await?;
             let conn_jmap = crate::mail::jmap::JmapConnection::connect(&jmap_config).await?;
-            for bytes in &raw_messages {
+            for path in &validated_paths {
+                let path_clone = path.clone();
+                let bytes = tokio::task::spawn_blocking(move || {
+                    std::fs::read(&path_clone)
+                })
+                .await
+                .map_err(|e| Error::Other(format!("Read task panicked: {}", e)))?
+                .map_err(|e| Error::Other(format!("Failed to read {}: {}", path.display(), e)))?;
                 conn_jmap
-                    .import_email_to_mailbox(&jmap_config, bytes, &target_folder, false)
+                    .import_email_to_mailbox(&jmap_config, &bytes, &target_folder, false)
                     .await?;
             }
         }

--- a/src-tauri/src/commands/actions.rs
+++ b/src-tauri/src/commands/actions.rs
@@ -297,18 +297,47 @@ pub async fn move_messages_cross_account(
         )));
     }
 
-    // Read raw bytes from disk using async I/O to avoid blocking the runtime
+    // Read raw bytes from disk using async I/O to avoid blocking the runtime.
+    // Validate each path: skip non-disk entries (graph: prefix) and reject
+    // absolute paths or ".." segments that could escape the data directory.
     let data_dir = state.data_dir.clone();
     let paths_clone = maildir_paths.clone();
     let raw_messages: Vec<Vec<u8>> = tokio::task::spawn_blocking(move || -> Result<Vec<Vec<u8>>> {
+        let canonical_data_dir = std::fs::canonicalize(&data_dir)
+            .unwrap_or_else(|_| data_dir.clone());
         let mut messages = Vec::with_capacity(paths_clone.len());
-        for (_, maildir_path) in &paths_clone {
+        for (msg_id, maildir_path) in &paths_clone {
+            // Skip non-disk entries (e.g. Graph API messages with "graph:" prefix)
+            if maildir_path.starts_with("graph:") {
+                return Err(Error::Other(format!(
+                    "Message {} is not stored on disk (Graph API). \
+                     Cross-account move requires locally synced messages.",
+                    msg_id
+                )));
+            }
+            let rel = std::path::Path::new(maildir_path);
+            if rel.is_absolute() || rel.components().any(|c| matches!(c, std::path::Component::ParentDir)) {
+                return Err(Error::Other(format!(
+                    "Invalid maildir path for message {}: '{}'",
+                    msg_id, maildir_path
+                )));
+            }
             let full_path = data_dir.join(maildir_path);
-            let bytes = std::fs::read(&full_path).map_err(|e| {
+            let canonical = std::fs::canonicalize(&full_path).map_err(|e| {
+                Error::Other(format!(
+                    "Failed to resolve maildir file {}: {}",
+                    full_path.display(), e
+                ))
+            })?;
+            if !canonical.starts_with(&canonical_data_dir) {
+                return Err(Error::Other(format!(
+                    "Path traversal detected for message {}", msg_id
+                )));
+            }
+            let bytes = std::fs::read(&canonical).map_err(|e| {
                 Error::Other(format!(
                     "Failed to read maildir file {}: {}",
-                    full_path.display(),
-                    e
+                    full_path.display(), e
                 ))
             })?;
             messages.push(bytes);

--- a/src-tauri/src/commands/actions.rs
+++ b/src-tauri/src/commands/actions.rs
@@ -252,6 +252,127 @@ pub async fn delete_messages(
     Ok(())
 }
 
+/// Move messages from one account to a folder in a *different* account.
+///
+/// Reads the raw RFC822 bytes from the source account's maildir, appends
+/// them to the destination folder via the destination protocol, and then
+/// deletes the source messages.
+#[tauri::command]
+pub async fn move_messages_cross_account(
+    app: tauri::AppHandle,
+    state: State<'_, AppState>,
+    source_account_id: String,
+    message_ids: Vec<String>,
+    target_account_id: String,
+    target_folder: String,
+) -> Result<()> {
+    log::info!(
+        "Cross-account move: {} -> {}/{} ({} messages)",
+        source_account_id,
+        target_account_id,
+        target_folder,
+        message_ids.len()
+    );
+
+    if source_account_id == target_account_id {
+        return Err(Error::Other(
+            "Use move_messages for same-account moves".into(),
+        ));
+    }
+
+    // Load target account and source maildir paths (scoped to source account)
+    let (target_account, maildir_paths) = {
+        let conn = state.db.lock().await;
+        let target = db::accounts::get_account_full(&conn, &target_account_id)?;
+        let paths = db::messages::get_maildir_paths(&conn, &source_account_id, &message_ids)?;
+        (target, paths)
+    };
+
+    if maildir_paths.len() != message_ids.len() {
+        return Err(Error::Other(format!(
+            "Cross-account move requires all messages to be synced locally \
+             (found {}/{} maildir files). Sync the source folder first.",
+            maildir_paths.len(),
+            message_ids.len()
+        )));
+    }
+
+    // Read raw bytes from disk using async I/O to avoid blocking the runtime
+    let data_dir = state.data_dir.clone();
+    let paths_clone = maildir_paths.clone();
+    let raw_messages: Vec<Vec<u8>> = tokio::task::spawn_blocking(move || -> Result<Vec<Vec<u8>>> {
+        let mut messages = Vec::with_capacity(paths_clone.len());
+        for (_, maildir_path) in &paths_clone {
+            let full_path = data_dir.join(maildir_path);
+            let bytes = std::fs::read(&full_path).map_err(|e| {
+                Error::Other(format!(
+                    "Failed to read maildir file {}: {}",
+                    full_path.display(),
+                    e
+                ))
+            })?;
+            messages.push(bytes);
+        }
+        Ok(messages)
+    })
+    .await
+    .map_err(|e| Error::Other(format!("Read task panicked: {}", e)))??;
+
+    // Append to destination
+    match target_account.mail_protocol.as_str() {
+        "imap" => {
+            let imap_config = build_imap_config(&target_account).await?;
+            let target_folder_clone = target_folder.clone();
+            tokio::task::spawn_blocking(move || -> Result<()> {
+                let mut conn = ImapConnection::connect(&imap_config)?;
+                for bytes in &raw_messages {
+                    conn.append_message_raw(&target_folder_clone, bytes)?;
+                }
+                conn.logout();
+                Ok(())
+            })
+            .await
+            .map_err(|e| Error::Other(format!("IMAP append task panicked: {}", e)))??;
+        }
+        "jmap" => {
+            let jmap_config =
+                crate::commands::sync_cmd::build_jmap_config(&target_account).await?;
+            let conn_jmap = crate::mail::jmap::JmapConnection::connect(&jmap_config).await?;
+            for bytes in &raw_messages {
+                conn_jmap
+                    .import_email_to_mailbox(&jmap_config, bytes, &target_folder, false)
+                    .await?;
+            }
+        }
+        "graph" => {
+            return Err(Error::Other(
+                "Cross-account move to Microsoft 365 (Graph) is not yet supported.".into(),
+            ));
+        }
+        other => {
+            return Err(Error::Other(format!(
+                "Unknown mail protocol for destination account: {}",
+                other
+            )));
+        }
+    }
+
+    // Append succeeded — delete from source
+    delete_messages(app.clone(), state, source_account_id.clone(), message_ids.clone()).await?;
+
+    // Emit events for the destination account too so its folder counts refresh
+    emit_messages_changed(&app, &target_account_id);
+    emit_folders_changed(&app, &target_account_id);
+
+    log::info!(
+        "Cross-account move complete: {} messages moved to {}/{}",
+        message_ids.len(),
+        target_account_id,
+        target_folder
+    );
+    Ok(())
+}
+
 /// Set or remove flags on messages (e.g., \Seen, \Flagged).
 #[tauri::command]
 pub async fn set_message_flags(

--- a/src-tauri/src/db/messages.rs
+++ b/src-tauri/src/db/messages.rs
@@ -400,6 +400,48 @@ pub fn get_message_uids(
     Ok(rows)
 }
 
+/// Returns (message_id, maildir_path) pairs for the given IDs within a specific account.
+/// Rows with empty maildir_path are omitted (message body not yet synced).
+pub fn get_maildir_paths(
+    conn: &Connection,
+    account_id: &str,
+    message_ids: &[String],
+) -> Result<Vec<(String, String)>> {
+    if message_ids.is_empty() {
+        return Ok(vec![]);
+    }
+
+    let placeholders: String = message_ids
+        .iter()
+        .enumerate()
+        .map(|(i, _)| format!("?{}", i + 2))
+        .collect::<Vec<_>>()
+        .join(",");
+
+    let query = format!(
+        "SELECT id, maildir_path FROM messages
+         WHERE account_id = ?1 AND id IN ({}) AND maildir_path != ''",
+        placeholders
+    );
+
+    let mut stmt = conn.prepare(&query)?;
+
+    let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
+    params.push(Box::new(account_id.to_string()));
+    for id in message_ids {
+        params.push(Box::new(id.clone()));
+    }
+    let param_refs: Vec<&dyn rusqlite::types::ToSql> = params.iter().map(|p| p.as_ref()).collect();
+
+    let rows = stmt
+        .query_map(param_refs.as_slice(), |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+
+    Ok(rows)
+}
+
 /// Delete messages from the local database by their IDs.
 pub fn delete_messages_by_ids(conn: &Connection, message_ids: &[String]) -> Result<()> {
     if message_ids.is_empty() {
@@ -842,4 +884,99 @@ pub fn unthread_message(conn: &Connection, message_id: &str) -> Result<()> {
         new_thread_id
     );
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::Connection;
+
+    fn setup_db() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE messages (
+                id TEXT PRIMARY KEY,
+                account_id TEXT NOT NULL,
+                folder_path TEXT NOT NULL,
+                uid INTEGER,
+                message_id TEXT,
+                in_reply_to TEXT,
+                thread_id TEXT,
+                subject TEXT,
+                from_name TEXT,
+                from_email TEXT,
+                to_addresses TEXT,
+                cc_addresses TEXT,
+                date TEXT NOT NULL,
+                size INTEGER,
+                has_attachments INTEGER DEFAULT 0,
+                is_encrypted INTEGER DEFAULT 0,
+                is_signed INTEGER DEFAULT 0,
+                flags TEXT DEFAULT '[]',
+                maildir_path TEXT,
+                snippet TEXT
+            );",
+        )
+        .unwrap();
+        conn
+    }
+
+    fn insert_row(conn: &Connection, id: &str, account_id: &str, maildir_path: &str) {
+        conn.execute(
+            "INSERT INTO messages (id, account_id, folder_path, date, maildir_path)
+             VALUES (?1, ?2, 'INBOX', '2026-04-11T00:00:00Z', ?3)",
+            params![id, account_id, maildir_path],
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn test_get_maildir_paths_returns_matching_rows() {
+        let conn = setup_db();
+        insert_row(&conn, "msg1", "acc1", "acc1/INBOX/cur/1:2,S");
+        insert_row(&conn, "msg2", "acc1", "acc1/INBOX/cur/2:2,S");
+        insert_row(&conn, "msg3", "acc1", "acc1/INBOX/cur/3:2,S");
+
+        let ids = vec!["msg1".to_string(), "msg3".to_string()];
+        let paths = get_maildir_paths(&conn, "acc1", &ids).unwrap();
+
+        assert_eq!(paths.len(), 2);
+        let map: std::collections::HashMap<_, _> = paths.into_iter().collect();
+        assert_eq!(map.get("msg1").map(String::as_str), Some("acc1/INBOX/cur/1:2,S"));
+        assert_eq!(map.get("msg3").map(String::as_str), Some("acc1/INBOX/cur/3:2,S"));
+    }
+
+    #[test]
+    fn test_get_maildir_paths_skips_empty_paths() {
+        let conn = setup_db();
+        insert_row(&conn, "msg1", "acc1", "acc1/INBOX/cur/1:2,S");
+        insert_row(&conn, "msg2", "acc1", "");
+
+        let ids = vec!["msg1".to_string(), "msg2".to_string()];
+        let paths = get_maildir_paths(&conn, "acc1", &ids).unwrap();
+
+        assert_eq!(paths.len(), 1);
+        assert_eq!(paths[0].0, "msg1");
+    }
+
+    #[test]
+    fn test_get_maildir_paths_scoped_by_account() {
+        let conn = setup_db();
+        insert_row(&conn, "msg1", "acc1", "acc1/INBOX/cur/1:2,S");
+        insert_row(&conn, "msg2", "acc2", "acc2/INBOX/cur/2:2,S");
+
+        // Requesting msg2 from acc1 should not return it
+        let ids = vec!["msg1".to_string(), "msg2".to_string()];
+        let paths = get_maildir_paths(&conn, "acc1", &ids).unwrap();
+
+        assert_eq!(paths.len(), 1);
+        assert_eq!(paths[0].0, "msg1");
+    }
+
+    #[test]
+    fn test_get_maildir_paths_empty_input() {
+        let conn = setup_db();
+        let paths = get_maildir_paths(&conn, "acc1", &[]).unwrap();
+        assert!(paths.is_empty());
+    }
 }

--- a/src-tauri/src/mail/imap.rs
+++ b/src-tauri/src/mail/imap.rs
@@ -560,6 +560,18 @@ impl ImapConnection {
         Ok(())
     }
 
+    /// Append a raw RFC5322 message to a folder preserving its original state
+    /// (no extra flags). Used for cross-account moves where we want to keep
+    /// the message as-is.
+    pub fn append_message_raw(&mut self, folder: &str, message: &[u8]) -> Result<()> {
+        log::info!("IMAP appending raw message ({} bytes) to folder '{}'", message.len(), folder);
+        self.session
+            .append(folder, message)
+            .map_err(|e| Error::Imap(format!("IMAP APPEND failed: {}", e)))?;
+        log::info!("IMAP raw message appended to '{}'", folder);
+        Ok(())
+    }
+
     /// Enter IMAP IDLE on the currently selected folder.
     /// Blocks until the server sends a notification (new mail, expunge, etc.)
     /// or the timeout expires. Returns true if there was a server notification.

--- a/src-tauri/src/mail/jmap.rs
+++ b/src-tauri/src/mail/jmap.rs
@@ -503,6 +503,73 @@ impl JmapConnection {
         self.api_request(&request, config).await?;
         Ok(())
     }
+    /// Import a raw RFC822 email into a specific mailbox on this account.
+    ///
+    /// Uploads the message as a blob, then issues Email/import so the server
+    /// stores it with the given mailbox membership and keywords. Used by
+    /// cross-account move.
+    pub async fn import_email_to_mailbox(
+        &self,
+        config: &JmapConfig,
+        raw_message: &[u8],
+        mailbox_id: &str,
+        seen: bool,
+    ) -> Result<()> {
+        log::debug!(
+            "JMAP importing {} bytes into mailbox {}",
+            raw_message.len(),
+            mailbox_id
+        );
+
+        let upload_url = self.upload_url_template
+            .replace("{accountId}", &self.account_id);
+        let resp = config.apply_auth(self.http.post(&upload_url))
+            .header("Content-Type", "message/rfc822")
+            .body(raw_message.to_vec())
+            .send().await
+            .map_err(|e| Error::Other(format!("JMAP upload failed: {}", e)))?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(Error::Other(format!("JMAP upload error {}: {}", status, body)));
+        }
+
+        let upload_resp: serde_json::Value = resp.json().await
+            .map_err(|e| Error::Other(format!("JMAP upload response parse error: {}", e)))?;
+        let blob_id = upload_resp["blobId"].as_str()
+            .ok_or_else(|| Error::Other("No blobId in upload response".into()))?
+            .to_string();
+
+        let mut keywords = serde_json::Map::new();
+        if seen {
+            keywords.insert("$seen".to_string(), serde_json::json!(true));
+        }
+
+        // Use a HashMap for mailboxIds so the key is the runtime value of
+        // mailbox_id, not the literal string "mailbox_id".
+        let mut mailbox_ids = serde_json::Map::new();
+        mailbox_ids.insert(mailbox_id.to_string(), serde_json::json!(true));
+
+        let request = serde_json::json!({
+            "using": ["urn:ietf:params:jmap:core", "urn:ietf:params:jmap:mail"],
+            "methodCalls": [
+                ["Email/import", {
+                    "accountId": self.account_id,
+                    "emails": {
+                        "e1": {
+                            "blobId": blob_id,
+                            "mailboxIds": mailbox_ids,
+                            "keywords": keywords
+                        }
+                    }
+                }, "i1"]
+            ]
+        });
+        self.api_request(&request, config).await?;
+        Ok(())
+    }
+
     pub async fn send_email(&self, config: &JmapConfig, raw_message: &[u8]) -> Result<()> {
         log::info!("JMAP sending email ({} bytes)", raw_message.len());
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -73,6 +73,7 @@ fn main() {
             commands::oauth::jmap_oidc_start,
             commands::oauth::jmap_oidc_complete,
             commands::actions::move_messages,
+            commands::actions::move_messages_cross_account,
             commands::actions::delete_messages,
             commands::actions::set_message_flags,
             commands::actions::copy_messages,

--- a/src/__tests__/cross-account-move.test.ts
+++ b/src/__tests__/cross-account-move.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-// Mock tauri invoke
-const invokeMock = vi.fn();
+// Use vi.hoisted so the mock is available before vi.mock's hoisted factory runs
+const { invokeMock } = vi.hoisted(() => ({ invokeMock: vi.fn() }));
 vi.mock("@tauri-apps/api/core", () => ({
   invoke: (...args: unknown[]) => invokeMock(...args),
 }));

--- a/src/__tests__/cross-account-move.test.ts
+++ b/src/__tests__/cross-account-move.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock tauri invoke
+const invokeMock = vi.fn();
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...args: unknown[]) => invokeMock(...args),
+}));
+
+import { moveMessagesCrossAccount } from "@/lib/tauri";
+
+describe("Cross-account move", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    invokeMock.mockResolvedValue(undefined);
+  });
+
+  it("invokes move_messages_cross_account with correct payload", async () => {
+    await moveMessagesCrossAccount("acc1", ["msg1", "msg2"], "acc2", "INBOX");
+    expect(invokeMock).toHaveBeenCalledWith("move_messages_cross_account", {
+      sourceAccountId: "acc1",
+      messageIds: ["msg1", "msg2"],
+      targetAccountId: "acc2",
+      targetFolder: "INBOX",
+    });
+  });
+
+  it("propagates errors from the backend", async () => {
+    invokeMock.mockRejectedValue(new Error("Cross-account move failed"));
+    await expect(
+      moveMessagesCrossAccount("acc1", ["msg1"], "acc2", "INBOX"),
+    ).rejects.toThrow("Cross-account move failed");
+  });
+});

--- a/src/components/mail/FolderTree.vue
+++ b/src/components/mail/FolderTree.vue
@@ -247,8 +247,10 @@ let dragExpandTimer: ReturnType<typeof setTimeout> | null = null;
 
 function onFolderMouseEnter(accountId: string, folderPath: string) {
   if (!isDragging.value) return;
-  if (dragSourceAccountId.value !== accountId) return;
-  if (foldersStore.activeFolderPath === folderPath && accountsStore.activeAccountId === accountId) return;
+  // Allow drops on any account (cross-account moves are supported)
+  if (dragSourceAccountId.value === accountId &&
+      foldersStore.activeFolderPath === folderPath &&
+      accountsStore.activeAccountId === accountId) return;
   dropTarget.value = `${accountId}:${folderPath}`;
   if (isFolderCollapsed(accountId, folderPath)) {
     dragExpandTimer = setTimeout(() => {
@@ -270,18 +272,29 @@ function onFolderMouseLeave(accountId: string, folderPath: string) {
 async function onFolderMouseUp(accountId: string, folderPath: string) {
   if (!isDragging.value || dragMessageIds.value.length === 0) return;
   dropTarget.value = null;
-  if (dragSourceAccountId.value !== accountId) return;
-  if (foldersStore.activeFolderPath === folderPath && accountsStore.activeAccountId === accountId) return;
+  const sourceAccountId = dragSourceAccountId.value;
+  if (!sourceAccountId) return;
+  if (sourceAccountId === accountId &&
+      foldersStore.activeFolderPath === folderPath &&
+      accountsStore.activeAccountId === accountId) return;
 
   const messageIds = [...dragMessageIds.value];
-  const moveToastId = showToast(`Moving ${messageIds.length} message(s)...`, "info", 0);
+  const isCrossAccount = sourceAccountId !== accountId;
+  const label = isCrossAccount ? "Moving (cross-account)" : "Moving";
+  const moveToastId = showToast(`${label} ${messageIds.length} message(s)...`, "info", 0);
   try {
-    await api.moveMessages(accountId, messageIds, folderPath);
+    if (isCrossAccount) {
+      await api.moveMessagesCrossAccount(sourceAccountId, messageIds, accountId, folderPath);
+    } else {
+      await api.moveMessages(accountId, messageIds, folderPath);
+    }
     messagesStore.clearSelection();
     messagesStore.activeMessage = null;
     messagesStore.activeMessageId = null;
   } catch (e) {
     console.error("Drag-and-drop move failed:", e);
+    const message = e instanceof Error ? e.message : String(e);
+    showToast(`Move failed: ${message}`, "error", 5000);
   } finally {
     dismissToast(moveToastId);
   }

--- a/src/components/mail/FolderTree.vue
+++ b/src/components/mail/FolderTree.vue
@@ -285,6 +285,10 @@ async function onFolderMouseUp(accountId: string, folderPath: string) {
   try {
     if (isCrossAccount) {
       await api.moveMessagesCrossAccount(sourceAccountId, messageIds, accountId, folderPath);
+      // Sync the destination account so the moved messages appear immediately
+      api.triggerSync(accountId, folderPath).catch((e) =>
+        console.error("Post-move sync failed:", e),
+      );
     } else {
       await api.moveMessages(accountId, messageIds, folderPath);
     }

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -147,6 +147,20 @@ export async function moveMessages(
   return invoke("move_messages", { accountId, messageIds, targetFolder });
 }
 
+export async function moveMessagesCrossAccount(
+  sourceAccountId: string,
+  messageIds: string[],
+  targetAccountId: string,
+  targetFolder: string,
+): Promise<void> {
+  return invoke("move_messages_cross_account", {
+    sourceAccountId,
+    messageIds,
+    targetAccountId,
+    targetFolder,
+  });
+}
+
 export async function deleteMessages(
   accountId: string,
   messageIds: string[],


### PR DESCRIPTION
## Summary

Implements #15 — move messages between different accounts by dragging them to a folder in another account's tree.

Supersedes #23 which was stale and had several bugs identified by Copilot review.

### Changes
- **Backend**: New `move_messages_cross_account` Tauri command with:
  - `AppHandle` for event emission on both source and destination accounts (fixes UI refresh bug)
  - `get_maildir_paths` scoped by `account_id` to prevent cross-account file access
  - `import_email_to_mailbox` JMAP helper with proper dynamic mailbox ID key (fixes `json!` literal key bug)
  - `append_message_raw` IMAP helper without `\Draft`/`\Seen` flags (fixes moved messages being marked as drafts)
  - Async file reads via `spawn_blocking` (fixes blocking the tokio runtime)
- **Frontend**: FolderTree drop handler routes to cross-account or same-account move, with toast notifications
- **Tests**: 4 Rust unit tests for `get_maildir_paths` + 2 frontend tests for invoke contract

### Bugs fixed from #23 review
- JMAP `json!({ mailbox_id: true })` used literal key instead of variable value
- IMAP append marked moved messages as `\Seen` + `\Draft`
- `get_maildir_paths` not scoped by account, allowing reads from unrelated accounts
- `std::fs::read` in async context blocked the tokio runtime
- No event emission meant UI never refreshed after cross-account move

## Test plan
- [x] Drag message from IMAP account to JMAP account folder
- [x] Drag message from JMAP account to IMAP account folder
- [x] Verify source folder count decrements and message disappears
- [x] Verify destination folder count increments after sync
- [x] Verify moved messages are not marked as Draft
- [x] Attempt drag to same folder (should be rejected)
- [x] `cargo test` — 93 tests pass
- [x] `pnpm test` — 162 tests pass