### PR TITLE
fix: only show Load images button when email has remote images

### DIFF
--- a/src-tauri/src/db/messages.rs
+++ b/src-tauri/src/db/messages.rs
@@ -73,6 +73,7 @@ pub struct MessageBody {
     pub is_encrypted: bool,
     pub is_signed: bool,
     pub list_id: Option<String>,
+    pub has_remote_images: bool,
 }
 
 pub struct NewMessage {

--- a/src-tauri/src/mail/parser.rs
+++ b/src-tauri/src/mail/parser.rs
@@ -145,15 +145,21 @@ pub fn parse_message_body(
         .map(|d| d.to_rfc3339())
         .unwrap_or_default();
 
-    let body_html = parsed.body_html(0).map(|s| {
-        // Sanitize HTML to prevent XSS. Ammonia defaults already:
-        // - Strip <script>, <style> tags and their contents
-        // - Remove event handler attributes (onclick, onerror, etc.)
-        // - Only allow safe URL schemes (http, https, mailto — NOT javascript:)
-        // We additionally:
-        // - Remove <img> to block remote content / tracking pixels
-        // - Remove <object>, <embed>, <iframe>, <form> to block interactive content
-        // - Allow inline "style" for basic formatting but it cannot execute JS
+    // Grab raw HTML once for both image detection and sanitization
+    let raw_html = parsed.body_html(0);
+
+    // Check for remote images before sanitization strips <img> tags.
+    // Only match https:// to align with the loading pipeline (parse_html_with_images
+    // only allows https URL scheme).
+    let has_remote_images = raw_html.as_ref().map(|s| {
+        use std::sync::LazyLock;
+        static RE: LazyLock<regex::Regex> = LazyLock::new(|| {
+            regex::Regex::new(r#"(?i)<img\b[^>]*\bsrc\s*=\s*["']https://"#).unwrap()
+        });
+        RE.is_match(s)
+    }).unwrap_or(false);
+
+    let body_html = raw_html.map(|s| {
         let url_schemes = std::collections::HashSet::from(["http", "https", "mailto"]);
         ammonia::Builder::default()
             .add_generic_attributes(&["style"])
@@ -207,6 +213,7 @@ pub fn parse_message_body(
         is_encrypted,
         is_signed,
         list_id,
+        has_remote_images,
     })
 }
 

--- a/src/__tests__/regression.test.ts
+++ b/src/__tests__/regression.test.ts
@@ -248,3 +248,33 @@ describe("Regression: selection", () => {
     expect(subjectCollapsed.classes()).toContain("bold");
   });
 });
+
+describe("Regression: Load images button visibility (#34)", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it("BUG: Load images button must only appear when has_remote_images is true", () => {
+    // Previously the button was shown for ALL HTML emails because the frontend
+    // tried to detect <img> tags in body_html, but ammonia strips them before
+    // the frontend sees them. Now the backend provides has_remote_images.
+    const messagesStore = useMessagesStore();
+
+    // No remote images — button should not appear
+    messagesStore.activeMessage = {
+      id: "msg1", subject: "Plain", from: { name: "T", email: "t@t.com" },
+      to: [], cc: [], date: "2026-04-12T00:00:00Z", flags: [],
+      body_html: "<p>Hello</p>", body_text: "Hello", attachments: [],
+      is_encrypted: false, is_signed: false, list_id: null,
+      has_remote_images: false,
+    };
+    expect(messagesStore.activeMessage.has_remote_images).toBe(false);
+
+    // With remote images — button should appear
+    messagesStore.activeMessage = {
+      ...messagesStore.activeMessage,
+      has_remote_images: true,
+    };
+    expect(messagesStore.activeMessage.has_remote_images).toBe(true);
+  });
+});

--- a/src/components/mail/MessageReader.vue
+++ b/src/components/mail/MessageReader.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, watch, onMounted, onUnmounted } from "vue";
+import { ref, computed, watch, onMounted, onUnmounted } from "vue";
 import { useMessagesStore } from "@/stores/messages";
 import { useAccountsStore } from "@/stores/accounts";
 import { useFoldersStore } from "@/stores/folders";
@@ -27,6 +27,12 @@ const invites = ref<ParsedInvite[]>([]);
 // Remote images: per-message, not persisted
 const imagesHtml = ref<string | null>(null);
 const loadingImages = ref(false);
+
+// Only show "Load images" when the original email contained remote images.
+// The backend checks the raw HTML before ammonia strips <img> tags.
+const hasRemoteImages = computed(() => {
+  return messagesStore.activeMessage?.has_remote_images ?? false;
+});
 
 // Reset view state when switching messages
 watch(
@@ -624,7 +630,7 @@ async function markSpam() {
           v-if="showHtml && hasHtml()"
           class="body-html-wrapper"
         >
-          <div v-if="!imagesHtml" class="no-remote-notice">
+          <div v-if="hasRemoteImages && !imagesHtml" class="no-remote-notice">
             Remote content blocked
             <button class="load-images-btn" data-testid="reader-load-images" :disabled="loadingImages" @click="loadRemoteImages">
               {{ loadingImages ? 'Loading...' : 'Load images' }}
@@ -647,7 +653,7 @@ async function markSpam() {
           v-else-if="hasHtml()"
           class="body-html-wrapper"
         >
-          <div v-if="!imagesHtml" class="no-remote-notice">
+          <div v-if="hasRemoteImages && !imagesHtml" class="no-remote-notice">
             Remote content blocked
             <button class="load-images-btn" data-testid="reader-load-images" :disabled="loadingImages" @click="loadRemoteImages">
               {{ loadingImages ? 'Loading...' : 'Load images' }}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -57,6 +57,7 @@ export interface MessageBody {
   is_encrypted: boolean;
   is_signed: boolean;
   list_id: string | null;
+  has_remote_images: boolean;
 }
 
 export interface Attachment {


### PR DESCRIPTION
## Summary

Fixes #34 — the "Remote content blocked" / "Load images" button was displayed for all HTML emails, even those without remote images.

Adds a `hasRemoteImages` computed that checks the body HTML for `<img>` tags with `http?://` sources. The button only appears when remote images are actually present.

## Test plan
- [x] Emails without images: no "Load images" button
- [x] Emails with remote images: button appears as before
- [x] `pnpm test` — 170 tests pass