### PR TITLE
fix: add missing is_subscribed migration, parallel calendar sync

### DIFF
--- a/src-tauri/src/db/schema.rs
+++ b/src-tauri/src/db/schema.rs
@@ -278,6 +278,17 @@ fn run_migrations(conn: &Connection) -> Result<()> {
         )?;
     }
 
+    // Add is_subscribed column to calendars if it doesn't exist
+    let has_is_subscribed: bool = conn
+        .prepare("SELECT is_subscribed FROM calendars LIMIT 0")
+        .is_ok();
+    if !has_is_subscribed {
+        log::info!("Migration: adding is_subscribed column to calendars table");
+        conn.execute_batch(
+            "ALTER TABLE calendars ADD COLUMN is_subscribed INTEGER NOT NULL DEFAULT 1;",
+        )?;
+    }
+
     // Add uid_next column to folders for IMAP preflight sync optimization
     let has_uid_next: bool = conn
         .prepare("SELECT uid_next FROM folders LIMIT 0")

--- a/src/stores/calendar.ts
+++ b/src/stores/calendar.ts
@@ -125,13 +125,16 @@ export const useCalendarStore = defineStore("calendar", () => {
     if (accountsStore.accounts.length === 0) {
       await accountsStore.fetchAccounts();
     }
-    for (const account of accountsStore.accounts) {
-      try {
-        await api.syncCalendars(account.id);
-      } catch (e) {
-        console.error("Calendar sync failed for", account.id, e);
-      }
-    }
+    // Sync all accounts in parallel so a hanging account doesn't block others.
+    // Each backend sync_calendars emits "calendar-changed" when done, which
+    // triggers fetchCalendars + fetchEvents via the event listener.
+    await Promise.allSettled(
+      accountsStore.accounts.map((account) =>
+        api.syncCalendars(account.id).catch((e) => {
+          console.error("Calendar sync failed for", account.id, e);
+        }),
+      ),
+    );
     await fetchCalendars();
     await fetchEvents();
   }

--- a/src/stores/calendar.ts
+++ b/src/stores/calendar.ts
@@ -128,13 +128,19 @@ export const useCalendarStore = defineStore("calendar", () => {
     // Sync all accounts in parallel so a hanging account doesn't block others.
     // Each backend sync_calendars emits "calendar-changed" when done, which
     // triggers fetchCalendars + fetchEvents via the event listener.
-    await Promise.allSettled(
+    // The final fetchCalendars/fetchEvents below is a safety net to ensure
+    // the UI is consistent after all syncs settle.
+    const results = await Promise.allSettled(
       accountsStore.accounts.map((account) =>
-        api.syncCalendars(account.id).catch((e) => {
-          console.error("Calendar sync failed for", account.id, e);
-        }),
+        api.syncCalendars(account.id),
       ),
     );
+    for (let i = 0; i < results.length; i++) {
+      const r = results[i];
+      if (r.status === "rejected") {
+        console.error("Calendar sync failed for", accountsStore.accounts[i]?.id, r.reason);
+      }
+    }
     await fetchCalendars();
     await fetchEvents();
   }


### PR DESCRIPTION
## Summary

Fixes #52 — Calendars were invisible in the sidebar for existing databases.

**Root cause:** The `calendars` table schema added an `is_subscribed` column for the subscribe/unsubscribe feature, but no migration existed for existing databases. Every `list_calendars` query failed silently with "no such column: is_subscribed", making all calendars invisible — not just new ones.

**Changes:**
- Add `ALTER TABLE calendars ADD COLUMN is_subscribed INTEGER NOT NULL DEFAULT 1` migration in `schema.rs`
- Sync calendar accounts in parallel (`Promise.allSettled`) so a hanging account (e.g. CalDAV discovery timeout) doesn't block calendars from other accounts

## Test plan

- [ ] Existing database with calendars: calendars reappear after migration runs on startup
- [ ] New database: calendars created with `is_subscribed = 1` by default
- [ ] Multiple accounts: all sync concurrently, fast-completing accounts show calendars immediately