### PR TITLE
feat: mark all folders as read from account context menu

### DIFF
--- a/src-tauri/src/commands/actions.rs
+++ b/src-tauri/src/commands/actions.rs
@@ -498,7 +498,7 @@ pub async fn mark_account_read(
             let folders = db::folders::list_folders(&conn, &account_id)?;
             folders.into_iter().map(|f| f.path).collect()
         };
-        tokio::task::spawn_blocking(move || -> Result<()> {
+        let imap_result = tokio::task::spawn_blocking(move || -> Result<()> {
             let mut conn = ImapConnection::connect(&imap_config)?;
             for folder_path in &folder_paths {
                 if let Err(e) = conn.select_folder(folder_path) {
@@ -513,9 +513,11 @@ pub async fn mark_account_read(
             Ok(())
         })
         .await
-        .map_err(|e| Error::Other(format!("Mark account read task panicked: {}", e)))??;
+        .map_err(|e| Error::Other(format!("Mark account read task panicked: {}", e)))?;
 
+        // Always resume IDLE, even if the mark-read operation failed
         resume_imap_idle_for_account(&app, &state, &resume_account, suspended_idle).await?;
+        imap_result?;
     } else if account.mail_protocol == "jmap" {
         // JMAP: bulk update all unread emails to $seen via Email/set
         let jmap_config = crate::commands::sync_cmd::build_jmap_config(&account).await?;

--- a/src-tauri/src/commands/actions.rs
+++ b/src-tauri/src/commands/actions.rs
@@ -447,6 +447,127 @@ pub async fn copy_messages(
     Ok(())
 }
 
+/// Mark all messages in all folders of an account as read.
+/// Updates both the remote server and local DB.
+#[tauri::command]
+pub async fn mark_account_read(
+    app: tauri::AppHandle,
+    state: State<'_, AppState>,
+    account_id: String,
+) -> Result<u64> {
+    log::info!("Marking all messages as read for account {}", account_id);
+
+    let account = {
+        let conn = state.db.lock().await;
+        db::accounts::get_account_full(&conn, &account_id)?
+    };
+
+    // Mark read on the server first
+    if account.mail_protocol == "graph" {
+        let unread_ids = {
+            let conn = state.db.lock().await;
+            let mut stmt = conn.prepare(
+                "SELECT id FROM messages WHERE account_id = ?1 AND flags NOT LIKE '%seen%'",
+            ).map_err(crate::error::Error::Database)?;
+            let ids: Vec<String> = stmt
+                .query_map(rusqlite::params![&account_id], |row| row.get::<_, String>(0))
+                .map_err(crate::error::Error::Database)?
+                .filter_map(|r| r.ok())
+                .collect();
+            ids
+        };
+        if !unread_ids.is_empty() {
+            let token = crate::mail::graph::get_graph_token(&account_id).await?;
+            let client = crate::mail::graph::GraphClient::new(&token);
+            let graph_ids: Vec<String> = unread_ids.iter().map(|mid| {
+                mid.strip_prefix(&format!("{}_", account_id)).unwrap_or(mid).to_string()
+            }).collect();
+            client.set_read_status(&graph_ids, true).await?;
+        }
+    } else if account.mail_protocol == "imap" {
+        // IMAP: SELECT each folder and STORE +FLAGS \Seen on all messages
+        let suspended_idle = if should_suspend_idle_for_imap_operation(&account.provider) {
+            suspend_imap_idle_for_account(&state, &account_id).await?
+        } else {
+            false
+        };
+        let resume_account = account.clone();
+        let imap_config = build_imap_config(&account).await?;
+        let folder_paths: Vec<String> = {
+            let conn = state.db.lock().await;
+            let folders = db::folders::list_folders(&conn, &account_id)?;
+            folders.into_iter().map(|f| f.path).collect()
+        };
+        tokio::task::spawn_blocking(move || -> Result<()> {
+            let mut conn = ImapConnection::connect(&imap_config)?;
+            for folder_path in &folder_paths {
+                if let Err(e) = conn.select_folder(folder_path) {
+                    log::warn!("Cannot select '{}' for mark-read: {}", folder_path, e);
+                    continue;
+                }
+                if let Err(e) = conn.mark_all_seen() {
+                    log::warn!("Mark all seen failed on '{}': {}", folder_path, e);
+                }
+            }
+            conn.logout();
+            Ok(())
+        })
+        .await
+        .map_err(|e| Error::Other(format!("Mark account read task panicked: {}", e)))??;
+
+        resume_imap_idle_for_account(&app, &state, &resume_account, suspended_idle).await?;
+    } else if account.mail_protocol == "jmap" {
+        // JMAP: bulk update all unread emails to $seen via Email/set
+        let jmap_config = crate::commands::sync_cmd::build_jmap_config(&account).await?;
+        let conn_jmap = crate::mail::jmap::JmapConnection::connect(&jmap_config).await?;
+
+        let unread_ids: Vec<String> = {
+            let conn = state.db.lock().await;
+            let mut stmt = conn.prepare(
+                "SELECT id FROM messages WHERE account_id = ?1 AND flags NOT LIKE '%seen%'",
+            ).map_err(crate::error::Error::Database)?;
+            let rows = stmt.query_map(rusqlite::params![&account_id], |row| row.get::<_, String>(0))
+                .map_err(crate::error::Error::Database)?;
+            let ids: Vec<String> = rows.filter_map(|r| r.ok()).collect();
+            ids
+        };
+
+        if !unread_ids.is_empty() {
+            // Extract JMAP email IDs from composite message IDs
+            let jmap_ids: Vec<String> = unread_ids.iter().map(|mid| {
+                let parts: Vec<&str> = mid.splitn(3, '_').collect();
+                if parts.len() == 3 { parts[2].to_string() } else { mid.clone() }
+            }).collect();
+
+            let flag_strs = vec!["seen"];
+            conn_jmap.set_flags(&jmap_config, &jmap_ids, &flag_strs, true).await?;
+        }
+    }
+
+    // Update local DB
+    let updated = {
+        let conn = state.db.lock().await;
+        let count = conn.execute(
+            "UPDATE messages SET flags = json_insert(flags, '$[#]', 'seen')
+             WHERE account_id = ?1 AND flags NOT LIKE '%seen%'",
+            rusqlite::params![account_id],
+        ).map_err(crate::error::Error::Database)?;
+        db::folders::recalculate_folder_counts(&conn, &account_id)?;
+        count
+    };
+
+    log::info!(
+        "mark_account_read: updated {} messages for account {}",
+        updated,
+        account_id,
+    );
+
+    emit_messages_changed(&app, &account_id);
+    emit_folders_changed(&app, &account_id);
+
+    Ok(updated as u64)
+}
+
 /// Group message UIDs by their folder path.
 ///
 /// Takes (message_id, folder_path, uid) rows and returns a HashMap

--- a/src-tauri/src/mail/graph.rs
+++ b/src-tauri/src/mail/graph.rs
@@ -429,9 +429,20 @@ impl GraphClient {
 
     /// Mark messages as read or unread.
     pub async fn set_read_status(&self, message_ids: &[String], is_read: bool) -> Result<()> {
-        let body = serde_json::json!({ "isRead": is_read });
-        for id in message_ids {
-            self.patch_json(&format!("/me/messages/{}", id), &body).await?;
+        // Batch up to 20 requests per $batch call (Graph API limit)
+        for chunk in message_ids.chunks(20) {
+            let requests: Vec<serde_json::Value> = chunk.iter().enumerate().map(|(i, id)| {
+                serde_json::json!({
+                    "id": format!("{}", i),
+                    "method": "PATCH",
+                    "url": format!("/me/messages/{}", id),
+                    "headers": { "Content-Type": "application/json" },
+                    "body": { "isRead": is_read }
+                })
+            }).collect();
+
+            let batch_body = serde_json::json!({ "requests": requests });
+            self.post_json("/$batch", &batch_body).await?;
         }
         Ok(())
     }

--- a/src-tauri/src/mail/imap.rs
+++ b/src-tauri/src/mail/imap.rs
@@ -497,6 +497,14 @@ impl ImapConnection {
         Ok(())
     }
 
+    /// Mark all messages in the currently selected folder as \Seen.
+    pub fn mark_all_seen(&mut self) -> Result<()> {
+        self.session
+            .uid_store("1:*", "+FLAGS (\\Seen)")
+            .map_err(|e| Error::Imap(format!("STORE +FLAGS \\Seen failed: {}", e)))?;
+        Ok(())
+    }
+
     /// Fetch current flags for all messages in the selected folder.
     /// Returns a map of UID → flags vec. Uses `1:*` to get everything.
     pub fn fetch_all_flags(&mut self) -> Result<Vec<(u32, Vec<String>)>> {

--- a/src-tauri/src/mail/imap.rs
+++ b/src-tauri/src/mail/imap.rs
@@ -498,10 +498,12 @@ impl ImapConnection {
     }
 
     /// Mark all messages in the currently selected folder as \Seen.
+    /// Uses .SILENT to suppress per-message FETCH responses, which can be
+    /// very large on folders with many messages.
     pub fn mark_all_seen(&mut self) -> Result<()> {
         self.session
-            .uid_store("1:*", "+FLAGS (\\Seen)")
-            .map_err(|e| Error::Imap(format!("STORE +FLAGS \\Seen failed: {}", e)))?;
+            .uid_store("1:*", "+FLAGS.SILENT (\\Seen)")
+            .map_err(|e| Error::Imap(format!("STORE +FLAGS.SILENT \\Seen failed: {}", e)))?;
         Ok(())
     }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -76,6 +76,7 @@ fn main() {
             commands::actions::delete_messages,
             commands::actions::set_message_flags,
             commands::actions::copy_messages,
+            commands::actions::mark_account_read,
             commands::filters::list_filters,
             commands::filters::save_filter,
             commands::filters::delete_filter,

--- a/src/components/mail/FolderTree.vue
+++ b/src/components/mail/FolderTree.vue
@@ -167,6 +167,22 @@ function openNewFolderFromAccount() {
   showNewFolderModal.value = true;
 }
 
+async function markAccountRead() {
+  const accountId = accountMenu.value?.accountId;
+  if (!accountId) return;
+  closeContextMenu();
+
+  try {
+    await api.markAccountRead(accountId);
+    await foldersStore.fetchAllAccountFolders();
+    if (accountsStore.activeAccountId === accountId) {
+      await messagesStore.fetchMessages();
+    }
+  } catch (e) {
+    console.error("Mark account read failed:", e);
+  }
+}
+
 async function syncThisFolder() {
   if (!contextMenu.value) return;
   const { folder, accountId } = contextMenu.value;
@@ -477,7 +493,8 @@ async function doDeleteFolder() {
         class="folder-context-menu"
         :style="{ left: accountMenu.x + 'px', top: accountMenu.y + 'px' }"
       >
-        <button class="ctx-item" @click="openNewFolderFromAccount">New Folder...</button>
+        <button class="ctx-item" data-testid="ctx-account-mark-read" @click="markAccountRead">Mark All Read</button>
+        <button class="ctx-item" data-testid="ctx-account-new-folder" @click="openNewFolderFromAccount">New Folder...</button>
       </div>
     </Teleport>
 

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -171,6 +171,10 @@ export async function copyMessages(
   return invoke("copy_messages", { accountId, messageIds, targetFolder });
 }
 
+export async function markAccountRead(accountId: string): Promise<number> {
+  return invoke("mark_account_read", { accountId });
+}
+
 // Threading
 export async function getThreadedMessages(
   accountId: string,


### PR DESCRIPTION
## Summary

Supersedes #9 — reimplemented cleanly on top of current main.

- Adds "Mark All Read" to the account right-click context menu
- Server-side propagation for IMAP (SELECT each folder + STORE +FLAGS \Seen), Graph (bulk set_read_status), and JMAP (Email/set with $seen keyword)
- Proper IDLE suspend/resume for IMAP operations
- Event emission for UI refresh after update
- `data-testid` on new menu items

### Bugs fixed from #9 review
- Copilot flagged the original as local-only (flags would revert on sync) — this version propagates to the server for all protocols
- Removed redundant double folder refresh

## Test plan
- [x] Right-click account → "Mark All Read" marks all messages as read
- [x] Folder unread counts update immediately
- [x] `cargo test` — 89 tests pass
- [x] `pnpm test` — 162 tests pass
- [x] Tested combined with cross-account move — no regressions