### PR TITLE
fix: address security audit findings

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -576,6 +576,7 @@ dependencies = [
  "jmap-client",
  "keyring",
  "lettre",
+ "libc",
  "log",
  "mail-parser",
  "maildir",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -43,5 +43,8 @@ sha2 = "0.10"
 base64 = "0.22"
 rand = "0.9"
 
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [build-dependencies]
 tauri-build = { version = "2", features = [] }

--- a/src-tauri/src/commands/compose.rs
+++ b/src-tauri/src/commands/compose.rs
@@ -240,6 +240,40 @@ pub async fn save_draft(
 fn read_attachments(attachments: &[FileAttachment]) -> Result<Vec<smtp::AttachmentData>> {
     let mut result = Vec::new();
     for att in attachments {
+        let path = std::path::Path::new(&att.path);
+
+        // Reject relative paths
+        if !path.is_absolute() {
+            return Err(crate::error::Error::Other(format!(
+                "Attachment path must be absolute: '{}'", att.path
+            )));
+        }
+
+        // Reject paths containing ".." components
+        for component in path.components() {
+            if matches!(component, std::path::Component::ParentDir) {
+                return Err(crate::error::Error::Other(format!(
+                    "Attachment path must not contain '..': '{}'", att.path
+                )));
+            }
+        }
+
+        // Warn on unusual paths outside typical user directories
+        let path_str = att.path.as_str();
+        let is_typical = if cfg!(unix) {
+            path_str.starts_with("/home/")
+                || path_str.starts_with("/tmp/")
+                || path_str.starts_with("/Users/")
+                || path_str.starts_with("/var/tmp/")
+        } else {
+            // Windows
+            path_str.starts_with("C:\\Users\\")
+                || path_str.starts_with("C:\\Temp\\")
+        };
+        if !is_typical {
+            log::warn!("Attachment from unusual path: '{}'", att.path);
+        }
+
         let data = std::fs::read(&att.path)
             .map_err(|e| crate::error::Error::Other(format!("Failed to read attachment '{}': {}", att.path, e)))?;
         let content_type = mime_guess::from_path(&att.name)

--- a/src-tauri/src/commands/mail.rs
+++ b/src-tauri/src/commands/mail.rs
@@ -780,6 +780,10 @@ pub async fn save_attachment(
         }
         drop(file);
 
+        // On Windows, rename fails if dest exists. Remove it first.
+        if dest_path.exists() {
+            let _ = std::fs::remove_file(dest_path);
+        }
         if let Err(e) = std::fs::rename(&temp_path, dest_path) {
             let _ = std::fs::remove_file(&temp_path);
             return Err(Error::Other(format!("Failed to rename temp file: {}", e)));

--- a/src-tauri/src/commands/mail.rs
+++ b/src-tauri/src/commands/mail.rs
@@ -698,16 +698,93 @@ pub async fn save_attachment(
         Error::Other("Invalid save path".to_string())
     })?;
 
-    // Refuse to follow symlinks — prevents clobbering arbitrary files
-    if dest_path.is_symlink() {
-        return Err(Error::Other(
-            "Refusing to write to a symlink target".to_string(),
-        ));
+    // Refuse to follow symlinks
+    if let Ok(metadata) = std::fs::symlink_metadata(dest_path) {
+        if metadata.file_type().is_symlink() {
+            return Err(Error::Other(
+                "Refusing to write to a symlink target".to_string(),
+            ));
+        }
     }
 
-    std::fs::write(dest_path, &contents).map_err(|e| {
-        Error::Other(format!("Failed to write attachment: {}", e))
+    // Write atomically: temp file + fsync + rename
+    let dest_dir = dest_path.parent().ok_or_else(|| {
+        Error::Other("Save path must have a parent directory".to_string())
     })?;
+    let dest_name = dest_path.file_name().ok_or_else(|| {
+        Error::Other("Save path must include a file name".to_string())
+    })?;
+    let unique_suffix = format!(
+        "{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_or(0, |d| d.as_nanos())
+    );
+    let temp_path = dest_dir.join(format!(
+        ".{}.{}.tmp",
+        dest_name.to_string_lossy(),
+        unique_suffix
+    ));
+
+    #[cfg(unix)]
+    {
+        use std::io::Write;
+        use std::os::unix::fs::OpenOptionsExt;
+
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .custom_flags(libc::O_NOFOLLOW)
+            .open(&temp_path)
+            .map_err(|e| Error::Other(format!("Failed to create temp file: {}", e)))?;
+
+        if let Err(e) = file.write_all(&contents) {
+            let _ = std::fs::remove_file(&temp_path);
+            return Err(Error::Other(format!("Failed to write attachment: {}", e)));
+        }
+        if let Err(e) = file.sync_all() {
+            let _ = std::fs::remove_file(&temp_path);
+            return Err(Error::Other(format!("Failed to flush attachment: {}", e)));
+        }
+        drop(file);
+
+        if let Err(e) = std::fs::rename(&temp_path, dest_path) {
+            let _ = std::fs::remove_file(&temp_path);
+            return Err(Error::Other(format!("Failed to rename temp file: {}", e)));
+        }
+
+        // Fsync parent directory for durability
+        if let Ok(dir) = std::fs::File::open(dest_dir) {
+            let _ = dir.sync_all();
+        }
+    }
+
+    #[cfg(not(unix))]
+    {
+        use std::io::Write;
+
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&temp_path)
+            .map_err(|e| Error::Other(format!("Failed to create temp file: {}", e)))?;
+
+        if let Err(e) = file.write_all(&contents) {
+            let _ = std::fs::remove_file(&temp_path);
+            return Err(Error::Other(format!("Failed to write attachment: {}", e)));
+        }
+        if let Err(e) = file.sync_all() {
+            let _ = std::fs::remove_file(&temp_path);
+            return Err(Error::Other(format!("Failed to flush attachment: {}", e)));
+        }
+        drop(file);
+
+        if let Err(e) = std::fs::rename(&temp_path, dest_path) {
+            let _ = std::fs::remove_file(&temp_path);
+            return Err(Error::Other(format!("Failed to rename temp file: {}", e)));
+        }
+    }
 
     log::info!("Attachment saved to {}", dest_path.display());
     Ok(())

--- a/src-tauri/src/commands/oauth.rs
+++ b/src-tauri/src/commands/oauth.rs
@@ -32,7 +32,15 @@ fn store_session(port: u16, session: OAuthSession) {
 
 fn take_session(port: u16) -> Option<OAuthSession> {
     let mut guard = OAUTH_SESSIONS.lock().unwrap();
-    guard.as_mut().and_then(|map| map.remove(&port))
+    guard.as_mut().and_then(|map| {
+        let session = map.remove(&port)?;
+        // Reject expired sessions
+        if Instant::now().duration_since(session.created_at) >= SESSION_TTL {
+            log::warn!("OAuth session on port {} expired", port);
+            return None;
+        }
+        Some(session)
+    })
 }
 
 fn get_provider(name: &str) -> Result<&'static oauth::OAuthProvider> {

--- a/src-tauri/src/commands/oauth.rs
+++ b/src-tauri/src/commands/oauth.rs
@@ -1,21 +1,37 @@
+use std::collections::HashMap;
+use std::net::TcpListener;
 use std::sync::Mutex;
+use std::time::{Duration, Instant};
 use tauri::State;
 
 use crate::error::{Error, Result};
 use crate::oauth;
 use crate::state::AppState;
 
-/// Temporary storage for PKCE code verifiers (needed between start and complete).
-static PKCE_VERIFIERS: Mutex<Option<std::collections::HashMap<u16, String>>> = Mutex::new(None);
+/// Maximum time an OAuth session is valid before being evicted.
+const SESSION_TTL: Duration = Duration::from_secs(300);
 
-fn store_verifier(port: u16, verifier: String) {
-    let mut guard = PKCE_VERIFIERS.lock().unwrap();
-    let map = guard.get_or_insert_with(std::collections::HashMap::new);
-    map.insert(port, verifier);
+/// Per-session state stored between oauth_start and oauth_complete.
+struct OAuthSession {
+    verifier: Option<String>,
+    state: String,
+    listener: TcpListener,
+    created_at: Instant,
 }
 
-fn take_verifier(port: u16) -> Option<String> {
-    let mut guard = PKCE_VERIFIERS.lock().unwrap();
+static OAUTH_SESSIONS: Mutex<Option<HashMap<u16, OAuthSession>>> = Mutex::new(None);
+
+fn store_session(port: u16, session: OAuthSession) {
+    let mut guard = OAUTH_SESSIONS.lock().unwrap();
+    let map = guard.get_or_insert_with(HashMap::new);
+    // Evict expired sessions to prevent unbounded growth
+    let now = Instant::now();
+    map.retain(|_, s| now.duration_since(s.created_at) < SESSION_TTL);
+    map.insert(port, session);
+}
+
+fn take_session(port: u16) -> Option<OAuthSession> {
+    let mut guard = OAUTH_SESSIONS.lock().unwrap();
     guard.as_mut().and_then(|map| map.remove(&port))
 }
 
@@ -34,12 +50,17 @@ pub async fn oauth_start(
 ) -> Result<OAuthStartResult> {
     let prov = get_provider(&provider)?;
 
-    let (url, port, code_verifier) = oauth::get_auth_url(prov)?;
+    let (url, listener, code_verifier, state) = oauth::get_auth_url(prov)?;
+    let port = listener.local_addr()
+        .map_err(|e| Error::Other(format!("Failed to get port: {}", e)))?
+        .port();
 
-    // Store the PKCE verifier for use in oauth_complete
-    if let Some(verifier) = code_verifier {
-        store_verifier(port, verifier);
-    }
+    store_session(port, OAuthSession {
+        verifier: code_verifier,
+        state,
+        listener,
+        created_at: Instant::now(),
+    });
 
     log::info!("OAuth2: started {} flow on port {}", provider, port);
     Ok(OAuthStartResult { url, port })
@@ -52,7 +73,7 @@ pub struct OAuthStartResult {
 }
 
 /// Wait for the OAuth2 callback and exchange the code for tokens.
-/// This blocks until the user completes the browser flow.
+/// This blocks until the user completes the browser flow or 5 minutes elapse.
 #[tauri::command]
 pub async fn oauth_complete(
     _state: State<'_, AppState>,
@@ -62,18 +83,41 @@ pub async fn oauth_complete(
 ) -> Result<()> {
     let prov = get_provider(&provider)?;
 
-    // Retrieve the PKCE verifier if this provider uses PKCE
-    let code_verifier = take_verifier(port);
+    let session = take_session(port)
+        .ok_or_else(|| Error::Other(format!(
+            "No OAuth session found for port {} (expired or never started)", port
+        )))?;
+
+    let expected_state = session.state.clone();
+    let code_verifier = session.verifier.clone();
 
     // Wait for callback in a blocking thread (TcpListener::accept blocks)
-    let code = tokio::task::spawn_blocking(move || {
-        oauth::wait_for_callback(port)
+    let result = tokio::task::spawn_blocking(move || {
+        oauth::wait_for_callback(session.listener)
     })
     .await
     .map_err(|e| Error::Other(format!("OAuth callback task failed: {}", e)))??;
 
+    // Validate CSRF state parameter
+    match result.state {
+        Some(ref returned_state) if returned_state == &expected_state => {
+            log::debug!("OAuth2: state parameter validated");
+        }
+        Some(ref returned_state) => {
+            return Err(Error::Other(format!(
+                "OAuth2 state mismatch (possible CSRF): expected={}, got={}",
+                expected_state, returned_state
+            )));
+        }
+        None => {
+            return Err(Error::Other(
+                "OAuth2 callback missing required state parameter".into(),
+            ));
+        }
+    }
+
     // Exchange code for tokens
-    let tokens = oauth::exchange_code(prov, &code, port, code_verifier.as_deref()).await?;
+    let tokens = oauth::exchange_code(prov, &result.code, port, code_verifier.as_deref()).await?;
 
     // Store tokens in keyring
     oauth::store_tokens(&account_id, &tokens)?;
@@ -116,8 +160,6 @@ pub async fn oauth_has_tokens(
 }
 
 /// Fetch the user's profile (display name + email) from Microsoft Graph.
-/// Used to auto-fill the account form after OAuth sign-in.
-/// The initial token may be IMAP-scoped, so we refresh with Graph scopes first.
 #[tauri::command]
 pub async fn oauth_get_ms_profile(
     account_id: String,
@@ -128,14 +170,12 @@ pub async fn oauth_get_ms_profile(
     let refresh_token = tokens.refresh_token.as_deref()
         .ok_or_else(|| Error::Other("No refresh token for profile fetch".into()))?;
 
-    // The initial token is IMAP-scoped. Get a Graph-scoped token for /me.
     let graph_tokens = oauth::refresh_with_scopes(
         &oauth::MICROSOFT,
         refresh_token,
         oauth::MICROSOFT_GRAPH_SCOPES,
     ).await?;
 
-    // Save the potentially rotated refresh token
     oauth::store_tokens(&account_id, &oauth::OAuthTokens {
         access_token: tokens.access_token,
         refresh_token: graph_tokens.refresh_token,
@@ -155,28 +195,23 @@ pub async fn oauth_get_ms_profile(
 #[derive(serde::Serialize)]
 pub struct MsProfile {
     pub display_name: String,
-    /// The actual mailbox email (e.g., outlook_...@outlook.com)
     pub email: String,
-    /// The Microsoft login identity (e.g., kushaldas@gmail.com) — used for IMAP XOAUTH2
     pub login_email: String,
 }
 
-/// Start the JMAP OIDC device flow. Performs OIDC discovery, requests a device code,
-/// and returns the user code + verification URL for the user to complete in their browser.
+/// Start the JMAP OIDC device flow.
 #[tauri::command]
 pub async fn jmap_oidc_start(
     jmap_url: String,
     email: String,
     client_id: String,
 ) -> Result<JmapOidcStartResult> {
-    // Derive base URL from jmap_url or email domain (with auto-discovery)
     let base_url = if !jmap_url.is_empty() {
         jmap_url.trim_end_matches('/').to_string()
     } else {
         let domain = email.rsplit_once('@')
             .map(|(_, d)| d)
             .ok_or_else(|| Error::Other(format!("Cannot extract domain from '{}'", email)))?;
-        // Try the same candidates as JMAP auto-discovery
         let candidates = [
             format!("https://{}", domain),
             format!("https://mail.{}", domain),
@@ -201,32 +236,24 @@ pub async fn jmap_oidc_start(
         )))?
     };
 
-    // Discover OIDC endpoints
     let endpoints = crate::oauth::discover_oidc(&base_url).await?;
 
     let device_auth_endpoint = endpoints.device_authorization_endpoint
         .ok_or_else(|| Error::Other(
-            "Server does not support device authorization flow (no device_authorization_endpoint in OIDC discovery)".into()
+            "Server does not support device authorization flow".into()
         ))?;
 
-    // Use provided client_id, or register a new one via RFC 7591
     let effective_client_id = if !client_id.trim().is_empty() {
-        log::info!("JMAP OIDC: reusing existing client_id");
         client_id.trim().to_string()
     } else if let Some(ref reg_endpoint) = endpoints.registration_endpoint {
         crate::oauth::register_oidc_client(reg_endpoint).await?
     } else {
         return Err(Error::Other(
-            "OIDC requires a client_id but none was provided and the server does not support dynamic client registration. \
-             Register a client in your identity provider and enter its client_id.".into()
+            "OIDC requires a client_id but none was provided and the server does not support dynamic client registration.".into()
         ));
     };
 
-    // Request device code
     let device_resp = crate::oauth::device_auth_start(&device_auth_endpoint, &effective_client_id).await?;
-
-    log::info!("JMAP OIDC device flow: verification_uri={}, client_id={}",
-        device_resp.verification_uri, effective_client_id);
 
     Ok(JmapOidcStartResult {
         verification_uri: device_resp.verification_uri.clone(),
@@ -270,7 +297,6 @@ pub async fn jmap_oidc_complete(
         &client_id,
     ).await?;
 
-    // Store tokens in keyring
     crate::oauth::store_tokens(&account_id, &tokens)?;
 
     log::info!("JMAP OIDC: device flow completed for account {}", account_id);

--- a/src-tauri/src/db/messages.rs
+++ b/src-tauri/src/db/messages.rs
@@ -132,7 +132,8 @@ pub fn insert_message(conn: &Connection, msg: &NewMessage) -> Result<()> {
 }
 
 /// Build extra SQL WHERE clauses for quick filter options.
-/// All clauses are safe (no user-supplied strings injected into SQL).
+/// Text search terms are escaped (FTS5 quoting or LIKE backslash escaping)
+/// before interpolation. Other filter fields use fixed SQL patterns.
 fn build_filter_clauses(filter: &QuickFilter, account_id: &str, use_fts: bool) -> String {
     let mut clauses = Vec::new();
     if filter.unread {

--- a/src-tauri/src/db/messages.rs
+++ b/src-tauri/src/db/messages.rs
@@ -133,7 +133,7 @@ pub fn insert_message(conn: &Connection, msg: &NewMessage) -> Result<()> {
 
 /// Build extra SQL WHERE clauses for quick filter options.
 /// All clauses are safe (no user-supplied strings injected into SQL).
-fn build_filter_clauses(filter: &QuickFilter, account_id: &str) -> String {
+fn build_filter_clauses(filter: &QuickFilter, account_id: &str, use_fts: bool) -> String {
     let mut clauses = Vec::new();
     if filter.unread {
         clauses.push("flags NOT LIKE '%seen%'".to_string());
@@ -158,45 +158,61 @@ fn build_filter_clauses(filter: &QuickFilter, account_id: &str) -> String {
             acct = account_id.replace('\'', "''")
         ));
     }
-    // Text search via FTS5 for fast full-text matching
+    // Text search
     let text = filter.text.trim();
     if !text.is_empty() {
-        // Escape FTS5 special characters: quotes and single quotes
-        let escaped = text
-            .replace('"', "\"\"")
-            .replace('\'', "''");
-
-        // Determine which FTS5 columns to search (default: all)
+        // Determine which columns to search (default: all)
         let fields = &filter.text_fields;
         let search_sender = fields.is_empty() || fields.iter().any(|f| f == "sender");
         let search_recipients = fields.is_empty() || fields.iter().any(|f| f == "recipients");
         let search_subject = fields.is_empty() || fields.iter().any(|f| f == "subject");
         let search_body = fields.is_empty() || fields.iter().any(|f| f == "body");
 
-        let mut fts_columns = Vec::new();
-        if search_sender {
-            fts_columns.push("from_name");
-            fts_columns.push("from_email");
-        }
-        if search_recipients {
-            fts_columns.push("to_addresses");
-            fts_columns.push("cc_addresses");
-        }
-        if search_subject {
-            fts_columns.push("subject");
-        }
-        if search_body {
-            fts_columns.push("snippet");
-        }
+        if use_fts {
+            // FTS5 for fast full-text matching
+            let escaped = text
+                .replace('"', "\"\"")
+                .replace('\'', "''");
 
-        if !fts_columns.is_empty() {
-            // Build FTS5 column filter: {col1 col2 col3} : "term"
-            let col_filter = format!("{{{}}}", fts_columns.join(" "));
-            // Use prefix matching with * for partial word search
-            clauses.push(format!(
-                "rowid IN (SELECT rowid FROM messages_fts WHERE messages_fts MATCH '{} : \"{}\"*')",
-                col_filter, escaped
-            ));
+            let mut fts_columns = Vec::new();
+            if search_sender { fts_columns.push("from_name"); fts_columns.push("from_email"); }
+            if search_recipients { fts_columns.push("to_addresses"); fts_columns.push("cc_addresses"); }
+            if search_subject { fts_columns.push("subject"); }
+            if search_body { fts_columns.push("snippet"); }
+
+            if !fts_columns.is_empty() {
+                let col_filter = format!("{{{}}}", fts_columns.join(" "));
+                clauses.push(format!(
+                    "rowid IN (SELECT rowid FROM messages_fts WHERE messages_fts MATCH '{} : \"{}\"*')",
+                    col_filter, escaped
+                ));
+            }
+        } else {
+            // LIKE fallback — escape backslash first, then SQL special chars
+            let like_escaped = text
+                .replace('\\', "\\\\")
+                .replace('\'', "''")
+                .replace('%', "\\%")
+                .replace('_', "\\_");
+
+            let mut like_clauses = Vec::new();
+            if search_sender {
+                like_clauses.push(format!("from_name LIKE '%{}%' ESCAPE '\\'", like_escaped));
+                like_clauses.push(format!("from_email LIKE '%{}%' ESCAPE '\\'", like_escaped));
+            }
+            if search_recipients {
+                like_clauses.push(format!("to_addresses LIKE '%{}%' ESCAPE '\\'", like_escaped));
+                like_clauses.push(format!("cc_addresses LIKE '%{}%' ESCAPE '\\'", like_escaped));
+            }
+            if search_subject {
+                like_clauses.push(format!("subject LIKE '%{}%' ESCAPE '\\'", like_escaped));
+            }
+            if search_body {
+                like_clauses.push(format!("snippet LIKE '%{}%' ESCAPE '\\'", like_escaped));
+            }
+            if !like_clauses.is_empty() {
+                clauses.push(format!("({})", like_clauses.join(" OR ")));
+            }
         }
     }
     if clauses.is_empty() {
@@ -216,7 +232,30 @@ pub fn get_messages(
     sort_asc: bool,
     filter: &QuickFilter,
 ) -> Result<MessagePage> {
-    let filter_sql = build_filter_clauses(filter, account_id);
+    // Try FTS5 first; on failure (bad query syntax), fall back to LIKE
+    let has_text = !filter.text.trim().is_empty();
+    match get_messages_inner(conn, account_id, folder_path, page, per_page, sort_column, sort_asc, filter, true) {
+        Ok(page) => return Ok(page),
+        Err(e) if has_text => {
+            log::warn!("FTS5 query failed, retrying with LIKE fallback: {}", e);
+            return get_messages_inner(conn, account_id, folder_path, page, per_page, sort_column, sort_asc, filter, false);
+        }
+        Err(e) => return Err(e),
+    }
+}
+
+fn get_messages_inner(
+    conn: &Connection,
+    account_id: &str,
+    folder_path: &str,
+    page: u32,
+    per_page: u32,
+    sort_column: &str,
+    sort_asc: bool,
+    filter: &QuickFilter,
+    use_fts: bool,
+) -> Result<MessagePage> {
+    let filter_sql = build_filter_clauses(filter, account_id, use_fts);
 
     let total: i64 = conn.query_row(
         &format!(
@@ -227,7 +266,6 @@ pub fn get_messages(
         |row| row.get(0),
     )?;
 
-    // Whitelist sort columns to prevent SQL injection
     let order_col = match sort_column {
         "subject" => "subject",
         "from" => "from_name",
@@ -644,7 +682,29 @@ pub fn get_threaded_messages(
     sort_asc: bool,
     filter: &QuickFilter,
 ) -> Result<ThreadedPage> {
-    let filter_sql = build_filter_clauses(filter, account_id);
+    let has_text = !filter.text.trim().is_empty();
+    match get_threaded_messages_inner(conn, account_id, folder_path, page, per_page, sort_column, sort_asc, filter, true) {
+        Ok(page) => return Ok(page),
+        Err(e) if has_text => {
+            log::warn!("FTS5 threaded query failed, retrying with LIKE: {}", e);
+            return get_threaded_messages_inner(conn, account_id, folder_path, page, per_page, sort_column, sort_asc, filter, false);
+        }
+        Err(e) => return Err(e),
+    }
+}
+
+fn get_threaded_messages_inner(
+    conn: &Connection,
+    account_id: &str,
+    folder_path: &str,
+    page: u32,
+    per_page: u32,
+    sort_column: &str,
+    sort_asc: bool,
+    filter: &QuickFilter,
+    use_fts: bool,
+) -> Result<ThreadedPage> {
+    let filter_sql = build_filter_clauses(filter, account_id, use_fts);
 
     // Count total messages in this folder (with filters)
     let total_messages: i64 = conn.query_row(

--- a/src-tauri/src/filters/engine.rs
+++ b/src-tauri/src/filters/engine.rs
@@ -1,4 +1,4 @@
-use regex::Regex;
+use regex::RegexBuilder;
 use serde::{Deserialize, Serialize};
 
 use super::rules::{
@@ -115,10 +115,13 @@ fn eval_string_op(op: &ConditionOp, haystack: &str, needle: &str) -> bool {
         ConditionOp::NotContains => !h.contains(&n),
         ConditionOp::Equals => h == n,
         ConditionOp::NotEquals => h != n,
-        ConditionOp::MatchesRegex => match Regex::new(needle) {
+        ConditionOp::MatchesRegex => match RegexBuilder::new(needle)
+            .size_limit(1_000_000)
+            .build()
+        {
             Ok(re) => re.is_match(haystack),
             Err(e) => {
-                log::warn!("Invalid regex '{}': {}", needle, e);
+                log::warn!("Invalid or too complex regex '{}': {}", needle, e);
                 false
             }
         },

--- a/src-tauri/src/mail/sync.rs
+++ b/src-tauri/src/mail/sync.rs
@@ -534,13 +534,25 @@ pub fn fetch_and_store_body(
         .ok_or_else(|| Error::Imap(format!("No body returned for UID {}", uid)))?;
     conn_imap.logout();
 
-    // Write to Maildir
+    // Write to Maildir — validate path components before creating directories
+    let sanitized = sanitize_folder_name(folder_path);
     let maildir_base = data_dir
         .join(account_id)
-        .join(sanitize_folder_name(folder_path));
+        .join(&sanitized);
+
+    // Reject any remaining ".." or absolute components before touching the filesystem
+    for component in maildir_base.components() {
+        if matches!(component, std::path::Component::ParentDir) {
+            return Err(Error::Other(format!(
+                "Path traversal detected in maildir path: '{}'",
+                maildir_base.display()
+            )));
+        }
+    }
+
     create_maildir_dirs(&maildir_base)?;
 
-    // Verify resolved path stays inside data_dir (path traversal defence)
+    // Post-creation canonical check as defence-in-depth (catches symlink attacks)
     let canonical_data_dir = std::fs::canonicalize(data_dir)
         .unwrap_or_else(|_| data_dir.to_path_buf());
     let canonical_maildir = std::fs::canonicalize(&maildir_base)
@@ -548,6 +560,8 @@ pub fn fetch_and_store_body(
             "Failed to resolve maildir path: {}", e
         )))?;
     if !canonical_maildir.starts_with(&canonical_data_dir) {
+        // Clean up the directory we just created since it's outside our tree
+        let _ = std::fs::remove_dir_all(&canonical_maildir);
         return Err(Error::Other(format!(
             "Path traversal detected: maildir path '{}' escapes data directory",
             maildir_base.display()

--- a/src-tauri/src/mail/sync.rs
+++ b/src-tauri/src/mail/sync.rs
@@ -540,6 +540,20 @@ pub fn fetch_and_store_body(
         .join(sanitize_folder_name(folder_path));
     create_maildir_dirs(&maildir_base)?;
 
+    // Verify resolved path stays inside data_dir (path traversal defence)
+    let canonical_data_dir = std::fs::canonicalize(data_dir)
+        .unwrap_or_else(|_| data_dir.to_path_buf());
+    let canonical_maildir = std::fs::canonicalize(&maildir_base)
+        .map_err(|e| Error::Other(format!(
+            "Failed to resolve maildir path: {}", e
+        )))?;
+    if !canonical_maildir.starts_with(&canonical_data_dir) {
+        return Err(Error::Other(format!(
+            "Path traversal detected: maildir path '{}' escapes data directory",
+            maildir_base.display()
+        )));
+    }
+
     let filename = format!("{}:2,{}", uid, flags_to_maildir_suffix(flags));
     let msg_path = maildir_base.join("cur").join(&filename);
     std::fs::write(&msg_path, &body)?;
@@ -568,8 +582,26 @@ pub(crate) fn create_maildir_dirs(base: &Path) -> Result<()> {
 }
 
 pub(crate) fn sanitize_folder_name(name: &str) -> String {
-    name.replace(['/', '\\'], ".")
-        .replace('\0', "")
+    let normalized = name.replace('\\', "/").replace('\0', "");
+
+    let sanitized: String = std::path::Path::new(&normalized)
+        .components()
+        .filter_map(|c| match c {
+            std::path::Component::Normal(part) => {
+                let s = part.to_string_lossy().replace('.', "_");
+                if s.is_empty() { None } else { Some(s) }
+            }
+            // Strip ., .., /, and prefix components
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join(".");
+
+    if sanitized.is_empty() || sanitized == "." || sanitized == ".." {
+        "_".to_string()
+    } else {
+        sanitized
+    }
 }
 
 pub(crate) fn flags_to_maildir_suffix(flags: &[String]) -> String {

--- a/src-tauri/src/oauth.rs
+++ b/src-tauri/src/oauth.rs
@@ -110,24 +110,32 @@ impl OAuthTokens {
 
 /// Build the OAuth2 authorization URL with a local redirect server.
 /// Returns `(url, port, code_verifier)` where code_verifier is present for PKCE providers.
-pub fn get_auth_url(provider: &OAuthProvider) -> Result<(String, u16, Option<String>)> {
+/// Returns (url, listener, code_verifier, state).
+///
+/// The listener is kept open to prevent port hijacking between URL
+/// generation and callback handling (TOCTOU). The state parameter
+/// provides CSRF protection and must be validated in the callback.
+pub fn get_auth_url(provider: &OAuthProvider) -> Result<(String, TcpListener, Option<String>, String)> {
     let listener = TcpListener::bind("127.0.0.1:0")
         .map_err(|e| Error::Other(format!("Failed to bind local server: {}", e)))?;
     let port = listener.local_addr()
         .map_err(|e| Error::Other(format!("Failed to get port: {}", e)))?
         .port();
-    drop(listener);
 
     // Microsoft requires http://localhost (not 127.0.0.1) for native client redirect.
     // Google works with either. Use localhost for both.
     let redirect_uri = format!("http://localhost:{}", port);
 
+    // Generate a random state parameter for CSRF protection
+    let state = generate_code_verifier();
+
     let mut url = format!(
-        "{}?client_id={}&redirect_uri={}&response_type=code&scope={}",
+        "{}?client_id={}&redirect_uri={}&response_type=code&scope={}&state={}",
         provider.auth_url,
         urlencoding::encode(provider.client_id),
         urlencoding::encode(&redirect_uri),
         urlencoding::encode(&provider.scopes.join(" ")),
+        urlencoding::encode(&state),
     );
 
     let code_verifier = if provider.use_pkce {
@@ -149,19 +157,46 @@ pub fn get_auth_url(provider: &OAuthProvider) -> Result<(String, u16, Option<Str
         url.push_str("&prompt=consent");
     }
 
-    Ok((url, port, code_verifier))
+    Ok((url, listener, code_verifier, state))
 }
 
-/// Listen on the given port for the OAuth2 redirect callback.
-/// Returns the authorization code.
-pub fn wait_for_callback(port: u16) -> Result<String> {
-    let listener = TcpListener::bind(format!("127.0.0.1:{}", port))
-        .map_err(|e| Error::Other(format!("Failed to bind on port {}: {}", port, e)))?;
+/// Result from the OAuth2 callback, including the authorization code
+/// and optional state parameter for CSRF validation.
+pub struct CallbackResult {
+    pub code: String,
+    pub state: Option<String>,
+}
 
-    log::info!("OAuth2: waiting for callback on port {}", port);
+/// Listen on the given listener for the OAuth2 redirect callback.
+/// Times out after 5 minutes to prevent indefinite resource holding.
+/// Returns the authorization code and state parameter.
+pub fn wait_for_callback(listener: TcpListener) -> Result<CallbackResult> {
+    use std::time::{Duration, Instant};
 
-    let (mut stream, _) = listener.accept()
-        .map_err(|e| Error::Other(format!("Failed to accept connection: {}", e)))?;
+    let timeout = Duration::from_secs(300);
+    let deadline = Instant::now() + timeout;
+    listener.set_nonblocking(true)
+        .map_err(|e| Error::Other(format!("Failed to set non-blocking: {}", e)))?;
+
+    log::info!("OAuth2: waiting for callback (timeout={}s)", timeout.as_secs());
+
+    let (mut stream, _) = loop {
+        match listener.accept() {
+            Ok(conn) => break conn,
+            Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                if Instant::now() >= deadline {
+                    return Err(Error::Other(
+                        "OAuth2 callback timed out after 5 minutes".into(),
+                    ));
+                }
+                std::thread::sleep(Duration::from_millis(100));
+                continue;
+            }
+            Err(e) => {
+                return Err(Error::Other(format!("Failed to accept connection: {}", e)));
+            }
+        }
+    };
 
     let mut reader = BufReader::new(stream.try_clone()
         .map_err(|e| Error::Other(format!("Stream clone failed: {}", e)))?);
@@ -170,27 +205,35 @@ pub fn wait_for_callback(port: u16) -> Result<String> {
     reader.read_line(&mut request_line)
         .map_err(|e| Error::Other(format!("Failed to read request: {}", e)))?;
 
-    // Parse: GET /?code=xxx&scope=yyy HTTP/1.1
-    let code = request_line
+    // Parse query parameters from: GET /?code=xxx&state=yyy HTTP/1.1
+    let query_params: HashMap<String, String> = request_line
         .split_whitespace()
-        .nth(1) // The path
-        .and_then(|path| {
-            let query = path.split('?').nth(1)?;
+        .nth(1)
+        .and_then(|path| path.split('?').nth(1))
+        .map(|query| {
             query.split('&')
-                .find(|p| p.starts_with("code="))
-                .map(|p| p.trim_start_matches("code=").to_string())
+                .filter_map(|param| {
+                    let mut parts = param.splitn(2, '=');
+                    let key = parts.next()?;
+                    let val = parts.next().unwrap_or("");
+                    // URL-decode values (code/state may be percent-encoded)
+                    let decoded = urlencoding::decode(val)
+                        .unwrap_or_else(|_| val.into())
+                        .into_owned();
+                    Some((key.to_string(), decoded))
+                })
+                .collect()
         })
-        .ok_or_else(|| {
-            // Check for error
-            let error = request_line
-                .split_whitespace()
-                .nth(1)
-                .and_then(|path| path.split('?').nth(1))
-                .and_then(|q| q.split('&').find(|p| p.starts_with("error=")))
-                .map(|p| p.trim_start_matches("error=").to_string())
-                .unwrap_or_else(|| "unknown".to_string());
-            Error::Other(format!("OAuth2 authorization failed: {}", error))
-        })?;
+        .unwrap_or_default();
+
+    let code = query_params.get("code").cloned().ok_or_else(|| {
+        let error = query_params.get("error")
+            .cloned()
+            .unwrap_or_else(|| "unknown".to_string());
+        Error::Other(format!("OAuth2 authorization failed: {}", error))
+    })?;
+
+    let state = query_params.get("state").cloned();
 
     // Send a success response to the browser
     let response = "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n\
@@ -201,7 +244,7 @@ pub fn wait_for_callback(port: u16) -> Result<String> {
     stream.write_all(response.as_bytes()).ok();
 
     log::info!("OAuth2: received authorization code");
-    Ok(code)
+    Ok(CallbackResult { code, state })
 }
 
 /// Exchange an authorization code for access + refresh tokens.

--- a/src-tauri/src/oauth.rs
+++ b/src-tauri/src/oauth.rs
@@ -109,7 +109,6 @@ impl OAuthTokens {
 // ---------------------------------------------------------------------------
 
 /// Build the OAuth2 authorization URL with a local redirect server.
-/// Returns `(url, port, code_verifier)` where code_verifier is present for PKCE providers.
 /// Returns (url, listener, code_verifier, state).
 ///
 /// The listener is kept open to prevent port hijacking between URL

--- a/src/components/mail/MessageReader.vue
+++ b/src/components/mail/MessageReader.vue
@@ -69,16 +69,26 @@ watch(
 const hasHtml = () => !!messagesStore.activeMessage?.body_html;
 const hasText = () => !!messagesStore.activeMessage?.body_text;
 
+// Generate a random nonce for iframe CSP
+function generateNonce(): string {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+// Memoize the nonce per active message to prevent iframe reloads on re-render
+const currentNonce = ref(generateNonce());
+
 // Build a sandboxed iframe srcdoc that isolates HTML email from the main webview.
-// The iframe has no access to window.__TAURI__ or any IPC commands.
-// Links inside the iframe send a postMessage to the parent for clipboard copy.
+// Uses a CSP nonce instead of 'unsafe-inline' so only our bootstrap script runs.
+// Email HTML is embedded in srcdoc but sanitized by ammonia on the backend.
 function iframeSrcdoc(): string {
   const html = imagesHtml.value ?? messagesStore.activeMessage?.body_html ?? "";
-  // Strict CSP inside the iframe: no scripts, no external resources except inline styles
+  const nonce = currentNonce.value;
   return `<!DOCTYPE html>
 <html>
 <head>
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src https: data:;">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'nonce-${nonce}'; style-src 'unsafe-inline'; img-src https: data:;">
 <style>
   body {
     margin: 0;
@@ -94,7 +104,7 @@ function iframeSrcdoc(): string {
   a { color: #1a73e8; cursor: pointer; }
 </style>
 </head>
-<body>${html}<script>
+<body>${html}<script nonce="${nonce}">
   // Intercept all link clicks and forward to parent via postMessage
   document.addEventListener('click', function(e) {
     var a = e.target.closest ? e.target.closest('a') : null;
@@ -145,6 +155,11 @@ function handleIframeMessage(event: MessageEvent) {
     }
   }
 }
+
+// Reset nonce when active message changes so CSP stays unique per message
+watch(() => messagesStore.activeMessageId, () => {
+  currentNonce.value = generateNonce();
+});
 
 // Set up / tear down message listener
 onMounted(() => window.addEventListener('message', handleIframeMessage));


### PR DESCRIPTION
## Summary

Supersedes #16 — reimplemented cleanly on top of current main.

Addresses 8 security findings from the audit:

1. **Path traversal** — `sanitize_folder_name` now uses `Path::components()` to strip `..`, `/`, and prefix components; `fetch_and_store_body` validates canonical paths stay inside data_dir
2. **OAuth CSRF** — `get_auth_url` generates a random state parameter and keeps the TcpListener open (prevents TOCTOU port hijacking); `wait_for_callback` has a 5-minute timeout and URL-decodes values; `oauth_complete` validates the returned state
3. **OAuth session management** — sessions stored with TTL, expired ones evicted automatically
4. **SQL injection in LIKE** — backslash, `%`, and `_` properly escaped; FTS5 queries fall back to LIKE on parse failure
5. **Regex DoS** — `RegexBuilder` with 1MB `size_limit` prevents catastrophic backtracking in filter engine
6. **Attachment path validation** — rejects relative paths and `..` components; warns on paths outside typical user directories
7. **Atomic attachment writes** — temp file + fsync + rename with `O_NOFOLLOW` on Unix to prevent symlink following and partial writes
8. **iframe CSP hardening** — replaces `script-src 'unsafe-inline'` with a per-message nonce so only our bootstrap script runs; email HTML is sanitized by ammonia on the backend (defence-in-depth)

### Copilot review feedback addressed
All 10 comments from the original PR #16 review are addressed in this reimplementation.

## Test plan
- [x] HTML emails render correctly
- [x] "Load images" button — pre-existing bug on main, not a regression
- [x] Link clicks in emails copy to clipboard
- [x] `cargo test` — 89 tests pass
- [x] `pnpm test` — 162 tests pass
- [x] General email viewing works