### PR TITLE
feat: configurable week start day

### DIFF
--- a/src/components/calendar/CalendarSidebar.vue
+++ b/src/components/calendar/CalendarSidebar.vue
@@ -2,6 +2,7 @@
 import { ref } from "vue";
 import { useCalendarStore } from "@/stores/calendar";
 import { useAccountsStore } from "@/stores/accounts";
+import { useUiStore } from "@/stores/ui";
 import type { Calendar } from "@/lib/types";
 import { dragCalendarEvent, isCalendarDragging } from "@/lib/calendar-drag-state";
 import { showToast } from "@/lib/toast";
@@ -19,6 +20,7 @@ const emit = defineEmits<{
 
 const calendarStore = useCalendarStore();
 const accountsStore = useAccountsStore();
+const uiStore = useUiStore();
 
 function getAccountLabel(accountId: string): string {
   const acc = accountsStore.accounts.find((a) => a.id === accountId);
@@ -146,6 +148,20 @@ async function unsubscribeThisCalendar() {
       </div>
     </div>
 
+    <div class="week-start-section">
+      <div class="section-header">Week starts on</div>
+      <div class="week-start-options">
+        <button
+          v-for="opt in [{ day: 0, label: 'Sunday' }, { day: 1, label: 'Monday' }, { day: 6, label: 'Saturday' }]"
+          :key="opt.day"
+          class="week-start-btn"
+          :class="{ active: uiStore.weekStartDay === opt.day }"
+          :data-testid="`week-start-${opt.day}`"
+          @click="uiStore.setWeekStartDay(opt.day)"
+        >{{ opt.label }}</button>
+      </div>
+    </div>
+
     <!-- Right-click context menu -->
     <Teleport to="body">
       <div
@@ -256,6 +272,45 @@ async function unsubscribeThisCalendar() {
   color: var(--color-text-muted);
   font-size: 12px;
   padding: 8px 4px;
+}
+
+.week-start-section {
+  margin-top: 16px;
+  padding-top: 12px;
+  border-top: 1px solid var(--color-border);
+}
+
+.section-header {
+  font-size: 10px;
+  font-weight: 700;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  padding: 0 4px 8px;
+}
+
+.week-start-options {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.week-start-btn {
+  padding: 4px 8px;
+  font-size: 12px;
+  color: var(--color-text-secondary);
+  text-align: left;
+  border-radius: 4px;
+  transition: background 0.1s;
+}
+
+.week-start-btn:hover {
+  background: var(--color-bg-hover);
+}
+
+.week-start-btn.active {
+  color: var(--color-accent);
+  font-weight: 600;
 }
 </style>
 

--- a/src/components/calendar/MonthView.vue
+++ b/src/components/calendar/MonthView.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, ref, onUnmounted } from "vue";
 import { useCalendarStore } from "@/stores/calendar";
+import { useUiStore } from "@/stores/ui";
 import type { CalendarEvent } from "@/lib/types";
 import { dragCalendarEvent, isCalendarDragging } from "@/lib/calendar-drag-state";
 
@@ -17,6 +18,7 @@ const emit = defineEmits<{
 }>();
 
 const calendarStore = useCalendarStore();
+const uiStore = useUiStore();
 
 const weeks = computed(() => {
   const d = new Date(calendarStore.currentDate);
@@ -25,9 +27,10 @@ const weeks = computed(() => {
   const firstDay = new Date(year, month, 1);
   const lastDay = new Date(year, month + 1, 0);
 
-  // Start from Sunday of the first week
+  // Start from the configured week start day
   const start = new Date(firstDay);
-  start.setDate(start.getDate() - start.getDay());
+  const offset = (start.getDay() - uiStore.weekStartDay + 7) % 7;
+  start.setDate(start.getDate() - offset);
 
   const rows: Date[][] = [];
   const current = new Date(start);
@@ -72,7 +75,11 @@ function getEventColor(event: { calendar_id: string }): string {
   return cal?.color || "#4285f4";
 }
 
-const dayNames = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+const allDayNames = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+const dayNames = computed(() => {
+  const s = uiStore.weekStartDay;
+  return [...allDayNames.slice(s), ...allDayNames.slice(0, s)];
+});
 
 // Drag-to-reschedule
 const dragStartPos = ref<{ x: number; y: number } | null>(null);

--- a/src/components/calendar/WeekView.vue
+++ b/src/components/calendar/WeekView.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref, nextTick } from "vue";
 import { useCalendarStore } from "@/stores/calendar";
+import { useUiStore } from "@/stores/ui";
 import type { CalendarEvent } from "@/lib/types";
 import { dragCalendarEvent, isCalendarDragging } from "@/lib/calendar-drag-state";
 
@@ -21,6 +22,7 @@ const emit = defineEmits<{
 }>();
 
 const calendarStore = useCalendarStore();
+const uiStore = useUiStore();
 const gridRef = ref<HTMLElement | null>(null);
 
 const hours = Array.from({ length: 24 }, (_, i) => i);
@@ -31,7 +33,8 @@ const days = computed(() => {
     return [new Date(d)];
   }
   const start = new Date(d);
-  start.setDate(d.getDate() - d.getDay()); // Sunday
+  const offset = (d.getDay() - uiStore.weekStartDay + 7) % 7;
+  start.setDate(d.getDate() - offset);
   return Array.from({ length: 7 }, (_, i) => {
     const day = new Date(start);
     day.setDate(start.getDate() + i);
@@ -67,7 +70,13 @@ function isToday(date: Date): boolean {
 }
 
 function isWeekend(date: Date): boolean {
-  return date.getDay() === 0 || date.getDay() === 6;
+  const day = date.getDay();
+  if (uiStore.weekStartDay === 6) {
+    // Saturday start → weekend is Thursday (4) + Friday (5)
+    return day === 4 || day === 5;
+  }
+  // Sunday or Monday start → weekend is Saturday (6) + Sunday (0)
+  return day === 0 || day === 6;
 }
 
 function isCurrentHour(hour: number): boolean {

--- a/src/stores/calendar.ts
+++ b/src/stores/calendar.ts
@@ -5,6 +5,7 @@ import type { Calendar, CalendarEvent, NewEventInput } from "@/lib/types";
 import { expandRRule } from "@/lib/rrule";
 import * as api from "@/lib/tauri";
 import { useAccountsStore } from "./accounts";
+import { useUiStore } from "./ui";
 
 export type CalendarViewMode = "day" | "week" | "month";
 
@@ -17,6 +18,7 @@ export const useCalendarStore = defineStore("calendar", () => {
   const selectedEvent = ref<CalendarEvent | null>(null);
 
   const accountsStore = useAccountsStore();
+  const uiStore = useUiStore();
 
   // Visible calendars (all by default). Persisted to localStorage so the
   // user's hide/show picks survive across sessions.
@@ -95,7 +97,8 @@ export const useCalendarStore = defineStore("calendar", () => {
       end.setHours(23, 59, 59, 999);
     } else if (viewMode.value === "week") {
       start = new Date(d);
-      start.setDate(d.getDate() - d.getDay()); // Sunday
+      const offset = (d.getDay() - uiStore.weekStartDay + 7) % 7;
+      start.setDate(d.getDate() - offset);
       start.setHours(0, 0, 0, 0);
       end = new Date(start);
       end.setDate(start.getDate() + 6);

--- a/src/stores/ui.ts
+++ b/src/stores/ui.ts
@@ -23,8 +23,12 @@ export const useUiStore = defineStore("ui", () => {
   );
 
   // Week start day: 0 = Sunday, 1 = Monday, 6 = Saturday
+  const VALID_WEEK_STARTS = [0, 1, 6];
   const weekStartDay = ref<number>(
-    parseInt(localStorage.getItem("chithi-week-start-day") || "0", 10),
+    (() => {
+      const stored = parseInt(localStorage.getItem("chithi-week-start-day") || "0", 10);
+      return VALID_WEEK_STARTS.includes(stored) ? stored : 0;
+    })(),
   );
 
   function toggleReader() {
@@ -62,6 +66,7 @@ export const useUiStore = defineStore("ui", () => {
   }
 
   function setWeekStartDay(day: number) {
+    if (!VALID_WEEK_STARTS.includes(day)) return;
     weekStartDay.value = day;
     localStorage.setItem("chithi-week-start-day", String(day));
   }

--- a/src/stores/ui.ts
+++ b/src/stores/ui.ts
@@ -22,6 +22,11 @@ export const useUiStore = defineStore("ui", () => {
     localStorage.getItem("chithi-decorations") !== "false",
   );
 
+  // Week start day: 0 = Sunday, 1 = Monday, 6 = Saturday
+  const weekStartDay = ref<number>(
+    parseInt(localStorage.getItem("chithi-week-start-day") || "0", 10),
+  );
+
   function toggleReader() {
     readerVisible.value = !readerVisible.value;
   }
@@ -54,6 +59,11 @@ export const useUiStore = defineStore("ui", () => {
     decorationsEnabled.value = enabled;
     localStorage.setItem("chithi-decorations", String(enabled));
     getCurrentWindow().setDecorations(enabled);
+  }
+
+  function setWeekStartDay(day: number) {
+    weekStartDay.value = day;
+    localStorage.setItem("chithi-week-start-day", String(day));
   }
 
   function initTheme() {
@@ -92,5 +102,7 @@ export const useUiStore = defineStore("ui", () => {
     initDecorations,
     operationsPanelOpen,
     toggleOperationsPanel,
+    weekStartDay,
+    setWeekStartDay,
   };
 });


### PR DESCRIPTION
## Summary

Fixes #41 — week view and month view always started on Sunday.

Adds a setting to choose the first day of the week: Sunday (default), Monday, or Saturday. The selector is in the calendar sidebar below the calendar list.

### Changes
- Week start day persisted to localStorage via UI store
- WeekView: week starts on configured day instead of hardcoded Sunday
- MonthView: grid and day name headers rotate to match
- Calendar store: date range calculation respects setting
- Saturday start uses Thursday+Friday as weekend (Islamic week pattern)
- Sunday/Monday start uses Saturday+Sunday as weekend
- `data-testid` on week start buttons

## Test plan
- [x] Sunday start: week Sun-Sat, weekend Sat+Sun
- [x] Monday start: week Mon-Sun, weekend Sat+Sun
- [x] Saturday start: week Sat-Fri, weekend Thu+Fri
- [x] Month view headers rotate correctly
- [x] Setting persists across app restarts
- [x] `pnpm test` — 173 tests pass
- [x] `cargo test` — 97 tests pass