### PR TITLE
fix(caldav): enable gzip/deflate response decoding (#56)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -120,6 +120,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compression"
+version = "0.4.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98ec5f6c2f8bc326c994cb9e241cc257ddaba9afa8555a43cffbb5dd86efaa37"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "async-executor"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -641,6 +654,23 @@ dependencies = [
  "bytes",
  "memchr",
 ]
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0f7ac3e5b97fdce45e8922fb05cae2c37f7bbd63d30dd94821dacfd8f3f2bf2"
+dependencies = [
+ "compression-core",
+ "flate2",
+ "memchr",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
 
 [[package]]
 name = "concurrent-queue"
@@ -5848,13 +5878,18 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
+ "async-compression",
  "bitflags 2.11.0",
  "bytes",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
+ "http-body-util",
  "iri-string",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -33,7 +33,7 @@ lettre = { version = "0.11", features = ["tokio1-native-tls", "builder"] }
 regex = "1"
 mailparse = "0.16"
 jmap-client = "0.4"
-reqwest = { version = "0.12", features = ["json", "stream"] }
+reqwest = { version = "0.12", features = ["json", "stream", "gzip", "deflate"] }
 url = "2"
 icalendar = "0.16"
 uppsala = "0.3"

--- a/src-tauri/src/mail/dav_http.rs
+++ b/src-tauri/src/mail/dav_http.rs
@@ -19,12 +19,18 @@ pub const DAV_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 pub const DAV_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Build a `reqwest::Client` pre-configured for DAV traffic: bounded
-/// redirects and both connect + overall request timeouts.
+/// redirects, connect + overall request timeouts, and automatic response
+/// decompression. Some CalDAV/CardDAV servers (or their reverse proxies)
+/// send `Content-Encoding: gzip` on PROPFIND/REPORT responses; without
+/// decompression `resp.text()` fails with "error decoding response body"
+/// (see #56).
 pub fn build_client() -> Result<Client> {
     Client::builder()
         .redirect(redirect::Policy::limited(10))
         .connect_timeout(DAV_CONNECT_TIMEOUT)
         .timeout(DAV_REQUEST_TIMEOUT)
+        .gzip(true)
+        .deflate(true)
         .build()
         .map_err(|e| Error::Other(format!("Failed to create DAV HTTP client: {}", e)))
 }


### PR DESCRIPTION
## Summary

Fixes #56 — CalDAV event fetch against cal.smolnet.org failed with:

\`\`\`
CalDAV REPORT read failed: error decoding response body
\`\`\`

**Root cause.** \`reqwest\` was built with only the \`json\` and \`stream\` features. When a CalDAV server (or a reverse proxy in front of it) returns a \`Content-Encoding: gzip\` response to PROPFIND/REPORT, reqwest hands back the raw compressed bytes and \`resp.text()\` fails the UTF-8 decode.

**Fix.** Enable the \`gzip\` and \`deflate\` features on \`reqwest\` in \`Cargo.toml\`, and set them explicitly on \`mail::dav_http::build_client()\` so the dependency on the feature flags is visible. reqwest auto-decodes the response when the server's \`Content-Encoding\` header matches.

Applies to all DAV traffic (CalDAV + CardDAV) through the shared client builder introduced in #67.

## Test plan

- [x] \`cargo test\` — 153 pass
- [x] \`cargo clippy --all-targets -- -D warnings\` — clean
- [x] \`cargo build\` — binary compiles with new features
- [ ] Manual: sync calendar from cal.smolnet.org and confirm events are fetched without "error decoding response body"