### PR TITLE
fix(caldav/carddav): add connect and request timeouts (#53)

### DIFF
--- a/src-tauri/src/mail/caldav.rs
+++ b/src-tauri/src/mail/caldav.rs
@@ -149,12 +149,7 @@ impl CalDavClient {
     /// Create a new CalDAV client. If `caldav_url` is empty, attempt
     /// auto-discovery via `.well-known/caldav`.
     pub async fn connect(config: &CalDavConfig) -> Result<Self> {
-        let http = reqwest::Client::builder()
-            .redirect(reqwest::redirect::Policy::limited(10))
-            .connect_timeout(std::time::Duration::from_secs(10))
-            .timeout(std::time::Duration::from_secs(30))
-            .build()
-            .map_err(|e| Error::Other(format!("Failed to create HTTP client: {}", e)))?;
+        let http = crate::mail::dav_http::build_client()?;
 
         let auth = DavAuth::Basic {
             username: config.username.clone(),
@@ -178,12 +173,7 @@ impl CalDavClient {
     pub async fn connect_with_token(caldav_url: &str, token: &str) -> Result<Self> {
         crate::mail::url_validation::require_https(caldav_url)?;
 
-        let http = reqwest::Client::builder()
-            .redirect(reqwest::redirect::Policy::limited(10))
-            .connect_timeout(std::time::Duration::from_secs(10))
-            .timeout(std::time::Duration::from_secs(30))
-            .build()
-            .map_err(|e| Error::Other(format!("Failed to create HTTP client: {}", e)))?;
+        let http = crate::mail::dav_http::build_client()?;
 
         let auth = DavAuth::Bearer { token: token.to_string() };
 

--- a/src-tauri/src/mail/caldav.rs
+++ b/src-tauri/src/mail/caldav.rs
@@ -151,6 +151,8 @@ impl CalDavClient {
     pub async fn connect(config: &CalDavConfig) -> Result<Self> {
         let http = reqwest::Client::builder()
             .redirect(reqwest::redirect::Policy::limited(10))
+            .connect_timeout(std::time::Duration::from_secs(10))
+            .timeout(std::time::Duration::from_secs(30))
             .build()
             .map_err(|e| Error::Other(format!("Failed to create HTTP client: {}", e)))?;
 
@@ -178,6 +180,8 @@ impl CalDavClient {
 
         let http = reqwest::Client::builder()
             .redirect(reqwest::redirect::Policy::limited(10))
+            .connect_timeout(std::time::Duration::from_secs(10))
+            .timeout(std::time::Duration::from_secs(30))
             .build()
             .map_err(|e| Error::Other(format!("Failed to create HTTP client: {}", e)))?;
 

--- a/src-tauri/src/mail/carddav.rs
+++ b/src-tauri/src/mail/carddav.rs
@@ -72,12 +72,7 @@ impl CardDavClient {
         password: &str,
         email: &str,
     ) -> Result<Self> {
-        let http = reqwest::Client::builder()
-            .redirect(reqwest::redirect::Policy::limited(10))
-            .connect_timeout(std::time::Duration::from_secs(10))
-            .timeout(std::time::Duration::from_secs(30))
-            .build()
-            .map_err(|e| Error::Other(format!("HTTP client error: {}", e)))?;
+        let http = crate::mail::dav_http::build_client()?;
 
         let auth = DavAuth::Basic {
             username: username.to_string(),

--- a/src-tauri/src/mail/carddav.rs
+++ b/src-tauri/src/mail/carddav.rs
@@ -74,6 +74,8 @@ impl CardDavClient {
     ) -> Result<Self> {
         let http = reqwest::Client::builder()
             .redirect(reqwest::redirect::Policy::limited(10))
+            .connect_timeout(std::time::Duration::from_secs(10))
+            .timeout(std::time::Duration::from_secs(30))
             .build()
             .map_err(|e| Error::Other(format!("HTTP client error: {}", e)))?;
 

--- a/src-tauri/src/mail/dav_http.rs
+++ b/src-tauri/src/mail/dav_http.rs
@@ -1,0 +1,30 @@
+//! Shared HTTP client configuration for DAV (CalDAV / CardDAV) requests.
+//!
+//! DAV clients built here are always configured with connect and overall
+//! request timeouts. Without them a server that accepts the TCP connection
+//! but stops responding mid-request causes `reqwest::send().await` to block
+//! forever, which can freeze the whole sync loop (see #53).
+
+use std::time::Duration;
+
+use reqwest::{redirect, Client};
+
+use crate::error::{Error, Result};
+
+/// Maximum time allowed to establish a TCP/TLS connection.
+pub const DAV_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Maximum time allowed for a full request/response round-trip, including
+/// body read. Caps the worst-case PROPFIND/REPORT latency.
+pub const DAV_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Build a `reqwest::Client` pre-configured for DAV traffic: bounded
+/// redirects and both connect + overall request timeouts.
+pub fn build_client() -> Result<Client> {
+    Client::builder()
+        .redirect(redirect::Policy::limited(10))
+        .connect_timeout(DAV_CONNECT_TIMEOUT)
+        .timeout(DAV_REQUEST_TIMEOUT)
+        .build()
+        .map_err(|e| Error::Other(format!("Failed to create DAV HTTP client: {}", e)))
+}

--- a/src-tauri/src/mail/mod.rs
+++ b/src-tauri/src/mail/mod.rs
@@ -1,5 +1,6 @@
 pub mod caldav;
 pub mod carddav;
+pub mod dav_http;
 pub mod graph;
 pub mod idle;
 pub mod imap;


### PR DESCRIPTION
## Summary

Fixes #53 — CalDAV principal discovery could hang silently and block the whole calendar sync.

**Root cause.** The `reqwest::Client` built in `CalDavClient::connect`, `CalDavClient::connect_with_token`, and `CardDavClient::connect` had no timeout configured. When a server accepted the TCP connection but stopped responding mid-request (misbehaving proxy, firewall black-hole, server stuck), `send().await` never returned. Since `syncCalendars` awaits accounts sequentially, one hung CalDAV account froze all calendars.

**Fix.** Introduce `mail::dav_http` with shared constants and a `build_client()` helper; use it from both CalDAV connect paths and from CardDAV:

- `DAV_CONNECT_TIMEOUT = 10s` — caps TCP/TLS connect hangs
- `DAV_REQUEST_TIMEOUT = 30s` — caps overall request, including PROPFIND body read

(JMAP has its own timeout configuration in `mail/jmap.rs` and is intentionally left as-is — it only sets an overall `timeout`, no `connect_timeout`. Aligning JMAP would be a separate follow-up.)

## Test plan

- [x] `cargo test` — 153 pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [ ] Manual: verify a reachable CalDAV account still syncs; verify an unreachable/hanging account surfaces a timeout error within ~30s instead of hanging