### PR TITLE
fix(security): enforce HTTPS for JMAP/CalDAV/CardDAV URLs

### DIFF
--- a/src-tauri/src/calendar/timezone.rs
+++ b/src-tauri/src/calendar/timezone.rs
@@ -1,7 +1,7 @@
-/// Timezone conversion utilities for calendar events.
-///
-/// All calendar events are stored with UTC times. This module handles
-/// converting provider-specific datetime+timezone pairs to UTC.
+//! Timezone conversion utilities for calendar events.
+//!
+//! All calendar events are stored with UTC times. This module handles
+//! converting provider-specific datetime+timezone pairs to UTC.
 
 /// Convert a datetime string to UTC given an IANA timezone identifier.
 ///

--- a/src-tauri/src/mail/caldav.rs
+++ b/src-tauri/src/mail/caldav.rs
@@ -25,6 +25,36 @@ pub struct CalDavConfig {
     pub email: String, // Used for domain extraction during auto-discovery
 }
 
+#[cfg(test)]
+mod connect_tests {
+    use super::*;
+
+    fn err_msg<T>(r: Result<T>) -> String {
+        match r {
+            Ok(_) => String::new(),
+            Err(e) => e.to_string(),
+        }
+    }
+
+    #[tokio::test]
+    async fn connect_rejects_http_url() {
+        let cfg = CalDavConfig {
+            caldav_url: "http://example.com/dav/".into(),
+            username: "u".into(),
+            password: "p".into(),
+            email: "u@example.com".into(),
+        };
+        let msg = err_msg(CalDavClient::connect(&cfg).await);
+        assert!(msg.contains("https"), "expected scheme error, got: {}", msg);
+    }
+
+    #[tokio::test]
+    async fn connect_with_token_rejects_http_url() {
+        let msg = err_msg(CalDavClient::connect_with_token("http://example.com/dav/", "tok").await);
+        assert!(msg.contains("https"), "expected scheme error, got: {}", msg);
+    }
+}
+
 /// A CalDAV client that holds an HTTP client and connection details.
 pub struct CalDavClient {
     http: reqwest::Client,
@@ -90,6 +120,7 @@ impl CalDavClient {
             log::info!("caldav: no URL configured, attempting auto-discovery");
             Self::auto_discover(&http, &auth, &config.email).await?
         } else {
+            crate::mail::url_validation::require_https(&config.caldav_url)?;
             config.caldav_url.clone()
         };
 
@@ -100,6 +131,8 @@ impl CalDavClient {
 
     /// Create a CalDAV client with OAuth2 bearer token authentication.
     pub async fn connect_with_token(caldav_url: &str, token: &str) -> Result<Self> {
+        crate::mail::url_validation::require_https(caldav_url)?;
+
         let http = reqwest::Client::builder()
             .redirect(reqwest::redirect::Policy::limited(10))
             .build()
@@ -171,6 +204,7 @@ impl CalDavClient {
                             final_url.host_str().unwrap_or(domain),
                             final_url.path().trim_end_matches('/')
                         );
+                        crate::mail::url_validation::require_https(&discovered)?;
                         log::info!("caldav: auto-discovered URL: {}", discovered);
                         return Ok(discovered);
                     }

--- a/src-tauri/src/mail/caldav.rs
+++ b/src-tauri/src/mail/caldav.rs
@@ -198,10 +198,15 @@ impl CalDavClient {
                     let final_url = resp.url().clone();
                     if status.is_success() || status.as_u16() == 207 {
                         // The redirect target (or final URL) is our CalDAV base
+                        let port_str = final_url
+                            .port()
+                            .map(|p| format!(":{}", p))
+                            .unwrap_or_default();
                         let discovered = format!(
-                            "{}://{}{}",
+                            "{}://{}{}{}",
                             final_url.scheme(),
                             final_url.host_str().unwrap_or(domain),
+                            port_str,
                             final_url.path().trim_end_matches('/')
                         );
                         crate::mail::url_validation::require_https(&discovered)?;

--- a/src-tauri/src/mail/caldav.rs
+++ b/src-tauri/src/mail/caldav.rs
@@ -36,6 +36,49 @@ mod connect_tests {
         }
     }
 
+    fn ok_str(r: Result<String>) -> String {
+        match r {
+            Ok(s) => s,
+            Err(e) => panic!("expected Ok, got Err: {}", e),
+        }
+    }
+
+    fn client_with_base(base: &str) -> CalDavClient {
+        CalDavClient {
+            http: reqwest::Client::new(),
+            base_url: base.to_string(),
+            auth: DavAuth::Basic {
+                username: "u".into(),
+                password: "p".into(),
+            },
+        }
+    }
+
+    #[test]
+    fn resolve_url_rejects_absolute_http_href() {
+        let client = client_with_base("https://example.com/dav/");
+        let msg = err_msg(client.resolve_url("http://evil.example.com/path"));
+        assert!(msg.contains("https"), "expected scheme error, got: {}", msg);
+    }
+
+    #[test]
+    fn resolve_url_accepts_absolute_https_href() {
+        let client = client_with_base("https://example.com/dav/");
+        assert_eq!(
+            ok_str(client.resolve_url("https://other.example.com/x")),
+            "https://other.example.com/x"
+        );
+    }
+
+    #[test]
+    fn resolve_url_resolves_relative_href() {
+        let client = client_with_base("https://example.com:8443/dav/");
+        assert_eq!(
+            ok_str(client.resolve_url("/calendars/user/default/")),
+            "https://example.com:8443/calendars/user/default/"
+        );
+    }
+
     #[tokio::test]
     async fn connect_rejects_http_url() {
         let cfg = CalDavConfig {
@@ -243,7 +286,7 @@ impl CalDavClient {
                 Error::Other("CalDAV: could not find current-user-principal in response".to_string())
             })?;
 
-        let principal_url = self.resolve_url(&principal);
+        let principal_url = self.resolve_url(&principal)?;
         log::info!("caldav: principal URL: {}", principal_url);
         Ok(principal_url)
     }
@@ -262,7 +305,7 @@ impl CalDavClient {
                 )
             })?;
 
-        let home_url = self.resolve_url(&home);
+        let home_url = self.resolve_url(&home)?;
         log::info!("caldav: calendar home URL: {}", home_url);
         Ok(home_url)
     }
@@ -299,7 +342,7 @@ impl CalDavClient {
 
     /// Fetch all events from a calendar collection using REPORT calendar-query.
     pub async fn fetch_events(&self, calendar_href: &str) -> Result<Vec<CalDavEvent>> {
-        let url = self.resolve_url(calendar_href);
+        let url = self.resolve_url(calendar_href)?;
         log::debug!("caldav: fetching events from {}", url);
 
         let resp = self.apply_auth(
@@ -342,9 +385,10 @@ impl CalDavClient {
         uid: &str,
         ical_data: &str,
     ) -> Result<String> {
+        let calendar_url = self.resolve_url(calendar_href)?;
         let event_url = format!(
             "{}/{}.ics",
-            self.resolve_url(calendar_href).trim_end_matches('/'),
+            calendar_url.trim_end_matches('/'),
             uid
         );
         log::info!("caldav: PUT event to {}", event_url);
@@ -383,7 +427,7 @@ impl CalDavClient {
 
     /// DELETE an event from the server.
     pub async fn delete_event(&self, event_href: &str) -> Result<()> {
-        let url = self.resolve_url(event_href);
+        let url = self.resolve_url(event_href)?;
         log::info!("caldav: DELETE event at {}", url);
 
         let resp = self.apply_auth(self.http.delete(&url))
@@ -449,12 +493,14 @@ impl CalDavClient {
     }
 
     /// Resolve a potentially relative URL against the base URL.
-    fn resolve_url(&self, href: &str) -> String {
-        if href.starts_with("http://") || href.starts_with("https://") {
-            return href.to_string();
-        }
-        // Parse the base URL to get the scheme and host
-        if let Ok(base) = url::Url::parse(&self.base_url) {
+    ///
+    /// Rejects absolute URLs with a scheme that would send auth-bearing
+    /// requests over cleartext (see `require_https`). Relative hrefs inherit
+    /// the base URL's scheme and are accepted as-is.
+    fn resolve_url(&self, href: &str) -> Result<String> {
+        let resolved = if href.starts_with("http://") || href.starts_with("https://") {
+            href.to_string()
+        } else if let Ok(base) = url::Url::parse(&self.base_url) {
             let scheme = base.scheme();
             let host = base.host_str().unwrap_or("");
             let port_str = base
@@ -465,7 +511,9 @@ impl CalDavClient {
         } else {
             // Fallback: just concatenate
             format!("{}{}", self.base_url.trim_end_matches('/'), href)
-        }
+        };
+        crate::mail::url_validation::require_https(&resolved)?;
+        Ok(resolved)
     }
 }
 

--- a/src-tauri/src/mail/carddav.rs
+++ b/src-tauri/src/mail/carddav.rs
@@ -289,10 +289,15 @@ async fn auto_discover(http: &reqwest::Client, auth: &DavAuth, email: &str) -> R
                 let status = resp.status();
                 let final_url = resp.url().clone();
                 if status.is_success() || status.as_u16() == 207 {
+                    let port_str = final_url
+                        .port()
+                        .map(|p| format!(":{}", p))
+                        .unwrap_or_default();
                     let discovered = format!(
-                        "{}://{}{}",
+                        "{}://{}{}{}",
                         final_url.scheme(),
                         final_url.host_str().unwrap_or(domain),
+                        port_str,
                         final_url.path().trim_end_matches('/')
                     );
                     crate::mail::url_validation::require_https(&discovered)?;

--- a/src-tauri/src/mail/carddav.rs
+++ b/src-tauri/src/mail/carddav.rs
@@ -86,6 +86,7 @@ impl CardDavClient {
             log::info!("carddav: no URL configured, attempting auto-discovery");
             auto_discover(&http, &auth, email).await?
         } else {
+            crate::mail::url_validation::require_https(carddav_url)?;
             carddav_url.to_string()
         };
 
@@ -294,6 +295,7 @@ async fn auto_discover(http: &reqwest::Client, auth: &DavAuth, email: &str) -> R
                         final_url.host_str().unwrap_or(domain),
                         final_url.path().trim_end_matches('/')
                     );
+                    crate::mail::url_validation::require_https(&discovered)?;
                     log::info!("carddav: auto-discovered URL: {}", discovered);
                     return Ok(discovered);
                 }
@@ -511,6 +513,27 @@ pub fn generate_vcard(
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod connect_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn connect_rejects_http_url() {
+        let msg = match CardDavClient::connect(
+            "http://example.com/dav/",
+            "u",
+            "p",
+            "u@example.com",
+        )
+        .await
+        {
+            Ok(_) => String::new(),
+            Err(e) => e.to_string(),
+        };
+        assert!(msg.contains("https"), "expected scheme error, got: {}", msg);
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/src-tauri/src/mail/carddav.rs
+++ b/src-tauri/src/mail/carddav.rs
@@ -132,11 +132,13 @@ impl CardDavClient {
         Ok(text)
     }
 
-    fn resolve_url(&self, href: &str) -> String {
-        if href.starts_with("http://") || href.starts_with("https://") {
-            return href.to_string();
-        }
-        if let Ok(base) = url::Url::parse(&self.base_url) {
+    /// Resolve a potentially relative URL against the base URL. Rejects
+    /// cleartext schemes via `require_https` so a server can't downgrade
+    /// subsequent auth-bearing requests by returning absolute `http://` hrefs.
+    fn resolve_url(&self, href: &str) -> Result<String> {
+        let resolved = if href.starts_with("http://") || href.starts_with("https://") {
+            href.to_string()
+        } else if let Ok(base) = url::Url::parse(&self.base_url) {
             let port_str = base.port().map(|p| format!(":{}", p)).unwrap_or_default();
             format!(
                 "{}://{}{}{}",
@@ -147,7 +149,9 @@ impl CardDavClient {
             )
         } else {
             format!("{}{}", self.base_url.trim_end_matches('/'), href)
-        }
+        };
+        crate::mail::url_validation::require_https(&resolved)?;
+        Ok(resolved)
     }
 
     /// Discover the current user's principal URL.
@@ -155,7 +159,7 @@ impl CardDavClient {
         let resp = self.propfind(&self.base_url, "0", PROPFIND_PRINCIPAL).await?;
         let principal = parse_href_from_xml(&resp, "current-user-principal")
             .ok_or_else(|| Error::Other("CardDAV: no current-user-principal".to_string()))?;
-        Ok(self.resolve_url(&principal))
+        self.resolve_url(&principal)
     }
 
     /// Discover the addressbook home set URL.
@@ -165,7 +169,7 @@ impl CardDavClient {
             .await?;
         let home = parse_href_from_xml(&resp, "addressbook-home-set")
             .ok_or_else(|| Error::Other("CardDAV: no addressbook-home-set".to_string()))?;
-        Ok(self.resolve_url(&home))
+        self.resolve_url(&home)
     }
 
     /// List all address books.
@@ -182,7 +186,7 @@ impl CardDavClient {
 
     /// Fetch all contacts from an address book.
     pub async fn fetch_contacts(&self, book_href: &str) -> Result<Vec<CardDavContact>> {
-        let url = self.resolve_url(book_href);
+        let url = self.resolve_url(book_href)?;
         log::debug!("carddav: fetching contacts from {}", url);
 
         let resp = self
@@ -218,11 +222,8 @@ impl CardDavClient {
 
     /// PUT a vCard to the server. Returns the new etag.
     pub async fn put_contact(&self, book_href: &str, uid: &str, vcard_data: &str) -> Result<String> {
-        let url = format!(
-            "{}/{}.vcf",
-            self.resolve_url(book_href).trim_end_matches('/'),
-            uid
-        );
+        let book_url = self.resolve_url(book_href)?;
+        let url = format!("{}/{}.vcf", book_url.trim_end_matches('/'), uid);
         log::info!("carddav: PUT contact to {}", url);
 
         let resp = self
@@ -244,7 +245,7 @@ impl CardDavClient {
 
     /// DELETE a contact from the server.
     pub async fn delete_contact(&self, contact_href: &str) -> Result<()> {
-        let url = self.resolve_url(contact_href);
+        let url = self.resolve_url(contact_href)?;
         let resp = self.apply_auth(self.http.delete(&url)).send().await
             .map_err(|e| Error::Other(format!("CardDAV DELETE failed: {}", e)))?;
         let status = resp.status();
@@ -537,6 +538,36 @@ mod connect_tests {
             Err(e) => e.to_string(),
         };
         assert!(msg.contains("https"), "expected scheme error, got: {}", msg);
+    }
+
+    fn client_with_base(base: &str) -> CardDavClient {
+        CardDavClient {
+            http: reqwest::Client::new(),
+            base_url: base.to_string(),
+            auth: DavAuth::Basic {
+                username: "u".into(),
+                password: "p".into(),
+            },
+        }
+    }
+
+    #[test]
+    fn resolve_url_rejects_absolute_http_href() {
+        let client = client_with_base("https://example.com/dav/");
+        let msg = match client.resolve_url("http://evil.example.com/path") {
+            Ok(_) => String::new(),
+            Err(e) => e.to_string(),
+        };
+        assert!(msg.contains("https"), "expected scheme error, got: {}", msg);
+    }
+
+    #[test]
+    fn resolve_url_resolves_relative_href_with_port() {
+        let client = client_with_base("https://example.com:8443/dav/");
+        let resolved = client
+            .resolve_url("/addressbooks/u/default/")
+            .expect("expected Ok");
+        assert_eq!(resolved, "https://example.com:8443/addressbooks/u/default/");
     }
 }
 

--- a/src-tauri/src/mail/jmap.rs
+++ b/src-tauri/src/mail/jmap.rs
@@ -42,6 +42,32 @@ pub struct JmapConfig {
     pub oidc_client_id: String,
 }
 
+#[cfg(test)]
+mod connect_tests {
+    use super::*;
+
+    fn http_config() -> JmapConfig {
+        JmapConfig {
+            jmap_url: "http://example.com/jmap".into(),
+            email: "u@example.com".into(),
+            username: "u".into(),
+            password: "p".into(),
+            access_token: None,
+            oidc_token_endpoint: String::new(),
+            oidc_client_id: String::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn connect_rejects_http_url() {
+        let msg = match JmapConnection::connect(&http_config()).await {
+            Ok(_) => String::new(),
+            Err(e) => e.to_string(),
+        };
+        assert!(msg.contains("https"), "expected scheme error, got: {}", msg);
+    }
+}
+
 impl JmapConfig {
     pub fn from_account(account: &crate::db::accounts::AccountFull) -> Self {
         Self {
@@ -114,6 +140,7 @@ impl JmapConnection {
         let base_url = if !config.jmap_url.is_empty() {
             let url = config.jmap_url.trim_end_matches('/').to_string();
             let url = url.trim_end_matches("/.well-known/jmap").to_string();
+            crate::mail::url_validation::require_https(&url)?;
             url
         } else {
             // Auto-discover

--- a/src-tauri/src/mail/mod.rs
+++ b/src-tauri/src/mail/mod.rs
@@ -9,3 +9,4 @@ pub mod jmap_sync;
 pub mod smtp;
 pub mod sync;
 pub mod parser;
+pub mod url_validation;

--- a/src-tauri/src/mail/url_validation.rs
+++ b/src-tauri/src/mail/url_validation.rs
@@ -1,0 +1,95 @@
+use crate::error::{Error, Result};
+
+/// Reject URLs that would send credentials over cleartext.
+///
+/// Accepts `https://` URLs, and `http://` only for loopback hosts
+/// (`localhost`, `127.0.0.0/8`, `::1`). Everything else is rejected.
+pub fn require_https(url: &str) -> Result<()> {
+    let parsed = url::Url::parse(url)
+        .map_err(|e| Error::Other(format!("Invalid URL '{}': {}", url, e)))?;
+
+    match parsed.scheme() {
+        "https" => Ok(()),
+        "http" if is_loopback_host(parsed.host_str()) => Ok(()),
+        scheme => Err(Error::Other(format!(
+            "URL must use https:// (got '{}'): {}",
+            scheme, url
+        ))),
+    }
+}
+
+fn is_loopback_host(host: Option<&str>) -> bool {
+    let Some(host) = host else { return false };
+    if host.eq_ignore_ascii_case("localhost") {
+        return true;
+    }
+    if let Ok(ip) = host.parse::<std::net::IpAddr>() {
+        return ip.is_loopback();
+    }
+    // Bracketed IPv6 literals arrive without brackets from url::Url::host_str,
+    // but handle the raw-string case for safety.
+    if let Some(stripped) = host.strip_prefix('[').and_then(|s| s.strip_suffix(']')) {
+        if let Ok(ip) = stripped.parse::<std::net::IpAddr>() {
+            return ip.is_loopback();
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_https_urls() {
+        assert!(require_https("https://example.com").is_ok());
+        assert!(require_https("https://example.com:8443/path").is_ok());
+        assert!(require_https("https://user@example.com").is_ok());
+    }
+
+    #[test]
+    fn rejects_http_on_public_host() {
+        let err = require_https("http://example.com").unwrap_err().to_string();
+        assert!(err.contains("https"), "error should mention https: {}", err);
+    }
+
+    #[test]
+    fn allows_http_loopback_localhost() {
+        assert!(require_https("http://localhost").is_ok());
+        assert!(require_https("http://localhost:8080/jmap").is_ok());
+        assert!(require_https("http://LocalHost").is_ok());
+    }
+
+    #[test]
+    fn allows_http_loopback_ipv4() {
+        assert!(require_https("http://127.0.0.1").is_ok());
+        assert!(require_https("http://127.0.0.1:8080").is_ok());
+        assert!(require_https("http://127.1.2.3").is_ok());
+    }
+
+    #[test]
+    fn allows_http_loopback_ipv6() {
+        assert!(require_https("http://[::1]").is_ok());
+        assert!(require_https("http://[::1]:8080").is_ok());
+    }
+
+    #[test]
+    fn rejects_non_http_schemes() {
+        assert!(require_https("ftp://example.com").is_err());
+        assert!(require_https("file:///etc/passwd").is_err());
+        assert!(require_https("javascript:alert(1)").is_err());
+    }
+
+    #[test]
+    fn rejects_invalid_urls() {
+        assert!(require_https("not a url").is_err());
+        assert!(require_https("").is_err());
+    }
+
+    #[test]
+    fn rejects_http_on_non_loopback_ip() {
+        assert!(require_https("http://192.168.1.1").is_err());
+        assert!(require_https("http://8.8.8.8").is_err());
+        assert!(require_https("http://[2001:db8::1]").is_err());
+    }
+}

--- a/src-tauri/src/mail/url_validation.rs
+++ b/src-tauri/src/mail/url_validation.rs
@@ -2,15 +2,17 @@ use crate::error::{Error, Result};
 
 /// Reject URLs that would send credentials over cleartext.
 ///
-/// Accepts `https://` URLs, and `http://` only for loopback hosts
-/// (`localhost`, `127.0.0.0/8`, `::1`). Everything else is rejected.
+/// Accepts `https://` URLs. In debug builds, `http://` is permitted for
+/// loopback hosts (`localhost`, `127.0.0.0/8`, `::1`) to support local
+/// development against test servers. Release builds reject all cleartext
+/// URLs unconditionally.
 pub fn require_https(url: &str) -> Result<()> {
     let parsed = url::Url::parse(url)
         .map_err(|e| Error::Other(format!("Invalid URL '{}': {}", url, e)))?;
 
     match parsed.scheme() {
         "https" => Ok(()),
-        "http" if is_loopback_host(parsed.host_str()) => Ok(()),
+        "http" if cfg!(debug_assertions) && is_loopback_host(parsed.host_str()) => Ok(()),
         scheme => Err(Error::Other(format!(
             "URL must use https:// (got '{}'): {}",
             scheme, url

--- a/src-tauri/src/mail/url_validation.rs
+++ b/src-tauri/src/mail/url_validation.rs
@@ -1,5 +1,20 @@
 use crate::error::{Error, Result};
 
+/// Format a URL for display in error messages with userinfo (user:password)
+/// stripped so credentials can't leak into logs or surfaced error text.
+/// Unparseable URLs are reported as `<invalid URL>` to avoid echoing back
+/// raw input that may also contain secrets.
+fn redact_url(url: &str) -> String {
+    match url::Url::parse(url) {
+        Ok(mut parsed) => {
+            let _ = parsed.set_username("");
+            let _ = parsed.set_password(None);
+            parsed.into()
+        }
+        Err(_) => "<invalid URL>".to_string(),
+    }
+}
+
 /// Reject URLs that would send credentials over cleartext.
 ///
 /// Accepts `https://` URLs. In debug builds, `http://` is permitted for
@@ -8,14 +23,15 @@ use crate::error::{Error, Result};
 /// URLs unconditionally.
 pub fn require_https(url: &str) -> Result<()> {
     let parsed = url::Url::parse(url)
-        .map_err(|e| Error::Other(format!("Invalid URL '{}': {}", url, e)))?;
+        .map_err(|e| Error::Other(format!("Invalid URL: {}", e)))?;
 
     match parsed.scheme() {
         "https" => Ok(()),
         "http" if cfg!(debug_assertions) && is_loopback_host(parsed.host_str()) => Ok(()),
         scheme => Err(Error::Other(format!(
             "URL must use https:// (got '{}'): {}",
-            scheme, url
+            scheme,
+            redact_url(url)
         ))),
     }
 }
@@ -93,5 +109,28 @@ mod tests {
         assert!(require_https("http://192.168.1.1").is_err());
         assert!(require_https("http://8.8.8.8").is_err());
         assert!(require_https("http://[2001:db8::1]").is_err());
+    }
+
+    #[test]
+    fn error_message_redacts_userinfo() {
+        let err = require_https("http://user:secret@example.com/path")
+            .unwrap_err()
+            .to_string();
+        assert!(!err.contains("secret"), "password leaked in error: {}", err);
+        assert!(!err.contains("user:"), "userinfo leaked in error: {}", err);
+        assert!(err.contains("example.com"), "expected host in error: {}", err);
+    }
+
+    #[test]
+    fn error_message_for_unparseable_url_does_not_echo_input() {
+        // Something that looks like userinfo but isn't a valid URL.
+        let err = require_https("http://user:topsecret!garbled")
+            .unwrap_err()
+            .to_string();
+        assert!(
+            !err.contains("topsecret"),
+            "parse-failure error leaked input: {}",
+            err
+        );
     }
 }


### PR DESCRIPTION
## Summary

Closes #58 (Copilot security audit finding A, Medium).

- Adds `mail::url_validation::require_https` helper that rejects non-HTTPS URLs, with a loopback exemption (`localhost`, `127/8`, `::1`) for local dev.
- Wires the check into every path that makes auth-bearing remote calls: `JmapConnection::connect`, `CalDavClient::connect` / `connect_with_token`, `CardDavClient::connect`.
- Also validates the post-redirect URL discovered during CalDAV/CardDAV auto-discovery, so a server cannot downgrade the scheme via redirect.
- 8 unit tests on the helper + 1 wiring test per connector.
- Drive-by: fixes a pre-existing clippy warning in `calendar/timezone.rs` (split into its own commit).

## Test plan

- [x] `cargo test` — 135 passing (8 new + 3 wiring tests added)
- [x] `cargo clippy -- -D warnings` — clean
- [ ] Manual: configure a JMAP/CalDAV/CardDAV account with `http://some-host` and verify it's rejected with a clear error
- [ ] Manual: existing `https://` configured accounts keep working