### PR TITLE
feat(settings): 12h/24h time format + theme-aware date picker (#57)

### DIFF
--- a/src/__tests__/date-input.test.ts
+++ b/src/__tests__/date-input.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Component tests for DateInput — the theme-aware replacement for the
+ * native <input type="date"> (see #57 PR).
+ *
+ * Covers: open/close, selecting a day emits the right YYYY-MM-DD,
+ * `min` disables earlier days, click-outside dismisses, Escape dismisses.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mount } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+import DateInput from "@/components/common/DateInput.vue";
+
+// jsdom's default is enough; we just need DOM + event plumbing.
+
+async function mountWith(modelValue: string, min?: string) {
+  // Attach to the real document so document-level listeners (click-outside,
+  // keydown) can fire on dispatched events.
+  const wrapper = mount(DateInput, {
+    attachTo: document.body,
+    props: {
+      modelValue,
+      min,
+      "onUpdate:modelValue": (v: string) => wrapper.setProps({ modelValue: v }),
+    },
+  });
+  return wrapper;
+}
+
+describe("DateInput", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    setActivePinia(createPinia());
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("starts closed and opens on trigger click", async () => {
+    const w = await mountWith("2026-04-15");
+    expect(w.find('[role="dialog"]').exists()).toBe(false);
+    await w.find("button.date-input-trigger").trigger("click");
+    expect(w.find('[role="dialog"]').exists()).toBe(true);
+  });
+
+  it("emits the clicked day as YYYY-MM-DD and closes", async () => {
+    const w = await mountWith("2026-04-15");
+    await w.find("button.date-input-trigger").trigger("click");
+
+    const day20 = w.find('[data-testid="date-picker-day-2026-04-20"]');
+    expect(day20.exists()).toBe(true);
+    await day20.trigger("click");
+
+    const emits = w.emitted("update:modelValue") ?? [];
+    expect(emits[emits.length - 1]).toEqual(["2026-04-20"]);
+    expect(w.find('[role="dialog"]').exists()).toBe(false);
+  });
+
+  it("disables days before `min` and refuses to emit", async () => {
+    const w = await mountWith("2026-04-15", "2026-04-15");
+    await w.find("button.date-input-trigger").trigger("click");
+
+    const day10 = w.find('[data-testid="date-picker-day-2026-04-10"]');
+    expect(day10.attributes("disabled")).toBeDefined();
+    expect(day10.classes()).toContain("disabled");
+
+    await day10.trigger("click");
+    expect(w.emitted("update:modelValue") ?? []).toEqual([]);
+    expect(w.find('[role="dialog"]').exists()).toBe(true);
+  });
+
+  it("closes on Escape", async () => {
+    const w = await mountWith("2026-04-15");
+    await w.find("button.date-input-trigger").trigger("click");
+    expect(w.find('[role="dialog"]').exists()).toBe(true);
+
+    const esc = new KeyboardEvent("keydown", { key: "Escape" });
+    document.dispatchEvent(esc);
+    await w.vm.$nextTick();
+    expect(w.find('[role="dialog"]').exists()).toBe(false);
+  });
+
+  it("closes on mousedown outside the component", async () => {
+    const outside = document.createElement("div");
+    document.body.appendChild(outside);
+
+    const w = await mountWith("2026-04-15");
+    await w.find("button.date-input-trigger").trigger("click");
+    expect(w.find('[role="dialog"]').exists()).toBe(true);
+
+    const evt = new MouseEvent("mousedown", { bubbles: true });
+    outside.dispatchEvent(evt);
+    await w.vm.$nextTick();
+    expect(w.find('[role="dialog"]').exists()).toBe(false);
+
+    outside.remove();
+  });
+
+  it("does NOT close when mousedown lands on the popup itself", async () => {
+    const w = await mountWith("2026-04-15");
+    await w.find("button.date-input-trigger").trigger("click");
+    const popup = w.find('[role="dialog"]').element;
+
+    const evt = new MouseEvent("mousedown", { bubbles: true });
+    popup.dispatchEvent(evt);
+    await w.vm.$nextTick();
+    expect(w.find('[role="dialog"]').exists()).toBe(true);
+  });
+
+  it("prev/next month navigation updates the visible grid", async () => {
+    const w = await mountWith("2026-04-15");
+    await w.find("button.date-input-trigger").trigger("click");
+    // April is visible — pick a day unique to April.
+    expect(
+      w.find('[data-testid="date-picker-day-2026-04-20"]').exists(),
+    ).toBe(true);
+
+    await w.find('[data-testid="date-picker-next"]').trigger("click");
+    // Should now show May.
+    expect(
+      w.find('[data-testid="date-picker-day-2026-05-20"]').exists(),
+    ).toBe(true);
+
+    await w.find('[data-testid="date-picker-prev"]').trigger("click");
+    await w.find('[data-testid="date-picker-prev"]').trigger("click");
+    // Should now show March.
+    expect(
+      w.find('[data-testid="date-picker-day-2026-03-20"]').exists(),
+    ).toBe(true);
+  });
+});

--- a/src/__tests__/select.test.ts
+++ b/src/__tests__/select.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Component tests for Select — the theme-aware replacement for the
+ * native <select> whose expanded popup is browser-chrome and ignores
+ * our CSS tokens on WebKitGTK.
+ *
+ * Covers: open/close, selecting an option emits the value, disabled
+ * options are skipped, Escape dismisses, mousedown outside dismisses,
+ * keyboard arrow navigation + Enter to commit.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mount } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+import Select from "@/components/common/Select.vue";
+
+const OPTIONS = [
+  { value: "a", label: "Alpha" },
+  { value: "b", label: "Bravo" },
+  { value: "c", label: "Charlie", disabled: true },
+  { value: "d", label: "Delta" },
+];
+
+async function mountWith(modelValue: string | null = "a") {
+  const wrapper = mount(Select, {
+    attachTo: document.body,
+    props: {
+      modelValue,
+      options: OPTIONS,
+      "onUpdate:modelValue": (v: string) => wrapper.setProps({ modelValue: v }),
+    },
+  });
+  return wrapper;
+}
+
+describe("Select", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    setActivePinia(createPinia());
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("renders the selected option's label on the trigger", async () => {
+    const w = await mountWith("b");
+    expect(w.find(".select-label").text()).toBe("Bravo");
+  });
+
+  it("opens the listbox on trigger click, closes on second click", async () => {
+    const w = await mountWith("a");
+    expect(w.find('[role="listbox"]').exists()).toBe(false);
+    await w.find(".select-trigger").trigger("click");
+    expect(w.find('[role="listbox"]').exists()).toBe(true);
+    await w.find(".select-trigger").trigger("click");
+    expect(w.find('[role="listbox"]').exists()).toBe(false);
+  });
+
+  it("emits the chosen value and closes on option mousedown", async () => {
+    const w = await mountWith("a");
+    await w.find(".select-trigger").trigger("click");
+    const options = w.findAll(".select-option");
+    await options[1].trigger("mousedown");
+    expect(w.emitted("update:modelValue")?.[0]).toEqual(["b"]);
+    expect(w.find('[role="listbox"]').exists()).toBe(false);
+  });
+
+  it("does not emit for disabled options", async () => {
+    const w = await mountWith("a");
+    await w.find(".select-trigger").trigger("click");
+    const options = w.findAll(".select-option");
+    await options[2].trigger("mousedown"); // Charlie, disabled
+    expect(w.emitted("update:modelValue")).toBeUndefined();
+    expect(w.find('[role="listbox"]').exists()).toBe(true);
+  });
+
+  it("ArrowDown skips disabled options and Enter commits", async () => {
+    const w = await mountWith("a"); // highlight starts at Alpha (0)
+    await w.find(".select-trigger").trigger("click");
+    // 0 (a) → 1 (b)
+    await w.find(".select-trigger").trigger("keydown", { key: "ArrowDown" });
+    // 1 (b) → skip 2 (c, disabled) → 3 (d)
+    await w.find(".select-trigger").trigger("keydown", { key: "ArrowDown" });
+    await w.find(".select-trigger").trigger("keydown", { key: "Enter" });
+    expect(w.emitted("update:modelValue")?.[0]).toEqual(["d"]);
+  });
+
+  it("closes on Escape", async () => {
+    const w = await mountWith("a");
+    await w.find(".select-trigger").trigger("click");
+    await w.find(".select-trigger").trigger("keydown", { key: "Escape" });
+    expect(w.find('[role="listbox"]').exists()).toBe(false);
+  });
+
+  it("closes on mousedown outside the component", async () => {
+    const outside = document.createElement("div");
+    document.body.appendChild(outside);
+
+    const w = await mountWith("a");
+    await w.find(".select-trigger").trigger("click");
+    expect(w.find('[role="listbox"]').exists()).toBe(true);
+
+    const evt = new MouseEvent("mousedown", { bubbles: true });
+    outside.dispatchEvent(evt);
+    await w.vm.$nextTick();
+    expect(w.find('[role="listbox"]').exists()).toBe(false);
+
+    outside.remove();
+  });
+
+  it("falls back to the placeholder when no option matches", async () => {
+    const w = mount(Select, {
+      props: {
+        modelValue: "zz",
+        options: OPTIONS,
+        placeholder: "Pick one…",
+      },
+    });
+    expect(w.find(".select-label").text()).toBe("Pick one…");
+    expect(w.find(".select-label").classes()).toContain("is-placeholder");
+  });
+});

--- a/src/__tests__/time-format.test.ts
+++ b/src/__tests__/time-format.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Tests for the time format user setting (#57).
+ *
+ * Verifies the ui store's timeFormat / hour12 contract:
+ * - "auto" resolves to undefined (Intl uses the locale's default)
+ * - "12" resolves to true (force AM/PM)
+ * - "24" resolves to false (force 24-hour)
+ * - invalid values are rejected and the stored value is unchanged
+ * - the choice persists to localStorage so reloads restore it
+ */
+import { beforeEach, describe, expect, it } from "vitest";
+import { createPinia, setActivePinia } from "pinia";
+import { useUiStore } from "@/stores/ui";
+
+describe("ui store: timeFormat", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    setActivePinia(createPinia());
+  });
+
+  it("defaults to 'auto' and hour12 is undefined", () => {
+    const ui = useUiStore();
+    expect(ui.timeFormat).toBe("auto");
+    expect(ui.hour12).toBeUndefined();
+  });
+
+  it("'12' resolves hour12 to true and persists", () => {
+    const ui = useUiStore();
+    ui.setTimeFormat("12");
+    expect(ui.timeFormat).toBe("12");
+    expect(ui.hour12).toBe(true);
+    expect(localStorage.getItem("chithi-time-format")).toBe("12");
+  });
+
+  it("'24' resolves hour12 to false and persists", () => {
+    const ui = useUiStore();
+    ui.setTimeFormat("24");
+    expect(ui.timeFormat).toBe("24");
+    expect(ui.hour12).toBe(false);
+    expect(localStorage.getItem("chithi-time-format")).toBe("24");
+  });
+
+  it("rejects invalid values", () => {
+    const ui = useUiStore();
+    ui.setTimeFormat("24");
+    // @ts-expect-error — invalid on purpose
+    ui.setTimeFormat("bogus");
+    expect(ui.timeFormat).toBe("24");
+    expect(localStorage.getItem("chithi-time-format")).toBe("24");
+  });
+
+  it("restores a previously persisted value on new store instance", () => {
+    localStorage.setItem("chithi-time-format", "24");
+    setActivePinia(createPinia());
+    const ui = useUiStore();
+    expect(ui.timeFormat).toBe("24");
+    expect(ui.hour12).toBe(false);
+  });
+
+  it("ignores a corrupt persisted value and falls back to auto", () => {
+    localStorage.setItem("chithi-time-format", "bogus");
+    setActivePinia(createPinia());
+    const ui = useUiStore();
+    expect(ui.timeFormat).toBe("auto");
+    expect(ui.hour12).toBeUndefined();
+  });
+});

--- a/src/__tests__/time-input.test.ts
+++ b/src/__tests__/time-input.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Component tests for TimeInput — the custom time-field replacement used
+ * where WebKitGTK's native <input type="time"> won't honor our time-format
+ * setting (see #57).
+ *
+ * Covers: canonical emission across 12h / 24h / auto, flexible parsing,
+ * min enforcement, and the "revert to last good value on invalid blur"
+ * contract the component header promises.
+ */
+import { beforeEach, describe, expect, it } from "vitest";
+import { mount } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+import TimeInput from "@/components/common/TimeInput.vue";
+import { useUiStore } from "@/stores/ui";
+
+async function mountWith(modelValue = "09:30", min?: string) {
+  const wrapper = mount(TimeInput, {
+    props: {
+      modelValue,
+      min,
+      "onUpdate:modelValue": (v: string) => wrapper.setProps({ modelValue: v }),
+    },
+  });
+  return wrapper;
+}
+
+function lastEmit(w: ReturnType<typeof mount>, event: string): unknown[] | undefined {
+  const list = w.emitted(event);
+  return list && list.length > 0 ? list[list.length - 1] : undefined;
+}
+
+describe("TimeInput", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    setActivePinia(createPinia());
+  });
+
+  it("emits canonical 24h HH:MM when user types 24h format", async () => {
+    const ui = useUiStore();
+    ui.setTimeFormat("24");
+    const w = await mountWith("09:30");
+    const input = w.find("input").element as HTMLInputElement;
+    input.value = "14:45";
+    await w.find("input").trigger("input");
+    await w.find("input").trigger("blur");
+    expect(lastEmit(w, "update:modelValue")).toEqual(["14:45"]);
+  });
+
+  it("accepts 12h AM/PM input and normalizes to 24h", async () => {
+    const ui = useUiStore();
+    ui.setTimeFormat("12");
+    const w = await mountWith("09:30");
+    const input = w.find("input").element as HTMLInputElement;
+    input.value = "2:30 PM";
+    await w.find("input").trigger("input");
+    await w.find("input").trigger("blur");
+    expect(lastEmit(w, "update:modelValue")).toEqual(["14:30"]);
+  });
+
+  it("accepts compact formats like '13' and '2 pm'", async () => {
+    const w = await mountWith("00:00");
+    const input = w.find("input").element as HTMLInputElement;
+
+    input.value = "13";
+    await w.find("input").trigger("input");
+    await w.find("input").trigger("blur");
+    expect(lastEmit(w, "update:modelValue")).toEqual(["13:00"]);
+
+    input.value = "2 pm";
+    await w.find("input").trigger("input");
+    await w.find("input").trigger("blur");
+    expect(lastEmit(w, "update:modelValue")).toEqual(["14:00"]);
+  });
+
+  it("rejects invalid input, marks the field invalid, and restores the last good display value", async () => {
+    const ui = useUiStore();
+    ui.setTimeFormat("24");
+    const w = await mountWith("09:30");
+    const inputEl = w.find("input").element as HTMLInputElement;
+
+    inputEl.value = "not a time";
+    await w.find("input").trigger("input");
+    await w.find("input").trigger("blur");
+
+    // No emission
+    expect(w.emitted("update:modelValue") ?? []).toEqual([]);
+    // invalid flag reflected in the DOM
+    expect(w.find("input").classes()).toContain("invalid");
+    // display restored to the last good value, not left as "not a time"
+    expect(inputEl.value).toBe("09:30");
+  });
+
+  it("rejects values below `min`", async () => {
+    const ui = useUiStore();
+    ui.setTimeFormat("24");
+    const w = await mountWith("10:00", "09:00");
+    const inputEl = w.find("input").element as HTMLInputElement;
+
+    inputEl.value = "08:30";
+    await w.find("input").trigger("input");
+    await w.find("input").trigger("blur");
+
+    expect(w.emitted("update:modelValue") ?? []).toEqual([]);
+    expect(w.find("input").classes()).toContain("invalid");
+    expect(inputEl.value).toBe("10:00");
+  });
+
+  it("treats empty input as no-op (no emission, invalid cleared)", async () => {
+    const ui = useUiStore();
+    ui.setTimeFormat("24");
+    const w = await mountWith("10:00");
+    const inputEl = w.find("input").element as HTMLInputElement;
+
+    inputEl.value = "  ";
+    await w.find("input").trigger("input");
+    await w.find("input").trigger("blur");
+
+    expect(w.emitted("update:modelValue") ?? []).toEqual([]);
+    expect(w.find("input").classes()).not.toContain("invalid");
+    expect(inputEl.value).toBe("10:00");
+  });
+});

--- a/src/components/calendar/CalendarSidebar.vue
+++ b/src/components/calendar/CalendarSidebar.vue
@@ -229,6 +229,20 @@ async function unsubscribeThisCalendar() {
       </div>
     </div>
 
+    <div class="time-format-section">
+      <div class="section-header">Time format</div>
+      <div class="time-format-options">
+        <button
+          v-for="opt in [{ value: 'auto' as const, label: 'Auto' }, { value: '12' as const, label: '12h' }, { value: '24' as const, label: '24h' }]"
+          :key="opt.value"
+          class="time-format-btn"
+          :class="{ active: uiStore.timeFormat === opt.value }"
+          :data-testid="`time-format-${opt.value}`"
+          @click="uiStore.setTimeFormat(opt.value)"
+        >{{ opt.label }}</button>
+      </div>
+    </div>
+
     <div class="timezone-section">
       <div class="section-header">Use timezone</div>
       <div class="timezone-picker">
@@ -427,6 +441,40 @@ async function unsubscribeThisCalendar() {
 
 .week-start-btn.active {
   color: var(--color-accent);
+  font-weight: 600;
+}
+
+.time-format-section {
+  margin-top: 16px;
+  padding-top: 12px;
+  border-top: 1px solid var(--color-border);
+}
+
+.time-format-options {
+  display: flex;
+  gap: 4px;
+  padding: 0 4px;
+}
+
+.time-format-btn {
+  flex: 1;
+  padding: 4px 0;
+  font-size: 12px;
+  color: var(--color-text-secondary);
+  text-align: center;
+  border-radius: 4px;
+  border: 1px solid var(--color-border);
+  background: transparent;
+  transition: background 0.1s, border-color 0.1s;
+}
+
+.time-format-btn:hover {
+  background: var(--color-bg-hover);
+}
+
+.time-format-btn.active {
+  color: var(--color-accent);
+  border-color: var(--color-accent);
   font-weight: 600;
 }
 

--- a/src/components/calendar/EventDetail.vue
+++ b/src/components/calendar/EventDetail.vue
@@ -434,13 +434,24 @@ async function handleDelete() {
   color: var(--color-text-secondary);
 }
 
+/* Sizing tokens consumed by DateInput / TimeInput so they match the
+   native inputs in this form. See .date-input-trigger / .time-input-text
+   in src/components/common/{DateInput,TimeInput}.vue. */
+.edit-group {
+  --input-height: 28px;
+  --input-padding: 6px 8px;
+  --input-border: 1px solid var(--color-border);
+  --input-bg: var(--color-bg);
+  --input-font-size: 13px;
+}
+
 .edit-group input,
 .edit-group textarea {
-  padding: 6px 8px;
-  border: 1px solid var(--color-border);
+  padding: var(--input-padding);
+  border: var(--input-border);
   border-radius: 4px;
-  background: var(--color-bg);
-  font-size: 13px;
+  background: var(--input-bg);
+  font-size: var(--input-font-size);
 }
 
 .edit-group textarea { resize: vertical; }

--- a/src/components/calendar/EventDetail.vue
+++ b/src/components/calendar/EventDetail.vue
@@ -6,6 +6,7 @@ import { useUiStore } from "@/stores/ui";
 import { formatInTimezone, getDateInTimezone, toTimeInTimezone, localInputToUTC } from "@/lib/datetime";
 import { message as tauriMessage } from "@tauri-apps/plugin-dialog";
 import * as api from "@/lib/tauri";
+import TimeInput from "@/components/common/TimeInput.vue";
 
 const emit = defineEmits<{
   close: [];
@@ -60,7 +61,7 @@ const editLocation = ref(event.location || "");
 const editDescription = ref(event.description || "");
 
 function formatDateTime(iso: string): string {
-  return formatInTimezone(iso, uiStore.displayTimezone);
+  return formatInTimezone(iso, uiStore.displayTimezone, { hour12: uiStore.hour12 });
 }
 
 function statusLabel(status: string | null): string {
@@ -274,7 +275,7 @@ async function handleDelete() {
           </div>
           <div v-if="!editAllDay" class="edit-group">
             <label>Start time</label>
-            <input v-model="editStartTime" type="time" data-testid="event-form-start-time" />
+            <TimeInput v-model="editStartTime" testid="event-form-start-time" />
           </div>
         </div>
         <div class="edit-row">
@@ -284,7 +285,7 @@ async function handleDelete() {
           </div>
           <div v-if="!editAllDay" class="edit-group">
             <label>End time</label>
-            <input v-model="editEndTime" type="time" data-testid="event-form-end-time" />
+            <TimeInput v-model="editEndTime" testid="event-form-end-time" />
           </div>
         </div>
         <div class="edit-group">

--- a/src/components/calendar/EventDetail.vue
+++ b/src/components/calendar/EventDetail.vue
@@ -7,6 +7,7 @@ import { formatInTimezone, getDateInTimezone, toTimeInTimezone, localInputToUTC 
 import { message as tauriMessage } from "@tauri-apps/plugin-dialog";
 import * as api from "@/lib/tauri";
 import TimeInput from "@/components/common/TimeInput.vue";
+import DateInput from "@/components/common/DateInput.vue";
 
 const emit = defineEmits<{
   close: [];
@@ -271,7 +272,7 @@ async function handleDelete() {
         <div class="edit-row">
           <div class="edit-group">
             <label>Start date</label>
-            <input v-model="editStartDate" type="date" data-testid="event-form-start" />
+            <DateInput v-model="editStartDate" testid="event-form-start" />
           </div>
           <div v-if="!editAllDay" class="edit-group">
             <label>Start time</label>
@@ -281,7 +282,7 @@ async function handleDelete() {
         <div class="edit-row">
           <div class="edit-group">
             <label>End date</label>
-            <input v-model="editEndDate" type="date" data-testid="event-form-end" />
+            <DateInput v-model="editEndDate" testid="event-form-end" />
           </div>
           <div v-if="!editAllDay" class="edit-group">
             <label>End time</label>

--- a/src/components/calendar/EventForm.vue
+++ b/src/components/calendar/EventForm.vue
@@ -8,6 +8,7 @@ import * as api from "@/lib/tauri";
 import RecurrenceEditor from "./RecurrenceEditor.vue";
 import AttendeeEditor from "./AttendeeEditor.vue";
 import TimeInput from "@/components/common/TimeInput.vue";
+import DateInput from "@/components/common/DateInput.vue";
 
 const props = defineProps<{
   initialStart?: string;
@@ -165,14 +166,14 @@ async function save() {
           <div class="form-group">
             <label>Start</label>
             <div class="datetime-inputs">
-              <input v-model="startDate" type="date" class="date-input" data-testid="event-form-start" />
+              <DateInput v-model="startDate" testid="event-form-start" />
               <TimeInput v-if="!allDay" v-model="startTime" class="time-input" testid="event-form-start-time" />
             </div>
           </div>
           <div class="form-group">
             <label>End</label>
             <div class="datetime-inputs">
-              <input v-model="endDate" type="date" class="date-input" :min="minEndDate" data-testid="event-form-end" />
+              <DateInput v-model="endDate" :min="minEndDate" testid="event-form-end" />
               <TimeInput v-if="!allDay" v-model="endTime" class="time-input" :min="minEndTime" testid="event-form-end-time" />
             </div>
           </div>

--- a/src/components/calendar/EventForm.vue
+++ b/src/components/calendar/EventForm.vue
@@ -166,14 +166,14 @@ async function save() {
           <div class="form-group">
             <label>Start</label>
             <div class="datetime-inputs">
-              <DateInput v-model="startDate" testid="event-form-start" />
+              <DateInput v-model="startDate" class="date-input" testid="event-form-start" />
               <TimeInput v-if="!allDay" v-model="startTime" class="time-input" testid="event-form-start-time" />
             </div>
           </div>
           <div class="form-group">
             <label>End</label>
             <div class="datetime-inputs">
-              <DateInput v-model="endDate" :min="minEndDate" testid="event-form-end" />
+              <DateInput v-model="endDate" class="date-input" :min="minEndDate" testid="event-form-end" />
               <TimeInput v-if="!allDay" v-model="endTime" class="time-input" :min="minEndTime" testid="event-form-end-time" />
             </div>
           </div>
@@ -293,16 +293,28 @@ async function save() {
   color: var(--color-text);
 }
 
+/* Sizing tokens consumed by DateInput / TimeInput so they visually match
+   the sibling native <input>/<select> elements. CSS custom properties
+   cross the scoped-styles boundary that :deep would otherwise be needed
+   for. */
+.form-group {
+  --input-height: 36px;
+  --input-padding: 0 12px;
+  --input-border: 0.8px solid var(--color-border);
+  --input-bg: var(--color-bg-secondary);
+  --input-font-size: 16px;
+}
+
 .form-group input,
 .form-group select,
 .form-group textarea {
   width: 100%;
-  height: 36px;
-  padding: 0 12px;
-  border: 0.8px solid var(--color-border);
+  height: var(--input-height);
+  padding: var(--input-padding);
+  border: var(--input-border);
   border-radius: 4px;
-  background: var(--color-bg-secondary);
-  font-size: 16px;
+  background: var(--input-bg);
+  font-size: var(--input-font-size);
 }
 
 .form-group textarea {

--- a/src/components/calendar/EventForm.vue
+++ b/src/components/calendar/EventForm.vue
@@ -7,6 +7,7 @@ import { localInputToUTC, toDateInTimezone, toTimeInTimezone } from "@/lib/datet
 import * as api from "@/lib/tauri";
 import RecurrenceEditor from "./RecurrenceEditor.vue";
 import AttendeeEditor from "./AttendeeEditor.vue";
+import TimeInput from "@/components/common/TimeInput.vue";
 
 const props = defineProps<{
   initialStart?: string;
@@ -165,14 +166,14 @@ async function save() {
             <label>Start</label>
             <div class="datetime-inputs">
               <input v-model="startDate" type="date" class="date-input" data-testid="event-form-start" />
-              <input v-if="!allDay" v-model="startTime" type="time" class="time-input" data-testid="event-form-start-time" />
+              <TimeInput v-if="!allDay" v-model="startTime" class="time-input" testid="event-form-start-time" />
             </div>
           </div>
           <div class="form-group">
             <label>End</label>
             <div class="datetime-inputs">
               <input v-model="endDate" type="date" class="date-input" :min="minEndDate" data-testid="event-form-end" />
-              <input v-if="!allDay" v-model="endTime" type="time" class="time-input" :min="minEndTime" data-testid="event-form-end-time" />
+              <TimeInput v-if="!allDay" v-model="endTime" class="time-input" :min="minEndTime" testid="event-form-end-time" />
             </div>
           </div>
         </div>

--- a/src/components/calendar/EventForm.vue
+++ b/src/components/calendar/EventForm.vue
@@ -9,6 +9,7 @@ import RecurrenceEditor from "./RecurrenceEditor.vue";
 import AttendeeEditor from "./AttendeeEditor.vue";
 import TimeInput from "@/components/common/TimeInput.vue";
 import DateInput from "@/components/common/DateInput.vue";
+import Select from "@/components/common/Select.vue";
 
 const props = defineProps<{
   initialStart?: string;
@@ -22,6 +23,13 @@ const emit = defineEmits<{
 const calendarStore = useCalendarStore();
 const accountsStore = useAccountsStore();
 const uiStore = useUiStore();
+
+const calendarOptions = computed(() =>
+  calendarStore.calendars.map((cal) => ({
+    value: cal.id,
+    label: `${cal.name} (${accountsStore.accounts.find((a) => a.id === cal.account_id)?.display_name || cal.account_id})`,
+  })),
+);
 
 const defaultStart = props.initialStart
   ? new Date(props.initialStart)
@@ -150,11 +158,7 @@ async function save() {
 
         <div class="form-group">
           <label>Calendar</label>
-          <select v-model="calendarId" data-testid="event-form-calendar">
-            <option v-for="cal in calendarStore.calendars" :key="cal.id" :value="cal.id">
-              {{ cal.name }} ({{ accountsStore.accounts.find(a => a.id === cal.account_id)?.display_name || cal.account_id }})
-            </option>
-          </select>
+          <Select v-model="calendarId" :options="calendarOptions" testid="event-form-calendar" />
         </div>
 
         <label class="checkbox-row">

--- a/src/components/calendar/InviteCard.vue
+++ b/src/components/calendar/InviteCard.vue
@@ -31,7 +31,7 @@ onMounted(async () => {
 });
 
 function formatDateTime(iso: string): string {
-  return formatInTimezone(iso, uiStore.displayTimezone);
+  return formatInTimezone(iso, uiStore.displayTimezone, { hour12: uiStore.hour12 });
 }
 
 async function respond(response: string) {

--- a/src/components/calendar/RecurrenceEditor.vue
+++ b/src/components/calendar/RecurrenceEditor.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, watch } from "vue";
+import DateInput from "@/components/common/DateInput.vue";
 
 const props = defineProps<{
   modelValue: string | null;
@@ -112,11 +113,9 @@ watch([enabled, freq, interval, endType, count, untilDate, byDays], update, { de
           min="1"
           class="num-input"
         />
-        <input
+        <DateInput
           v-if="endType === 'until'"
-          type="date"
           v-model="untilDate"
-          class="date-input"
         />
       </div>
     </template>

--- a/src/components/calendar/RecurrenceEditor.vue
+++ b/src/components/calendar/RecurrenceEditor.vue
@@ -149,14 +149,22 @@ watch([enabled, freq, interval, endType, count, untilDate, byDays], update, { de
   min-width: 40px;
 }
 
+/* Sizing tokens consumed by DateInput's trigger button. */
+.recurrence-row {
+  --input-height: 24px;
+  --input-padding: 4px 6px;
+  --input-border: 1px solid var(--color-border);
+  --input-bg: var(--color-bg);
+  --input-font-size: 12px;
+}
+
 .recurrence-row select,
-.num-input,
-.date-input {
-  padding: 4px 6px;
-  border: 1px solid var(--color-border);
+.num-input {
+  padding: var(--input-padding);
+  border: var(--input-border);
   border-radius: 4px;
-  background: var(--color-bg);
-  font-size: 12px;
+  background: var(--input-bg);
+  font-size: var(--input-font-size);
 }
 
 .num-input {

--- a/src/components/calendar/RecurrenceEditor.vue
+++ b/src/components/calendar/RecurrenceEditor.vue
@@ -1,6 +1,20 @@
 <script setup lang="ts">
 import { ref, watch } from "vue";
 import DateInput from "@/components/common/DateInput.vue";
+import Select from "@/components/common/Select.vue";
+
+const freqOptions = [
+  { value: "DAILY", label: "day(s)" },
+  { value: "WEEKLY", label: "week(s)" },
+  { value: "MONTHLY", label: "month(s)" },
+  { value: "YEARLY", label: "year(s)" },
+];
+
+const endTypeOptions = [
+  { value: "never", label: "Never" },
+  { value: "count", label: "After N times" },
+  { value: "until", label: "On date" },
+];
 
 const props = defineProps<{
   modelValue: string | null;
@@ -74,12 +88,7 @@ watch([enabled, freq, interval, endType, count, untilDate, byDays], update, { de
       <div class="recurrence-row">
         <label>Every</label>
         <input type="number" v-model.number="interval" min="1" max="99" class="num-input" />
-        <select v-model="freq">
-          <option value="DAILY">day(s)</option>
-          <option value="WEEKLY">week(s)</option>
-          <option value="MONTHLY">month(s)</option>
-          <option value="YEARLY">year(s)</option>
-        </select>
+        <Select v-model="freq" :options="freqOptions" class="freq-select" />
       </div>
 
       <div v-if="freq === 'WEEKLY'" class="day-picker">
@@ -101,11 +110,7 @@ watch([enabled, freq, interval, endType, count, untilDate, byDays], update, { de
 
       <div class="recurrence-row">
         <label>Ends</label>
-        <select v-model="endType">
-          <option value="never">Never</option>
-          <option value="count">After N times</option>
-          <option value="until">On date</option>
-        </select>
+        <Select v-model="endType" :options="endTypeOptions" class="end-type-select" />
         <input
           v-if="endType === 'count'"
           type="number"
@@ -158,13 +163,18 @@ watch([enabled, freq, interval, endType, count, untilDate, byDays], update, { de
   --input-font-size: 12px;
 }
 
-.recurrence-row select,
 .num-input {
   padding: var(--input-padding);
   border: var(--input-border);
   border-radius: 4px;
   background: var(--input-bg);
   font-size: var(--input-font-size);
+}
+
+.freq-select,
+.end-type-select {
+  width: auto;
+  min-width: 100px;
 }
 
 .num-input {

--- a/src/components/calendar/WeekView.vue
+++ b/src/components/calendar/WeekView.vue
@@ -83,10 +83,23 @@ function formatDayNum(date: Date): string {
 }
 
 function formatHour(hour: number): string {
-  if (hour === 0) return "12 AM";
-  if (hour < 12) return `${hour} AM`;
-  if (hour === 12) return "12 PM";
-  return `${hour - 12} PM`;
+  // Honor the user's time-format preference. For 24-hour we render a
+  // zero-padded hour; for 12-hour we keep the old AM/PM labels; for "auto"
+  // we let Intl pick for the locale.
+  const h12 = uiStore.hour12;
+  if (h12 === false) {
+    return String(hour).padStart(2, "0");
+  }
+  if (h12 === true) {
+    if (hour === 0) return "12 AM";
+    if (hour < 12) return `${hour} AM`;
+    if (hour === 12) return "12 PM";
+    return `${hour - 12} PM`;
+  }
+  // auto / locale default
+  const d = new Date();
+  d.setHours(hour, 0, 0, 0);
+  return d.toLocaleTimeString(undefined, { hour: "numeric" });
 }
 
 function isToday(date: Date): boolean {
@@ -556,7 +569,7 @@ onUnmounted(() => {
         >
           <span class="event-title">{{ seg.event.title }}</span>
           <span class="event-time">
-            {{ formatInTimezone(seg.segStart.toISOString(), uiStore.displayTimezone, { hour: 'numeric', minute: '2-digit' }) }}
+            {{ formatInTimezone(seg.segStart.toISOString(), uiStore.displayTimezone, { hour: 'numeric', minute: '2-digit', hour12: uiStore.hour12 }) }}
           </span>
         </div>
       </div>

--- a/src/components/common/DateInput.vue
+++ b/src/components/common/DateInput.vue
@@ -1,0 +1,393 @@
+<script setup lang="ts">
+// Theme-aware date input used in place of `<input type="date">`. WebKitGTK's
+// native date picker ignores our CSS variables, can only be dismissed with
+// Esc (not by clicking outside), and uses a hostile light background on the
+// dark theme. This component renders a trigger button that matches the rest
+// of the app's surfaces and opens an in-DOM calendar popup.
+//
+// The v-model contract is the same as the native input: a "YYYY-MM-DD"
+// string (blank when no date is selected), so callers and existing
+// `localInputToUTC` logic don't need to change.
+
+import { computed, onMounted, onUnmounted, ref, watch } from "vue";
+import { useUiStore } from "@/stores/ui";
+
+const props = defineProps<{
+  modelValue: string;
+  min?: string;
+  testid?: string;
+}>();
+const emit = defineEmits<{
+  "update:modelValue": [value: string];
+}>();
+
+const uiStore = useUiStore();
+const rootEl = ref<HTMLElement | null>(null);
+const open = ref(false);
+const viewYear = ref(new Date().getFullYear());
+const viewMonth = ref(new Date().getMonth());
+
+function parseYMD(s: string): Date | null {
+  const m = s?.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (!m) return null;
+  return new Date(parseInt(m[1], 10), parseInt(m[2], 10) - 1, parseInt(m[3], 10));
+}
+
+function toYMD(d: Date): string {
+  const y = d.getFullYear();
+  const mo = String(d.getMonth() + 1).padStart(2, "0");
+  const da = String(d.getDate()).padStart(2, "0");
+  return `${y}-${mo}-${da}`;
+}
+
+function openPicker() {
+  const d = parseYMD(props.modelValue) ?? new Date();
+  viewYear.value = d.getFullYear();
+  viewMonth.value = d.getMonth();
+  open.value = true;
+}
+
+function closePicker() {
+  open.value = false;
+}
+
+// Keep the calendar's viewed month in sync when the parent replaces the
+// value while the popup is open (e.g. watchers that push endDate forward).
+watch(
+  () => props.modelValue,
+  (v) => {
+    if (!open.value) return;
+    const d = parseYMD(v);
+    if (d) {
+      viewYear.value = d.getFullYear();
+      viewMonth.value = d.getMonth();
+    }
+  },
+);
+
+const weeks = computed<Date[][]>(() => {
+  const first = new Date(viewYear.value, viewMonth.value, 1);
+  const offset = (first.getDay() - uiStore.weekStartDay + 7) % 7;
+  const start = new Date(viewYear.value, viewMonth.value, 1 - offset);
+  const result: Date[][] = [];
+  for (let w = 0; w < 6; w++) {
+    const row: Date[] = [];
+    for (let d = 0; d < 7; d++) {
+      const day = new Date(start);
+      day.setDate(start.getDate() + w * 7 + d);
+      row.push(day);
+    }
+    result.push(row);
+  }
+  return result;
+});
+
+const dayNames = computed(() => {
+  const base = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+  const rotated = [...base];
+  for (let i = 0; i < uiStore.weekStartDay; i++) rotated.push(rotated.shift()!);
+  return rotated;
+});
+
+const monthLabel = computed(() => {
+  const d = new Date(viewYear.value, viewMonth.value, 1);
+  return d.toLocaleDateString(undefined, { month: "long", year: "numeric" });
+});
+
+function goPrev() {
+  if (viewMonth.value === 0) {
+    viewMonth.value = 11;
+    viewYear.value--;
+  } else {
+    viewMonth.value--;
+  }
+}
+
+function goNext() {
+  if (viewMonth.value === 11) {
+    viewMonth.value = 0;
+    viewYear.value++;
+  } else {
+    viewMonth.value++;
+  }
+}
+
+function isToday(d: Date): boolean {
+  const now = new Date();
+  return (
+    d.getFullYear() === now.getFullYear() &&
+    d.getMonth() === now.getMonth() &&
+    d.getDate() === now.getDate()
+  );
+}
+
+function isSelected(d: Date): boolean {
+  return toYMD(d) === props.modelValue;
+}
+
+function isCurrentMonth(d: Date): boolean {
+  return d.getMonth() === viewMonth.value;
+}
+
+function isDisabled(d: Date): boolean {
+  return props.min ? toYMD(d) < props.min : false;
+}
+
+function selectDay(d: Date) {
+  if (isDisabled(d)) return;
+  emit("update:modelValue", toYMD(d));
+  closePicker();
+}
+
+function onDocMouseDown(e: MouseEvent) {
+  if (!open.value) return;
+  if (rootEl.value && !rootEl.value.contains(e.target as Node)) {
+    closePicker();
+  }
+}
+
+function onDocKeydown(e: KeyboardEvent) {
+  if (open.value && e.key === "Escape") {
+    e.stopPropagation();
+    closePicker();
+  }
+}
+
+onMounted(() => {
+  document.addEventListener("mousedown", onDocMouseDown);
+  document.addEventListener("keydown", onDocKeydown);
+});
+
+onUnmounted(() => {
+  document.removeEventListener("mousedown", onDocMouseDown);
+  document.removeEventListener("keydown", onDocKeydown);
+});
+</script>
+
+<template>
+  <div ref="rootEl" class="date-input-wrap">
+    <button
+      type="button"
+      class="date-input-trigger"
+      :data-testid="testid"
+      @click="open ? closePicker() : openPicker()"
+    >
+      <span class="date-value">{{ modelValue || "Select date" }}</span>
+      <svg
+        class="cal-icon"
+        width="14"
+        height="14"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        aria-hidden="true"
+      >
+        <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
+        <line x1="16" y1="2" x2="16" y2="6" />
+        <line x1="8" y1="2" x2="8" y2="6" />
+        <line x1="3" y1="10" x2="21" y2="10" />
+      </svg>
+    </button>
+    <div v-if="open" class="date-picker-popup" role="dialog" aria-label="Choose a date">
+      <div class="date-picker-header">
+        <button
+          type="button"
+          class="nav-btn"
+          aria-label="Previous month"
+          data-testid="date-picker-prev"
+          @click="goPrev"
+        >
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <polyline points="15 18 9 12 15 6" />
+          </svg>
+        </button>
+        <span class="month-label">{{ monthLabel }}</span>
+        <button
+          type="button"
+          class="nav-btn"
+          aria-label="Next month"
+          data-testid="date-picker-next"
+          @click="goNext"
+        >
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <polyline points="9 18 15 12 9 6" />
+          </svg>
+        </button>
+      </div>
+      <div class="day-names">
+        <span v-for="d in dayNames" :key="d" class="day-name">{{ d }}</span>
+      </div>
+      <div class="day-grid">
+        <template v-for="(week, wi) in weeks" :key="wi">
+          <button
+            v-for="day in week"
+            :key="day.toISOString()"
+            type="button"
+            class="day-cell"
+            :class="{
+              today: isToday(day),
+              selected: isSelected(day),
+              'other-month': !isCurrentMonth(day),
+              disabled: isDisabled(day),
+            }"
+            :disabled="isDisabled(day)"
+            :data-testid="`date-picker-day-${toYMD(day)}`"
+            @click="selectDay(day)"
+          >
+            {{ day.getDate() }}
+          </button>
+        </template>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.date-input-wrap {
+  position: relative;
+  display: inline-block;
+}
+
+.date-input-trigger {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  color: var(--color-text);
+  cursor: pointer;
+  font-size: 13px;
+  font-variant-numeric: tabular-nums;
+  min-width: 120px;
+  transition: background 0.1s, border-color 0.1s;
+}
+
+.date-input-trigger:hover {
+  background: var(--color-bg-hover);
+}
+
+.date-input-trigger:focus-visible {
+  outline: none;
+  border-color: var(--color-accent);
+}
+
+.date-value {
+  flex: 1;
+  text-align: left;
+}
+
+.cal-icon {
+  color: var(--color-text-muted);
+  flex-shrink: 0;
+}
+
+.date-picker-popup {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  z-index: 1000;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  padding: 10px;
+  min-width: 240px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
+}
+
+.date-picker-header {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-bottom: 8px;
+}
+
+.month-label {
+  flex: 1;
+  text-align: center;
+  font-weight: 600;
+  font-size: 13px;
+  color: var(--color-text);
+}
+
+.nav-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--color-text);
+  cursor: pointer;
+  transition: background 0.1s;
+}
+
+.nav-btn:hover {
+  background: var(--color-bg-hover);
+}
+
+.day-names {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 2px;
+  margin-bottom: 4px;
+}
+
+.day-name {
+  text-align: center;
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--color-text-muted);
+  letter-spacing: 0.5px;
+  padding: 2px 0;
+}
+
+.day-grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 2px;
+}
+
+.day-cell {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 28px;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--color-text);
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+  cursor: pointer;
+  transition: background 0.1s;
+}
+
+.day-cell:hover:not(.disabled):not(.selected) {
+  background: var(--color-bg-hover);
+}
+
+.day-cell.today {
+  font-weight: 700;
+  box-shadow: inset 0 0 0 1px var(--color-accent);
+}
+
+.day-cell.selected {
+  background: var(--color-accent);
+  color: #fff;
+}
+
+.day-cell.other-month {
+  color: var(--color-text-muted);
+  opacity: 0.5;
+}
+
+.day-cell.disabled {
+  opacity: 0.3;
+  cursor: not-allowed;
+}
+</style>

--- a/src/components/common/DateInput.vue
+++ b/src/components/common/DateInput.vue
@@ -249,21 +249,27 @@ onUnmounted(() => {
 .date-input-wrap {
   position: relative;
   display: inline-block;
+  width: 100%;
 }
 
+/* Sizing tokens are inherited from the nearest enclosing parent (see
+   EventForm .form-group / EventDetail .edit-group / RecurrenceEditor
+   .recurrence-row). Defaults cover compact/standalone use. */
 .date-input-trigger {
   display: flex;
   align-items: center;
   gap: 6px;
-  padding: 4px 8px;
-  background: var(--color-bg);
-  border: 1px solid var(--color-border);
+  width: 100%;
+  box-sizing: border-box;
+  height: var(--input-height, 28px);
+  padding: var(--input-padding, 4px 8px);
+  background: var(--input-bg, var(--color-bg));
+  border: var(--input-border, 1px solid var(--color-border));
   border-radius: 4px;
   color: var(--color-text);
   cursor: pointer;
-  font-size: 13px;
+  font-size: var(--input-font-size, 13px);
   font-variant-numeric: tabular-nums;
-  min-width: 120px;
   transition: background 0.1s, border-color 0.1s;
 }
 

--- a/src/components/common/Select.vue
+++ b/src/components/common/Select.vue
@@ -1,0 +1,332 @@
+<script setup lang="ts">
+// Theme-aware dropdown used in place of native <select>. WebKitGTK renders
+// the expanded popup with its own chrome (ignoring our CSS tokens), so the
+// dropdown looks out of place in both the dark and light themes. This
+// component replaces the native picker with an in-DOM popup that uses the
+// same CSS variables as DateInput / TimeInput.
+//
+// The v-model contract stays a single primitive value (string / number /
+// boolean) and the component accepts an `options` array of { value, label }.
+// Options can be disabled individually.
+
+import { computed, nextTick, onMounted, onUnmounted, ref, watch } from "vue";
+
+export interface SelectOption<T> {
+  value: T;
+  label: string;
+  disabled?: boolean;
+}
+
+// Using `any` on the prop type so each call site can constrain the value
+// type via its template binding without the parent having to type-narrow
+// the whole component generic (Vue 3.5 supports generics on defineProps
+// but they're still fiddly for v-model with primitives).
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type SelectValue = any;
+
+const props = defineProps<{
+  modelValue: SelectValue;
+  options: SelectOption<SelectValue>[];
+  placeholder?: string;
+  testid?: string;
+  ariaLabel?: string;
+}>();
+const emit = defineEmits<{
+  "update:modelValue": [value: SelectValue];
+}>();
+
+const rootEl = ref<HTMLElement | null>(null);
+const listEl = ref<HTMLElement | null>(null);
+const open = ref(false);
+const highlight = ref(-1);
+
+const selectedOption = computed(() =>
+  props.options.find((o) => o.value === props.modelValue),
+);
+
+const selectedLabel = computed(
+  () => selectedOption.value?.label ?? props.placeholder ?? "",
+);
+
+function openMenu() {
+  const idx = props.options.findIndex(
+    (o) => o.value === props.modelValue && !o.disabled,
+  );
+  highlight.value = idx >= 0 ? idx : firstEnabledIndex();
+  open.value = true;
+  nextTick(() => scrollHighlightedIntoView());
+}
+
+function closeMenu() {
+  open.value = false;
+}
+
+function toggleMenu() {
+  if (open.value) closeMenu();
+  else openMenu();
+}
+
+function firstEnabledIndex(): number {
+  for (let i = 0; i < props.options.length; i++) {
+    if (!props.options[i].disabled) return i;
+  }
+  return -1;
+}
+
+function lastEnabledIndex(): number {
+  for (let i = props.options.length - 1; i >= 0; i--) {
+    if (!props.options[i].disabled) return i;
+  }
+  return -1;
+}
+
+function moveHighlight(delta: 1 | -1) {
+  if (props.options.length === 0) return;
+  let i = highlight.value;
+  for (let step = 0; step < props.options.length; step++) {
+    i = (i + delta + props.options.length) % props.options.length;
+    if (!props.options[i].disabled) {
+      highlight.value = i;
+      scrollHighlightedIntoView();
+      return;
+    }
+  }
+}
+
+function scrollHighlightedIntoView() {
+  if (!listEl.value || highlight.value < 0) return;
+  const el = listEl.value.children[highlight.value] as HTMLElement | undefined;
+  el?.scrollIntoView({ block: "nearest" });
+}
+
+function commit(idx: number) {
+  const opt = props.options[idx];
+  if (!opt || opt.disabled) return;
+  emit("update:modelValue", opt.value);
+  closeMenu();
+}
+
+function onTriggerKeydown(e: KeyboardEvent) {
+  if (!open.value) {
+    if (e.key === "Enter" || e.key === " " || e.key === "ArrowDown" || e.key === "ArrowUp") {
+      e.preventDefault();
+      openMenu();
+    }
+    return;
+  }
+  if (e.key === "ArrowDown") {
+    e.preventDefault();
+    moveHighlight(1);
+  } else if (e.key === "ArrowUp") {
+    e.preventDefault();
+    moveHighlight(-1);
+  } else if (e.key === "Home") {
+    e.preventDefault();
+    highlight.value = firstEnabledIndex();
+    scrollHighlightedIntoView();
+  } else if (e.key === "End") {
+    e.preventDefault();
+    highlight.value = lastEnabledIndex();
+    scrollHighlightedIntoView();
+  } else if (e.key === "Enter" || e.key === " ") {
+    e.preventDefault();
+    if (highlight.value >= 0) commit(highlight.value);
+  } else if (e.key === "Escape") {
+    e.preventDefault();
+    e.stopPropagation();
+    closeMenu();
+  } else if (e.key === "Tab") {
+    closeMenu();
+  }
+}
+
+function onOptionMouseEnter(idx: number) {
+  if (!props.options[idx].disabled) highlight.value = idx;
+}
+
+function onOptionClick(idx: number) {
+  commit(idx);
+}
+
+function onDocMouseDown(e: MouseEvent) {
+  if (!open.value) return;
+  if (rootEl.value && !rootEl.value.contains(e.target as Node)) {
+    closeMenu();
+  }
+}
+
+// When parent updates the model while open, move the highlight to match.
+watch(
+  () => props.modelValue,
+  () => {
+    if (!open.value) return;
+    const idx = props.options.findIndex((o) => o.value === props.modelValue);
+    if (idx >= 0) highlight.value = idx;
+  },
+);
+
+onMounted(() => {
+  document.addEventListener("mousedown", onDocMouseDown);
+});
+onUnmounted(() => {
+  document.removeEventListener("mousedown", onDocMouseDown);
+});
+</script>
+
+<template>
+  <div ref="rootEl" class="select-wrap">
+    <button
+      type="button"
+      class="select-trigger"
+      :aria-haspopup="'listbox'"
+      :aria-expanded="open"
+      :aria-label="ariaLabel"
+      :data-testid="testid"
+      @click="toggleMenu"
+      @keydown="onTriggerKeydown"
+    >
+      <span class="select-label" :class="{ 'is-placeholder': !selectedOption }">{{ selectedLabel }}</span>
+      <svg
+        class="select-caret"
+        width="12"
+        height="12"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        aria-hidden="true"
+      >
+        <polyline points="6 9 12 15 18 9" />
+      </svg>
+    </button>
+    <ul
+      v-if="open"
+      ref="listEl"
+      class="select-menu"
+      role="listbox"
+      :aria-activedescendant="highlight >= 0 ? `${testid ?? 'select'}-opt-${highlight}` : undefined"
+    >
+      <li
+        v-for="(opt, idx) in options"
+        :id="`${testid ?? 'select'}-opt-${idx}`"
+        :key="String(opt.value)"
+        role="option"
+        class="select-option"
+        :class="{
+          selected: opt.value === modelValue,
+          highlighted: idx === highlight,
+          disabled: opt.disabled,
+        }"
+        :aria-selected="opt.value === modelValue"
+        :aria-disabled="opt.disabled"
+        @mousedown.prevent="onOptionClick(idx)"
+        @mouseenter="onOptionMouseEnter(idx)"
+      >
+        {{ opt.label }}
+      </li>
+    </ul>
+  </div>
+</template>
+
+<style scoped>
+.select-wrap {
+  position: relative;
+  display: inline-block;
+  width: 100%;
+}
+
+/* Sizing tokens inherited from the nearest enclosing parent (see
+   EventForm .form-group / EventDetail .edit-group / RecurrenceEditor
+   .recurrence-row). Defaults cover compact / standalone use. */
+.select-trigger {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  box-sizing: border-box;
+  height: var(--input-height, 28px);
+  padding: var(--input-padding, 4px 8px);
+  background: var(--input-bg, var(--color-bg));
+  border: var(--input-border, 1px solid var(--color-border));
+  border-radius: 4px;
+  color: var(--color-text);
+  cursor: pointer;
+  font-size: var(--input-font-size, 13px);
+  text-align: left;
+  transition: background 0.1s, border-color 0.1s;
+}
+
+.select-trigger:hover {
+  background: var(--color-bg-hover);
+}
+
+.select-trigger:focus-visible {
+  outline: none;
+  border-color: var(--color-accent);
+}
+
+.select-label {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.select-label.is-placeholder {
+  color: var(--color-text-muted);
+}
+
+.select-caret {
+  color: var(--color-text-muted);
+  flex-shrink: 0;
+}
+
+.select-menu {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  right: 0;
+  z-index: 1000;
+  max-height: 280px;
+  overflow-y: auto;
+  margin: 0;
+  padding: 4px;
+  list-style: none;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
+}
+
+.select-option {
+  padding: 6px 10px;
+  border-radius: 4px;
+  color: var(--color-text);
+  font-size: var(--input-font-size, 13px);
+  cursor: pointer;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.select-option.highlighted:not(.disabled) {
+  background: var(--color-bg-hover);
+}
+
+.select-option.selected {
+  color: var(--color-accent);
+  font-weight: 600;
+}
+
+.select-option.selected.highlighted {
+  background: var(--color-bg-hover);
+}
+
+.select-option.disabled {
+  color: var(--color-text-muted);
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+</style>

--- a/src/components/common/TimeInput.vue
+++ b/src/components/common/TimeInput.vue
@@ -1,0 +1,132 @@
+<script setup lang="ts">
+// A format-aware time input used in place of `<input type="time">` where
+// the display needs to follow the user's time-format preference (#57).
+//
+// WebKitGTK — and Chromium generally — ignore the `lang` attribute on
+// native time inputs; the picker and inline display are locked to the
+// OS/browser locale. This component keeps a text-input surface, renders
+// the value in the preferred format (12h / 24h / auto), and accepts
+// either form on input (e.g. "14:30", "2:30 PM", "2 pm", "13"). The
+// v-model value is always a 24-hour "HH:MM" string so existing callers
+// and `localInputToUTC` logic don't need to change.
+
+import { computed, ref, watch } from "vue";
+import { useUiStore } from "@/stores/ui";
+
+const props = defineProps<{
+  modelValue: string; // canonical 24h "HH:MM"
+  min?: string; // 24h "HH:MM"
+  testid?: string;
+}>();
+const emit = defineEmits<{
+  "update:modelValue": [value: string];
+}>();
+
+const uiStore = useUiStore();
+const displayValue = ref(toDisplay(props.modelValue));
+const invalid = ref(false);
+
+watch(
+  () => props.modelValue,
+  (v) => {
+    displayValue.value = toDisplay(v);
+    invalid.value = false;
+  },
+);
+
+watch(
+  () => uiStore.timeFormat,
+  () => {
+    displayValue.value = toDisplay(props.modelValue);
+  },
+);
+
+function toDisplay(hhmm: string): string {
+  if (!hhmm) return "";
+  const parts = hhmm.split(":");
+  if (parts.length < 2) return hhmm;
+  const h = parseInt(parts[0], 10);
+  const m = parseInt(parts[1], 10);
+  if (isNaN(h) || isNaN(m)) return hhmm;
+  const d = new Date();
+  d.setHours(h, m, 0, 0);
+  return d.toLocaleTimeString(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: uiStore.hour12,
+  });
+}
+
+// Accept: "14", "14:30", "2:30", "2:30 PM", "2 pm", "02:30am".
+function parse(raw: string): string | null {
+  const match = raw.trim().match(/^(\d{1,2})(?::(\d{1,2}))?\s*(am|pm)?$/i);
+  if (!match) return null;
+  let hour = parseInt(match[1], 10);
+  const minute = match[2] ? parseInt(match[2], 10) : 0;
+  const period = match[3]?.toLowerCase();
+  if (period === "pm" && hour < 12) hour += 12;
+  if (period === "am" && hour === 12) hour = 0;
+  if (hour < 0 || hour > 23 || minute < 0 || minute > 59) return null;
+  return `${String(hour).padStart(2, "0")}:${String(minute).padStart(2, "0")}`;
+}
+
+function belowMin(value: string): boolean {
+  if (!props.min) return false;
+  return value < props.min;
+}
+
+function onInput(e: Event) {
+  displayValue.value = (e.target as HTMLInputElement).value;
+}
+
+function onBlur() {
+  if (displayValue.value.trim() === "") {
+    // Empty value: keep whatever the parent had; nothing to emit.
+    displayValue.value = toDisplay(props.modelValue);
+    invalid.value = false;
+    return;
+  }
+  const parsed = parse(displayValue.value);
+  if (parsed === null || belowMin(parsed)) {
+    invalid.value = true;
+    return;
+  }
+  invalid.value = false;
+  emit("update:modelValue", parsed);
+  displayValue.value = toDisplay(parsed);
+}
+
+const placeholder = computed(() => {
+  if (uiStore.hour12 === false) return "HH:MM";
+  if (uiStore.hour12 === true) return "h:mm AM";
+  return "";
+});
+</script>
+
+<template>
+  <input
+    type="text"
+    class="time-input-text"
+    :class="{ invalid }"
+    :value="displayValue"
+    :placeholder="placeholder"
+    :data-testid="testid"
+    inputmode="numeric"
+    autocomplete="off"
+    spellcheck="false"
+    @input="onInput"
+    @blur="onBlur"
+    @keydown.enter.prevent="onBlur"
+  />
+</template>
+
+<style scoped>
+.time-input-text {
+  font-variant-numeric: tabular-nums;
+}
+
+.time-input-text.invalid {
+  border-color: var(--color-danger, #c0392b);
+  outline: 1px solid var(--color-danger, #c0392b);
+}
+</style>

--- a/src/components/common/TimeInput.vue
+++ b/src/components/common/TimeInput.vue
@@ -77,6 +77,10 @@ function belowMin(value: string): boolean {
 
 function onInput(e: Event) {
   displayValue.value = (e.target as HTMLInputElement).value;
+  // Clear the invalid flag as soon as the user is typing again; the real
+  // check happens on blur. Leaving the red outline on while editing is
+  // distracting.
+  invalid.value = false;
 }
 
 function onBlur() {
@@ -88,7 +92,12 @@ function onBlur() {
   }
   const parsed = parse(displayValue.value);
   if (parsed === null || belowMin(parsed)) {
+    // Restore the last known-good display so the field doesn't get stuck
+    // in an invalid state — matches the behavior documented at the top
+    // of the file and in the PR description. Flash the red outline
+    // briefly so the user sees why the value didn't take.
     invalid.value = true;
+    displayValue.value = toDisplay(props.modelValue);
     return;
   }
   invalid.value = false;
@@ -121,7 +130,20 @@ const placeholder = computed(() => {
 </template>
 
 <style scoped>
+/* The parent form styles sizing by setting these custom properties on the
+   enclosing element (see EventForm .form-group, EventDetail .edit-group).
+   The defaults here cover standalone usage / the compact form in
+   RecurrenceEditor. */
 .time-input-text {
+  width: 100%;
+  box-sizing: border-box;
+  height: var(--input-height, 28px);
+  padding: var(--input-padding, 4px 8px);
+  border: var(--input-border, 1px solid var(--color-border));
+  border-radius: 4px;
+  background: var(--input-bg, var(--color-bg));
+  color: var(--color-text);
+  font-size: var(--input-font-size, 13px);
   font-variant-numeric: tabular-nums;
 }
 

--- a/src/components/mail/FolderTree.vue
+++ b/src/components/mail/FolderTree.vue
@@ -895,6 +895,14 @@ async function doDeleteFolder() {
   font-size: 14px;
 }
 
+.nf-select {
+  --input-height: 36px;
+  --input-padding: 0 10px;
+  --input-border: 1px solid var(--color-border);
+  --input-bg: var(--color-bg);
+  --input-font-size: 14px;
+}
+
 .nf-input:focus,
 .nf-select:focus {
   outline: none;

--- a/src/components/mail/FolderTree.vue
+++ b/src/components/mail/FolderTree.vue
@@ -8,6 +8,7 @@ import * as api from "@/lib/tauri";
 import { dragMessageIds, dragSourceAccountId, isDragging } from "@/lib/drag-state";
 import { showToast, dismissToast } from "@/lib/toast";
 import { acctColor } from "@/lib/account-colors";
+import Select from "@/components/common/Select.vue";
 
 const foldersStore = useFoldersStore();
 const accountsStore = useAccountsStore();
@@ -545,11 +546,7 @@ async function doDeleteFolder() {
             </div>
             <div class="nf-field">
               <label>Create as a subfolder of:</label>
-              <select v-model="newFolderParent" class="nf-select">
-                <option v-for="opt in buildParentOptions()" :key="opt.value" :value="opt.value">
-                  {{ opt.label }}
-                </option>
-              </select>
+              <Select v-model="newFolderParent" :options="buildParentOptions()" class="nf-select" />
             </div>
           </div>
           <div class="nf-footer">

--- a/src/components/mail/MessageList.vue
+++ b/src/components/mail/MessageList.vue
@@ -216,7 +216,7 @@ async function ctxReply() {
   const msg = messagesStore.activeMessage;
   if (!msg) return;
   const body = msg.body_text || "";
-  const date = new Date(msg.date).toLocaleString();
+  const date = new Date(msg.date).toLocaleString(undefined, { hour12: uiStore.hour12 });
   const from = msg.from.name ? `${msg.from.name} <${msg.from.email}>` : msg.from.email;
   const quoted = body.split("\n").map((l: string) => `> ${l}`).join("\n");
   openComposeWindow({
@@ -239,7 +239,7 @@ async function ctxReplyAll() {
   const allTo = [msg.from.email, ...msg.to.map((a: { email: string }) => a.email).filter((e: string) => e !== myEmail)];
   const allCc = msg.cc.map((a: { email: string }) => a.email).filter((e: string) => e !== myEmail);
   const body = msg.body_text || "";
-  const date = new Date(msg.date).toLocaleString();
+  const date = new Date(msg.date).toLocaleString(undefined, { hour12: uiStore.hour12 });
   const from = msg.from.name ? `${msg.from.name} <${msg.from.email}>` : msg.from.email;
   const quoted = body.split("\n").map((l: string) => `> ${l}`).join("\n");
   openComposeWindow({
@@ -260,7 +260,7 @@ async function ctxForward() {
   const msg = messagesStore.activeMessage;
   if (!msg) return;
   const text = msg.body_text || "";
-  const date = new Date(msg.date).toLocaleString();
+  const date = new Date(msg.date).toLocaleString(undefined, { hour12: uiStore.hour12 });
   const from = msg.from.name ? `${msg.from.name} <${msg.from.email}>` : msg.from.email;
   const toStr = msg.to.map((a: { name: string | null; email: string }) => a.name || a.email).join(", ");
   openComposeWindow({

--- a/src/components/mail/MessageListItem.vue
+++ b/src/components/mail/MessageListItem.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { MessageSummary } from "@/lib/types";
+import { useUiStore } from "@/stores/ui";
 
 defineProps<{
   message: MessageSummary;
@@ -13,12 +14,14 @@ defineEmits<{
   toggleStar: [];
 }>();
 
+const uiStore = useUiStore();
+
 function formatDate(dateStr: string): string {
   const date = new Date(dateStr);
   const now = new Date();
   const isToday = date.toDateString() === now.toDateString();
   if (isToday) {
-    return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+    return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", hour12: uiStore.hour12 });
   }
   const isThisYear = date.getFullYear() === now.getFullYear();
   if (isThisYear) {

--- a/src/components/mail/MessageReader.vue
+++ b/src/components/mail/MessageReader.vue
@@ -1229,6 +1229,13 @@ async function markSpam() {
   color: var(--color-text);
 }
 
+.contact-form-modal .form-select {
+  --input-padding: 6px 8px;
+  --input-border: 1px solid var(--color-border);
+  --input-bg: var(--color-bg);
+  --input-font-size: 13px;
+}
+
 .contact-form-modal .form-input:focus,
 .contact-form-modal .form-select:focus {
   outline: none;

--- a/src/components/mail/MessageReader.vue
+++ b/src/components/mail/MessageReader.vue
@@ -6,8 +6,21 @@ import { useAccountsStore } from "@/stores/accounts";
 import { useFoldersStore } from "@/stores/folders";
 import type { ParsedInvite, Contact, ContactBook } from "@/lib/types";
 import InviteCard from "@/components/calendar/InviteCard.vue";
+import Select from "@/components/common/Select.vue";
 import { openComposeWindow } from "@/lib/compose-window";
 import * as api from "@/lib/tauri";
+
+const EMAIL_LABEL_OPTIONS = [
+  { value: "work", label: "Work" },
+  { value: "home", label: "Home" },
+  { value: "other", label: "Other" },
+];
+
+const PHONE_LABEL_OPTIONS = [
+  { value: "mobile", label: "Mobile" },
+  { value: "work", label: "Work" },
+  { value: "home", label: "Home" },
+];
 
 defineProps<{
   standalone?: boolean;
@@ -713,9 +726,11 @@ async function markSpam() {
 
             <div v-if="contactBooks.length > 0" class="form-group">
               <label>Contact Book</label>
-              <select v-model="cfBookId" class="form-select">
-                <option v-for="book in contactBooks" :key="book.id" :value="book.id">{{ book.name }}</option>
-              </select>
+              <Select
+                v-model="cfBookId"
+                :options="contactBooks.map(b => ({ value: b.id, label: b.name }))"
+                class="form-select"
+              />
             </div>
 
             <div class="form-row">
@@ -737,11 +752,7 @@ async function markSpam() {
               <label>Emails</label>
               <div v-for="(e, i) in cfEmails" :key="i" class="multi-field-row">
                 <input v-model="e.email" type="email" class="form-input" placeholder="email@example.com" />
-                <select v-model="e.label" class="form-select form-select-sm">
-                  <option value="work">Work</option>
-                  <option value="home">Home</option>
-                  <option value="other">Other</option>
-                </select>
+                <Select v-model="e.label" :options="EMAIL_LABEL_OPTIONS" class="form-select form-select-sm" />
                 <button v-if="cfEmails.length > 1" class="remove-btn" @click="cfEmails.splice(i, 1)">&times;</button>
               </div>
               <button class="add-field-btn" @click="cfEmails.push({ email: '', label: 'work' })">+ Add Email</button>
@@ -751,11 +762,7 @@ async function markSpam() {
               <label>Phones</label>
               <div v-for="(p, i) in cfPhones" :key="i" class="multi-field-row">
                 <input v-model="p.number" type="tel" class="form-input" placeholder="+1 555-0100" />
-                <select v-model="p.label" class="form-select form-select-sm">
-                  <option value="mobile">Mobile</option>
-                  <option value="work">Work</option>
-                  <option value="home">Home</option>
-                </select>
+                <Select v-model="p.label" :options="PHONE_LABEL_OPTIONS" class="form-select form-select-sm" />
                 <button class="remove-btn" @click="cfPhones.splice(i, 1)">&times;</button>
               </div>
               <button class="add-field-btn" @click="cfPhones.push({ number: '', label: 'mobile' })">+ Add Phone</button>

--- a/src/components/mail/MessageReader.vue
+++ b/src/components/mail/MessageReader.vue
@@ -393,7 +393,7 @@ function quoteBody(): string {
   const msg = messagesStore.activeMessage;
   if (!msg) return "";
   const text = msg.body_text || "";
-  const date = new Date(msg.date).toLocaleString();
+  const date = new Date(msg.date).toLocaleString(undefined, { hour12: uiStore.hour12 });
   const from = msg.from.name
     ? `${msg.from.name} <${msg.from.email}>`
     : msg.from.email;
@@ -440,7 +440,7 @@ function forward() {
   const msg = messagesStore.activeMessage;
   if (!msg) return;
   const text = msg.body_text || "";
-  const date = new Date(msg.date).toLocaleString();
+  const date = new Date(msg.date).toLocaleString(undefined, { hour12: uiStore.hour12 });
   const from = msg.from.name
     ? `${msg.from.name} <${msg.from.email}>`
     : msg.from.email;
@@ -594,7 +594,7 @@ async function markSpam() {
         </div>
         <div class="header-row" data-testid="reader-date">
           <span class="header-label">Date:</span>
-          <span class="header-value">{{ new Date(messagesStore.activeMessage.date).toLocaleString() }}</span>
+          <span class="header-value">{{ new Date(messagesStore.activeMessage.date).toLocaleString(undefined, { hour12: uiStore.hour12 }) }}</span>
         </div>
         <div v-if="messagesStore.activeMessage.list_id" class="header-row">
           <span class="header-label">List:</span>

--- a/src/components/mail/ThreadRow.vue
+++ b/src/components/mail/ThreadRow.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { ThreadSummary } from "@/lib/types";
+import { useUiStore } from "@/stores/ui";
 
 const props = defineProps<{
   thread: ThreadSummary;
@@ -15,12 +16,14 @@ defineEmits<{
   toggleStar: [];
 }>();
 
+const uiStore = useUiStore();
+
 function formatDate(dateStr: string): string {
   const date = new Date(dateStr);
   const now = new Date();
   const isToday = date.toDateString() === now.toDateString();
   if (isToday) {
-    return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+    return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", hour12: uiStore.hour12 });
   }
   const isThisYear = date.getFullYear() === now.getFullYear();
   if (isThisYear) {

--- a/src/stores/ui.ts
+++ b/src/stores/ui.ts
@@ -1,10 +1,11 @@
 import { defineStore } from "pinia";
-import { ref } from "vue";
+import { computed, ref } from "vue";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import * as api from "@/lib/tauri";
 
 export type MessageViewMode = "right" | "bottom" | "tab";
 export type Theme = "dark" | "light";
+export type TimeFormat = "auto" | "12" | "24";
 
 export const useUiStore = defineStore("ui", () => {
   const threadingEnabled = ref(
@@ -36,6 +37,25 @@ export const useUiStore = defineStore("ui", () => {
   const _storedTz = localStorage.getItem("chithi-display-timezone");
   const displayTimezone = ref<string>(_storedTz || "UTC");
   const timezoneList = ref<string[]>([]);
+
+  // Time format: "12" (AM/PM), "24" (00-23), or "auto" (follow OS locale).
+  const VALID_TIME_FORMATS: TimeFormat[] = ["auto", "12", "24"];
+  const timeFormat = ref<TimeFormat>(
+    (() => {
+      const stored = localStorage.getItem("chithi-time-format") as TimeFormat | null;
+      return stored && VALID_TIME_FORMATS.includes(stored) ? stored : "auto";
+    })(),
+  );
+
+  // Resolved `hour12` value to pass into Intl.DateTimeFormatOptions. `true`
+  // forces 12-hour, `false` forces 24-hour, `undefined` lets the locale
+  // decide (which is what Intl does by default).
+  const hour12 = computed<boolean | undefined>(() => {
+    if (timeFormat.value === "12") return true;
+    if (timeFormat.value === "24") return false;
+    return undefined;
+  });
+
 
   function toggleReader() {
     readerVisible.value = !readerVisible.value;
@@ -75,6 +95,12 @@ export const useUiStore = defineStore("ui", () => {
     if (!VALID_WEEK_STARTS.includes(day)) return;
     weekStartDay.value = day;
     localStorage.setItem("chithi-week-start-day", String(day));
+  }
+
+  function setTimeFormat(tf: TimeFormat) {
+    if (!VALID_TIME_FORMATS.includes(tf)) return;
+    timeFormat.value = tf;
+    localStorage.setItem("chithi-time-format", tf);
   }
 
   function setDisplayTimezone(tz: string) {
@@ -146,5 +172,8 @@ export const useUiStore = defineStore("ui", () => {
     timezoneList,
     setDisplayTimezone,
     initTimezone,
+    timeFormat,
+    hour12,
+    setTimeFormat,
   };
 });

--- a/src/views/ComposeView.vue
+++ b/src/views/ComposeView.vue
@@ -813,14 +813,11 @@ async function send() {
 
 .field-select {
   width: 306px;
-  height: 32px;
-  padding: 0 8px;
-  border: 0.8px solid var(--color-border);
-  border-radius: 4px;
-  background: var(--color-bg-secondary);
-  color: var(--color-text);
-  font-size: 14px;
-  appearance: auto;
+  --input-height: 32px;
+  --input-padding: 0 8px;
+  --input-border: 0.8px solid var(--color-border);
+  --input-bg: var(--color-bg-secondary);
+  --input-font-size: 14px;
 }
 
 .field-input-group {

--- a/src/views/ComposeView.vue
+++ b/src/views/ComposeView.vue
@@ -7,6 +7,7 @@ import { open, message as tauriMessage } from "@tauri-apps/plugin-dialog";
 import type { Account, ComposeAttachment } from "@/lib/types";
 import * as api from "@/lib/tauri";
 import { acctColor } from "@/lib/account-colors";
+import Select from "@/components/common/Select.vue";
 
 const route = useRoute();
 const accountsStore = useAccountsStore();
@@ -527,11 +528,12 @@ async function send() {
             :style="{ background: acctColor(selectedAccountId).fill }"
             aria-hidden="true"
           ></span>
-          <select v-model="selectedAccountId" class="field-select" data-testid="compose-account-select">
-            <option v-for="acc in accounts" :key="acc.id" :value="acc.id">
-              {{ acc.display_name }} &lt;{{ acc.email }}&gt;
-            </option>
-          </select>
+          <Select
+            v-model="selectedAccountId"
+            :options="accounts.map(a => ({ value: a.id, label: `${a.display_name} <${a.email}>` }))"
+            class="field-select"
+            testid="compose-account-select"
+          />
         </div>
         <div class="field-row addr-field-row">
           <label class="field-label">To</label>

--- a/src/views/ContactsView.vue
+++ b/src/views/ContactsView.vue
@@ -830,13 +830,21 @@ function getAccountName(accountId: string): string {
 
 .form-group { margin-bottom: 16px; }
 .form-group label { display: block; margin-bottom: 4px; font-size: 14px; font-weight: 500; color: var(--color-text-secondary); }
-.form-group input, .form-group select, .form-group textarea {
+.form-group {
+  --input-height: 36px;
+  --input-padding: 0 12px;
+  --input-border: 0.8px solid var(--color-border);
+  --input-bg: var(--color-bg-secondary);
+  --input-font-size: 16px;
+}
+
+.form-group input, .form-group textarea {
   width: 100%; height: 36px; padding: 0 12px;
   border: 0.8px solid var(--color-border); border-radius: 4px;
   background: var(--color-bg-secondary); font-size: 16px;
 }
 .form-group textarea { height: 96px; padding: 8px 12px; resize: vertical; line-height: 1.5; }
-.form-group input:focus, .form-group select:focus, .form-group textarea:focus {
+.form-group input:focus, .form-group textarea:focus {
   outline: none; border-color: var(--color-accent);
 }
 
@@ -845,7 +853,7 @@ function getAccountName(accountId: string): string {
 
 .multi-row { display: flex; gap: 6px; margin-bottom: 6px; }
 .multi-row input { flex: 1; }
-.multi-row select { width: 100px; flex-shrink: 0; }
+.multi-row .label-select { width: 100px; flex-shrink: 0; }
 
 .rm-btn {
   width: 36px; height: 36px; border-radius: 4px; font-size: 18px;

--- a/src/views/ContactsView.vue
+++ b/src/views/ContactsView.vue
@@ -5,6 +5,19 @@ import { useAccountsStore } from "@/stores/accounts";
 import type { ContactBook, Contact } from "@/lib/types";
 import * as api from "@/lib/tauri";
 import { acctColor } from "@/lib/account-colors";
+import Select from "@/components/common/Select.vue";
+
+const EMAIL_LABEL_OPTIONS = [
+  { value: "work", label: "Work" },
+  { value: "home", label: "Home" },
+  { value: "other", label: "Other" },
+];
+
+const PHONE_LABEL_OPTIONS = [
+  { value: "mobile", label: "Mobile" },
+  { value: "work", label: "Work" },
+  { value: "home", label: "Home" },
+];
 
 const accountsStore = useAccountsStore();
 
@@ -395,11 +408,10 @@ function getAccountName(accountId: string): string {
 
             <div class="form-group">
               <label>Contact Book</label>
-              <select v-model="formBookId">
-                <option v-for="book in contactBooks" :key="book.id" :value="book.id">
-                  {{ book.name }} ({{ getAccountName(book.account_id) }})
-                </option>
-              </select>
+              <Select
+                v-model="formBookId"
+                :options="contactBooks.map(b => ({ value: b.id, label: `${b.name} (${getAccountName(b.account_id)})` }))"
+              />
             </div>
 
             <div class="name-row">
@@ -421,11 +433,7 @@ function getAccountName(accountId: string): string {
               <label>Email</label>
               <div v-for="(em, idx) in formEmails" :key="idx" class="multi-row">
                 <input v-model="em.email" type="email" placeholder="email@example.com" />
-                <select v-model="em.label">
-                  <option value="work">Work</option>
-                  <option value="home">Home</option>
-                  <option value="other">Other</option>
-                </select>
+                <Select v-model="em.label" :options="EMAIL_LABEL_OPTIONS" class="label-select" />
                 <button v-if="formEmails.length > 1" class="rm-btn" @click="removeEmailField(idx)">&times;</button>
               </div>
               <button class="add-btn" @click="addEmailField">+ Add email</button>
@@ -435,11 +443,7 @@ function getAccountName(accountId: string): string {
               <label>Phone</label>
               <div v-for="(ph, idx) in formPhones" :key="idx" class="multi-row">
                 <input v-model="ph.number" type="tel" placeholder="+1 (555) 123-4567" />
-                <select v-model="ph.label">
-                  <option value="mobile">Mobile</option>
-                  <option value="work">Work</option>
-                  <option value="home">Home</option>
-                </select>
+                <Select v-model="ph.label" :options="PHONE_LABEL_OPTIONS" class="label-select" />
                 <button class="rm-btn" @click="removePhoneField(idx)">&times;</button>
               </div>
               <button class="add-btn" @click="addPhoneField">+ Add phone</button>

--- a/src/views/FiltersView.vue
+++ b/src/views/FiltersView.vue
@@ -599,13 +599,11 @@ const actionFolderOptions = computed(() => [
 
 .apply-select {
   width: 100%;
-  height: 36px;
-  padding: 0 8px;
-  border: 1px solid var(--color-border);
-  border-radius: 4px;
-  background: var(--color-bg-secondary);
-  color: var(--color-text);
-  font-size: 13px;
+  --input-height: 36px;
+  --input-padding: 0 8px;
+  --input-border: 1px solid var(--color-border);
+  --input-bg: var(--color-bg-secondary);
+  --input-font-size: 13px;
 }
 
 .btn-apply {
@@ -681,6 +679,14 @@ const actionFolderOptions = computed(() => [
   background: var(--color-bg-secondary);
   color: var(--color-text);
   font-size: 14px;
+}
+
+.field-select {
+  --input-height: 36px;
+  --input-padding: 0 12px;
+  --input-border: 1px solid var(--color-border);
+  --input-bg: var(--color-bg-secondary);
+  --input-font-size: 14px;
 }
 
 .field-input:focus,

--- a/src/views/FiltersView.vue
+++ b/src/views/FiltersView.vue
@@ -1,9 +1,32 @@
 <script setup lang="ts">
-import { onMounted, ref } from "vue";
+import { onMounted, ref, computed } from "vue";
 import { useFiltersStore } from "@/stores/filters";
 import { useAccountsStore } from "@/stores/accounts";
 import { useFoldersStore } from "@/stores/folders";
 import type { FilterRule, FilterAction } from "@/lib/types";
+import Select from "@/components/common/Select.vue";
+
+const MATCH_TYPE_OPTIONS = [
+  { value: "all", label: "All conditions (AND)" },
+  { value: "any", label: "Any condition (OR)" },
+];
+
+const ACTION_TYPE_OPTIONS = [
+  { value: "move", label: "Move to folder" },
+  { value: "copy", label: "Copy to folder" },
+  { value: "delete", label: "Delete" },
+  { value: "flag", label: "Add flag" },
+  { value: "unflag", label: "Remove flag" },
+  { value: "mark_read", label: "Mark as read" },
+  { value: "mark_unread", label: "Mark as unread" },
+  { value: "stop", label: "Stop processing" },
+];
+
+const FLAG_OPTIONS = [
+  { value: "flagged", label: "Flagged" },
+  { value: "seen", label: "Seen" },
+  { value: "answered", label: "Answered" },
+];
 
 const filtersStore = useFiltersStore();
 const accountsStore = useAccountsStore();
@@ -157,6 +180,8 @@ const fieldLabels: Record<string, string> = {
   has_attachment: "Has Attachment",
 };
 
+const FIELD_OPTIONS = Object.entries(fieldLabels).map(([value, label]) => ({ value, label }));
+
 const opLabels: Record<string, string> = {
   contains: "contains",
   not_contains: "does not contain",
@@ -166,6 +191,22 @@ const opLabels: Record<string, string> = {
   greater_than: "greater than",
   less_than: "less than",
 };
+
+const OP_OPTIONS = Object.entries(opLabels).map(([value, label]) => ({ value, label }));
+
+const accountOptions = computed(() =>
+  accountsStore.accounts.map((a) => ({ value: a.id, label: a.display_name })),
+);
+
+const folderOptions = computed(() => [
+  { value: null as string | null, label: "Select folder…", disabled: true },
+  ...foldersStore.getFlatFolders().map((f) => ({ value: f.path, label: f.name })),
+]);
+
+const actionFolderOptions = computed(() => [
+  { value: "", label: "Select folder…", disabled: true },
+  ...foldersStore.getFlatFolders().map((f) => ({ value: f.path, label: f.name })),
+]);
 </script>
 
 <template>
@@ -174,11 +215,12 @@ const opLabels: Record<string, string> = {
     <div class="filters-left">
       <div class="left-header">
         <h2 class="left-title">Message Filters</h2>
-        <select class="account-select" :value="accountsStore.activeAccountId ?? ''" @change="accountsStore.setActiveAccount(($event.target as HTMLSelectElement).value)">
-          <option v-for="acc in accountsStore.accounts" :key="acc.id" :value="acc.id">
-            {{ acc.display_name }}
-          </option>
-        </select>
+        <Select
+          :model-value="accountsStore.activeAccountId ?? ''"
+          :options="accountOptions"
+          class="account-select"
+          @update:model-value="accountsStore.setActiveAccount($event)"
+        />
         <button class="btn-new-filter" :disabled="!accountsStore.activeAccountId" data-testid="filter-new-btn" @click="newFilter">
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19" /><line x1="5" y1="12" x2="19" y2="12" /></svg>
           New Filter
@@ -225,12 +267,7 @@ const opLabels: Record<string, string> = {
 
       <div class="apply-section">
         <label class="apply-label">Apply filters to folder</label>
-        <select v-model="applyingFolder" class="apply-select">
-          <option :value="null" disabled>Select folder...</option>
-          <option v-for="f in foldersStore.getFlatFolders()" :key="f.path" :value="f.path">
-            {{ f.name }}
-          </option>
-        </select>
+        <Select v-model="applyingFolder" :options="folderOptions" class="apply-select" />
         <button class="btn-apply" :disabled="!applyingFolder" data-testid="filter-apply-btn" @click="applyToFolder">
           Apply Filters to Folder
         </button>
@@ -257,10 +294,7 @@ const opLabels: Record<string, string> = {
           </div>
           <div class="form-group match-group">
             <label class="field-label">Match Type</label>
-            <select v-model="editingRule.match_type" class="field-select">
-              <option value="all">All conditions (AND)</option>
-              <option value="any">Any condition (OR)</option>
-            </select>
+            <Select v-model="editingRule.match_type" :options="MATCH_TYPE_OPTIONS" class="field-select" />
           </div>
           <label class="checkbox-label">
             <input v-model="editingRule.enabled" type="checkbox" />
@@ -292,12 +326,8 @@ const opLabels: Record<string, string> = {
           :key="'c' + i"
           class="condition-row"
         >
-          <select v-model="cond.field" class="field-select cond-field">
-            <option v-for="(label, key) in fieldLabels" :key="key" :value="key">{{ label }}</option>
-          </select>
-          <select v-model="cond.op" class="field-select cond-op">
-            <option v-for="(label, key) in opLabels" :key="key" :value="key">{{ label }}</option>
-          </select>
+          <Select v-model="cond.field" :options="FIELD_OPTIONS" class="field-select cond-field" />
+          <Select v-model="cond.op" :options="OP_OPTIONS" class="field-select cond-op" />
           <input v-model="cond.value" type="text" class="field-input cond-value" placeholder="Value" />
           <button class="btn-remove" @click="removeCondition(i)">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" /></svg>
@@ -317,37 +347,26 @@ const opLabels: Record<string, string> = {
           :key="'a' + i"
           class="action-row"
         >
-          <select class="field-select action-type" :value="getActionType(action)" @change="updateAction(i, ($event.target as HTMLSelectElement).value)">
-            <option value="move">Move to folder</option>
-            <option value="copy">Copy to folder</option>
-            <option value="delete">Delete</option>
-            <option value="flag">Add flag</option>
-            <option value="unflag">Remove flag</option>
-            <option value="mark_read">Mark as read</option>
-            <option value="mark_unread">Mark as unread</option>
-            <option value="stop">Stop processing</option>
-          </select>
-          <select
+          <Select
+            :model-value="getActionType(action)"
+            :options="ACTION_TYPE_OPTIONS"
+            class="field-select action-type"
+            @update:model-value="updateAction(i, $event)"
+          />
+          <Select
             v-if="needsTarget(action)"
+            :model-value="getActionTarget(action)"
+            :options="actionFolderOptions"
             class="field-select action-target"
-            :value="getActionTarget(action)"
-            @change="setActionTarget(i, ($event.target as HTMLSelectElement).value)"
-          >
-            <option value="" disabled>Select folder...</option>
-            <option v-for="f in foldersStore.getFlatFolders()" :key="f.path" :value="f.path">
-              {{ f.name }}
-            </option>
-          </select>
-          <select
+            @update:model-value="setActionTarget(i, $event)"
+          />
+          <Select
             v-else-if="needsValue(action)"
+            :model-value="getActionTarget(action)"
+            :options="FLAG_OPTIONS"
             class="field-select action-target"
-            :value="getActionTarget(action)"
-            @change="setActionTarget(i, ($event.target as HTMLSelectElement).value)"
-          >
-            <option value="flagged">Flagged</option>
-            <option value="seen">Seen</option>
-            <option value="answered">Answered</option>
-          </select>
+            @update:model-value="setActionTarget(i, $event)"
+          />
           <button class="btn-remove" @click="removeAction(i)">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" /></svg>
           </button>


### PR DESCRIPTION
## Summary

Fixes #57 — the app was hard-coded to 12-hour AM/PM time display (inheriting OS locale) and had no way to switch. While wiring the setting through, two related WebKitGTK nits fell out:

- Native \`<input type="time">\` ignores the \`lang\` attribute on WebKitGTK, so no amount of Intl options or \`lang=\"en-GB\"\` can force 24h display on that input. WebKitGTK also doesn't render a time picker at all — the element is effectively a strict-format text field.
- Native \`<input type=\"date\">\` on WebKitGTK ignores our theme tokens (hostile light background on dark theme), and the popup can only be dismissed with Esc, not by clicking outside.

Both are addressed by small format-aware replacement components that keep the same v-model contract as the native inputs.

## Changes

### Store (\`src/stores/ui.ts\`)
- \`timeFormat: \"auto\" | \"12\" | \"24\"\`, persisted to \`localStorage\` under \`chithi-time-format\` (default \`\"auto\"\`).
- \`hour12\` computed that resolves to \`true\` / \`false\` / \`undefined\` so call sites drop it straight into \`Intl.DateTimeFormatOptions\`.

### Intl-driven surfaces (hour12 option added)
- \`WeekView\` hour-gutter labels and event-block times.
- \`EventDetail\` event-time line.
- \`InviteCard\` invite time.
- \`ThreadRow\` / \`MessageListItem\` \"today\" time column.
- \`MessageReader\` header date + reply / forward quote headers.
- \`MessageList\` context-menu reply / forward quote headers.

### New \`TimeInput.vue\`
- Text input that renders the value in the user's preferred format (12h / 24h / auto).
- Accepts both forms on input (\`14:30\`, \`2:30 PM\`, \`2 pm\`, \`13\`).
- Validates on blur, restores the last good value on invalid input.
- Emits canonical 24h \`\"HH:MM\"\` via v-model.
- Used in \`EventForm\` (start/end) and \`EventDetail\` edit mode (start/end).

### New \`DateInput.vue\`
- Trigger button that uses theme tokens, opens an in-DOM calendar popup below the field.
- Dismisses on click-outside or Esc.
- Respects \`uiStore.weekStartDay\` for column order and day-name rotation.
- Honors an optional \`min\` prop (greys out and refuses days < min).
- Today outlined with accent, selected filled with accent.
- Keeps v-model as \`\"YYYY-MM-DD\"\` so existing \`localInputToUTC\` logic is unchanged.
- Used in \`EventForm\` (start/end), \`EventDetail\` edit mode (start/end), and \`RecurrenceEditor\` (until).

### UI control
- New \"Time format\" section in \`CalendarSidebar\` between \"Week starts on\" and \"Use timezone\", with Auto / 12h / 24h buttons.

### Tests
- New \`time-format.test.ts\` covers the store contract: default, set 12/24, persistence, corrupt-value fallback, invalid rejection.

## Test plan

- [x] \`pnpm run build\` — vue-tsc + vite build clean
- [x] \`pnpm test\` — 206 pass (6 new, 200 pre-existing)
- [x] Manual: toggle Auto / 12h / 24h → WeekView hour labels, event-block times, EventDetail, InviteCard, ThreadRow/MessageListItem \"today\" time, and MessageReader date header all update immediately.
- [x] Manual: \`TimeInput\` accepts both \`14:30\` and \`2:30 PM\`, revalidates on blur, invalid input reverts.
- [x] Manual: \`DateInput\` popup theme-correct in dark + light; click-outside and Esc dismiss; prev/next month; end-date greys out days before start.
- [x] Manual: recurrence \"ends on\" uses the new date picker.