### PR TITLE
feat: unsubscribe from calendars

### DIFF
--- a/src-tauri/src/commands/calendar.rs
+++ b/src-tauri/src/commands/calendar.rs
@@ -2177,7 +2177,11 @@ async fn sync_calendars_graph(
         ).ok())
         .unwrap_or_default();
 
-    // Check if the default calendar is unsubscribed
+    // Graph sync currently maps all events to the default calendar.
+    // Unlike JMAP/Google/CalDAV, there's no per-calendar event fetch,
+    // so we only check the default calendar's subscription status.
+    // TODO: when multi-calendar Graph support is added, use the same
+    // HashSet<String> pattern as the other sync paths.
     let default_subscribed = if !default_cal_local_id.is_empty() {
         let cal = db::calendar::get_calendar(&conn, &default_cal_local_id)?;
         cal.is_subscribed

--- a/src-tauri/src/commands/calendar.rs
+++ b/src-tauri/src/commands/calendar.rs
@@ -667,7 +667,7 @@ async fn sync_calendars_jmap(
         let cals = db::calendar::list_calendars(&conn, account_id)?;
         cals.into_iter()
             .filter(|c| !c.is_subscribed)
-            .map(|c| c.remote_id.unwrap_or_default())
+            .filter_map(|c| c.remote_id)
             .collect()
     };
 
@@ -872,7 +872,7 @@ async fn sync_calendars_google(
         let cals = db::calendar::list_calendars(&conn, account_id)?;
         cals.into_iter()
             .filter(|c| !c.is_subscribed)
-            .map(|c| c.remote_id.unwrap_or_default())
+            .filter_map(|c| c.remote_id)
             .collect()
     };
 
@@ -1106,7 +1106,7 @@ async fn sync_calendars_caldav(
         let cals = db::calendar::list_calendars(&conn, account_id)?;
         cals.into_iter()
             .filter(|c| !c.is_subscribed)
-            .map(|c| c.remote_id.unwrap_or_default())
+            .filter_map(|c| c.remote_id)
             .collect()
     };
 

--- a/src-tauri/src/commands/calendar.rs
+++ b/src-tauri/src/commands/calendar.rs
@@ -103,6 +103,19 @@ pub async fn delete_calendar(
     Ok(())
 }
 
+#[tauri::command]
+pub async fn unsubscribe_calendar(
+    state: State<'_, AppState>,
+    calendar_id: String,
+) -> Result<()> {
+    log::info!("unsubscribe_calendar: id={}", calendar_id);
+    let conn = state.db.lock().await;
+    db::calendar::set_calendar_subscribed(&conn, &calendar_id, false)?;
+    let deleted = db::calendar::delete_calendar_events(&conn, &calendar_id)?;
+    log::info!("unsubscribe_calendar: deleted {} events for calendar {}", deleted, calendar_id);
+    Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // Event management commands
 // ---------------------------------------------------------------------------
@@ -648,8 +661,22 @@ async fn sync_calendars_jmap(
         }
     }
 
-    // Step 2: For each calendar, fetch events and upsert into local DB
+    // Collect unsubscribed calendar IDs to skip event fetching
+    let unsubscribed: std::collections::HashSet<String> = {
+        let conn = state.db.lock().await;
+        let cals = db::calendar::list_calendars(&conn, account_id)?;
+        cals.into_iter()
+            .filter(|c| !c.is_subscribed)
+            .map(|c| c.remote_id.unwrap_or_default())
+            .collect()
+    };
+
+    // Step 2: For each subscribed calendar, fetch events and upsert into local DB
     for jcal in &jmap_calendars {
+        if unsubscribed.contains(&jcal.id) {
+            log::debug!("sync_calendars: skipping unsubscribed calendar '{}'", jcal.name);
+            continue;
+        }
         let events = match jmap_conn
             .fetch_calendar_events(&jmap_config, Some(&jcal.id))
             .await
@@ -839,8 +866,22 @@ async fn sync_calendars_google(
         }
     }
 
-    // Step 2: Fetch events for each calendar (with syncToken for incremental sync)
+    // Collect unsubscribed calendar IDs to skip event fetching
+    let unsubscribed: std::collections::HashSet<String> = {
+        let conn = state.db.lock().await;
+        let cals = db::calendar::list_calendars(&conn, account_id)?;
+        cals.into_iter()
+            .filter(|c| !c.is_subscribed)
+            .map(|c| c.remote_id.unwrap_or_default())
+            .collect()
+    };
+
+    // Step 2: Fetch events for each subscribed calendar
     for (remote_cal_id, local_cal_id) in &remote_to_local {
+        if unsubscribed.contains(remote_cal_id) {
+            log::debug!("sync_calendars_google: skipping unsubscribed calendar {}", remote_cal_id);
+            continue;
+        }
         let sync_key = format!("google_sync_token_{}_{}", account_id, remote_cal_id);
 
         // Check for existing syncToken
@@ -1059,8 +1100,22 @@ async fn sync_calendars_caldav(
         }
     }
 
-    // Step 2: For each calendar, fetch events and upsert into local DB
+    // Collect unsubscribed calendar IDs to skip event fetching
+    let unsubscribed: std::collections::HashSet<String> = {
+        let conn = state.db.lock().await;
+        let cals = db::calendar::list_calendars(&conn, account_id)?;
+        cals.into_iter()
+            .filter(|c| !c.is_subscribed)
+            .map(|c| c.remote_id.unwrap_or_default())
+            .collect()
+    };
+
+    // Step 2: For each subscribed calendar, fetch events and upsert into local DB
     for cal in &caldav_calendars {
+        if unsubscribed.contains(&cal.href) {
+            log::debug!("sync_calendars_caldav: skipping unsubscribed calendar '{}'", cal.name);
+            continue;
+        }
         let caldav_events = match client.fetch_events(&cal.href).await {
             Ok(evts) => evts,
             Err(e) => {
@@ -2121,6 +2176,19 @@ async fn sync_calendars_graph(
             |row| row.get(0),
         ).ok())
         .unwrap_or_default();
+
+    // Check if the default calendar is unsubscribed
+    let default_subscribed = if !default_cal_local_id.is_empty() {
+        let cal = db::calendar::get_calendar(&conn, &default_cal_local_id)?;
+        cal.is_subscribed
+    } else {
+        true
+    };
+
+    if !default_subscribed {
+        log::debug!("sync_calendars_graph: default calendar unsubscribed, skipping events");
+        return Ok(());
+    }
 
     for ge in &graph_events {
         // Find local calendar ID for this event

--- a/src-tauri/src/db/calendar.rs
+++ b/src-tauri/src/db/calendar.rs
@@ -110,10 +110,15 @@ pub fn get_calendar(conn: &Connection, id: &str) -> Result<Calendar> {
 }
 
 pub fn set_calendar_subscribed(conn: &Connection, id: &str, subscribed: bool) -> Result<()> {
-    conn.execute(
+    let rows = conn.execute(
         "UPDATE calendars SET is_subscribed = ?1 WHERE id = ?2",
         params![subscribed, id],
     )?;
+    if rows == 0 {
+        return Err(crate::error::Error::Other(format!(
+            "Calendar not found: {}", id
+        )));
+    }
     Ok(())
 }
 
@@ -490,6 +495,7 @@ mod tests {
                 color TEXT DEFAULT '#4285f4',
                 is_default INTEGER DEFAULT 0,
                 remote_id TEXT,
+                is_subscribed INTEGER NOT NULL DEFAULT 1,
                 UNIQUE(account_id, remote_id)
             );
             CREATE TABLE calendar_events (
@@ -824,5 +830,69 @@ mod tests {
         assert!(get_event(&conn, "e1").is_ok());
         assert!(get_event(&conn, "e2").is_ok());
         assert!(get_event(&conn, "e3").is_err(), "C should be deleted");
+    }
+
+    fn make_cal(account_id: &str, name: &str, is_default: bool) -> NewCalendar {
+        NewCalendar {
+            account_id: account_id.to_string(),
+            name: name.to_string(),
+            color: "#4285f4".to_string(),
+            is_default,
+        }
+    }
+
+    #[test]
+    fn test_set_calendar_subscribed() {
+        let conn = setup_db();
+        insert_calendar(&conn, "cal1", &make_cal("acc1", "Work", true)).unwrap();
+
+        let cal = get_calendar(&conn, "cal1").unwrap();
+        assert!(cal.is_subscribed);
+
+        set_calendar_subscribed(&conn, "cal1", false).unwrap();
+        let cal = get_calendar(&conn, "cal1").unwrap();
+        assert!(!cal.is_subscribed);
+
+        set_calendar_subscribed(&conn, "cal1", true).unwrap();
+        let cal = get_calendar(&conn, "cal1").unwrap();
+        assert!(cal.is_subscribed);
+    }
+
+    #[test]
+    fn test_set_calendar_subscribed_not_found() {
+        let conn = setup_db();
+        let result = set_calendar_subscribed(&conn, "nonexistent", false);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_delete_calendar_events() {
+        let conn = setup_db();
+        insert_calendar(&conn, "cal1", &make_cal("acc1", "Work", true)).unwrap();
+        insert_calendar(&conn, "cal2", &make_cal("acc1", "Personal", false)).unwrap();
+        let mut e1 = make_event("e1", "Event 1", None);
+        e1.calendar_id = "cal1".to_string();
+        insert_event(&conn, &e1).unwrap();
+        let mut e2 = make_event("e2", "Event 2", None);
+        e2.calendar_id = "cal1".to_string();
+        insert_event(&conn, &e2).unwrap();
+        let mut e3 = make_event("e3", "Event 3", None);
+        e3.calendar_id = "cal2".to_string();
+        insert_event(&conn, &e3).unwrap();
+
+        let deleted = delete_calendar_events(&conn, "cal1").unwrap();
+        assert_eq!(deleted, 2);
+
+        assert!(get_event(&conn, "e3").is_ok());
+        assert!(get_event(&conn, "e1").is_err());
+        assert!(get_event(&conn, "e2").is_err());
+    }
+
+    #[test]
+    fn test_delete_calendar_events_empty() {
+        let conn = setup_db();
+        insert_calendar(&conn, "cal1", &make_cal("acc1", "Work", true)).unwrap();
+        let deleted = delete_calendar_events(&conn, "cal1").unwrap();
+        assert_eq!(deleted, 0);
     }
 }

--- a/src-tauri/src/db/calendar.rs
+++ b/src-tauri/src/db/calendar.rs
@@ -15,6 +15,7 @@ pub struct Calendar {
     pub color: String,
     pub is_default: bool,
     pub remote_id: Option<String>,
+    pub is_subscribed: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -62,7 +63,7 @@ pub struct Attendee {
 
 pub fn list_calendars(conn: &Connection, account_id: &str) -> Result<Vec<Calendar>> {
     let mut stmt = conn.prepare(
-        "SELECT id, account_id, name, color, is_default, remote_id
+        "SELECT id, account_id, name, color, is_default, remote_id, is_subscribed
          FROM calendars
          WHERE account_id = ?1
          ORDER BY is_default DESC, name ASC",
@@ -76,6 +77,7 @@ pub fn list_calendars(conn: &Connection, account_id: &str) -> Result<Vec<Calenda
                 color: row.get(3)?,
                 is_default: row.get(4)?,
                 remote_id: row.get(5)?,
+                is_subscribed: row.get(6)?,
             })
         })?
         .collect::<std::result::Result<Vec<_>, _>>()?;
@@ -84,7 +86,7 @@ pub fn list_calendars(conn: &Connection, account_id: &str) -> Result<Vec<Calenda
 
 pub fn get_calendar(conn: &Connection, id: &str) -> Result<Calendar> {
     conn.query_row(
-        "SELECT id, account_id, name, color, is_default, remote_id
+        "SELECT id, account_id, name, color, is_default, remote_id, is_subscribed
          FROM calendars WHERE id = ?1",
         params![id],
         |row| {
@@ -95,6 +97,7 @@ pub fn get_calendar(conn: &Connection, id: &str) -> Result<Calendar> {
                 color: row.get(3)?,
                 is_default: row.get(4)?,
                 remote_id: row.get(5)?,
+                is_subscribed: row.get(6)?,
             })
         },
     )
@@ -104,6 +107,22 @@ pub fn get_calendar(conn: &Connection, id: &str) -> Result<Calendar> {
         }
         other => crate::error::Error::Database(other),
     })
+}
+
+pub fn set_calendar_subscribed(conn: &Connection, id: &str, subscribed: bool) -> Result<()> {
+    conn.execute(
+        "UPDATE calendars SET is_subscribed = ?1 WHERE id = ?2",
+        params![subscribed, id],
+    )?;
+    Ok(())
+}
+
+pub fn delete_calendar_events(conn: &Connection, calendar_id: &str) -> Result<usize> {
+    let count = conn.execute(
+        "DELETE FROM calendar_events WHERE calendar_id = ?1",
+        params![calendar_id],
+    )?;
+    Ok(count)
 }
 
 pub fn insert_calendar(conn: &Connection, id: &str, calendar: &NewCalendar) -> Result<()> {

--- a/src-tauri/src/db/schema.rs
+++ b/src-tauri/src/db/schema.rs
@@ -288,6 +288,17 @@ fn run_migrations(conn: &Connection) -> Result<()> {
         log::info!("Migration: FTS5 index populated");
     }
 
+    // Add is_subscribed column to calendars if it doesn't exist
+    let has_is_subscribed: bool = conn
+        .prepare("SELECT is_subscribed FROM calendars LIMIT 0")
+        .is_ok();
+    if !has_is_subscribed {
+        log::info!("Migration: adding is_subscribed column to calendars table");
+        conn.execute_batch(
+            "ALTER TABLE calendars ADD COLUMN is_subscribed INTEGER NOT NULL DEFAULT 1;",
+        )?;
+    }
+
     Ok(())
 }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -86,6 +86,7 @@ fn main() {
             commands::calendar::create_calendar,
             commands::calendar::update_calendar,
             commands::calendar::delete_calendar,
+            commands::calendar::unsubscribe_calendar,
             commands::calendar::get_events,
             commands::calendar::create_event,
             commands::calendar::update_event,

--- a/src/__tests__/calendar.test.ts
+++ b/src/__tests__/calendar.test.ts
@@ -9,6 +9,7 @@ vi.mock("@/lib/tauri", () => ({
   updateEvent: vi.fn().mockResolvedValue(undefined),
   deleteEvent: vi.fn().mockResolvedValue(undefined),
   syncCalendars: vi.fn().mockResolvedValue(undefined),
+  unsubscribeCalendar: vi.fn().mockResolvedValue(undefined),
   getEmailInvites: vi.fn().mockResolvedValue([]),
   getInviteStatus: vi.fn().mockResolvedValue(null),
   respondToInvite: vi.fn().mockResolvedValue(undefined),
@@ -164,6 +165,35 @@ describe("Calendar store", () => {
       await store.fetchCalendars();
 
       expect(store.calendars).toEqual([]);
+    });
+  });
+
+  describe("unsubscribeCalendar", () => {
+    it("should call backend and refresh calendars and events", async () => {
+      setupAccounts();
+      const store = useCalendarStore();
+      const cal = makeCalendar("cal1", "Work", "remote-1");
+      vi.mocked(api.listCalendars).mockResolvedValue([cal]);
+      vi.mocked(api.getEvents).mockResolvedValue([]);
+
+      await store.unsubscribeCalendar("cal1");
+
+      expect(api.unsubscribeCalendar).toHaveBeenCalledWith("cal1");
+      expect(api.listCalendars).toHaveBeenCalled();
+      expect(api.getEvents).toHaveBeenCalled();
+    });
+
+    it("should filter out unsubscribed calendars from fetchCalendars", async () => {
+      setupAccounts();
+      const store = useCalendarStore();
+      const subscribed = makeCalendar("cal1", "Work", "remote-1");
+      const unsubscribed = { ...makeCalendar("cal2", "Holidays", "remote-2"), is_subscribed: false };
+      vi.mocked(api.listCalendars).mockResolvedValueOnce([subscribed, unsubscribed]);
+
+      await store.fetchCalendars();
+
+      expect(store.calendars).toHaveLength(1);
+      expect(store.calendars[0].id).toBe("cal1");
     });
   });
 

--- a/src/__tests__/calendar.test.ts
+++ b/src/__tests__/calendar.test.ts
@@ -55,7 +55,7 @@ function setupAccounts() {
 function makeCalendar(id: string, name: string, remoteId: string | null = null) {
   return {
     id, account_id: "acc1", name, color: "#4285f4",
-    is_default: true, remote_id: remoteId,
+    is_default: true, remote_id: remoteId, is_subscribed: true,
   };
 }
 

--- a/src/components/calendar/CalendarSidebar.vue
+++ b/src/components/calendar/CalendarSidebar.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
-import { ref } from "vue";
+import { ref, onMounted, onUnmounted } from "vue";
 import { useCalendarStore } from "@/stores/calendar";
 import { useAccountsStore } from "@/stores/accounts";
 import type { Calendar } from "@/lib/types";
 import { dragCalendarEvent, isCalendarDragging } from "@/lib/calendar-drag-state";
+import { showToast, dismissToast } from "@/lib/toast";
 import * as api from "@/lib/tauri";
 
 const emit = defineEmits<{
@@ -33,12 +34,22 @@ function getCalendarColor(color: string): string {
 
 function onContextMenu(event: MouseEvent, calId: string, accountId: string) {
   event.preventDefault();
+  event.stopPropagation();
   contextMenu.value = { x: event.clientX, y: event.clientY, calendarId: calId, accountId };
 }
 
 function closeContextMenu() {
   contextMenu.value = null;
 }
+
+function onKeyDown(e: KeyboardEvent) {
+  if (e.key === "Escape" && contextMenu.value) {
+    closeContextMenu();
+  }
+}
+
+onMounted(() => document.addEventListener("keydown", onKeyDown));
+onUnmounted(() => document.removeEventListener("keydown", onKeyDown));
 
 const dropTargetCalendarId = ref<string | null>(null);
 
@@ -69,6 +80,24 @@ function onCalendarItemDrop(cal: Calendar) {
     attendeesJson: ev.attendees_json,
     organizerEmail: ev.organizer_email,
   });
+}
+
+async function unsubscribeThisCalendar() {
+  if (!contextMenu.value) return;
+  const calendarId = contextMenu.value.calendarId;
+  const cal = calendarStore.calendars.find((c) => c.id === calendarId);
+  const calName = cal?.name || "Calendar";
+  closeContextMenu();
+  const toastId = showToast(`Unsubscribing from "${calName}"...`, "info", 0);
+  try {
+    await calendarStore.unsubscribeCalendar(calendarId);
+    dismissToast(toastId);
+    showToast(`Unsubscribed from "${calName}"`, "success");
+  } catch (e) {
+    dismissToast(toastId);
+    const msg = e instanceof Error ? e.message : String(e);
+    showToast(`Failed to unsubscribe: ${msg}`, "error", 5000);
+  }
 }
 
 async function syncThisCalendar() {
@@ -126,12 +155,15 @@ async function syncThisCalendar() {
 
     <!-- Right-click context menu -->
     <Teleport to="body">
+      <div v-if="contextMenu" class="cal-menu-overlay" @click="closeContextMenu" @contextmenu.prevent="closeContextMenu"></div>
       <div
         v-if="contextMenu"
         class="cal-context-menu"
         :style="{ left: contextMenu.x + 'px', top: contextMenu.y + 'px' }"
+        @keydown.esc="closeContextMenu"
       >
-        <button class="ctx-item" @click="syncThisCalendar" data-testid="calendar-sync">Sync this calendar</button>
+        <button class="ctx-item" data-testid="calendar-sync" @click="syncThisCalendar">Sync this calendar</button>
+        <button class="ctx-item" data-testid="calendar-unsubscribe" @click="unsubscribeThisCalendar">Unsubscribe</button>
       </div>
     </Teleport>
   </div>
@@ -221,6 +253,15 @@ async function syncThisCalendar() {
 </style>
 
 <style>
+.cal-menu-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 9998;
+}
+
 .cal-context-menu {
   position: fixed;
   z-index: 9999;

--- a/src/components/calendar/CalendarSidebar.vue
+++ b/src/components/calendar/CalendarSidebar.vue
@@ -88,6 +88,7 @@ async function unsubscribeThisCalendar() {
   const cal = calendarStore.calendars.find((c) => c.id === calendarId);
   const calName = cal?.name || "Calendar";
   closeContextMenu();
+  if (!confirm(`Unsubscribe from "${calName}"? Local events will be removed.`)) return;
   const toastId = showToast(`Unsubscribing from "${calName}"...`, "info", 0);
   try {
     await calendarStore.unsubscribeCalendar(calendarId);

--- a/src/components/calendar/CalendarSidebar.vue
+++ b/src/components/calendar/CalendarSidebar.vue
@@ -160,7 +160,6 @@ async function syncThisCalendar() {
         v-if="contextMenu"
         class="cal-context-menu"
         :style="{ left: contextMenu.x + 'px', top: contextMenu.y + 'px' }"
-        @keydown.esc="closeContextMenu"
       >
         <button class="ctx-item" data-testid="calendar-sync" @click="syncThisCalendar">Sync this calendar</button>
         <button class="ctx-item" data-testid="calendar-unsubscribe" @click="unsubscribeThisCalendar">Unsubscribe</button>

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -247,6 +247,10 @@ export async function deleteCalendar(calendarId: string): Promise<void> {
   return invoke("delete_calendar", { calendarId });
 }
 
+export async function unsubscribeCalendar(calendarId: string): Promise<void> {
+  return invoke("unsubscribe_calendar", { calendarId });
+}
+
 export async function getEvents(
   accountId: string,
   start: string,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -166,6 +166,7 @@ export interface Calendar {
   color: string;
   is_default: boolean;
   remote_id: string | null;
+  is_subscribed: boolean;
 }
 
 export interface CalendarEvent {

--- a/src/stores/calendar.ts
+++ b/src/stores/calendar.ts
@@ -140,7 +140,7 @@ export const useCalendarStore = defineStore("calendar", () => {
     for (const account of accountsStore.accounts) {
       try {
         const cals = await api.listCalendars(account.id);
-        all = all.concat(cals);
+        all = all.concat(cals.filter((c) => c.is_subscribed));
       } catch (e) {
         console.error("Failed to fetch calendars for", account.id, e);
       }
@@ -242,6 +242,12 @@ export const useCalendarStore = defineStore("calendar", () => {
     }
   }
 
+  async function unsubscribeCalendar(calendarId: string) {
+    await api.unsubscribeCalendar(calendarId);
+    await fetchCalendars();
+    await fetchEvents();
+  }
+
   async function deleteEvent(eventId: string) {
     await api.deleteEvent(eventId);
     if (selectedEvent.value?.id === eventId) {
@@ -312,6 +318,7 @@ export const useCalendarStore = defineStore("calendar", () => {
     updateEvent,
     moveEventToCalendar,
     deleteEvent,
+    unsubscribeCalendar,
     setViewMode,
     goToDate,
     goToday,


### PR DESCRIPTION
## Summary

Fixes #32 — Phase 1 of calendar subscription management.

Adds the ability to unsubscribe from individual calendars via the sidebar context menu. Unsubscribed calendars stop syncing events, their local events are deleted, and they are hidden from the sidebar. Re-subscribing will be available in Phase 3 (#43) with the calendar management UI.

### Changes
- **DB**: `is_subscribed` column on calendars table (migration)
- **Backend**: `unsubscribe_calendar` command; all four sync functions (JMAP, CalDAV, Google, Graph) skip event fetching for unsubscribed calendars
- **Frontend**: Context menu with "Unsubscribe" + toast feedback; unsubscribed calendars filtered from sidebar; context menu UX fix (overlay dismiss, Escape key)

### Future phases
- #42 — Account-level calendar sync toggle
- #43 — Standalone CalDAV/JMAP calendar-only accounts + re-subscribe UI
- #44 — Rename calendars

## Test plan
- [x] Right-click calendar → Unsubscribe → events disappear, calendar removed from sidebar
- [x] Sync skips unsubscribed calendars
- [x] Context menu stays open after right-click, dismisses on click-outside or Escape
- [x] `pnpm test` — 171 tests pass
- [x] `cargo check` passes