### PR TITLE
fix(oauth): self-heal stale Secret Service item handles on token store

### DIFF
--- a/src-tauri/src/oauth.rs
+++ b/src-tauri/src/oauth.rs
@@ -776,8 +776,21 @@ pub fn store_tokens(account_id: &str, tokens: &OAuthTokens) -> Result<()> {
         .map_err(|e| Error::Other(format!("Token serialize failed: {}", e)))?;
     let entry = keyring::Entry::new(KEYRING_SERVICE, account_id)
         .map_err(|e| Error::Keyring(format!("Failed to create keyring entry: {}", e)))?;
-    entry.set_password(&json)
-        .map_err(|e| Error::Keyring(format!("Failed to store tokens: {}", e)))?;
+    if let Err(first) = entry.set_password(&json) {
+        // Secret Service backends (gnome-keyring on Linux) can return
+        // "Object does not exist at path …" when their in-memory item
+        // registry is desynced from disk after a daemon crash/restart:
+        // SearchItems resolves a stale path and the SetSecret on it fails.
+        // Drop the stale credential and retry once with a fresh CreateItem.
+        log::warn!(
+            "OAuth2: keyring set_password failed for {} ({}); attempting recovery",
+            account_id, first,
+        );
+        let _ = entry.delete_credential();
+        entry.set_password(&json).map_err(|e| {
+            Error::Keyring(format!("Failed to store tokens (after recovery): {}", e))
+        })?;
+    }
     log::info!("OAuth2: tokens stored in keyring for account {}", account_id);
     Ok(())
 }


### PR DESCRIPTION
When the Linux Secret Service backend (gnome-keyring) crashes and restarts, its in-memory item registry can desync from disk: SearchItems resolves a stale DBus path like /org/freedesktop/secrets/collection/ login/<id>, and the follow-up SetSecret on that path fails with "Object does not exist at path". The user sees a hard "Keyring error: Failed to store tokens" on every Google/Microsoft sign-in until they log out and back in.

store_tokens() now catches the first set_password failure, drops the stale credential via delete_credential(), and retries once with a fresh CreateItem. Happy path is unchanged; recovery only kicks in on actual error and is logged at warn level.