### PR TITLE
feat: calendar event drag-and-drop

### DIFF
--- a/src/components/calendar/CalendarSidebar.vue
+++ b/src/components/calendar/CalendarSidebar.vue
@@ -2,7 +2,19 @@
 import { ref } from "vue";
 import { useCalendarStore } from "@/stores/calendar";
 import { useAccountsStore } from "@/stores/accounts";
+import type { Calendar } from "@/lib/types";
+import { dragCalendarEvent, isCalendarDragging } from "@/lib/calendar-drag-state";
 import * as api from "@/lib/tauri";
+
+const emit = defineEmits<{
+  calendarDrop: [payload: {
+    eventId: string;
+    targetCalendarId: string;
+    targetAccountId: string;
+    attendeesJson: string | null;
+    organizerEmail: string | null;
+  }];
+}>();
 
 const calendarStore = useCalendarStore();
 const accountsStore = useAccountsStore();
@@ -26,6 +38,37 @@ function onContextMenu(event: MouseEvent, calId: string, accountId: string) {
 
 function closeContextMenu() {
   contextMenu.value = null;
+}
+
+const dropTargetCalendarId = ref<string | null>(null);
+
+function onCalendarItemEnter(calId: string) {
+  if (!isCalendarDragging.value || !dragCalendarEvent.value) return;
+  if (dragCalendarEvent.value.calendar_id === calId) return;
+  dropTargetCalendarId.value = calId;
+}
+
+function onCalendarItemLeave(calId: string) {
+  if (dropTargetCalendarId.value === calId) {
+    dropTargetCalendarId.value = null;
+  }
+}
+
+function onCalendarItemDrop(cal: Calendar) {
+  if (!isCalendarDragging.value || !dragCalendarEvent.value) return;
+  const ev = dragCalendarEvent.value;
+  if (ev.calendar_id === cal.id) {
+    dropTargetCalendarId.value = null;
+    return;
+  }
+  dropTargetCalendarId.value = null;
+  emit("calendarDrop", {
+    eventId: ev.id,
+    targetCalendarId: cal.id,
+    targetAccountId: cal.account_id,
+    attendeesJson: ev.attendees_json,
+    organizerEmail: ev.organizer_email,
+  });
 }
 
 async function syncThisCalendar() {
@@ -54,8 +97,12 @@ async function syncThisCalendar() {
         v-for="cal in calendarStore.calendars"
         :key="cal.id"
         class="calendar-item"
-        :class="{ syncing: syncing === cal.id }"
+        :class="{ syncing: syncing === cal.id, 'drag-over': dropTargetCalendarId === cal.id }"
+        :data-testid="`calendar-item-${cal.id}`"
         @contextmenu="onContextMenu($event, cal.id, cal.account_id)"
+        @mouseenter="onCalendarItemEnter(cal.id)"
+        @mouseleave="onCalendarItemLeave(cal.id)"
+        @mouseup="onCalendarItemDrop(cal)"
       >
         <label class="calendar-label">
           <input
@@ -121,6 +168,13 @@ async function syncThisCalendar() {
 
 .calendar-item.syncing {
   opacity: 0.6;
+}
+
+.calendar-item.drag-over {
+  background: rgba(66, 133, 244, 0.12);
+  border-radius: 4px;
+  outline: 1px dashed var(--color-accent);
+  outline-offset: -1px;
 }
 
 .calendar-label {

--- a/src/components/calendar/MonthView.vue
+++ b/src/components/calendar/MonthView.vue
@@ -1,10 +1,19 @@
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, ref } from "vue";
 import { useCalendarStore } from "@/stores/calendar";
+import type { CalendarEvent } from "@/lib/types";
+import { dragCalendarEvent, isCalendarDragging } from "@/lib/calendar-drag-state";
 
 const emit = defineEmits<{
   dateClick: [date: string];
   eventClick: [eventId: string];
+  eventReschedule: [payload: {
+    eventId: string;
+    newStart: string;
+    newEnd: string;
+    attendeesJson: string | null;
+    organizerEmail: string | null;
+  }];
 }>();
 
 const calendarStore = useCalendarStore();
@@ -58,6 +67,102 @@ function getEventColor(event: { calendar_id: string }): string {
 }
 
 const dayNames = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+// Drag-to-reschedule
+const dragStartPos = ref<{ x: number; y: number } | null>(null);
+const dragGhost = ref<HTMLElement | null>(null);
+const dragOverDay = ref<string | null>(null);
+const DRAG_THRESHOLD = 5;
+
+function onEventMouseDown(event: MouseEvent, ev: CalendarEvent) {
+  if (event.button !== 0) return;
+  if (/_\d{4}-/.test(ev.id) && ev.recurrence_rule) return;
+  if (ev.all_day) return;
+
+  dragStartPos.value = { x: event.clientX, y: event.clientY };
+  const sourceEvent = ev;
+
+  const handleMove = (e: MouseEvent) => {
+    if (!dragStartPos.value) return;
+    const dx = e.clientX - dragStartPos.value.x;
+    const dy = e.clientY - dragStartPos.value.y;
+    if (!isCalendarDragging.value && Math.sqrt(dx * dx + dy * dy) < DRAG_THRESHOLD) return;
+
+    if (!isCalendarDragging.value) {
+      dragCalendarEvent.value = sourceEvent;
+      isCalendarDragging.value = true;
+      const ghost = document.createElement("div");
+      ghost.textContent = sourceEvent.title;
+      ghost.dataset.testid = "cal-drag-ghost";
+      ghost.style.cssText = "position:fixed;z-index:99999;padding:4px 10px;background:#3366cc;color:white;border-radius:4px;font-size:12px;font-weight:500;white-space:nowrap;pointer-events:none;";
+      document.body.appendChild(ghost);
+      dragGhost.value = ghost;
+      document.body.style.cursor = "grabbing";
+    }
+
+    if (dragGhost.value) {
+      dragGhost.value.style.left = e.clientX + 12 + "px";
+      dragGhost.value.style.top = e.clientY + 12 + "px";
+    }
+  };
+
+  const handleUp = () => {
+    document.body.style.cursor = "";
+    if (isCalendarDragging.value) {
+      setTimeout(() => {
+        isCalendarDragging.value = false;
+        dragCalendarEvent.value = null;
+        dragOverDay.value = null;
+        if (dragGhost.value) {
+          dragGhost.value.remove();
+          dragGhost.value = null;
+        }
+      }, 0);
+    }
+    dragStartPos.value = null;
+    document.removeEventListener("mousemove", handleMove);
+    document.removeEventListener("mouseup", handleUp);
+  };
+
+  document.addEventListener("mousemove", handleMove);
+  document.addEventListener("mouseup", handleUp);
+}
+
+function onCellEnter(day: Date) {
+  if (!isCalendarDragging.value) return;
+  dragOverDay.value = day.toISOString().split("T")[0];
+}
+
+function onCellLeave(day: Date) {
+  if (dragOverDay.value === day.toISOString().split("T")[0]) {
+    dragOverDay.value = null;
+  }
+}
+
+function onCellDrop(day: Date) {
+  if (!isCalendarDragging.value || !dragCalendarEvent.value) return;
+  dragOverDay.value = null;
+
+  const ev = dragCalendarEvent.value;
+  const originalStart = new Date(ev.start_time);
+  const originalEnd = new Date(ev.end_time);
+  const durationMs = originalEnd.getTime() - originalStart.getTime();
+
+  // Keep same time-of-day, change the date
+  const newStart = new Date(day);
+  newStart.setHours(originalStart.getHours(), originalStart.getMinutes(), 0, 0);
+  const newEnd = new Date(newStart.getTime() + durationMs);
+
+  if (newStart.getTime() === originalStart.getTime()) return;
+
+  emit("eventReschedule", {
+    eventId: ev.id,
+    newStart: newStart.toISOString(),
+    newEnd: newEnd.toISOString(),
+    attendeesJson: ev.attendees_json,
+    organizerEmail: ev.organizer_email,
+  });
+}
 </script>
 
 <template>
@@ -74,8 +179,13 @@ const dayNames = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
           :class="{
             today: isToday(day),
             'other-month': !isCurrentMonth(day),
+            'drag-over': isCalendarDragging && dragOverDay === day.toISOString().split('T')[0],
           }"
+          :data-testid="`cal-month-cell-${day.toISOString().split('T')[0]}`"
           @click="emit('dateClick', day.toISOString().split('T')[0])"
+          @mouseenter="onCellEnter(day)"
+          @mouseleave="onCellLeave(day)"
+          @mouseup="onCellDrop(day)"
         >
           <span class="day-number">{{ day.getDate() }}</span>
           <div class="month-events">
@@ -83,9 +193,11 @@ const dayNames = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
               v-for="event in getEventsForDay(day).slice(0, 3)"
               :key="event.id"
               class="month-event"
+              :class="{ dragging: isCalendarDragging && dragCalendarEvent?.id === event.id }"
               :data-testid="`cal-event-${event.id}`"
               :style="{ backgroundColor: getEventColor(event) }"
               @click.stop="emit('eventClick', event.id)"
+              @mousedown="onEventMouseDown($event, event)"
             >
               {{ event.title }}
             </div>
@@ -169,6 +281,12 @@ const dayNames = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
   opacity: 0.4;
 }
 
+.month-cell.drag-over {
+  background: rgba(66, 133, 244, 0.15);
+  outline: 1px dashed var(--color-accent);
+  outline-offset: -1px;
+}
+
 .day-number {
   font-size: 12px;
   color: var(--color-text-secondary);
@@ -190,6 +308,11 @@ const dayNames = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
   text-overflow: ellipsis;
   white-space: nowrap;
   cursor: pointer;
+}
+
+.month-event.dragging {
+  opacity: 0.4;
+  pointer-events: none;
 }
 
 .month-more {

--- a/src/components/calendar/MonthView.vue
+++ b/src/components/calendar/MonthView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref } from "vue";
+import { computed, ref, onUnmounted } from "vue";
 import { useCalendarStore } from "@/stores/calendar";
 import type { CalendarEvent } from "@/lib/types";
 import { dragCalendarEvent, isCalendarDragging } from "@/lib/calendar-drag-state";
@@ -73,6 +73,7 @@ const dragStartPos = ref<{ x: number; y: number } | null>(null);
 const dragGhost = ref<HTMLElement | null>(null);
 const dragOverDay = ref<string | null>(null);
 const DRAG_THRESHOLD = 5;
+let dragCleanup: (() => void) | null = null;
 
 function onEventMouseDown(event: MouseEvent, ev: CalendarEvent) {
   if (event.button !== 0) return;
@@ -122,11 +123,17 @@ function onEventMouseDown(event: MouseEvent, ev: CalendarEvent) {
     dragStartPos.value = null;
     document.removeEventListener("mousemove", handleMove);
     document.removeEventListener("mouseup", handleUp);
+    dragCleanup = null;
   };
 
   document.addEventListener("mousemove", handleMove);
   document.addEventListener("mouseup", handleUp);
+  dragCleanup = handleUp;
 }
+
+onUnmounted(() => {
+  if (dragCleanup) dragCleanup();
+});
 
 function onCellEnter(day: Date) {
   if (!isCalendarDragging.value) return;

--- a/src/components/calendar/WeekView.vue
+++ b/src/components/calendar/WeekView.vue
@@ -2,6 +2,7 @@
 import { computed, onMounted, ref, nextTick } from "vue";
 import { useCalendarStore } from "@/stores/calendar";
 import type { CalendarEvent } from "@/lib/types";
+import { dragCalendarEvent, isCalendarDragging } from "@/lib/calendar-drag-state";
 
 const props = defineProps<{
   singleDay?: boolean;
@@ -10,6 +11,13 @@ const props = defineProps<{
 const emit = defineEmits<{
   timeClick: [dateTime: string];
   eventClick: [eventId: string];
+  eventReschedule: [payload: {
+    eventId: string;
+    newStart: string;
+    newEnd: string;
+    attendeesJson: string | null;
+    organizerEmail: string | null;
+  }];
 }>();
 
 const calendarStore = useCalendarStore();
@@ -164,9 +172,116 @@ function getEventStyle(event: { my_status: string | null }): Record<string, stri
 }
 
 function onSlotClick(date: Date, hour: number) {
+  if (isCalendarDragging.value) return;
   const dt = new Date(date);
   dt.setHours(hour, 0, 0, 0);
   emit("timeClick", dt.toISOString());
+}
+
+// Drag-to-reschedule
+const dragStartPos = ref<{ x: number; y: number } | null>(null);
+const dragGhost = ref<HTMLElement | null>(null);
+const dragOverCell = ref<{ day: string; hour: number } | null>(null);
+const DRAG_THRESHOLD = 5;
+
+function onEventMouseDown(event: MouseEvent, seg: EventSegment) {
+  if (event.button !== 0) return;
+  const ev = seg.event;
+
+  // Block recurring occurrences (synthetic ID: originalId_2026-...)
+  if (/_\d{4}-/.test(ev.id) && ev.recurrence_rule) return;
+  // Block all-day events
+  if (ev.all_day) return;
+
+  dragStartPos.value = { x: event.clientX, y: event.clientY };
+  const sourceEvent = ev;
+
+  const handleMove = (e: MouseEvent) => {
+    if (!dragStartPos.value) return;
+    const dx = e.clientX - dragStartPos.value.x;
+    const dy = e.clientY - dragStartPos.value.y;
+    if (!isCalendarDragging.value && Math.sqrt(dx * dx + dy * dy) < DRAG_THRESHOLD) return;
+
+    if (!isCalendarDragging.value) {
+      dragCalendarEvent.value = sourceEvent;
+      isCalendarDragging.value = true;
+      const ghost = document.createElement("div");
+      ghost.textContent = sourceEvent.title;
+      ghost.dataset.testid = "cal-drag-ghost";
+      ghost.style.cssText = "position:fixed;z-index:99999;padding:4px 10px;background:#3366cc;color:white;border-radius:4px;font-size:12px;font-weight:500;white-space:nowrap;pointer-events:none;";
+      document.body.appendChild(ghost);
+      dragGhost.value = ghost;
+      document.body.style.cursor = "grabbing";
+    }
+
+    if (dragGhost.value) {
+      dragGhost.value.style.left = e.clientX + 12 + "px";
+      dragGhost.value.style.top = e.clientY + 12 + "px";
+    }
+  };
+
+  const handleUp = () => {
+    document.body.style.cursor = "";
+    if (isCalendarDragging.value) {
+      setTimeout(() => {
+        isCalendarDragging.value = false;
+        dragCalendarEvent.value = null;
+        dragOverCell.value = null;
+        if (dragGhost.value) {
+          dragGhost.value.remove();
+          dragGhost.value = null;
+        }
+      }, 0);
+    }
+    dragStartPos.value = null;
+    document.removeEventListener("mousemove", handleMove);
+    document.removeEventListener("mouseup", handleUp);
+  };
+
+  document.addEventListener("mousemove", handleMove);
+  document.addEventListener("mouseup", handleUp);
+}
+
+function onTimeCellEnter(day: Date, hour: number) {
+  if (!isCalendarDragging.value) return;
+  dragOverCell.value = { day: day.toISOString().split("T")[0], hour };
+}
+
+function onTimeCellLeave(day: Date, hour: number) {
+  if (dragOverCell.value?.day === day.toISOString().split("T")[0] &&
+      dragOverCell.value?.hour === hour) {
+    dragOverCell.value = null;
+  }
+}
+
+function isDragOver(day: Date, hour: number): boolean {
+  return isCalendarDragging.value &&
+    dragOverCell.value?.day === day.toISOString().split("T")[0] &&
+    dragOverCell.value?.hour === hour;
+}
+
+function onTimeCellDrop(day: Date, hour: number) {
+  if (!isCalendarDragging.value || !dragCalendarEvent.value) return;
+  dragOverCell.value = null;
+
+  const ev = dragCalendarEvent.value;
+  const originalStart = new Date(ev.start_time);
+  const originalEnd = new Date(ev.end_time);
+  const durationMs = originalEnd.getTime() - originalStart.getTime();
+
+  const newStart = new Date(day);
+  newStart.setHours(hour, 0, 0, 0);
+  const newEnd = new Date(newStart.getTime() + durationMs);
+
+  if (newStart.getTime() === originalStart.getTime()) return;
+
+  emit("eventReschedule", {
+    eventId: ev.id,
+    newStart: newStart.toISOString(),
+    newEnd: newEnd.toISOString(),
+    attendeesJson: ev.attendees_json,
+    organizerEmail: ev.organizer_email,
+  });
 }
 
 // Scroll to current hour (or 8 AM if before that) on mount
@@ -229,8 +344,12 @@ onMounted(async () => {
           v-for="day in days"
           :key="day.toISOString() + hour"
           class="time-cell"
-          :class="{ today: isToday(day), weekend: isWeekend(day) }"
+          :class="{ today: isToday(day), weekend: isWeekend(day), 'drag-over': isDragOver(day, hour) }"
+          :data-testid="`cal-time-cell-${day.toISOString().split('T')[0]}-${hour}`"
           @click="onSlotClick(day, hour)"
+          @mouseenter="onTimeCellEnter(day, hour)"
+          @mouseleave="onTimeCellLeave(day, hour)"
+          @mouseup="onTimeCellDrop(day, hour)"
         >
           <!-- Current time marker positioned within the hour -->
           <div
@@ -242,9 +361,11 @@ onMounted(async () => {
             v-for="seg in getEventsForDayHour(day, hour)"
             :key="seg.event.id + '-' + seg.segStart.toISOString()"
             class="event-block"
+            :class="{ dragging: isCalendarDragging && dragCalendarEvent?.id === seg.event.id }"
             :data-testid="`cal-event-${seg.event.id}`"
             :style="eventBlockStyle(seg)"
             @click.stop="emit('eventClick', seg.event.id)"
+            @mousedown="onEventMouseDown($event, seg)"
           >
             <span class="event-time">
               {{ seg.segStart.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' }) }}
@@ -477,6 +598,17 @@ onMounted(async () => {
 .event-block:hover {
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
   transform: translateY(-1px);
+}
+
+.event-block.dragging {
+  opacity: 0.4;
+  pointer-events: none;
+}
+
+.time-cell.drag-over {
+  background: rgba(66, 133, 244, 0.15);
+  outline: 1px dashed var(--color-accent);
+  outline-offset: -1px;
 }
 
 .event-time {

--- a/src/components/calendar/WeekView.vue
+++ b/src/components/calendar/WeekView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, ref, nextTick } from "vue";
+import { computed, onMounted, onUnmounted, ref, nextTick } from "vue";
 import { useCalendarStore } from "@/stores/calendar";
 import type { CalendarEvent } from "@/lib/types";
 import { dragCalendarEvent, isCalendarDragging } from "@/lib/calendar-drag-state";
@@ -183,6 +183,7 @@ const dragStartPos = ref<{ x: number; y: number } | null>(null);
 const dragGhost = ref<HTMLElement | null>(null);
 const dragOverCell = ref<{ day: string; hour: number } | null>(null);
 const DRAG_THRESHOLD = 5;
+let dragCleanup: (() => void) | null = null;
 
 function onEventMouseDown(event: MouseEvent, seg: EventSegment) {
   if (event.button !== 0) return;
@@ -236,10 +237,12 @@ function onEventMouseDown(event: MouseEvent, seg: EventSegment) {
     dragStartPos.value = null;
     document.removeEventListener("mousemove", handleMove);
     document.removeEventListener("mouseup", handleUp);
+    dragCleanup = null;
   };
 
   document.addEventListener("mousemove", handleMove);
   document.addEventListener("mouseup", handleUp);
+  dragCleanup = handleUp;
 }
 
 function onTimeCellEnter(day: Date, hour: number) {
@@ -293,6 +296,10 @@ onMounted(async () => {
     const scrollToHour = Math.max(now.value.getHours() - 2, 0);
     gridRef.value.scrollTop = hourHeight * scrollToHour;
   }
+});
+
+onUnmounted(() => {
+  if (dragCleanup) dragCleanup();
 });
 </script>
 

--- a/src/lib/calendar-drag-state.ts
+++ b/src/lib/calendar-drag-state.ts
@@ -1,0 +1,6 @@
+import { ref } from "vue";
+import type { CalendarEvent } from "./types";
+
+/** Shared reactive state for calendar event drag-and-drop. */
+export const dragCalendarEvent = ref<CalendarEvent | null>(null);
+export const isCalendarDragging = ref(false);

--- a/src/stores/calendar.ts
+++ b/src/stores/calendar.ts
@@ -177,6 +177,54 @@ export const useCalendarStore = defineStore("calendar", () => {
     return id;
   }
 
+  async function updateEvent(
+    eventId: string,
+    patch: Partial<NewEventInput>,
+  ): Promise<void> {
+    // Optimistic local update first for instant UI feedback
+    const idx = events.value.findIndex((e) => e.id === eventId);
+    if (idx !== -1) {
+      if (patch.start_time) events.value[idx].start_time = patch.start_time;
+      if (patch.end_time) events.value[idx].end_time = patch.end_time;
+      if (patch.calendar_id) events.value[idx].calendar_id = patch.calendar_id;
+    }
+    await api.updateEvent(eventId, patch);
+    await fetchEvents();
+  }
+
+  async function moveEventToCalendar(
+    eventId: string,
+    targetCalendarId: string,
+    targetAccountId: string,
+  ): Promise<void> {
+    const ev = events.value.find((e) => e.id === eventId);
+    if (!ev) return;
+
+    if (ev.account_id === targetAccountId) {
+      // Same account — just update the calendar_id
+      await updateEvent(eventId, { calendar_id: targetCalendarId });
+    } else {
+      // Cross-account — delete from source, create on destination
+      const attendees: Array<{ email: string; name: string | null; status: string }> =
+        ev.attendees_json ? JSON.parse(ev.attendees_json) : [];
+      await api.createEvent({
+        account_id: targetAccountId,
+        calendar_id: targetCalendarId,
+        title: ev.title,
+        description: ev.description,
+        location: ev.location,
+        start_time: ev.start_time,
+        end_time: ev.end_time,
+        all_day: ev.all_day,
+        timezone: ev.timezone,
+        recurrence_rule: ev.recurrence_rule,
+        attendees,
+      });
+      await api.deleteEvent(eventId);
+      await fetchEvents();
+    }
+  }
+
   async function deleteEvent(eventId: string) {
     await api.deleteEvent(eventId);
     if (selectedEvent.value?.id === eventId) {
@@ -244,6 +292,8 @@ export const useCalendarStore = defineStore("calendar", () => {
     fetchCalendars,
     fetchEvents,
     createEvent,
+    updateEvent,
+    moveEventToCalendar,
     deleteEvent,
     setViewMode,
     goToDate,

--- a/src/stores/calendar.ts
+++ b/src/stores/calendar.ts
@@ -181,33 +181,49 @@ export const useCalendarStore = defineStore("calendar", () => {
     eventId: string,
     patch: Partial<NewEventInput>,
   ): Promise<void> {
-    // Optimistic local update first for instant UI feedback
+    // Save original values for rollback on failure
     const idx = events.value.findIndex((e) => e.id === eventId);
+    const snapshot = idx !== -1 ? { ...events.value[idx] } : null;
+
+    // Optimistic local update first for instant UI feedback
     if (idx !== -1) {
       if (patch.start_time) events.value[idx].start_time = patch.start_time;
       if (patch.end_time) events.value[idx].end_time = patch.end_time;
       if (patch.calendar_id) events.value[idx].calendar_id = patch.calendar_id;
     }
-    await api.updateEvent(eventId, patch);
-    await fetchEvents();
+    try {
+      await api.updateEvent(eventId, patch);
+      await fetchEvents();
+    } catch (e) {
+      // Rollback optimistic update
+      if (snapshot && idx !== -1 && idx < events.value.length) {
+        Object.assign(events.value[idx], snapshot);
+      }
+      throw e;
+    }
+  }
+
+  function safeParseAttendees(json: string | null): Array<{ email: string; name: string | null; status: string }> {
+    if (!json) return [];
+    try { return JSON.parse(json); } catch { return []; }
   }
 
   async function moveEventToCalendar(
     eventId: string,
     targetCalendarId: string,
     targetAccountId: string,
-  ): Promise<void> {
+  ): Promise<string> {
     const ev = events.value.find((e) => e.id === eventId);
-    if (!ev) return;
+    if (!ev) return eventId;
 
     if (ev.account_id === targetAccountId) {
       // Same account — just update the calendar_id
       await updateEvent(eventId, { calendar_id: targetCalendarId });
+      return eventId;
     } else {
-      // Cross-account — delete from source, create on destination
-      const attendees: Array<{ email: string; name: string | null; status: string }> =
-        ev.attendees_json ? JSON.parse(ev.attendees_json) : [];
-      await api.createEvent({
+      // Cross-account — create on destination, then delete source
+      const attendees = safeParseAttendees(ev.attendees_json);
+      const newId = await api.createEvent({
         account_id: targetAccountId,
         calendar_id: targetCalendarId,
         title: ev.title,
@@ -222,6 +238,7 @@ export const useCalendarStore = defineStore("calendar", () => {
       });
       await api.deleteEvent(eventId);
       await fetchEvents();
+      return newId;
     }
   }
 

--- a/src/views/CalendarView.vue
+++ b/src/views/CalendarView.vue
@@ -3,6 +3,8 @@ import { onMounted, ref } from "vue";
 import { useCalendarStore } from "@/stores/calendar";
 import { useAccountsStore } from "@/stores/accounts";
 import type { CalendarViewMode } from "@/stores/calendar";
+import { showToast, dismissToast } from "@/lib/toast";
+import * as api from "@/lib/tauri";
 import CalendarSidebar from "@/components/calendar/CalendarSidebar.vue";
 import WeekView from "@/components/calendar/WeekView.vue";
 import MonthView from "@/components/calendar/MonthView.vue";
@@ -29,6 +31,92 @@ function onEventClick(eventId: string) {
   if (event) calendarStore.selectEvent(event);
 }
 
+function tryParseAttendees(json: string | null): Array<{ email: string }> {
+  if (!json) return [];
+  try { return JSON.parse(json); } catch { return []; }
+}
+
+function isOrganizer(accountId: string, organizerEmail: string | null): boolean {
+  if (!organizerEmail) return true;
+  const account = accountsStore.accounts.find((a) => a.id === accountId);
+  return account?.email === organizerEmail;
+}
+
+async function promptAttendeeNotification(
+  accountId: string,
+  eventId: string,
+  attendeesJson: string | null,
+  organizerEmail: string | null,
+) {
+  const attendees = tryParseAttendees(attendeesJson);
+  if (attendees.length === 0) return;
+  const ev = calendarStore.events.find((e) => e.id === eventId);
+  if (!ev || !isOrganizer(accountId, organizerEmail)) return;
+
+  // Simple confirm — Tauri dialog requires plugin import, use browser confirm for now
+  const send = confirm("This event has attendees. Send an update notification?");
+  if (send) {
+    try {
+      await api.sendInvites(accountId, eventId, attendees.map((a) => a.email));
+      showToast("Update sent to attendees", "success");
+    } catch (e) {
+      showToast(`Failed to send updates: ${e}`, "error", 5000);
+    }
+  }
+}
+
+async function onEventReschedule(payload: {
+  eventId: string;
+  newStart: string;
+  newEnd: string;
+  attendeesJson: string | null;
+  organizerEmail: string | null;
+}) {
+  const toastId = showToast("Moving event...", "info", 0);
+  try {
+    await calendarStore.updateEvent(payload.eventId, {
+      start_time: payload.newStart,
+      end_time: payload.newEnd,
+    });
+    dismissToast(toastId);
+    showToast("Event rescheduled", "success");
+
+    const ev = calendarStore.events.find((e) => e.id === payload.eventId);
+    if (ev) {
+      await promptAttendeeNotification(ev.account_id, payload.eventId, payload.attendeesJson, payload.organizerEmail);
+    }
+  } catch (e) {
+    dismissToast(toastId);
+    showToast(`Failed to reschedule: ${e}`, "error", 5000);
+  }
+}
+
+async function onCalendarDrop(payload: {
+  eventId: string;
+  targetCalendarId: string;
+  targetAccountId: string;
+  attendeesJson: string | null;
+  organizerEmail: string | null;
+}) {
+  const ev = calendarStore.events.find((e) => e.id === payload.eventId);
+  if (!ev) return;
+
+  const toastId = showToast("Moving to calendar...", "info", 0);
+  try {
+    await calendarStore.moveEventToCalendar(
+      payload.eventId,
+      payload.targetCalendarId,
+      payload.targetAccountId,
+    );
+    dismissToast(toastId);
+    showToast("Event moved to calendar", "success");
+    await promptAttendeeNotification(ev.account_id, payload.eventId, payload.attendeesJson, payload.organizerEmail);
+  } catch (e) {
+    dismissToast(toastId);
+    showToast(`Failed to move event: ${e}`, "error", 5000);
+  }
+}
+
 onMounted(async () => {
   // Ensure accounts are loaded — App.vue loads them but it may not be done yet
   if (accountsStore.accounts.length === 0) {
@@ -48,7 +136,7 @@ onMounted(async () => {
 <template>
   <div class="calendar-view">
     <div class="calendar-sidebar-pane">
-      <CalendarSidebar />
+      <CalendarSidebar @calendar-drop="onCalendarDrop" />
     </div>
     <div class="calendar-main">
       <!-- Toolbar -->
@@ -89,11 +177,13 @@ onMounted(async () => {
           :single-day="calendarStore.viewMode === 'day'"
           @time-click="onTimeSlotClick"
           @event-click="onEventClick"
+          @event-reschedule="onEventReschedule"
         />
         <MonthView
           v-else
           @date-click="(d) => { calendarStore.setViewMode('day'); calendarStore.goToDate(d); }"
           @event-click="onEventClick"
+          @event-reschedule="onEventReschedule"
         />
       </div>
     </div>

--- a/src/views/CalendarView.vue
+++ b/src/views/CalendarView.vue
@@ -60,7 +60,8 @@ async function promptAttendeeNotification(
       await api.sendInvites(accountId, eventId, attendees.map((a) => a.email));
       showToast("Update sent to attendees", "success");
     } catch (e) {
-      showToast(`Failed to send updates: ${e}`, "error", 5000);
+      const msg = e instanceof Error ? e.message : String(e);
+      showToast(`Failed to send updates: ${msg}`, "error", 5000);
     }
   }
 }
@@ -87,7 +88,8 @@ async function onEventReschedule(payload: {
     }
   } catch (e) {
     dismissToast(toastId);
-    showToast(`Failed to reschedule: ${e}`, "error", 5000);
+    const msg = e instanceof Error ? e.message : String(e);
+    showToast(`Failed to reschedule: ${msg}`, "error", 5000);
   }
 }
 
@@ -103,17 +105,24 @@ async function onCalendarDrop(payload: {
 
   const toastId = showToast("Moving to calendar...", "info", 0);
   try {
-    await calendarStore.moveEventToCalendar(
+    const newId = await calendarStore.moveEventToCalendar(
       payload.eventId,
       payload.targetCalendarId,
       payload.targetAccountId,
     );
     dismissToast(toastId);
     showToast("Event moved to calendar", "success");
-    await promptAttendeeNotification(ev.account_id, payload.eventId, payload.attendeesJson, payload.organizerEmail);
+    // Use the destination account + new event ID for attendee notification
+    await promptAttendeeNotification(
+      payload.targetAccountId,
+      newId,
+      payload.attendeesJson,
+      payload.organizerEmail,
+    );
   } catch (e) {
     dismissToast(toastId);
-    showToast(`Failed to move event: ${e}`, "error", 5000);
+    const msg = e instanceof Error ? e.message : String(e);
+    showToast(`Failed to move event: ${msg}`, "error", 5000);
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes #28 — drag-and-drop support for calendar events across all views.

### Features
- **Week/Day view**: drag events to a different time slot to reschedule (snaps to full hours)
- **Month view**: drag events to a different day (preserves time-of-day)
- **Sidebar**: drag events to a different calendar (same or cross-account)
- Cross-account calendar moves via delete + create
- Optimistic UI update — event snaps to new position before server sync
- Ghost badge and drop target highlighting (blue outline)
- Recurring and all-day events blocked from dragging

### Implementation
- Shared drag state module (`calendar-drag-state.ts`) following mail DnD pattern
- `updateEvent` and `moveEventToCalendar` actions added to calendar store
- Attendee notification prompt when rescheduling events with participants
- `data-testid` attributes on time cells, month cells, calendar items

## Test plan
- [x] Drag event to new hour in week view → reschedules
- [x] Drag event to new hour in day view → reschedules  
- [x] Drag event to new day in month view → reschedules (keeps time)
- [x] Drag event to different calendar (same account) → moves
- [x] Drag event to different calendar (cross-account) → moves via delete+create
- [x] Click without dragging → still opens event detail
- [x] Drop on same slot → no-op
- [x] `pnpm test` — 171 tests pass