### PR TITLE
ci: add GitHub Actions workflows and security policy (#62)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,8 @@ jobs:
 
       # Tauri 2 system deps on Ubuntu. Required by the Rust build even for
       # check/clippy/test because tauri links against webkit2gtk at compile.
+      # gnome-keyring + dbus-x11 are needed by the db::accounts tests, which
+      # round-trip passwords through the real OS Secret Service.
       - name: Install system dependencies
         run: |
           sudo apt-get update
@@ -61,7 +63,9 @@ jobs:
             libayatana-appindicator3-dev \
             librsvg2-dev \
             build-essential \
-            pkg-config
+            pkg-config \
+            gnome-keyring \
+            dbus-x11
 
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable branch
@@ -82,6 +86,16 @@ jobs:
         working-directory: src-tauri
         run: cargo clippy --locked --all-targets -- -D warnings
 
+      # Some db::accounts tests store/retrieve passwords in the OS keyring,
+      # so they need a D-Bus session with an unlocked gnome-keyring Secret
+      # Service available. `dbus-run-session` gives us a throwaway bus; we
+      # unlock the keyring with an empty password on first use.
       - name: cargo test
         working-directory: src-tauri
-        run: cargo test --locked --all-targets
+        run: |
+          dbus-run-session -- bash -c '
+            echo -n "" | gnome-keyring-daemon --unlock
+            eval "$(echo -n "" | gnome-keyring-daemon --start --components=secrets)"
+            export GNOME_KEYRING_CONTROL SSH_AUTH_SOCK
+            cargo test --locked --all-targets
+          '

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        with:
+          version: 10.27.0
 
       - name: Setup Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
@@ -78,8 +80,8 @@ jobs:
 
       - name: cargo clippy
         working-directory: src-tauri
-        run: cargo clippy --all-targets -- -D warnings
+        run: cargo clippy --locked --all-targets -- -D warnings
 
       - name: cargo test
         working-directory: src-tauri
-        run: cargo test --all-targets
+        run: cargo test --locked --all-targets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,85 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+# Cancel superseded runs on the same ref (e.g. re-pushes to a PR branch).
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  frontend:
+    name: Frontend (Vitest + vue-tsc)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+
+      - name: Setup Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Type-check
+        run: pnpm exec vue-tsc --noEmit
+
+      - name: Test
+        run: pnpm test
+
+  rust:
+    name: Rust (fmt + clippy + test)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      # Tauri 2 system deps on Ubuntu. Required by the Rust build even for
+      # check/clippy/test because tauri links against webkit2gtk at compile.
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libwebkit2gtk-4.1-dev \
+            libxdo-dev \
+            libssl-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            build-essential \
+            pkg-config
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable branch
+        with:
+          toolchain: stable
+          components: rustfmt, clippy
+
+      - name: Cargo cache
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          workspaces: src-tauri
+
+      - name: cargo fmt
+        working-directory: src-tauri
+        run: cargo fmt --all -- --check
+
+      - name: cargo clippy
+        working-directory: src-tauri
+        run: cargo clippy --all-targets -- -D warnings
+
+      - name: cargo test
+        working-directory: src-tauri
+        run: cargo test --all-targets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,15 +87,19 @@ jobs:
         run: cargo clippy --locked --all-targets -- -D warnings
 
       # Some db::accounts tests store/retrieve passwords in the OS keyring,
-      # so they need a D-Bus session with an unlocked gnome-keyring Secret
-      # Service available. `dbus-run-session` gives us a throwaway bus; we
-      # unlock the keyring with an empty password on first use.
+      # so they need a D-Bus session with a usable gnome-keyring Secret
+      # Service. Pattern adapted from keyring-rs' own CI:
+      # - dbus-run-session provides a throwaway session bus.
+      # - Removing ~/.local/share/keyrings forces a fresh login keyring.
+      # - `gnome-keyring-daemon --unlock` with a non-empty password creates
+      #   and unlocks the login keyring; the daemon then registers as the
+      #   default Secret Service collection on the bus.
       - name: cargo test
         working-directory: src-tauri
         run: |
           dbus-run-session -- bash -c '
-            echo -n "" | gnome-keyring-daemon --unlock
-            eval "$(echo -n "" | gnome-keyring-daemon --start --components=secrets)"
-            export GNOME_KEYRING_CONTROL SSH_AUTH_SOCK
+            rm -rf "$HOME/.local/share/keyrings"
+            mkdir -p "$HOME/.local/share/keyrings"
+            echo -n "test" | gnome-keyring-daemon --unlock
             cargo test --locked --all-targets
           '

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,31 @@
+name: Security audit
+
+on:
+  schedule:
+    # Daily at 06:17 UTC. Offset from :00 to avoid the GitHub cron rush.
+    - cron: "17 6 * * *"
+  push:
+    paths:
+      - "src-tauri/Cargo.toml"
+      - "src-tauri/Cargo.lock"
+      - ".github/workflows/security.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+  checks: write
+
+jobs:
+  cargo-audit:
+    name: cargo audit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Run cargo audit
+        uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          working-directory: src-tauri

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,38 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please **do not** open public GitHub issues for security vulnerabilities.
+
+Instead, email the Chithi maintainers directly:
+
+- Kushal Das, <kushal@sunet.se>
+- Micke Nordin, <kano@sunet.se>
+
+Include, where possible:
+
+- A description of the issue and its impact.
+- Steps to reproduce (proof-of-concept code or a minimal test case if you have one).
+- The affected version or commit.
+- Any suggested mitigations.
+
+We aim to acknowledge reports within a few working days and to provide a first
+assessment within two weeks. Once a fix is available, we will coordinate
+disclosure with you.
+
+## Scope
+
+Chithi is a desktop mail and calendar client built on Tauri. Reports in scope include:
+
+- Memory-safety or logic bugs in the Rust backend (`src-tauri/`).
+- Handling of credentials, tokens, or user data in the frontend or storage layer.
+- Issues in the handling of untrusted network input (IMAP/SMTP/JMAP/CalDAV/CardDAV responses, iCalendar/vCard payloads, HTML mail).
+- Insecure defaults in built releases.
+
+Vulnerabilities in upstream dependencies should normally be reported to those
+projects directly; if a dependency CVE materially affects Chithi users, we
+still appreciate a heads-up.
+
+## Supported versions
+
+Chithi is currently pre-1.0. Only the `main` branch receives security fixes.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4339,9 +4339,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/src-tauri/src/calendar/ical.rs
+++ b/src-tauri/src/calendar/ical.rs
@@ -8,13 +8,13 @@ use crate::db::calendar::Attendee;
 /// A parsed calendar invite extracted from an email or raw iCalendar text.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ParsedInvite {
-    pub method: String,              // REQUEST, REPLY, CANCEL
+    pub method: String, // REQUEST, REPLY, CANCEL
     pub uid: String,
     pub summary: Option<String>,
     pub description: Option<String>,
     pub location: Option<String>,
-    pub dtstart: String,             // ISO 8601
-    pub dtend: String,               // ISO 8601
+    pub dtstart: String, // ISO 8601
+    pub dtend: String,   // ISO 8601
     pub all_day: bool,
     pub timezone: Option<String>,
     pub organizer_email: Option<String>,
@@ -22,7 +22,7 @@ pub struct ParsedInvite {
     pub attendees: Vec<Attendee>,
     pub recurrence_rule: Option<String>,
     pub sequence: u32,
-    pub ical_raw: String,            // Original iCalendar text
+    pub ical_raw: String, // Original iCalendar text
 }
 
 /// Parse calendar invites from a raw RFC 5322 email message.
@@ -42,8 +42,7 @@ pub fn parse_ical_from_email(raw_message: &[u8]) -> Vec<ParsedInvite> {
         let content_type = part.content_type();
         let is_calendar = content_type
             .map(|ct| {
-                ct.ctype() == "text"
-                    && ct.subtype().map(|s| s == "calendar").unwrap_or(false)
+                ct.ctype() == "text" && ct.subtype().map(|s| s == "calendar").unwrap_or(false)
             })
             .unwrap_or(false);
 
@@ -90,11 +89,11 @@ pub fn parse_ical_data(ical_text: &str) -> Vec<ParsedInvite> {
     // unfold both forms — CRLF folds first, then anything remaining
     // after CRLF→LF normalization is treated as LF folding.
     let normalized = ical_text
-        .replace("\r\n ", "")   // Unfold CRLF + space
-        .replace("\r\n\t", "")  // Unfold CRLF + tab
-        .replace("\r\n", "\n")  // Normalize remaining CRLF to LF
-        .replace("\n ", "")     // Unfold LF + space
-        .replace("\n\t", "");   // Unfold LF + tab
+        .replace("\r\n ", "") // Unfold CRLF + space
+        .replace("\r\n\t", "") // Unfold CRLF + tab
+        .replace("\r\n", "\n") // Normalize remaining CRLF to LF
+        .replace("\n ", "") // Unfold LF + space
+        .replace("\n\t", ""); // Unfold LF + tab
 
     // Exchange/Outlook emit DESCRIPTION;ALTREP="data:text/html,...":plain text
     // where the quoted value contains raw unescaped " chars (RFC-violating but
@@ -119,8 +118,7 @@ pub fn parse_ical_data(ical_text: &str) -> Vec<ParsedInvite> {
             continue;
         }
 
-        let method = find_property_value(vcal, "METHOD")
-            .unwrap_or_else(|| "REQUEST".to_string());
+        let method = find_property_value(vcal, "METHOD").unwrap_or_else(|| "REQUEST".to_string());
 
         // Look for VEVENT sub-components
         for vevent in &vcal.components {
@@ -142,9 +140,7 @@ pub fn parse_ical_data(ical_text: &str) -> Vec<ParsedInvite> {
             let recurrence_rule = find_property_value(vevent, "RRULE");
 
             let sequence_str = find_property_value(vevent, "SEQUENCE");
-            let sequence: u32 = sequence_str
-                .and_then(|s| s.parse().ok())
-                .unwrap_or(0);
+            let sequence: u32 = sequence_str.and_then(|s| s.parse().ok()).unwrap_or(0);
 
             // Parse DTSTART and DTEND
             let (dtstart, all_day, timezone) = parse_dt_property(vevent, "DTSTART");
@@ -229,15 +225,29 @@ pub fn generate_reply(invite: &ParsedInvite, user_email: &str, response: &str) -
         if let Some(ref tz) = invite.timezone {
             let local_start = crate::mail::caldav::utc_to_local(&invite.dtstart, tz);
             let local_end = crate::mail::caldav::utc_to_local(&invite.dtend, tz);
-            lines.push(format!("DTSTART;TZID={}:{}", tz, to_ical_datetime(&local_start)));
-            lines.push(format!("DTEND;TZID={}:{}", tz, to_ical_datetime(&local_end)));
+            lines.push(format!(
+                "DTSTART;TZID={}:{}",
+                tz,
+                to_ical_datetime(&local_start)
+            ));
+            lines.push(format!(
+                "DTEND;TZID={}:{}",
+                tz,
+                to_ical_datetime(&local_end)
+            ));
         } else {
             lines.push(format!("DTSTART:{}", to_ical_datetime(&invite.dtstart)));
             lines.push(format!("DTEND:{}", to_ical_datetime(&invite.dtend)));
         }
     } else {
-        lines.push(format!("DTSTART;VALUE=DATE:{}", invite.dtstart.split('T').next().unwrap_or(&invite.dtstart)));
-        lines.push(format!("DTEND;VALUE=DATE:{}", invite.dtend.split('T').next().unwrap_or(&invite.dtend)));
+        lines.push(format!(
+            "DTSTART;VALUE=DATE:{}",
+            invite.dtstart.split('T').next().unwrap_or(&invite.dtstart)
+        ));
+        lines.push(format!(
+            "DTEND;VALUE=DATE:{}",
+            invite.dtend.split('T').next().unwrap_or(&invite.dtend)
+        ));
     }
     lines.push(format!("SEQUENCE:{}", invite.sequence));
     lines.push(format!("DTSTAMP:{}", now));
@@ -296,8 +306,16 @@ pub fn generate_invite(
     if let Some(tz) = timezone {
         let local_start = crate::mail::caldav::utc_to_local(dtstart, tz);
         let local_end = crate::mail::caldav::utc_to_local(dtend, tz);
-        lines.push(format!("DTSTART;TZID={}:{}", tz, to_ical_datetime(&local_start)));
-        lines.push(format!("DTEND;TZID={}:{}", tz, to_ical_datetime(&local_end)));
+        lines.push(format!(
+            "DTSTART;TZID={}:{}",
+            tz,
+            to_ical_datetime(&local_start)
+        ));
+        lines.push(format!(
+            "DTEND;TZID={}:{}",
+            tz,
+            to_ical_datetime(&local_end)
+        ));
     } else {
         lines.push(format!("DTSTART:{}", to_ical_datetime(dtstart)));
         lines.push(format!("DTEND:{}", to_ical_datetime(dtend)));
@@ -439,10 +457,7 @@ fn altrep_value_end(bytes: &[u8], after_eq: usize) -> usize {
 }
 
 /// Find a property value by name on a parser component.
-fn find_property_value(
-    component: &icalendar::parser::Component<'_>,
-    name: &str,
-) -> Option<String> {
+fn find_property_value(component: &icalendar::parser::Component<'_>, name: &str) -> Option<String> {
     component
         .find_prop(name)
         .map(|p| p.val.as_str().to_string())
@@ -503,8 +518,12 @@ fn ical_datetime_to_iso(val: &str, all_day: bool, tzid: Option<&str>) -> String 
         let utc_suffix = if val.ends_with('Z') { "Z" } else { "" };
         let iso = format!(
             "{}-{}-{}T{}:{}:{}{}",
-            &val[0..4], &val[4..6], &val[6..8],
-            &val[9..11], &val[11..13], &val[13..15],
+            &val[0..4],
+            &val[4..6],
+            &val[6..8],
+            &val[9..11],
+            &val[11..13],
+            &val[13..15],
             utc_suffix,
         );
 
@@ -525,19 +544,20 @@ fn to_ical_datetime(iso: &str) -> String {
     // Convert ISO 8601 to iCalendar format: "2025-04-15T10:00:00.000Z" -> "20250415T100000Z"
     // Parse with chrono to normalize, then format as iCal UTC.
     if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(iso) {
-        return dt.with_timezone(&chrono::Utc).format("%Y%m%dT%H%M%SZ").to_string();
+        return dt
+            .with_timezone(&chrono::Utc)
+            .format("%Y%m%dT%H%M%SZ")
+            .to_string();
     }
     // Try parsing without timezone (treat as UTC)
-    if let Ok(dt) = chrono::NaiveDateTime::parse_from_str(
-        iso.trim_end_matches('Z'),
-        "%Y-%m-%dT%H:%M:%S%.f",
-    ) {
+    if let Ok(dt) =
+        chrono::NaiveDateTime::parse_from_str(iso.trim_end_matches('Z'), "%Y-%m-%dT%H:%M:%S%.f")
+    {
         return dt.format("%Y%m%dT%H%M%SZ").to_string();
     }
-    if let Ok(dt) = chrono::NaiveDateTime::parse_from_str(
-        iso.trim_end_matches('Z'),
-        "%Y-%m-%dT%H:%M:%S",
-    ) {
+    if let Ok(dt) =
+        chrono::NaiveDateTime::parse_from_str(iso.trim_end_matches('Z'), "%Y-%m-%dT%H:%M:%S")
+    {
         return dt.format("%Y%m%dT%H%M%SZ").to_string();
     }
     // Fallback: just strip dashes/colons
@@ -716,15 +736,27 @@ mod tests {
 
     #[test]
     fn test_extract_mailto() {
-        assert_eq!(extract_mailto("mailto:alice@example.com"), Some("alice@example.com".to_string()));
-        assert_eq!(extract_mailto("MAILTO:Bob@Example.com"), Some("Bob@Example.com".to_string()));
-        assert_eq!(extract_mailto("alice@example.com"), Some("alice@example.com".to_string()));
+        assert_eq!(
+            extract_mailto("mailto:alice@example.com"),
+            Some("alice@example.com".to_string())
+        );
+        assert_eq!(
+            extract_mailto("MAILTO:Bob@Example.com"),
+            Some("Bob@Example.com".to_string())
+        );
+        assert_eq!(
+            extract_mailto("alice@example.com"),
+            Some("alice@example.com".to_string())
+        );
         assert_eq!(extract_mailto("not-an-email"), None);
     }
 
     #[test]
     fn test_to_ical_datetime_from_rfc3339() {
-        assert_eq!(to_ical_datetime("2026-04-07T17:00:00.000Z"), "20260407T170000Z");
+        assert_eq!(
+            to_ical_datetime("2026-04-07T17:00:00.000Z"),
+            "20260407T170000Z"
+        );
         assert_eq!(to_ical_datetime("2026-04-07T17:00:00Z"), "20260407T170000Z");
     }
 
@@ -751,10 +783,7 @@ mod tests {
 
     #[test]
     fn test_ical_datetime_to_iso_allday() {
-        assert_eq!(
-            ical_datetime_to_iso("20260407", true, None),
-            "2026-04-07"
-        );
+        assert_eq!(ical_datetime_to_iso("20260407", true, None), "2026-04-07");
     }
 
     #[test]
@@ -828,7 +857,11 @@ END:VCALENDAR";
         let invites = parse_ical_data(ical);
         assert_eq!(invites.len(), 1);
         // dtend should be computed from dtstart + duration
-        assert!(invites[0].dtend.contains("17:30:00"), "dtend should be 30min after dtstart, got: {}", invites[0].dtend);
+        assert!(
+            invites[0].dtend.contains("17:30:00"),
+            "dtend should be 30min after dtstart, got: {}",
+            invites[0].dtend
+        );
     }
 
     #[test]
@@ -875,7 +908,11 @@ END:VCALENDAR";
         let ical = "BEGIN:VCALENDAR\r\nMETHOD:REQUEST\r\nPRODID:Microsoft Exchange Server 2010\r\nVERSION:2.0\r\nBEGIN:VTIMEZONE\r\nTZID:UTC\r\nBEGIN:STANDARD\r\nDTSTART:16010101T000000\r\nTZOFFSETFROM:+0000\r\nTZOFFSETTO:+0000\r\nEND:STANDARD\r\nBEGIN:DAYLIGHT\r\nDTSTART:16010101T000000\r\nTZOFFSETFROM:+0000\r\nTZOFFSETTO:+0000\r\nEND:DAYLIGHT\r\nEND:VTIMEZONE\r\nBEGIN:VEVENT\r\nORGANIZER;CN=kushal das:mailto:chithiapp@outlook.com\r\nATTENDEE;ROLE=REQ-PARTICIPANT;PARTSTAT=NEEDS-ACTION;RSVP=TRUE;CN=sdossec@gm\r\n ail.com:mailto:sdossec@gmail.com\r\nDESCRIPTION;LANGUAGE=en-US:This is yo food event.\r\nUID:040000008200E00074C5B7101A82E008000000009B9A10BF48CBDC01000000000000000\r\n 0100000009B9409D22D123D48BA2ABC0BABC17911\r\nSUMMARY;LANGUAGE=en-US:Yo food\r\nDTSTART;TZID=UTC:20260414T170000\r\nDTEND;TZID=UTC:20260414T180000\r\nCLASS:PUBLIC\r\nPRIORITY:5\r\nDTSTAMP:20260413T132342Z\r\nTRANSP:OPAQUE\r\nSTATUS:CONFIRMED\r\nSEQUENCE:0\r\nBEGIN:VALARM\r\nDESCRIPTION:REMINDER\r\nTRIGGER;RELATED=START:-PT15M\r\nACTION:DISPLAY\r\nEND:VALARM\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n";
 
         let invites = parse_ical_data(ical);
-        assert_eq!(invites.len(), 1, "Should parse 1 invite from Microsoft Exchange iCal");
+        assert_eq!(
+            invites.len(),
+            1,
+            "Should parse 1 invite from Microsoft Exchange iCal"
+        );
         let inv = &invites[0];
         assert_eq!(inv.summary, Some("Yo food".to_string()));
         assert_eq!(inv.method, "REQUEST");
@@ -942,10 +979,17 @@ END:VEVENT\r\n\
 END:VCALENDAR\r\n";
 
         let invites = parse_ical_data(ical);
-        assert_eq!(invites.len(), 1, "Should parse 1 invite with ALTREP DESCRIPTION");
+        assert_eq!(
+            invites.len(),
+            1,
+            "Should parse 1 invite with ALTREP DESCRIPTION"
+        );
         let inv = &invites[0];
         assert_eq!(inv.uid, "altrep-test-uid");
-        assert_eq!(inv.summary, Some("Meeting with ALTREP description".to_string()));
+        assert_eq!(
+            inv.summary,
+            Some("Meeting with ALTREP description".to_string())
+        );
         assert_eq!(
             inv.description,
             Some("Plain text fallback description".to_string())
@@ -954,7 +998,8 @@ END:VCALENDAR\r\n";
 
     #[test]
     fn test_strip_altrep_quoted_with_inner_quotes() {
-        let line = "DESCRIPTION;LANGUAGE=en-US;ALTREP=\"data:text/html,<p class=\"a\">x</p>\":plain\n";
+        let line =
+            "DESCRIPTION;LANGUAGE=en-US;ALTREP=\"data:text/html,<p class=\"a\">x</p>\":plain\n";
         assert_eq!(
             strip_altrep_from_line(line).as_ref(),
             "DESCRIPTION;LANGUAGE=en-US:plain\n"
@@ -998,7 +1043,10 @@ END:VCALENDAR\r\n";
         let line = "SUMMARY:Team Standup\n";
         let out = strip_altrep_from_line(line);
         assert_eq!(out.as_ref(), line);
-        assert!(matches!(out, Cow::Borrowed(_)), "no-ALTREP lines must not allocate");
+        assert!(
+            matches!(out, Cow::Borrowed(_)),
+            "no-ALTREP lines must not allocate"
+        );
     }
 
     #[test]
@@ -1057,11 +1105,23 @@ END:VCALENDAR\r\n";
         let reply = generate_reply(&invite, "bob@example.com", "accepted");
 
         assert!(reply.contains("METHOD:REPLY"), "Should have METHOD:REPLY");
-        assert!(reply.contains("PARTSTAT=ACCEPTED"), "Should have ACCEPTED partstat");
-        assert!(reply.contains("mailto:bob@example.com"), "Should contain attendee email");
+        assert!(
+            reply.contains("PARTSTAT=ACCEPTED"),
+            "Should have ACCEPTED partstat"
+        );
+        assert!(
+            reply.contains("mailto:bob@example.com"),
+            "Should contain attendee email"
+        );
         assert!(reply.contains("UID:test-uid-123"), "Should preserve UID");
-        assert!(reply.contains("ORGANIZER;CN=Alice:mailto:alice@example.com"), "Should preserve organizer");
-        assert!(reply.contains("SUMMARY:Team Standup"), "Should preserve summary");
+        assert!(
+            reply.contains("ORGANIZER;CN=Alice:mailto:alice@example.com"),
+            "Should preserve organizer"
+        );
+        assert!(
+            reply.contains("SUMMARY:Team Standup"),
+            "Should preserve summary"
+        );
     }
 
     #[test]
@@ -1092,8 +1152,16 @@ END:VCALENDAR\r\n";
     #[test]
     fn test_generate_invite_with_attendees() {
         let attendees = vec![
-            Attendee { email: "bob@example.com".to_string(), name: Some("Bob".to_string()), status: "needs-action".to_string() },
-            Attendee { email: "carol@example.com".to_string(), name: None, status: "needs-action".to_string() },
+            Attendee {
+                email: "bob@example.com".to_string(),
+                name: Some("Bob".to_string()),
+                status: "needs-action".to_string(),
+            },
+            Attendee {
+                email: "carol@example.com".to_string(),
+                name: None,
+                status: "needs-action".to_string(),
+            },
         ];
 
         let ical = generate_invite(
@@ -1125,9 +1193,11 @@ END:VCALENDAR\r\n";
     #[test]
     fn test_generate_invite_roundtrip() {
         // Generate an invite, then parse it back
-        let attendees = vec![
-            Attendee { email: "bob@example.com".to_string(), name: None, status: "needs-action".to_string() },
-        ];
+        let attendees = vec![Attendee {
+            email: "bob@example.com".to_string(),
+            name: None,
+            status: "needs-action".to_string(),
+        }];
 
         let ical = generate_invite(
             "roundtrip-uid",
@@ -1148,7 +1218,10 @@ END:VCALENDAR\r\n";
         assert_eq!(parsed[0].uid, "roundtrip-uid");
         assert_eq!(parsed[0].summary, Some("Roundtrip Test".to_string()));
         assert_eq!(parsed[0].method, "REQUEST");
-        assert_eq!(parsed[0].organizer_email, Some("alice@example.com".to_string()));
+        assert_eq!(
+            parsed[0].organizer_email,
+            Some("alice@example.com".to_string())
+        );
         assert_eq!(parsed[0].attendees.len(), 1);
         assert_eq!(parsed[0].attendees[0].email, "bob@example.com");
     }
@@ -1163,15 +1236,19 @@ END:VCALENDAR\r\n";
             "Test Meeting",
             "2026-04-07T17:00:00Z",
             "2026-04-07T18:00:00Z",
-            None, None,
+            None,
+            None,
             "kushal@civilized.systems",
             None, // No organizer name
             &[],
             None,
             None,
         );
-        assert!(ical.contains("ORGANIZER:mailto:kushal@civilized.systems"),
-            "Should have ORGANIZER without CN, got: {}", ical);
+        assert!(
+            ical.contains("ORGANIZER:mailto:kushal@civilized.systems"),
+            "Should have ORGANIZER without CN, got: {}",
+            ical
+        );
         assert!(!ical.contains("CN="), "Should NOT have CN parameter");
     }
 
@@ -1182,7 +1259,8 @@ END:VCALENDAR\r\n";
             "Test Meeting",
             "2026-04-07T17:00:00Z",
             "2026-04-07T18:00:00Z",
-            None, None,
+            None,
+            None,
             "kushal@civilized.systems",
             Some("Kushal Das"),
             &[],
@@ -1194,12 +1272,20 @@ END:VCALENDAR\r\n";
 
     #[test]
     fn test_parse_ical_duration() {
-        assert_eq!(parse_ical_duration("PT1H"), Some(chrono::Duration::hours(1)));
-        assert_eq!(parse_ical_duration("PT30M"), Some(chrono::Duration::minutes(30)));
-        assert_eq!(parse_ical_duration("PT1H30M"), Some(chrono::Duration::minutes(90)));
+        assert_eq!(
+            parse_ical_duration("PT1H"),
+            Some(chrono::Duration::hours(1))
+        );
+        assert_eq!(
+            parse_ical_duration("PT30M"),
+            Some(chrono::Duration::minutes(30))
+        );
+        assert_eq!(
+            parse_ical_duration("PT1H30M"),
+            Some(chrono::Duration::minutes(90))
+        );
         assert_eq!(parse_ical_duration("P1D"), Some(chrono::Duration::days(1)));
         assert_eq!(parse_ical_duration("P1W"), Some(chrono::Duration::weeks(1)));
         assert_eq!(parse_ical_duration("invalid"), None);
     }
 }
-

--- a/src-tauri/src/calendar/timezone.rs
+++ b/src-tauri/src/calendar/timezone.rs
@@ -48,9 +48,7 @@ pub fn to_utc(datetime: &str, tzid: &str) -> String {
     // Naive datetime + IANA timezone → convert via chrono-tz
     if !tzid.is_empty() {
         if let Ok(tz) = tzid.parse::<chrono_tz::Tz>() {
-            if let Ok(naive) =
-                chrono::NaiveDateTime::parse_from_str(dt, "%Y-%m-%dT%H:%M:%S")
-            {
+            if let Ok(naive) = chrono::NaiveDateTime::parse_from_str(dt, "%Y-%m-%dT%H:%M:%S") {
                 use chrono::TimeZone;
                 match tz.from_local_datetime(&naive) {
                     chrono::LocalResult::Single(local) => {
@@ -73,7 +71,9 @@ pub fn to_utc(datetime: &str, tzid: &str) -> String {
                         );
                         for mins in 1..=120 {
                             let shifted = naive + chrono::Duration::minutes(mins);
-                            if let chrono::LocalResult::Single(local) = tz.from_local_datetime(&shifted) {
+                            if let chrono::LocalResult::Single(local) =
+                                tz.from_local_datetime(&shifted)
+                            {
                                 return local
                                     .with_timezone(&chrono::Utc)
                                     .format("%Y-%m-%dT%H:%M:%SZ")
@@ -103,29 +103,44 @@ mod tests {
 
     #[test]
     fn test_already_utc_ignores_tzid() {
-        assert_eq!(to_utc("2026-04-14T12:00:00Z", "America/New_York"), "2026-04-14T12:00:00Z");
+        assert_eq!(
+            to_utc("2026-04-14T12:00:00Z", "America/New_York"),
+            "2026-04-14T12:00:00Z"
+        );
     }
 
     #[test]
     fn test_with_positive_offset() {
-        assert_eq!(to_utc("2026-04-14T14:00:00+02:00", ""), "2026-04-14T12:00:00Z");
+        assert_eq!(
+            to_utc("2026-04-14T14:00:00+02:00", ""),
+            "2026-04-14T12:00:00Z"
+        );
     }
 
     #[test]
     fn test_with_negative_offset() {
-        assert_eq!(to_utc("2026-04-14T08:00:00-04:00", ""), "2026-04-14T12:00:00Z");
+        assert_eq!(
+            to_utc("2026-04-14T08:00:00-04:00", ""),
+            "2026-04-14T12:00:00Z"
+        );
     }
 
     #[test]
     fn test_naive_with_tzid_stockholm() {
         // Stockholm is UTC+2 in April (CEST)
-        assert_eq!(to_utc("2026-04-14T14:00:00", "Europe/Stockholm"), "2026-04-14T12:00:00Z");
+        assert_eq!(
+            to_utc("2026-04-14T14:00:00", "Europe/Stockholm"),
+            "2026-04-14T12:00:00Z"
+        );
     }
 
     #[test]
     fn test_offset_datetime_tzid_ignored() {
         // Offset already present → parsed directly, tzid ignored
-        assert_eq!(to_utc("2026-04-14T08:00:00-04:00", "America/New_York"), "2026-04-14T12:00:00Z");
+        assert_eq!(
+            to_utc("2026-04-14T08:00:00-04:00", "America/New_York"),
+            "2026-04-14T12:00:00Z"
+        );
     }
 
     #[test]
@@ -135,7 +150,10 @@ mod tests {
 
     #[test]
     fn test_invalid_tzid_treated_as_utc() {
-        assert_eq!(to_utc("2026-04-14T14:00:00", "Not/A/Timezone"), "2026-04-14T14:00:00Z");
+        assert_eq!(
+            to_utc("2026-04-14T14:00:00", "Not/A/Timezone"),
+            "2026-04-14T14:00:00Z"
+        );
     }
 
     #[test]
@@ -145,12 +163,18 @@ mod tests {
 
     #[test]
     fn test_with_fractional_seconds() {
-        assert_eq!(to_utc("2026-04-14T12:00:00.000Z", ""), "2026-04-14T12:00:00Z");
+        assert_eq!(
+            to_utc("2026-04-14T12:00:00.000Z", ""),
+            "2026-04-14T12:00:00Z"
+        );
     }
 
     #[test]
     fn test_winter_time_stockholm() {
         // Stockholm is UTC+1 in January (CET)
-        assert_eq!(to_utc("2026-01-14T13:00:00", "Europe/Stockholm"), "2026-01-14T12:00:00Z");
+        assert_eq!(
+            to_utc("2026-01-14T13:00:00", "Europe/Stockholm"),
+            "2026-01-14T12:00:00Z"
+        );
     }
 }

--- a/src-tauri/src/commands/accounts.rs
+++ b/src-tauri/src/commands/accounts.rs
@@ -7,9 +7,7 @@ use crate::error::Result;
 use crate::state::AppState;
 
 #[tauri::command]
-pub async fn list_accounts(
-    state: State<'_, AppState>,
-) -> Result<Vec<db::accounts::Account>> {
+pub async fn list_accounts(state: State<'_, AppState>) -> Result<Vec<db::accounts::Account>> {
     log::debug!("Listing accounts");
     let conn = state.db.reader();
     let accounts = db::accounts::list_accounts(&conn)?;
@@ -56,7 +54,11 @@ pub async fn add_account(
         is_default: true,
     };
     db::calendar::insert_calendar(&conn, &cal_id, &default_calendar)?;
-    log::info!("Default calendar created with id={} for account={}", cal_id, id);
+    log::info!(
+        "Default calendar created with id={} for account={}",
+        cal_id,
+        id
+    );
 
     Ok(id)
 }
@@ -105,10 +107,7 @@ pub async fn update_account(
 }
 
 #[tauri::command]
-pub async fn delete_account(
-    state: State<'_, AppState>,
-    account_id: String,
-) -> Result<()> {
+pub async fn delete_account(state: State<'_, AppState>, account_id: String) -> Result<()> {
     log::info!("Deleting account {}", account_id);
     let conn = state.db.writer().await;
     db::accounts::delete_account(&conn, &account_id)?;

--- a/src-tauri/src/commands/actions.rs
+++ b/src-tauri/src/commands/actions.rs
@@ -3,8 +3,7 @@ use tauri::{Emitter, State};
 
 use crate::commands::events::{emit_folders_changed, emit_messages_changed};
 use crate::commands::sync_cmd::{
-    resume_imap_idle_for_account,
-    should_suspend_idle_for_imap_operation,
+    resume_imap_idle_for_account, should_suspend_idle_for_imap_operation,
     suspend_imap_idle_for_account,
 };
 use crate::db;
@@ -18,11 +17,15 @@ async fn build_imap_config(account: &db::accounts::AccountFull) -> Result<ImapCo
     let (password, use_xoauth2) = if account.provider == "o365" {
         let tokens = crate::oauth::load_tokens(&account.id)?
             .ok_or_else(|| Error::Other("No O365 tokens".into()))?;
-        let refresh = tokens.refresh_token
+        let refresh = tokens
+            .refresh_token
             .ok_or_else(|| Error::Other("No O365 refresh token".into()))?;
         let new = crate::oauth::refresh_with_scopes(
-            &crate::oauth::MICROSOFT, &refresh, crate::oauth::MICROSOFT_IMAP_SCOPES,
-        ).await?;
+            &crate::oauth::MICROSOFT,
+            &refresh,
+            crate::oauth::MICROSOFT_IMAP_SCOPES,
+        )
+        .await?;
         crate::oauth::store_tokens(&account.id, &new)?;
         (new.access_token, true)
     } else {
@@ -129,8 +132,9 @@ pub async fn move_messages(
                     let client = crate::mail::graph::GraphClient::new(&token);
                     let mut errors: Vec<String> = Vec::new();
                     for mid in &message_ids_bg {
-                        let graph_id =
-                            mid.strip_prefix(&format!("{}_", account_id_bg)).unwrap_or(mid);
+                        let graph_id = mid
+                            .strip_prefix(&format!("{}_", account_id_bg))
+                            .unwrap_or(mid);
                         if let Err(e) = client.move_message(graph_id, &target_folder_bg).await {
                             log::error!("Graph move failed for {}: {}", graph_id, e);
                             errors.push(format!("{}: {}", graph_id, e));
@@ -181,16 +185,17 @@ pub async fn move_messages(
                     "target_folder": target_folder_bg,
                 });
                 let conn = db_bg.writer().await;
-                match crate::ops::offline::queue_offline_op(
-                    &conn, &account_id_bg, "move", &payload,
-                ) {
+                match crate::ops::offline::queue_offline_op(&conn, &account_id_bg, "move", &payload)
+                {
                     Ok(id) => log::info!(
                         "Queued failed JMAP/Graph move to outbox (id={}) for account {}",
-                        id, account_id_bg
+                        id,
+                        account_id_bg
                     ),
                     Err(db_err) => log::error!(
                         "Failed to queue offline move op for account {}: {}",
-                        account_id_bg, db_err
+                        account_id_bg,
+                        db_err
                     ),
                 }
                 app_bg
@@ -268,7 +273,11 @@ pub async fn delete_messages(
                 })
                 .await
             {
-                log::error!("Failed to queue delete op for account {}: {}", account_id, e);
+                log::error!(
+                    "Failed to queue delete op for account {}: {}",
+                    account_id,
+                    e
+                );
                 app.emit(
                     "op-failed",
                     serde_json::json!({
@@ -294,8 +303,9 @@ pub async fn delete_messages(
                     let client = crate::mail::graph::GraphClient::new(&token);
                     let mut errors: Vec<String> = Vec::new();
                     for mid in &message_ids_bg {
-                        let graph_id =
-                            mid.strip_prefix(&format!("{}_", account_id_bg)).unwrap_or(mid);
+                        let graph_id = mid
+                            .strip_prefix(&format!("{}_", account_id_bg))
+                            .unwrap_or(mid);
                         if let Err(e) = client.delete_message(graph_id).await {
                             log::error!("Graph delete failed for {}: {}", graph_id, e);
                             errors.push(format!("{}: {}", graph_id, e));
@@ -325,9 +335,7 @@ pub async fn delete_messages(
                     if !jmap_ids.is_empty() {
                         let conn_jmap =
                             crate::mail::jmap::JmapConnection::connect(&jmap_config).await?;
-                        conn_jmap
-                            .delete_emails(&jmap_config, &jmap_ids)
-                            .await?;
+                        conn_jmap.delete_emails(&jmap_config, &jmap_ids).await?;
                     }
                 }
                 Ok(())
@@ -347,15 +355,20 @@ pub async fn delete_messages(
                 });
                 let conn = db_bg.writer().await;
                 match crate::ops::offline::queue_offline_op(
-                    &conn, &account_id_bg, "delete", &payload,
+                    &conn,
+                    &account_id_bg,
+                    "delete",
+                    &payload,
                 ) {
                     Ok(id) => log::info!(
                         "Queued failed JMAP/Graph delete to outbox (id={}) for account {}",
-                        id, account_id_bg
+                        id,
+                        account_id_bg
                     ),
                     Err(db_err) => log::error!(
                         "Failed to queue offline delete op for account {}: {}",
-                        account_id_bg, db_err
+                        account_id_bg,
+                        db_err
                     ),
                 }
                 app_bg
@@ -424,8 +437,8 @@ pub async fn move_messages_cross_account(
     // Rejects non-disk entries (graph: prefix), absolute paths, and ".." segments.
     let data_dir = state.data_dir.clone();
     let validated_paths: Vec<std::path::PathBuf> = {
-        let canonical_data_dir = std::fs::canonicalize(&data_dir)
-            .unwrap_or_else(|_| data_dir.clone());
+        let canonical_data_dir =
+            std::fs::canonicalize(&data_dir).unwrap_or_else(|_| data_dir.clone());
         let mut paths = Vec::with_capacity(maildir_paths.len());
         for (msg_id, maildir_path) in &maildir_paths {
             if maildir_path.starts_with("graph:") {
@@ -436,7 +449,11 @@ pub async fn move_messages_cross_account(
                 )));
             }
             let rel = std::path::Path::new(maildir_path);
-            if rel.is_absolute() || rel.components().any(|c| matches!(c, std::path::Component::ParentDir)) {
+            if rel.is_absolute()
+                || rel
+                    .components()
+                    .any(|c| matches!(c, std::path::Component::ParentDir))
+            {
                 return Err(Error::Other(format!(
                     "Invalid maildir path for message {}: '{}'",
                     msg_id, maildir_path
@@ -446,12 +463,14 @@ pub async fn move_messages_cross_account(
             let canonical = std::fs::canonicalize(&full_path).map_err(|e| {
                 Error::Other(format!(
                     "Failed to resolve maildir file {}: {}",
-                    full_path.display(), e
+                    full_path.display(),
+                    e
                 ))
             })?;
             if !canonical.starts_with(&canonical_data_dir) {
                 return Err(Error::Other(format!(
-                    "Path traversal detected for message {}", msg_id
+                    "Path traversal detected for message {}",
+                    msg_id
                 )));
             }
             paths.push(canonical);
@@ -482,17 +501,16 @@ pub async fn move_messages_cross_account(
         }
         "jmap" => {
             // JMAP: read each message in a blocking task, then import async
-            let jmap_config =
-                crate::commands::sync_cmd::build_jmap_config(&target_account).await?;
+            let jmap_config = crate::commands::sync_cmd::build_jmap_config(&target_account).await?;
             let conn_jmap = crate::mail::jmap::JmapConnection::connect(&jmap_config).await?;
             for path in &validated_paths {
                 let path_clone = path.clone();
-                let bytes = tokio::task::spawn_blocking(move || {
-                    std::fs::read(&path_clone)
-                })
-                .await
-                .map_err(|e| Error::Other(format!("Read task panicked: {}", e)))?
-                .map_err(|e| Error::Other(format!("Failed to read {}: {}", path.display(), e)))?;
+                let bytes = tokio::task::spawn_blocking(move || std::fs::read(&path_clone))
+                    .await
+                    .map_err(|e| Error::Other(format!("Read task panicked: {}", e)))?
+                    .map_err(|e| {
+                        Error::Other(format!("Failed to read {}: {}", path.display(), e))
+                    })?;
                 conn_jmap
                     .import_email_to_mailbox(&jmap_config, &bytes, &target_folder, false)
                     .await?;
@@ -512,7 +530,13 @@ pub async fn move_messages_cross_account(
     }
 
     // Append succeeded — delete from source
-    delete_messages(app.clone(), state, source_account_id.clone(), message_ids.clone()).await?;
+    delete_messages(
+        app.clone(),
+        state,
+        source_account_id.clone(),
+        message_ids.clone(),
+    )
+    .await?;
 
     // Emit events for the destination account too so its folder counts refresh
     emit_messages_changed(&app, &target_account_id);
@@ -556,10 +580,7 @@ pub async fn set_message_flags(
     {
         let conn = state.db.writer().await;
 
-        let normalized_flags: Vec<String> = flags
-            .iter()
-            .map(|f| normalize_flag_name(f))
-            .collect();
+        let normalized_flags: Vec<String> = flags.iter().map(|f| normalize_flag_name(f)).collect();
 
         for msg_id in &message_ids {
             if let Ok((_, _, _, _, flags_json, _, _)) =
@@ -576,8 +597,8 @@ pub async fn set_message_flags(
                 } else {
                     current.retain(|f| !normalized_flags.contains(f));
                 }
-                let updated_json = serde_json::to_string(&current)
-                    .unwrap_or_else(|_| "[]".to_string());
+                let updated_json =
+                    serde_json::to_string(&current).unwrap_or_else(|_| "[]".to_string());
                 db::messages::update_flags(&conn, msg_id, &updated_json)?;
             }
         }
@@ -590,9 +611,14 @@ pub async fn set_message_flags(
         let client = crate::mail::graph::GraphClient::new(&token);
         let is_seen_flag = flags.iter().any(|f| f == "seen" || f == "\\Seen");
         if is_seen_flag {
-            let graph_ids: Vec<String> = message_ids.iter().map(|mid| {
-                mid.strip_prefix(&format!("{}_", account_id)).unwrap_or(mid).to_string()
-            }).collect();
+            let graph_ids: Vec<String> = message_ids
+                .iter()
+                .map(|mid| {
+                    mid.strip_prefix(&format!("{}_", account_id))
+                        .unwrap_or(mid)
+                        .to_string()
+                })
+                .collect();
             client.set_read_status(&graph_ids, add).await?;
         }
     } else if account.mail_protocol == "jmap" {
@@ -600,15 +626,24 @@ pub async fn set_message_flags(
         let jmap_config = crate::commands::sync_cmd::build_jmap_config(&account).await?;
 
         // Extract JMAP email IDs from composite message IDs
-        let jmap_ids: Vec<String> = message_ids.iter().map(|mid| {
-            // Format: {account_id}_{folder}_{jmap_email_id}
-            let parts: Vec<&str> = mid.splitn(3, '_').collect();
-            if parts.len() == 3 { parts[2].to_string() } else { mid.clone() }
-        }).collect();
+        let jmap_ids: Vec<String> = message_ids
+            .iter()
+            .map(|mid| {
+                // Format: {account_id}_{folder}_{jmap_email_id}
+                let parts: Vec<&str> = mid.splitn(3, '_').collect();
+                if parts.len() == 3 {
+                    parts[2].to_string()
+                } else {
+                    mid.clone()
+                }
+            })
+            .collect();
 
         let conn_jmap = crate::mail::jmap::JmapConnection::connect(&jmap_config).await?;
         let flag_strs: Vec<&str> = flags.iter().map(|s| s.as_str()).collect();
-        conn_jmap.set_flags(&jmap_config, &jmap_ids, &flag_strs, add).await?;
+        conn_jmap
+            .set_flags(&jmap_config, &jmap_ids, &flag_strs, add)
+            .await?;
     } else {
         // IMAP path: send through worker queue (persistent connection, no IDLE suspend needed)
         let by_folder = {
@@ -630,7 +665,11 @@ pub async fn set_message_flags(
                 })
                 .await
             {
-                log::error!("Failed to queue set_flags op for account {}: {}", account_id, e);
+                log::error!(
+                    "Failed to queue set_flags op for account {}: {}",
+                    account_id,
+                    e
+                );
                 app.emit(
                     "op-failed",
                     serde_json::json!({
@@ -756,11 +795,15 @@ pub async fn mark_account_read(
     if account.mail_protocol == "graph" {
         let unread_ids = {
             let conn = state.db.reader();
-            let mut stmt = conn.prepare(
-                "SELECT id FROM messages WHERE account_id = ?1 AND flags NOT LIKE '%seen%'",
-            ).map_err(crate::error::Error::Database)?;
+            let mut stmt = conn
+                .prepare(
+                    "SELECT id FROM messages WHERE account_id = ?1 AND flags NOT LIKE '%seen%'",
+                )
+                .map_err(crate::error::Error::Database)?;
             let ids: Vec<String> = stmt
-                .query_map(rusqlite::params![&account_id], |row| row.get::<_, String>(0))
+                .query_map(rusqlite::params![&account_id], |row| {
+                    row.get::<_, String>(0)
+                })
                 .map_err(crate::error::Error::Database)?
                 .filter_map(|r| r.ok())
                 .collect();
@@ -769,9 +812,14 @@ pub async fn mark_account_read(
         if !unread_ids.is_empty() {
             let token = crate::mail::graph::get_graph_token(&account_id).await?;
             let client = crate::mail::graph::GraphClient::new(&token);
-            let graph_ids: Vec<String> = unread_ids.iter().map(|mid| {
-                mid.strip_prefix(&format!("{}_", account_id)).unwrap_or(mid).to_string()
-            }).collect();
+            let graph_ids: Vec<String> = unread_ids
+                .iter()
+                .map(|mid| {
+                    mid.strip_prefix(&format!("{}_", account_id))
+                        .unwrap_or(mid)
+                        .to_string()
+                })
+                .collect();
             client.set_read_status(&graph_ids, true).await?;
         }
     } else if account.mail_protocol == "imap" {
@@ -815,10 +863,15 @@ pub async fn mark_account_read(
 
         let unread_ids: Vec<String> = {
             let conn = state.db.reader();
-            let mut stmt = conn.prepare(
-                "SELECT id FROM messages WHERE account_id = ?1 AND flags NOT LIKE '%seen%'",
-            ).map_err(crate::error::Error::Database)?;
-            let rows = stmt.query_map(rusqlite::params![&account_id], |row| row.get::<_, String>(0))
+            let mut stmt = conn
+                .prepare(
+                    "SELECT id FROM messages WHERE account_id = ?1 AND flags NOT LIKE '%seen%'",
+                )
+                .map_err(crate::error::Error::Database)?;
+            let rows = stmt
+                .query_map(rusqlite::params![&account_id], |row| {
+                    row.get::<_, String>(0)
+                })
                 .map_err(crate::error::Error::Database)?;
             let ids: Vec<String> = rows.filter_map(|r| r.ok()).collect();
             ids
@@ -826,24 +879,35 @@ pub async fn mark_account_read(
 
         if !unread_ids.is_empty() {
             // Extract JMAP email IDs from composite message IDs
-            let jmap_ids: Vec<String> = unread_ids.iter().map(|mid| {
-                let parts: Vec<&str> = mid.splitn(3, '_').collect();
-                if parts.len() == 3 { parts[2].to_string() } else { mid.clone() }
-            }).collect();
+            let jmap_ids: Vec<String> = unread_ids
+                .iter()
+                .map(|mid| {
+                    let parts: Vec<&str> = mid.splitn(3, '_').collect();
+                    if parts.len() == 3 {
+                        parts[2].to_string()
+                    } else {
+                        mid.clone()
+                    }
+                })
+                .collect();
 
             let flag_strs = vec!["seen"];
-            conn_jmap.set_flags(&jmap_config, &jmap_ids, &flag_strs, true).await?;
+            conn_jmap
+                .set_flags(&jmap_config, &jmap_ids, &flag_strs, true)
+                .await?;
         }
     }
 
     // Update local DB
     let updated = {
         let conn = state.db.writer().await;
-        let count = conn.execute(
-            "UPDATE messages SET flags = json_insert(flags, '$[#]', 'seen')
+        let count = conn
+            .execute(
+                "UPDATE messages SET flags = json_insert(flags, '$[#]', 'seen')
              WHERE account_id = ?1 AND flags NOT LIKE '%seen%'",
-            rusqlite::params![account_id],
-        ).map_err(crate::error::Error::Database)?;
+                rusqlite::params![account_id],
+            )
+            .map_err(crate::error::Error::Database)?;
         db::folders::recalculate_folder_counts(&conn, &account_id)?;
         count
     };

--- a/src-tauri/src/commands/calendar.rs
+++ b/src-tauri/src/commands/calendar.rs
@@ -57,10 +57,7 @@ pub async fn list_calendars(
 }
 
 #[tauri::command]
-pub async fn create_calendar(
-    state: State<'_, AppState>,
-    calendar: NewCalendar,
-) -> Result<String> {
+pub async fn create_calendar(state: State<'_, AppState>, calendar: NewCalendar) -> Result<String> {
     log::info!(
         "create_calendar: account={} name='{}'",
         calendar.account_id,
@@ -92,10 +89,7 @@ pub async fn update_calendar(
 }
 
 #[tauri::command]
-pub async fn delete_calendar(
-    state: State<'_, AppState>,
-    calendar_id: String,
-) -> Result<()> {
+pub async fn delete_calendar(state: State<'_, AppState>, calendar_id: String) -> Result<()> {
     log::info!("delete_calendar: id={}", calendar_id);
     let conn = state.db.writer().await;
     db::calendar::delete_calendar(&conn, &calendar_id)?;
@@ -108,15 +102,16 @@ pub async fn delete_calendar(
 // ---------------------------------------------------------------------------
 
 #[tauri::command]
-pub async fn unsubscribe_calendar(
-    state: State<'_, AppState>,
-    calendar_id: String,
-) -> Result<()> {
+pub async fn unsubscribe_calendar(state: State<'_, AppState>, calendar_id: String) -> Result<()> {
     log::info!("unsubscribe_calendar: id={}", calendar_id);
     let conn = state.db.writer().await;
     db::calendar::set_calendar_subscribed(&conn, &calendar_id, false)?;
     let deleted = db::calendar::delete_calendar_events(&conn, &calendar_id)?;
-    log::info!("unsubscribe_calendar: deleted {} events for calendar {}", deleted, calendar_id);
+    log::info!(
+        "unsubscribe_calendar: deleted {} events for calendar {}",
+        deleted,
+        calendar_id
+    );
     Ok(())
 }
 
@@ -138,22 +133,14 @@ pub async fn get_events(
         calendar_id
     );
     let conn = state.db.reader();
-    let events = db::calendar::list_events(
-        &conn,
-        &account_id,
-        calendar_id.as_deref(),
-        &start,
-        &end,
-    )?;
+    let events =
+        db::calendar::list_events(&conn, &account_id, calendar_id.as_deref(), &start, &end)?;
     log::debug!("get_events: found {} events", events.len());
     Ok(events)
 }
 
 #[tauri::command]
-pub async fn create_event(
-    state: State<'_, AppState>,
-    event: NewEventInput,
-) -> Result<String> {
+pub async fn create_event(state: State<'_, AppState>, event: NewEventInput) -> Result<String> {
     log::info!(
         "create_event: account={} calendar={} title='{}' attendees={}",
         event.account_id,
@@ -232,20 +219,33 @@ pub async fn create_event(
                 }
                 if let Some(ref att_json) = cal_event.attendees_json {
                     if let Ok(atts) = serde_json::from_str::<Vec<serde_json::Value>>(att_json) {
-                        let google_attendees: Vec<serde_json::Value> = atts.iter()
-                            .filter_map(|a| a["email"].as_str().map(|e| serde_json::json!({"email": e})))
+                        let google_attendees: Vec<serde_json::Value> = atts
+                            .iter()
+                            .filter_map(|a| {
+                                a["email"].as_str().map(|e| serde_json::json!({"email": e}))
+                            })
                             .collect();
                         if !google_attendees.is_empty() {
                             google_event["attendees"] = serde_json::json!(google_attendees);
                         }
                     }
                 }
-                let send_updates = if cal_event.attendees_json.is_some() { "all" } else { "none" };
+                let send_updates = if cal_event.attendees_json.is_some() {
+                    "all"
+                } else {
+                    "none"
+                };
                 let url = format!(
                     "https://www.googleapis.com/calendar/v3/calendars/primary/events?sendUpdates={}",
                     send_updates
                 );
-                match http.post(&url).bearer_auth(&token).json(&google_event).send().await {
+                match http
+                    .post(&url)
+                    .bearer_auth(&token)
+                    .json(&google_event)
+                    .send()
+                    .await
+                {
                     Ok(resp) if resp.status().is_success() => {
                         if let Ok(data) = resp.json::<serde_json::Value>().await {
                             let remote_id = data["id"].as_str().unwrap_or_default().to_string();
@@ -254,15 +254,20 @@ pub async fn create_event(
                             conn.execute(
                                 "UPDATE calendar_events SET remote_id = ?1 WHERE id = ?2",
                                 rusqlite::params![remote_id, id],
-                            ).ok();
+                            )
+                            .ok();
                             // Update local UID to match Google's iCalUID so RSVP
                             // replies can be matched back to the event.
                             if let Some(ical_uid) = data["iCalUID"].as_str() {
                                 conn.execute(
                                     "UPDATE calendar_events SET uid = ?1 WHERE id = ?2",
                                     rusqlite::params![ical_uid, id],
-                                ).ok();
-                                log::info!("create_event: updated local UID to Google iCalUID={}", ical_uid);
+                                )
+                                .ok();
+                                log::info!(
+                                    "create_event: updated local UID to Google iCalUID={}",
+                                    ical_uid
+                                );
                             }
                         }
                     }
@@ -292,7 +297,8 @@ pub async fn create_event(
                     "isAllDay": cal_event.all_day,
                 });
                 if let Some(ref desc) = cal_event.description {
-                    graph_event["body"] = serde_json::json!({"contentType": "text", "content": desc});
+                    graph_event["body"] =
+                        serde_json::json!({"contentType": "text", "content": desc});
                 }
                 if let Some(ref loc) = cal_event.location {
                     graph_event["location"] = serde_json::json!({"displayName": loc});
@@ -316,19 +322,30 @@ pub async fn create_event(
                         if !graph_atts.is_empty() {
                             graph_event["attendees"] = serde_json::json!(graph_atts);
                         }
-                        log::info!("create_event: O365 event with {} attendees", graph_atts.len());
+                        log::info!(
+                            "create_event: O365 event with {} attendees",
+                            graph_atts.len()
+                        );
                     }
                 }
                 // Graph sends invite emails automatically when attendees are present
-                log::debug!("create_event: O365 graph_event JSON: {}", serde_json::to_string_pretty(&graph_event).unwrap_or_default());
+                log::debug!(
+                    "create_event: O365 graph_event JSON: {}",
+                    serde_json::to_string_pretty(&graph_event).unwrap_or_default()
+                );
                 match client.create_event(&graph_event).await {
                     Ok((remote_id, ical_uid)) => {
-                        log::info!("create_event: pushed to Graph Calendar, id={}, iCalUid={:?}", remote_id, ical_uid);
+                        log::info!(
+                            "create_event: pushed to Graph Calendar, id={}, iCalUid={:?}",
+                            remote_id,
+                            ical_uid
+                        );
                         let conn = state.db.writer().await;
                         conn.execute(
                             "UPDATE calendar_events SET remote_id = ?1 WHERE id = ?2",
                             rusqlite::params![remote_id, id],
-                        ).ok();
+                        )
+                        .ok();
                         // Update the local UID to match Exchange's iCalUid so that
                         // incoming RSVP reply emails (which reference this UID) can
                         // be matched back to the event by process_invite_reply.
@@ -336,8 +353,12 @@ pub async fn create_event(
                             conn.execute(
                                 "UPDATE calendar_events SET uid = ?1 WHERE id = ?2",
                                 rusqlite::params![ical_uid, id],
-                            ).ok();
-                            log::info!("create_event: updated local UID to Exchange iCalUid={}", ical_uid);
+                            )
+                            .ok();
+                            log::info!(
+                                "create_event: updated local UID to Exchange iCalUid={}",
+                                ical_uid
+                            );
                         }
                     }
                     Err(e) => log::error!("create_event: Graph Calendar push failed: {}", e),
@@ -348,7 +369,10 @@ pub async fn create_event(
             let calendar = db::calendar::get_calendar(&conn, &cal_event.calendar_id)?;
             let remote_cal_id = calendar.remote_id.clone().unwrap_or_default();
             if remote_cal_id.is_empty() {
-                log::warn!("create_event: no remote calendar ID for local calendar '{}'", cal_event.calendar_id);
+                log::warn!(
+                    "create_event: no remote calendar ID for local calendar '{}'",
+                    cal_event.calendar_id
+                );
             }
             drop(conn); // Release lock before async call
             let jmap_config = crate::commands::sync_cmd::build_jmap_config(&account).await?;
@@ -369,14 +393,18 @@ pub async fn create_event(
             };
             match crate::mail::jmap::JmapConnection::connect(&jmap_config).await {
                 Ok(conn_jmap) => {
-                    match conn_jmap.create_calendar_event(&jmap_config, &jmap_event).await {
+                    match conn_jmap
+                        .create_calendar_event(&jmap_config, &jmap_event)
+                        .await
+                    {
                         Ok(remote_id) => {
                             log::info!("create_event: pushed to JMAP, remote_id={}", remote_id);
                             let conn = state.db.writer().await;
                             conn.execute(
                                 "UPDATE calendar_events SET remote_id = ?1 WHERE id = ?2",
                                 rusqlite::params![remote_id, id],
-                            ).ok();
+                            )
+                            .ok();
                         }
                         Err(e) => log::error!("create_event: JMAP push failed: {}", e),
                     }
@@ -443,78 +471,85 @@ pub async fn update_event(
     // Push update to server
     let account = db::accounts::get_account_full(&conn, &existing.account_id)?;
     if let Some(ref remote_id) = existing.remote_id.filter(|r| !r.is_empty()) {
-            if account.provider == "gmail" {
-                drop(conn);
-                if let Ok(token) = get_google_token(&existing.account_id).await {
-                    let http = reqwest::Client::new();
-                    let mut patch = serde_json::json!({
-                        "summary": existing.title,
-                        "start": if existing.all_day {
-                            serde_json::json!({"date": existing.start_time.split('T').next().unwrap_or_default()})
-                        } else {
-                            serde_json::json!({"dateTime": existing.start_time})
-                        },
-                        "end": if existing.all_day {
-                            serde_json::json!({"date": existing.end_time.split('T').next().unwrap_or_default()})
-                        } else {
-                            serde_json::json!({"dateTime": existing.end_time})
-                        },
-                    });
-                    if let Some(ref desc) = existing.description {
-                        patch["description"] = serde_json::json!(desc);
-                    }
-                    if let Some(ref loc) = existing.location {
-                        patch["location"] = serde_json::json!(loc);
-                    }
-                    let send_updates = if existing.attendees_json.is_some() { "all" } else { "none" };
-                    let url = format!(
+        if account.provider == "gmail" {
+            drop(conn);
+            if let Ok(token) = get_google_token(&existing.account_id).await {
+                let http = reqwest::Client::new();
+                let mut patch = serde_json::json!({
+                    "summary": existing.title,
+                    "start": if existing.all_day {
+                        serde_json::json!({"date": existing.start_time.split('T').next().unwrap_or_default()})
+                    } else {
+                        serde_json::json!({"dateTime": existing.start_time})
+                    },
+                    "end": if existing.all_day {
+                        serde_json::json!({"date": existing.end_time.split('T').next().unwrap_or_default()})
+                    } else {
+                        serde_json::json!({"dateTime": existing.end_time})
+                    },
+                });
+                if let Some(ref desc) = existing.description {
+                    patch["description"] = serde_json::json!(desc);
+                }
+                if let Some(ref loc) = existing.location {
+                    patch["location"] = serde_json::json!(loc);
+                }
+                let send_updates = if existing.attendees_json.is_some() {
+                    "all"
+                } else {
+                    "none"
+                };
+                let url = format!(
                         "https://www.googleapis.com/calendar/v3/calendars/primary/events/{}?sendUpdates={}",
                         urlencoding::encode(remote_id), send_updates
                     );
-                    match http.patch(&url).bearer_auth(&token).json(&patch).send().await {
-                        Ok(resp) if resp.status().is_success() => {
-                            log::info!("update_event: updated on Google Calendar");
-                        }
-                        Ok(resp) => {
-                            let body = resp.text().await.unwrap_or_default();
-                            log::error!("update_event: Google Calendar PATCH failed: {}", body);
-                        }
-                        Err(e) => log::error!("update_event: Google Calendar request failed: {}", e),
+                match http
+                    .patch(&url)
+                    .bearer_auth(&token)
+                    .json(&patch)
+                    .send()
+                    .await
+                {
+                    Ok(resp) if resp.status().is_success() => {
+                        log::info!("update_event: updated on Google Calendar");
                     }
-                }
-            } else if account.provider == "o365" {
-                drop(conn);
-                if let Ok(token) = crate::mail::graph::get_graph_token(&existing.account_id).await {
-                    let client = crate::mail::graph::GraphClient::new(&token);
-                    let mut patch = serde_json::json!({
-                        "subject": existing.title,
-                        "start": {"dateTime": existing.start_time, "timeZone": "UTC"},
-                        "end": {"dateTime": existing.end_time, "timeZone": "UTC"},
-                        "isAllDay": existing.all_day,
-                    });
-                    if let Some(ref desc) = existing.description {
-                        patch["body"] = serde_json::json!({"contentType": "text", "content": desc});
+                    Ok(resp) => {
+                        let body = resp.text().await.unwrap_or_default();
+                        log::error!("update_event: Google Calendar PATCH failed: {}", body);
                     }
-                    if let Some(ref loc) = existing.location {
-                        patch["location"] = serde_json::json!({"displayName": loc});
-                    }
-                    match client.update_event(remote_id, &patch).await {
-                        Ok(()) => log::info!("update_event: updated on Graph Calendar"),
-                        Err(e) => log::error!("update_event: Graph Calendar PATCH failed: {}", e),
-                    }
+                    Err(e) => log::error!("update_event: Google Calendar request failed: {}", e),
                 }
             }
-            // JMAP update is handled by existing code path via update_calendar_event
+        } else if account.provider == "o365" {
+            drop(conn);
+            if let Ok(token) = crate::mail::graph::get_graph_token(&existing.account_id).await {
+                let client = crate::mail::graph::GraphClient::new(&token);
+                let mut patch = serde_json::json!({
+                    "subject": existing.title,
+                    "start": {"dateTime": existing.start_time, "timeZone": "UTC"},
+                    "end": {"dateTime": existing.end_time, "timeZone": "UTC"},
+                    "isAllDay": existing.all_day,
+                });
+                if let Some(ref desc) = existing.description {
+                    patch["body"] = serde_json::json!({"contentType": "text", "content": desc});
+                }
+                if let Some(ref loc) = existing.location {
+                    patch["location"] = serde_json::json!({"displayName": loc});
+                }
+                match client.update_event(remote_id, &patch).await {
+                    Ok(()) => log::info!("update_event: updated on Graph Calendar"),
+                    Err(e) => log::error!("update_event: Graph Calendar PATCH failed: {}", e),
+                }
+            }
+        }
+        // JMAP update is handled by existing code path via update_calendar_event
     }
 
     Ok(())
 }
 
 #[tauri::command]
-pub async fn delete_event(
-    state: State<'_, AppState>,
-    event_id: String,
-) -> Result<()> {
+pub async fn delete_event(state: State<'_, AppState>, event_id: String) -> Result<()> {
     log::info!("delete_event: id={}", event_id);
 
     // Look up the event, account, and calendar remote_id
@@ -523,7 +558,9 @@ pub async fn delete_event(
         let evt = db::calendar::get_event(&conn, &event_id)?;
         let acc = db::accounts::get_account_full(&conn, &evt.account_id)?;
         let cal = db::calendar::get_calendar(&conn, &evt.calendar_id).ok();
-        let cal_rid = cal.and_then(|c| c.remote_id).unwrap_or_else(|| "primary".to_string());
+        let cal_rid = cal
+            .and_then(|c| c.remote_id)
+            .unwrap_or_else(|| "primary".to_string());
         (evt, acc, cal_rid)
     };
 
@@ -541,17 +578,29 @@ pub async fn delete_event(
                             urlencoding::encode(remote_id)
                         );
                         match http.delete(&url).bearer_auth(&token).send().await {
-                            Ok(resp) if resp.status().is_success() || resp.status().as_u16() == 204 || resp.status().as_u16() == 410 => {
+                            Ok(resp)
+                                if resp.status().is_success()
+                                    || resp.status().as_u16() == 204
+                                    || resp.status().as_u16() == 410 =>
+                            {
                                 log::info!("delete_event: deleted from Google Calendar");
                             }
                             Ok(resp) => {
                                 let body = resp.text().await.unwrap_or_default();
-                                log::error!("delete_event: Google Calendar delete failed: {}", body);
+                                log::error!(
+                                    "delete_event: Google Calendar delete failed: {}",
+                                    body
+                                );
                             }
-                            Err(e) => log::error!("delete_event: Google Calendar request failed: {}", e),
+                            Err(e) => {
+                                log::error!("delete_event: Google Calendar request failed: {}", e)
+                            }
                         }
                     }
-                    Err(e) => log::warn!("delete_event: no Google OAuth token, skipping server delete: {}", e),
+                    Err(e) => log::warn!(
+                        "delete_event: no Google OAuth token, skipping server delete: {}",
+                        e
+                    ),
                 }
             } else if account.provider == "o365" {
                 match crate::mail::graph::get_graph_token(&event.account_id).await {
@@ -563,13 +612,19 @@ pub async fn delete_event(
                             log::info!("delete_event: deleted from Graph Calendar");
                         }
                     }
-                    Err(e) => log::warn!("delete_event: no Graph token, skipping server delete: {}", e),
+                    Err(e) => log::warn!(
+                        "delete_event: no Graph token, skipping server delete: {}",
+                        e
+                    ),
                 }
             } else if account.mail_protocol == "jmap" {
                 let jmap_config = crate::commands::sync_cmd::build_jmap_config(&account).await?;
                 match crate::mail::jmap::JmapConnection::connect(&jmap_config).await {
                     Ok(conn_jmap) => {
-                        if let Err(e) = conn_jmap.delete_calendar_event(&jmap_config, remote_id).await {
+                        if let Err(e) = conn_jmap
+                            .delete_calendar_event(&jmap_config, remote_id)
+                            .await
+                        {
                             log::error!("delete_event: JMAP server delete failed: {}", e);
                         }
                     }
@@ -609,8 +664,7 @@ pub async fn sync_calendars(
     app: tauri::AppHandle,
     state: State<'_, AppState>,
     account_id: String,
-    #[allow(unused_variables)]
-    force_full_sync: Option<bool>,
+    #[allow(unused_variables)] force_full_sync: Option<bool>,
 ) -> Result<()> {
     log::info!("sync_calendars: account={}", account_id);
 
@@ -624,8 +678,12 @@ pub async fn sync_calendars(
         conn.execute(
             "DELETE FROM app_metadata WHERE key LIKE ?1 ESCAPE '\\'",
             rusqlite::params![format!("google_sync_token_{escaped_id}_%")],
-        ).ok();
-        log::info!("sync_calendars: cleared sync tokens for full sync (account={})", account_id);
+        )
+        .ok();
+        log::info!(
+            "sync_calendars: cleared sync tokens for full sync (account={})",
+            account_id
+        );
     }
 
     let account = {
@@ -640,7 +698,10 @@ pub async fn sync_calendars(
         match sync_calendars_google(&state, &account_id, &account).await {
             Ok(()) => {}
             Err(e) => {
-                log::warn!("sync_calendars: Gmail CalDAV sync failed (OAuth may not be configured): {}", e);
+                log::warn!(
+                    "sync_calendars: Gmail CalDAV sync failed (OAuth may not be configured): {}",
+                    e
+                );
                 // Fall back to configured CalDAV URL if available
                 if !account.caldav_url.is_empty() {
                     sync_calendars_caldav(&state, &account_id, &account).await?;
@@ -727,10 +788,7 @@ async fn sync_calendars_jmap(
             jcal.name
         );
 
-        let local_cal_id = remote_to_local
-            .get(&jcal.id)
-            .cloned()
-            .unwrap_or_default();
+        let local_cal_id = remote_to_local.get(&jcal.id).cloned().unwrap_or_default();
 
         let conn = state.db.writer().await;
         for ev in &events {
@@ -784,12 +842,20 @@ async fn sync_calendars_jmap(
         let mut deleted = 0u32;
         for (local_id, remote_id) in &local_synced {
             if !server_ids.contains(remote_id) {
-                conn.execute("DELETE FROM calendar_events WHERE id = ?1", rusqlite::params![local_id]).ok();
+                conn.execute(
+                    "DELETE FROM calendar_events WHERE id = ?1",
+                    rusqlite::params![local_id],
+                )
+                .ok();
                 deleted += 1;
             }
         }
         if deleted > 0 {
-            log::info!("sync_calendars: removed {} server-deleted events from '{}'", deleted, jcal.name);
+            log::info!(
+                "sync_calendars: removed {} server-deleted events from '{}'",
+                deleted,
+                jcal.name
+            );
         }
     }
 
@@ -799,18 +865,25 @@ async fn sync_calendars_jmap(
         let local_events: Vec<CalendarEvent> = get_unpushed_events(&conn, account_id)?;
 
         if !local_events.is_empty() {
-            log::info!("sync_calendars: pushing {} local events to JMAP", local_events.len());
+            log::info!(
+                "sync_calendars: pushing {} local events to JMAP",
+                local_events.len()
+            );
             drop(conn); // Release lock for async calls
 
             for ev in &local_events {
                 // Find the remote calendar ID for this event's local calendar
-                let remote_cal_id = remote_to_local.iter()
+                let remote_cal_id = remote_to_local
+                    .iter()
                     .find(|(_, local_id)| **local_id == ev.calendar_id)
                     .map(|(remote_id, _)| remote_id.clone())
                     .unwrap_or_default();
 
                 if remote_cal_id.is_empty() {
-                    log::warn!("sync_calendars: no remote calendar for local event '{}'", ev.title);
+                    log::warn!(
+                        "sync_calendars: no remote calendar for local event '{}'",
+                        ev.title
+                    );
                     continue;
                 }
 
@@ -830,16 +903,26 @@ async fn sync_calendars_jmap(
                     attendees_json: ev.attendees_json.clone(),
                 };
 
-                match jmap_conn.create_calendar_event(&jmap_config, &jmap_event).await {
+                match jmap_conn
+                    .create_calendar_event(&jmap_config, &jmap_event)
+                    .await
+                {
                     Ok(remote_id) => {
-                        log::info!("sync_calendars: pushed event '{}' to JMAP, remote_id={}", ev.title, remote_id);
+                        log::info!(
+                            "sync_calendars: pushed event '{}' to JMAP, remote_id={}",
+                            ev.title,
+                            remote_id
+                        );
                         let conn = state.db.writer().await;
                         conn.execute(
                             "UPDATE calendar_events SET remote_id = ?1 WHERE id = ?2",
                             rusqlite::params![remote_id, ev.id],
-                        ).ok();
+                        )
+                        .ok();
                     }
-                    Err(e) => log::error!("sync_calendars: failed to push event '{}': {}", ev.title, e),
+                    Err(e) => {
+                        log::error!("sync_calendars: failed to push event '{}': {}", ev.title, e)
+                    }
                 }
             }
         }
@@ -867,14 +950,21 @@ async fn sync_calendars_google(
 
     if !resp.status().is_success() {
         let body = resp.text().await.unwrap_or_default();
-        return Err(crate::error::Error::Other(format!("Google Calendar API error: {}", body)));
+        return Err(crate::error::Error::Other(format!(
+            "Google Calendar API error: {}",
+            body
+        )));
     }
 
-    let data: serde_json::Value = resp.json().await
-        .map_err(|e| crate::error::Error::Other(format!("Google Calendar API parse error: {}", e)))?;
+    let data: serde_json::Value = resp.json().await.map_err(|e| {
+        crate::error::Error::Other(format!("Google Calendar API parse error: {}", e))
+    })?;
 
     let items = data["items"].as_array();
-    log::info!("sync_calendars_google: fetched {} calendars", items.map(|i| i.len()).unwrap_or(0));
+    log::info!(
+        "sync_calendars_google: fetched {} calendars",
+        items.map(|i| i.len()).unwrap_or(0)
+    );
 
     let mut remote_to_local: std::collections::HashMap<String, String> =
         std::collections::HashMap::new();
@@ -907,58 +997,77 @@ async fn sync_calendars_google(
                 "SELECT value FROM app_metadata WHERE key = ?1",
                 rusqlite::params![sync_key],
                 |row| row.get(0),
-            ).ok()
+            )
+            .ok()
         };
 
         let resp = if let Some(ref token) = existing_token {
             // Incremental sync
-            log::debug!("sync_calendars_google: incremental sync for calendar {}", remote_cal_id);
+            log::debug!(
+                "sync_calendars_google: incremental sync for calendar {}",
+                remote_cal_id
+            );
             http.get(format!(
-                    "https://www.googleapis.com/calendar/v3/calendars/{}/events",
-                    urlencoding::encode(remote_cal_id)
-                ))
-                .bearer_auth(&access_token)
-                .query(&[("syncToken", token.as_str())])
-                .send()
-                .await
+                "https://www.googleapis.com/calendar/v3/calendars/{}/events",
+                urlencoding::encode(remote_cal_id)
+            ))
+            .bearer_auth(&access_token)
+            .query(&[("syncToken", token.as_str())])
+            .send()
+            .await
         } else {
             // Full sync
             let now = chrono::Utc::now();
             let time_min = (now - chrono::Duration::days(30)).to_rfc3339();
             let time_max = (now + chrono::Duration::days(180)).to_rfc3339();
             http.get(format!(
-                    "https://www.googleapis.com/calendar/v3/calendars/{}/events",
-                    urlencoding::encode(remote_cal_id)
-                ))
-                .bearer_auth(&access_token)
-                .query(&[
-                    ("timeMin", time_min.as_str()),
-                    ("timeMax", time_max.as_str()),
-                    ("singleEvents", "true"),
-                    ("maxResults", "500"),
-                ])
-                .send()
-                .await
+                "https://www.googleapis.com/calendar/v3/calendars/{}/events",
+                urlencoding::encode(remote_cal_id)
+            ))
+            .bearer_auth(&access_token)
+            .query(&[
+                ("timeMin", time_min.as_str()),
+                ("timeMax", time_max.as_str()),
+                ("singleEvents", "true"),
+                ("maxResults", "500"),
+            ])
+            .send()
+            .await
         };
 
         let resp = match resp {
             Ok(r) => r,
             Err(e) => {
-                log::error!("sync_calendars_google: events fetch failed for {}: {}", remote_cal_id, e);
+                log::error!(
+                    "sync_calendars_google: events fetch failed for {}: {}",
+                    remote_cal_id,
+                    e
+                );
                 continue;
             }
         };
 
         if resp.status().as_u16() == 410 {
             // syncToken expired — clear it and retry with full sync on next cycle
-            log::info!("sync_calendars_google: syncToken expired for {}, will full sync next time", remote_cal_id);
+            log::info!(
+                "sync_calendars_google: syncToken expired for {}, will full sync next time",
+                remote_cal_id
+            );
             let conn = state.db.writer().await;
-            conn.execute("DELETE FROM app_metadata WHERE key = ?1", rusqlite::params![sync_key]).ok();
+            conn.execute(
+                "DELETE FROM app_metadata WHERE key = ?1",
+                rusqlite::params![sync_key],
+            )
+            .ok();
             continue;
         }
         if !resp.status().is_success() {
             let body = resp.text().await.unwrap_or_default();
-            log::error!("sync_calendars_google: events error for {}: {}", remote_cal_id, body);
+            log::error!(
+                "sync_calendars_google: events error for {}: {}",
+                remote_cal_id,
+                body
+            );
             continue;
         }
 
@@ -972,10 +1081,15 @@ async fn sync_calendars_google(
 
         let events = events_data["items"].as_array();
         let count = events.map(|e| e.len()).unwrap_or(0);
-        log::info!("sync_calendars_google: fetched {} events for calendar {}", count, remote_cal_id);
+        log::info!(
+            "sync_calendars_google: fetched {} events for calendar {}",
+            count,
+            remote_cal_id
+        );
 
         let conn = state.db.writer().await;
-        let mut server_event_ids: std::collections::HashSet<String> = std::collections::HashSet::new();
+        let mut server_event_ids: std::collections::HashSet<String> =
+            std::collections::HashSet::new();
         let mut server_uids: std::collections::HashSet<String> = std::collections::HashSet::new();
         if let Some(events) = events {
             for ev in events {
@@ -987,10 +1101,12 @@ async fn sync_calendars_google(
 
                 // Incremental sync: cancelled events should be deleted locally
                 if ev["status"].as_str() == Some("cancelled") {
-                    let deleted = conn.execute(
-                        "DELETE FROM calendar_events WHERE account_id = ?1 AND remote_id = ?2",
-                        rusqlite::params![account_id, event_id_remote],
-                    ).unwrap_or(0);
+                    let deleted = conn
+                        .execute(
+                            "DELETE FROM calendar_events WHERE account_id = ?1 AND remote_id = ?2",
+                            rusqlite::params![account_id, event_id_remote],
+                        )
+                        .unwrap_or(0);
                     // Also delete by iCalUID for events created locally via respond_to_invite
                     if let Some(ical_uid) = ev["iCalUID"].as_str() {
                         conn.execute(
@@ -999,7 +1115,10 @@ async fn sync_calendars_google(
                         ).ok();
                     }
                     if deleted > 0 {
-                        log::info!("sync_calendars_google: deleted cancelled event '{}'", event_id_remote);
+                        log::info!(
+                            "sync_calendars_google: deleted cancelled event '{}'",
+                            event_id_remote
+                        );
                     }
                     continue;
                 }
@@ -1011,7 +1130,10 @@ async fn sync_calendars_google(
                 // Parse start/end — can be date (all-day) or dateTime
                 let start_tz = ev["start"]["timeZone"].as_str().map(|s| s.to_string());
                 let (start_time, all_day) = if let Some(dt) = ev["start"]["dateTime"].as_str() {
-                    (crate::calendar::timezone::to_utc(dt, start_tz.as_deref().unwrap_or("")), false)
+                    (
+                        crate::calendar::timezone::to_utc(dt, start_tz.as_deref().unwrap_or("")),
+                        false,
+                    )
                 } else if let Some(d) = ev["start"]["date"].as_str() {
                     (d.to_string(), true)
                 } else {
@@ -1067,8 +1189,12 @@ async fn sync_calendars_google(
             conn.execute(
                 "INSERT OR REPLACE INTO app_metadata (key, value) VALUES (?1, ?2)",
                 rusqlite::params![sync_key, next_token],
-            ).ok();
-            log::debug!("sync_calendars_google: saved syncToken for calendar {}", remote_cal_id);
+            )
+            .ok();
+            log::debug!(
+                "sync_calendars_google: saved syncToken for calendar {}",
+                remote_cal_id
+            );
         }
 
         // During full sync (no syncToken), reconcile: delete local events
@@ -1081,7 +1207,7 @@ async fn sync_calendars_google(
                     "SELECT ce.id, ce.remote_id FROM calendar_events ce
                      JOIN calendars c ON ce.calendar_id = c.id
                      WHERE ce.account_id = ?1 AND ce.remote_id IS NOT NULL AND ce.remote_id != ''
-                     AND c.remote_id = ?2"
+                     AND c.remote_id = ?2",
                 )
                 .map(|mut stmt| {
                     stmt.query_map(rusqlite::params![account_id, remote_cal_id], |row| {
@@ -1106,7 +1232,7 @@ async fn sync_calendars_google(
                         "SELECT ce.id, ce.uid FROM calendar_events ce
                          JOIN calendars c ON ce.calendar_id = c.id
                          WHERE ce.account_id = ?1 AND (ce.remote_id IS NULL OR ce.remote_id = '')
-                         AND ce.uid IS NOT NULL AND c.remote_id = ?2"
+                         AND ce.uid IS NOT NULL AND c.remote_id = ?2",
                     )
                     .map(|mut stmt| {
                         stmt.query_map(rusqlite::params![account_id, remote_cal_id], |row| {
@@ -1124,27 +1250,36 @@ async fn sync_calendars_google(
                 }
             }
             if deleted > 0 {
-                log::info!("sync_calendars_google: removed {} server-deleted events from '{}'", deleted, remote_cal_id);
+                log::info!(
+                    "sync_calendars_google: removed {} server-deleted events from '{}'",
+                    deleted,
+                    remote_cal_id
+                );
             }
         }
     }
 
-    log::info!("sync_calendars_google: completed for account {}", account_id);
+    log::info!(
+        "sync_calendars_google: completed for account {}",
+        account_id
+    );
     Ok(())
 }
 
 /// Get a valid Google OAuth2 access token, refreshing if expired.
 async fn get_google_token(account_id: &str) -> Result<String> {
-    let tokens = crate::oauth::load_tokens(account_id)?
-        .ok_or_else(|| crate::error::Error::Other(
+    let tokens = crate::oauth::load_tokens(account_id)?.ok_or_else(|| {
+        crate::error::Error::Other(
             "No Google OAuth tokens. Please sign in with Google in Settings.".into(),
-        ))?;
+        )
+    })?;
 
     if !tokens.is_expired() {
         return Ok(tokens.access_token);
     }
 
-    let refresh_token = tokens.refresh_token
+    let refresh_token = tokens
+        .refresh_token
         .ok_or_else(|| crate::error::Error::Other("No refresh token".into()))?;
     match crate::oauth::refresh_access_token(&crate::oauth::GOOGLE, &refresh_token).await {
         Ok(new_tokens) => {
@@ -1190,12 +1325,7 @@ async fn sync_calendars_caldav(
             let color = cal.color.as_deref().unwrap_or("#4285f4");
             let is_default = idx == 0; // First calendar is default
             let local_id = db::calendar::upsert_calendar_by_remote_id(
-                &conn,
-                account_id,
-                &cal.href,
-                &cal.name,
-                color,
-                is_default,
+                &conn, account_id, &cal.href, &cal.name, color, is_default,
             )?;
             remote_to_local.insert(cal.href.clone(), local_id);
         }
@@ -1221,10 +1351,7 @@ async fn sync_calendars_caldav(
             cal.name
         );
 
-        let local_cal_id = remote_to_local
-            .get(&cal.href)
-            .cloned()
-            .unwrap_or_default();
+        let local_cal_id = remote_to_local.get(&cal.href).cloned().unwrap_or_default();
 
         let conn = state.db.writer().await;
         for ev in &caldav_events {
@@ -1242,10 +1369,7 @@ async fn sync_calendars_caldav(
             let attendees_json = if invite.attendees.is_empty() {
                 None
             } else {
-                Some(
-                    serde_json::to_string(&invite.attendees)
-                        .unwrap_or_else(|_| "[]".to_string()),
-                )
+                Some(serde_json::to_string(&invite.attendees).unwrap_or_else(|_| "[]".to_string()))
             };
 
             let event_id = uuid::Uuid::new_v4().to_string();
@@ -1301,12 +1425,20 @@ async fn sync_calendars_caldav(
         let mut deleted = 0u32;
         for (local_id, remote_id) in &local_synced {
             if !server_hrefs.contains(remote_id) {
-                conn.execute("DELETE FROM calendar_events WHERE id = ?1", rusqlite::params![local_id]).ok();
+                conn.execute(
+                    "DELETE FROM calendar_events WHERE id = ?1",
+                    rusqlite::params![local_id],
+                )
+                .ok();
                 deleted += 1;
             }
         }
         if deleted > 0 {
-            log::info!("sync_calendars: removed {} server-deleted events from CalDAV calendar '{}'", deleted, cal.name);
+            log::info!(
+                "sync_calendars: removed {} server-deleted events from CalDAV calendar '{}'",
+                deleted,
+                cal.name
+            );
         }
     }
 
@@ -1359,11 +1491,8 @@ async fn sync_calendars_caldav(
 
                 match client.put_event(&remote_cal_href, &uid, &ical_data).await {
                     Ok(etag) => {
-                        let remote_id = format!(
-                            "{}/{}.ics",
-                            remote_cal_href.trim_end_matches('/'),
-                            uid
-                        );
+                        let remote_id =
+                            format!("{}/{}.ics", remote_cal_href.trim_end_matches('/'), uid);
                         log::info!(
                             "sync_calendars: pushed event '{}' to CalDAV, remote_id={}",
                             ev.title,
@@ -1423,7 +1552,8 @@ pub async fn get_email_invites(
     let raw = std::fs::read(&full_path).map_err(|e| {
         crate::error::Error::Other(format!(
             "Failed to read message file '{}': {}",
-            full_path.display(), e
+            full_path.display(),
+            e
         ))
     })?;
 
@@ -1480,7 +1610,8 @@ pub async fn respond_to_invite(
         let raw = std::fs::read(&full_path).map_err(|e| {
             crate::error::Error::Other(format!(
                 "Failed to read message file '{}': {}",
-                full_path.display(), e
+                full_path.display(),
+                e
             ))
         })?;
 
@@ -1567,7 +1698,10 @@ pub async fn respond_to_invite(
     // Find the best calendar for this account: prefer default, then any with
     // a remote_id (synced from server), then any existing, finally create one.
     let calendars = db::calendar::list_calendars(&conn, &account_id)?;
-    let calendar_id = if let Some(cal) = calendars.iter().find(|c| c.is_default && c.remote_id.is_some()) {
+    let calendar_id = if let Some(cal) = calendars
+        .iter()
+        .find(|c| c.is_default && c.remote_id.is_some())
+    {
         cal.id.clone()
     } else if let Some(cal) = calendars.iter().find(|c| c.is_default) {
         cal.id.clone()
@@ -1612,7 +1746,10 @@ pub async fn respond_to_invite(
             account_id: account_id.clone(),
             calendar_id,
             uid: Some(invite.uid.clone()),
-            title: invite.summary.clone().unwrap_or_else(|| "(No title)".to_string()),
+            title: invite
+                .summary
+                .clone()
+                .unwrap_or_else(|| "(No title)".to_string()),
             description: invite.description.clone(),
             location: invite.location.clone(),
             start_time: invite.dtstart.clone(),
@@ -1656,7 +1793,8 @@ pub async fn respond_to_invite(
             if let Ok(resp) = http.get(&search_url).bearer_auth(&token).send().await {
                 if let Ok(data) = resp.json::<serde_json::Value>().await {
                     if let Some(items) = data["items"].as_array() {
-                        google_event_id_found = items.first()
+                        google_event_id_found = items
+                            .first()
                             .and_then(|e| e["id"].as_str())
                             .map(|s| s.to_string());
                     }
@@ -1686,8 +1824,12 @@ pub async fn respond_to_invite(
                         "self": true,
                     }],
                 });
-                match http.post("https://www.googleapis.com/calendar/v3/calendars/primary/events/import")
-                    .bearer_auth(&token).json(&import_event).send().await
+                match http
+                    .post("https://www.googleapis.com/calendar/v3/calendars/primary/events/import")
+                    .bearer_auth(&token)
+                    .json(&import_event)
+                    .send()
+                    .await
                 {
                     Ok(resp) if resp.status().is_success() => {
                         if let Ok(data) = resp.json::<serde_json::Value>().await {
@@ -1699,7 +1841,10 @@ pub async fn respond_to_invite(
                         let body = resp.text().await.unwrap_or_default();
                         log::warn!("respond_to_invite: Google Calendar import failed: {}", body);
                     }
-                    Err(e) => log::warn!("respond_to_invite: Google Calendar import request failed: {}", e),
+                    Err(e) => log::warn!(
+                        "respond_to_invite: Google Calendar import request failed: {}",
+                        e
+                    ),
                 }
             }
             // PATCH the attendee status on Google
@@ -1716,19 +1861,26 @@ pub async fn respond_to_invite(
                             "self": true,
                         }]
                     });
-                    match http.patch(&patch_url)
+                    match http
+                        .patch(&patch_url)
                         .bearer_auth(&token)
                         .json(&attendees_patch)
-                        .send().await
+                        .send()
+                        .await
                     {
                         Ok(r) if r.status().is_success() => {
-                            log::info!("respond_to_invite: updated Google Calendar response to {}", google_status);
+                            log::info!(
+                                "respond_to_invite: updated Google Calendar response to {}",
+                                google_status
+                            );
                         }
                         Ok(r) => {
                             let body = r.text().await.unwrap_or_default();
                             log::warn!("respond_to_invite: Google Calendar PATCH failed: {}", body);
                         }
-                        Err(e) => log::warn!("respond_to_invite: Google Calendar request failed: {}", e),
+                        Err(e) => {
+                            log::warn!("respond_to_invite: Google Calendar request failed: {}", e)
+                        }
                     }
                 }
             }
@@ -1741,7 +1893,10 @@ pub async fn respond_to_invite(
                         "UPDATE calendar_events SET remote_id = ?1 WHERE uid = ?2 AND account_id = ?3 AND (remote_id IS NULL OR remote_id = '')",
                         rusqlite::params![geid, invite_uid, account_id],
                     ).ok();
-                    log::info!("respond_to_invite: stored Google Calendar remote_id={}", geid);
+                    log::info!(
+                        "respond_to_invite: stored Google Calendar remote_id={}",
+                        geid
+                    );
                 }
             }
         }
@@ -1756,7 +1911,10 @@ pub async fn respond_to_invite(
                     Ok(Some(graph_event_id)) => {
                         match client.rsvp_event(&graph_event_id, &response, "").await {
                             Ok(()) => {
-                                log::info!("respond_to_invite: updated O365 Calendar response to {}", response);
+                                log::info!(
+                                    "respond_to_invite: updated O365 Calendar response to {}",
+                                    response
+                                );
                                 // Store remote_id so process_invite_reply can find the event later
                                 let conn = state.db.writer().await;
                                 conn.execute(
@@ -1764,11 +1922,17 @@ pub async fn respond_to_invite(
                                     rusqlite::params![graph_event_id, invite_uid, account_id],
                                 ).ok();
                             }
-                            Err(e) => log::warn!("respond_to_invite: O365 Graph RSVP failed: {}", e),
+                            Err(e) => {
+                                log::warn!("respond_to_invite: O365 Graph RSVP failed: {}", e)
+                            }
                         }
                     }
-                    Ok(None) => log::debug!("respond_to_invite: event not found on O365 Calendar by iCalUId"),
-                    Err(e) => log::warn!("respond_to_invite: O365 Graph event lookup failed: {}", e),
+                    Ok(None) => log::debug!(
+                        "respond_to_invite: event not found on O365 Calendar by iCalUId"
+                    ),
+                    Err(e) => {
+                        log::warn!("respond_to_invite: O365 Graph event lookup failed: {}", e)
+                    }
                 }
             }
             Err(e) => log::warn!("respond_to_invite: failed to get O365 token: {}", e),
@@ -1822,9 +1986,9 @@ fn build_calendar_reply_message(
     let from_mailbox: Mailbox = from.parse().map_err(|e| {
         crate::error::Error::Other(format!("Invalid 'from' address '{}': {}", from, e))
     })?;
-    let to_mailbox: Mailbox = to.parse().map_err(|e| {
-        crate::error::Error::Other(format!("Invalid 'to' address '{}': {}", to, e))
-    })?;
+    let to_mailbox: Mailbox = to
+        .parse()
+        .map_err(|e| crate::error::Error::Other(format!("Invalid 'to' address '{}': {}", to, e)))?;
 
     let message = Message::builder()
         .from(from_mailbox)
@@ -1854,24 +2018,27 @@ fn build_calendar_reply_message(
 }
 
 /// Get SMTP credentials for an account, refreshing OAuth tokens for O365.
-async fn get_smtp_credentials(
-    account: &db::accounts::AccountFull,
-) -> Result<(String, bool)> {
+async fn get_smtp_credentials(account: &db::accounts::AccountFull) -> Result<(String, bool)> {
     if account.provider == "o365" {
         let tokens = crate::oauth::load_tokens(&account.id)?
             .ok_or_else(|| crate::error::Error::Other("No O365 tokens for SMTP".into()))?;
-        let refresh_token = tokens.refresh_token
+        let refresh_token = tokens
+            .refresh_token
             .ok_or_else(|| crate::error::Error::Other("No O365 refresh token for SMTP".into()))?;
         let smtp_tokens = crate::oauth::refresh_with_scopes(
             &crate::oauth::MICROSOFT,
             &refresh_token,
             crate::oauth::MICROSOFT_IMAP_SCOPES, // SMTP.Send is in the same scope set
-        ).await?;
-        crate::oauth::store_tokens(&account.id, &crate::oauth::OAuthTokens {
-            access_token: smtp_tokens.access_token.clone(),
-            refresh_token: smtp_tokens.refresh_token,
-            expires_at: smtp_tokens.expires_at,
-        })?;
+        )
+        .await?;
+        crate::oauth::store_tokens(
+            &account.id,
+            &crate::oauth::OAuthTokens {
+                access_token: smtp_tokens.access_token.clone(),
+                refresh_token: smtp_tokens.refresh_token,
+                expires_at: smtp_tokens.expires_at,
+            },
+        )?;
         Ok((smtp_tokens.access_token, true))
     } else {
         Ok((account.password.clone(), false))
@@ -1940,11 +2107,8 @@ async fn send_raw_smtp(
         .parse()
         .map_err(|e| crate::error::Error::Other(format!("Invalid to address: {}", e)))?;
 
-    let envelope = lettre::address::Envelope::new(
-        Some(from_addr),
-        vec![to_addr],
-    )
-    .map_err(|e| crate::error::Error::Other(format!("Failed to create envelope: {}", e)))?;
+    let envelope = lettre::address::Envelope::new(Some(from_addr), vec![to_addr])
+        .map_err(|e| crate::error::Error::Other(format!("Failed to create envelope: {}", e)))?;
 
     transport
         .send_raw(&envelope, raw_message)
@@ -2009,7 +2173,9 @@ pub async fn send_invites(
 ) -> Result<()> {
     log::info!(
         "send_invites: account={} event={} attendees={:?}",
-        account_id, event_id, attendee_emails
+        account_id,
+        event_id,
+        attendee_emails
     );
 
     let (account, event) = {
@@ -2030,16 +2196,21 @@ pub async fn send_invites(
         // Still update attendees in the local DB
         let conn = state.db.writer().await;
         let attendees_json = serde_json::to_string(
-            &attendee_emails.iter().map(|e| Attendee {
-                email: e.clone(),
-                name: None,
-                status: "needs-action".to_string(),
-            }).collect::<Vec<_>>()
-        ).unwrap_or_default();
+            &attendee_emails
+                .iter()
+                .map(|e| Attendee {
+                    email: e.clone(),
+                    name: None,
+                    status: "needs-action".to_string(),
+                })
+                .collect::<Vec<_>>(),
+        )
+        .unwrap_or_default();
         conn.execute(
             "UPDATE calendar_events SET attendees_json = ?1 WHERE id = ?2",
             rusqlite::params![attendees_json, event_id],
-        ).ok();
+        )
+        .ok();
         return Ok(());
     }
 
@@ -2064,7 +2235,11 @@ pub async fn send_invites(
         None, // Use email as organizer name — display_name is the account label, not a person's name
         &attendees,
         event.recurrence_rule.as_deref(),
-        if event.all_day { None } else { event.timezone.as_deref() },
+        if event.all_day {
+            None
+        } else {
+            event.timezone.as_deref()
+        },
     );
 
     let subject = format!("Invitation: {}", event.title);
@@ -2073,20 +2248,21 @@ pub async fn send_invites(
         event.title,
         event.start_time,
         event.end_time,
-        event.location.as_deref().map(|l| format!("Where: {}\n", l)).unwrap_or_default()
+        event
+            .location
+            .as_deref()
+            .map(|l| format!("Where: {}\n", l))
+            .unwrap_or_default()
     );
 
     for attendee_email in &attendee_emails {
-        let raw = build_invite_message(
-            &account.email,
-            attendee_email,
-            &subject,
-            &body_text,
-            &ical,
-        );
+        let raw = build_invite_message(&account.email, attendee_email, &subject, &body_text, &ical);
 
         if raw.is_empty() {
-            log::error!("send_invites: failed to build invite message for {}", attendee_email);
+            log::error!(
+                "send_invites: failed to build invite message for {}",
+                attendee_email
+            );
             continue;
         }
 
@@ -2136,18 +2312,24 @@ pub async fn process_invite_reply(
     account_id: String,
     message_id: String,
 ) -> Result<()> {
-    log::info!("process_invite_reply: account={} message={}", account_id, message_id);
+    log::info!(
+        "process_invite_reply: account={} message={}",
+        account_id,
+        message_id
+    );
 
     let raw = {
         let conn = state.db.writer().await;
-        let (maildir_path, _, _, _, _, _, _) = db::messages::get_message_metadata(&conn, &account_id, &message_id)?;
+        let (maildir_path, _, _, _, _, _, _) =
+            db::messages::get_message_metadata(&conn, &account_id, &message_id)?;
         let data_dir = state.data_dir.clone();
         std::fs::read(data_dir.join(maildir_path))
             .map_err(|e| crate::error::Error::Other(format!("Failed to read message: {}", e)))?
     };
 
     let replies = ical::parse_ical_from_email(&raw);
-    let reply_invites: Vec<_> = replies.iter()
+    let reply_invites: Vec<_> = replies
+        .iter()
         .filter(|inv| inv.method.to_uppercase() == "REPLY")
         .collect();
 
@@ -2172,12 +2354,15 @@ pub async fn process_invite_reply(
             let status = &attendee.status;
             log::info!(
                 "process_invite_reply: {} responded '{}' to event '{}'",
-                attendee.email, status, event.title
+                attendee.email,
+                status,
+                event.title
             );
 
             // Update local attendees_json
             if let Some(ref att_json) = event.attendees_json {
-                if let Ok(mut attendees) = serde_json::from_str::<Vec<serde_json::Value>>(att_json) {
+                if let Ok(mut attendees) = serde_json::from_str::<Vec<serde_json::Value>>(att_json)
+                {
                     for att in attendees.iter_mut() {
                         if att["email"].as_str() == Some(&attendee.email) {
                             att["status"] = serde_json::json!(status);
@@ -2187,31 +2372,45 @@ pub async fn process_invite_reply(
                     conn.execute(
                         "UPDATE calendar_events SET attendees_json = ?1 WHERE id = ?2",
                         rusqlite::params![updated_json, event.id],
-                    ).ok();
+                    )
+                    .ok();
                 }
             }
 
             // Update on JMAP server if applicable
             if account.mail_protocol == "jmap" {
                 if let Some(ref remote_id) = event.remote_id {
-                    let jmap_config = crate::commands::sync_cmd::build_jmap_config(&account).await?;
+                    let jmap_config =
+                        crate::commands::sync_cmd::build_jmap_config(&account).await?;
                     // Find participant key by matching email
                     // We need to fetch the event to find the right participant key
                     drop(conn);
-                    if let Ok(jmap_conn) = crate::mail::jmap::JmapConnection::connect(&jmap_config).await {
+                    if let Ok(jmap_conn) =
+                        crate::mail::jmap::JmapConnection::connect(&jmap_config).await
+                    {
                         // Fetch current event to find participant key
-                        if let Ok(events) = jmap_conn.fetch_calendar_events(&jmap_config, None).await {
+                        if let Ok(events) =
+                            jmap_conn.fetch_calendar_events(&jmap_config, None).await
+                        {
                             for ev in &events {
                                 if ev.id == *remote_id {
                                     // Parse attendees to find the key
                                     if let Some(ref aj) = ev.attendees_json {
-                                        if let Ok(atts) = serde_json::from_str::<Vec<serde_json::Value>>(aj) {
+                                        if let Ok(atts) =
+                                            serde_json::from_str::<Vec<serde_json::Value>>(aj)
+                                        {
                                             for (i, a) in atts.iter().enumerate() {
                                                 if a["email"].as_str() == Some(&attendee.email) {
                                                     let key = format!("att{}", i);
-                                                    jmap_conn.update_participant_status(
-                                                        &jmap_config, remote_id, &key, status,
-                                                    ).await.ok();
+                                                    jmap_conn
+                                                        .update_participant_status(
+                                                            &jmap_config,
+                                                            remote_id,
+                                                            &key,
+                                                            status,
+                                                        )
+                                                        .await
+                                                        .ok();
                                                     break;
                                                 }
                                             }
@@ -2243,18 +2442,24 @@ pub async fn process_cancelled_invite(
     account_id: String,
     message_id: String,
 ) -> Result<()> {
-    log::info!("process_cancelled_invite: account={} message={}", account_id, message_id);
+    log::info!(
+        "process_cancelled_invite: account={} message={}",
+        account_id,
+        message_id
+    );
 
     let raw = {
         let conn = state.db.reader();
-        let (maildir_path, _, _, _, _, _, _) = db::messages::get_message_metadata(&conn, &account_id, &message_id)?;
+        let (maildir_path, _, _, _, _, _, _) =
+            db::messages::get_message_metadata(&conn, &account_id, &message_id)?;
         let data_dir = state.data_dir.clone();
         std::fs::read(data_dir.join(maildir_path))
             .map_err(|e| crate::error::Error::Other(format!("Failed to read message: {}", e)))?
     };
 
     let invites = ical::parse_ical_from_email(&raw);
-    let cancels: Vec<_> = invites.iter()
+    let cancels: Vec<_> = invites
+        .iter()
         .filter(|inv| inv.method.to_uppercase() == "CANCEL")
         .collect();
 
@@ -2282,7 +2487,11 @@ pub async fn process_cancelled_invite(
             }
             db::calendar::delete_event(&conn, &event.id)?;
             deleted += 1;
-            log::info!("process_cancelled_invite: deleted event '{}' (UID={})", event.title, cancel.uid);
+            log::info!(
+                "process_cancelled_invite: deleted event '{}' (UID={})",
+                event.title,
+                cancel.uid
+            );
         }
     }
 
@@ -2291,7 +2500,10 @@ pub async fn process_cancelled_invite(
         app.emit("calendar-changed", account_id.as_str()).ok();
     }
 
-    log::info!("process_cancelled_invite: completed for account {}", account_id);
+    log::info!(
+        "process_cancelled_invite: completed for account {}",
+        account_id
+    );
     Ok(())
 }
 
@@ -2348,13 +2560,16 @@ pub fn auto_process_calendar_emails(
         match invite.method.to_uppercase().as_str() {
             "REPLY" => {
                 // Update attendee status on organizer's local event
-                if let Some(event) = db::calendar::get_event_by_uid(&conn_w, account_id, &invite.uid)
-                    .ok()
-                    .flatten()
+                if let Some(event) =
+                    db::calendar::get_event_by_uid(&conn_w, account_id, &invite.uid)
+                        .ok()
+                        .flatten()
                 {
                     for attendee in &invite.attendees {
                         if let Some(ref att_json) = event.attendees_json {
-                            if let Ok(mut attendees) = serde_json::from_str::<Vec<serde_json::Value>>(att_json) {
+                            if let Ok(mut attendees) =
+                                serde_json::from_str::<Vec<serde_json::Value>>(att_json)
+                            {
                                 let mut updated = false;
                                 for att in attendees.iter_mut() {
                                     if att["email"].as_str() == Some(&attendee.email) {
@@ -2363,14 +2578,17 @@ pub fn auto_process_calendar_emails(
                                     }
                                 }
                                 if updated {
-                                    let updated_json = serde_json::to_string(&attendees).unwrap_or_default();
+                                    let updated_json =
+                                        serde_json::to_string(&attendees).unwrap_or_default();
                                     conn_w.execute(
                                         "UPDATE calendar_events SET attendees_json = ?1 WHERE id = ?2",
                                         rusqlite::params![updated_json, event.id],
                                     ).ok();
                                     log::info!(
                                         "auto_process: {} responded '{}' to event '{}'",
-                                        attendee.email, attendee.status, event.title
+                                        attendee.email,
+                                        attendee.status,
+                                        event.title
                                     );
                                     calendar_changed = true;
                                 }
@@ -2381,14 +2599,16 @@ pub fn auto_process_calendar_emails(
             }
             "CANCEL" => {
                 // Delete cancelled event
-                if let Some(event) = db::calendar::get_event_by_uid(&conn_w, account_id, &invite.uid)
-                    .ok()
-                    .flatten()
+                if let Some(event) =
+                    db::calendar::get_event_by_uid(&conn_w, account_id, &invite.uid)
+                        .ok()
+                        .flatten()
                 {
                     if db::calendar::delete_event(&conn_w, &event.id).is_ok() {
                         log::info!(
                             "auto_process: deleted cancelled event '{}' (UID={})",
-                            event.title, invite.uid
+                            event.title,
+                            invite.uid
                         );
                         calendar_changed = true;
                     }
@@ -2464,10 +2684,7 @@ fn build_invite_message(
 // Microsoft Graph calendar sync
 // ---------------------------------------------------------------------------
 
-async fn sync_calendars_graph(
-    state: &State<'_, AppState>,
-    account_id: &str,
-) -> Result<()> {
+async fn sync_calendars_graph(state: &State<'_, AppState>, account_id: &str) -> Result<()> {
     log::info!("sync_calendars_graph: starting for account {}", account_id);
 
     let token = match crate::mail::graph::get_graph_token(account_id).await {
@@ -2487,16 +2704,21 @@ async fn sync_calendars_graph(
             return Err(e);
         }
     };
-    log::info!("sync_calendars_graph: fetched {} calendars", graph_calendars.len());
+    log::info!(
+        "sync_calendars_graph: fetched {} calendars",
+        graph_calendars.len()
+    );
 
     let conn = state.db.writer().await;
     for gc in &graph_calendars {
         // Check if calendar with this remote_id already exists
-        let existing: Option<String> = conn.query_row(
-            "SELECT id FROM calendars WHERE account_id = ?1 AND remote_id = ?2",
-            rusqlite::params![account_id, gc.id],
-            |row| row.get(0),
-        ).ok();
+        let existing: Option<String> = conn
+            .query_row(
+                "SELECT id FROM calendars WHERE account_id = ?1 AND remote_id = ?2",
+                rusqlite::params![account_id, gc.id],
+                |row| row.get(0),
+            )
+            .ok();
 
         match existing {
             Some(_) => {
@@ -2520,18 +2742,22 @@ async fn sync_calendars_graph(
                 conn.execute(
                     "UPDATE calendars SET remote_id = ?1 WHERE id = ?2",
                     rusqlite::params![gc.id, cal_id],
-                ).ok();
-                log::info!("sync_calendars_graph: created calendar '{}' ({})", gc.name, gc.id);
+                )
+                .ok();
+                log::info!(
+                    "sync_calendars_graph: created calendar '{}' ({})",
+                    gc.name,
+                    gc.id
+                );
             }
         }
     }
 
     // 2. Fetch events for a 6-month window
     let now = chrono::Utc::now();
-    let start = (now - chrono::Duration::days(90))
-        .to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
-    let end = (now + chrono::Duration::days(90))
-        .to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
+    let start =
+        (now - chrono::Duration::days(90)).to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
+    let end = (now + chrono::Duration::days(90)).to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
     drop(conn); // Release lock before async call
 
     let graph_events = match client.list_events(&start, &end).await {
@@ -2541,7 +2767,10 @@ async fn sync_calendars_graph(
             return Err(e);
         }
     };
-    log::info!("sync_calendars_graph: fetched {} events", graph_events.len());
+    log::info!(
+        "sync_calendars_graph: fetched {} events",
+        graph_events.len()
+    );
 
     let conn = state.db.writer().await;
 
@@ -2552,11 +2781,14 @@ async fn sync_calendars_graph(
     // Find the default calendar's local ID
     let default_cal = graph_calendars.iter().find(|c| c.is_default);
     let default_cal_local_id: String = default_cal
-        .and_then(|dc| conn.query_row(
-            "SELECT id FROM calendars WHERE account_id = ?1 AND remote_id = ?2",
-            rusqlite::params![account_id, dc.id],
-            |row| row.get(0),
-        ).ok())
+        .and_then(|dc| {
+            conn.query_row(
+                "SELECT id FROM calendars WHERE account_id = ?1 AND remote_id = ?2",
+                rusqlite::params![account_id, dc.id],
+                |row| row.get(0),
+            )
+            .ok()
+        })
         .unwrap_or_default();
 
     for ge in &graph_events {
@@ -2592,7 +2824,8 @@ async fn sync_calendars_graph(
                         ge.timezone,
                         local_id,
                     ],
-                ).ok();
+                )
+                .ok();
             }
             Err(_) => {
                 // Insert new event
@@ -2641,7 +2874,10 @@ async fn sync_calendars_graph(
         }
     }
     if deleted > 0 {
-        log::info!("sync_calendars_graph: removed {} server-deleted events", deleted);
+        log::info!(
+            "sync_calendars_graph: removed {} server-deleted events",
+            deleted
+        );
     }
 
     log::info!("sync_calendars_graph: completed for account {}", account_id);

--- a/src-tauri/src/commands/compose.rs
+++ b/src-tauri/src/commands/compose.rs
@@ -66,18 +66,23 @@ pub async fn send_message(
     let smtp_creds = if account.mail_protocol != "jmap" && account.provider == "o365" {
         let tokens = crate::oauth::load_tokens(&account_id)?
             .ok_or_else(|| Error::Other("No O365 tokens for SMTP".into()))?;
-        let refresh_token = tokens.refresh_token
+        let refresh_token = tokens
+            .refresh_token
             .ok_or_else(|| Error::Other("No O365 refresh token for SMTP".into()))?;
         let smtp_tokens = crate::oauth::refresh_with_scopes(
             &crate::oauth::MICROSOFT,
             &refresh_token,
             crate::oauth::MICROSOFT_IMAP_SCOPES,
-        ).await?;
-        crate::oauth::store_tokens(&account_id, &crate::oauth::OAuthTokens {
-            access_token: smtp_tokens.access_token.clone(),
-            refresh_token: smtp_tokens.refresh_token,
-            expires_at: smtp_tokens.expires_at,
-        })?;
+        )
+        .await?;
+        crate::oauth::store_tokens(
+            &account_id,
+            &crate::oauth::OAuthTokens {
+                access_token: smtp_tokens.access_token.clone(),
+                refresh_token: smtp_tokens.refresh_token,
+                expires_at: smtp_tokens.expires_at,
+            },
+        )?;
         Some((account.username.clone(), smtp_tokens.access_token, true))
     } else {
         None
@@ -89,10 +94,14 @@ pub async fn send_message(
     } else {
         message.subject.clone()
     };
-    app.emit("send-started", serde_json::json!({
-        "account_id": account_id,
-        "subject": subject_display,
-    })).ok();
+    app.emit(
+        "send-started",
+        serde_json::json!({
+            "account_id": account_id,
+            "subject": subject_display,
+        }),
+    )
+    .ok();
 
     // --- Persist to outbox before spawning background send ---
     // This ensures the message survives a crash during sending.
@@ -108,7 +117,11 @@ pub async fn send_message(
         let conn = state.db.writer().await;
         crate::ops::offline::queue_offline_op(&conn, &account_id, "send", &send_payload)?
     };
-    log::info!("Persisted send to outbox (id={}) for account {}", outbox_id, account_id);
+    log::info!(
+        "Persisted send to outbox (id={}) for account {}",
+        outbox_id,
+        account_id
+    );
 
     // --- Background: actual network send ---
     // The command returns Ok(()) here so the compose window can close.
@@ -116,7 +129,12 @@ pub async fn send_message(
     let account_id_bg = account_id.clone();
     let subject_bg = subject_display.clone();
     let db_bg = state.db.clone();
-    let recipients: Vec<String> = message.to.iter().chain(message.cc.iter()).cloned().collect();
+    let recipients: Vec<String> = message
+        .to
+        .iter()
+        .chain(message.cc.iter())
+        .cloned()
+        .collect();
 
     tokio::spawn(async move {
         let result: std::result::Result<(), Error> = async {
@@ -154,7 +172,8 @@ pub async fn send_message(
                 .await?;
             }
             Ok(())
-        }.await;
+        }
+        .await;
 
         match result {
             Ok(()) => {
@@ -164,15 +183,21 @@ pub async fn send_message(
                 if let Err(e) = crate::ops::offline::mark_completed(&conn, outbox_id) {
                     log::warn!("Failed to remove sent message from outbox: {}", e);
                 }
-                app_bg.emit("send-complete", serde_json::json!({
-                    "account_id": account_id_bg,
-                    "subject": subject_bg,
-                })).ok();
+                app_bg
+                    .emit(
+                        "send-complete",
+                        serde_json::json!({
+                            "account_id": account_id_bg,
+                            "subject": subject_bg,
+                        }),
+                    )
+                    .ok();
 
                 // Auto-collect recipients to "Collected Contacts"
                 let conn = db_bg.writer().await;
                 for addr in &recipients {
-                    if let Err(e) = db::contacts::collect_contact(&conn, &account_id_bg, addr, None) {
+                    if let Err(e) = db::contacts::collect_contact(&conn, &account_id_bg, addr, None)
+                    {
                         log::warn!("Failed to collect contact '{}': {}", addr, e);
                     }
                 }
@@ -182,11 +207,16 @@ pub async fn send_message(
                 // Leave the message in the outbox for retry (mark as failed)
                 let conn = db_bg.writer().await;
                 let _ = crate::ops::offline::mark_failed(&conn, outbox_id, &e.to_string());
-                app_bg.emit("send-failed", serde_json::json!({
-                    "account_id": account_id_bg,
-                    "subject": subject_bg,
-                    "error": e.to_string(),
-                })).ok();
+                app_bg
+                    .emit(
+                        "send-failed",
+                        serde_json::json!({
+                            "account_id": account_id_bg,
+                            "subject": subject_bg,
+                            "error": e.to_string(),
+                        }),
+                    )
+                    .ok();
             }
         }
     });
@@ -233,16 +263,21 @@ pub async fn save_draft(
 
     if account.mail_protocol == "graph" {
         // Save draft via Graph API: POST /me/messages creates a draft without sending
-        log::info!("Saving draft via Microsoft Graph for account {}", account.email);
+        log::info!(
+            "Saving draft via Microsoft Graph for account {}",
+            account.email
+        );
         let token = crate::mail::graph::get_graph_token(&account_id).await?;
         let client = crate::mail::graph::GraphClient::new(&token);
-        client.save_draft(&crate::mail::graph::GraphSendMessage {
-            to: message.to.clone(),
-            cc: message.cc.clone(),
-            bcc: message.bcc.clone(),
-            subject: message.subject.clone(),
-            body_text: message.body_text.clone(),
-        }).await?;
+        client
+            .save_draft(&crate::mail::graph::GraphSendMessage {
+                to: message.to.clone(),
+                cc: message.cc.clone(),
+                bcc: message.bcc.clone(),
+                subject: message.subject.clone(),
+                body_text: message.body_text.clone(),
+            })
+            .await?;
     } else if account.mail_protocol == "jmap" {
         let jmap_config = crate::commands::sync_cmd::build_jmap_config(&account).await?;
         let conn_jmap = JmapConnection::connect(&jmap_config).await?;
@@ -252,11 +287,15 @@ pub async fn save_draft(
         let (imap_password, imap_xoauth2) = if account.provider == "o365" {
             let tokens = crate::oauth::load_tokens(&account.id)?
                 .ok_or_else(|| Error::Other("No O365 tokens".into()))?;
-            let refresh = tokens.refresh_token
+            let refresh = tokens
+                .refresh_token
                 .ok_or_else(|| Error::Other("No O365 refresh token".into()))?;
             let new = crate::oauth::refresh_with_scopes(
-                &crate::oauth::MICROSOFT, &refresh, crate::oauth::MICROSOFT_IMAP_SCOPES,
-            ).await?;
+                &crate::oauth::MICROSOFT,
+                &refresh,
+                crate::oauth::MICROSOFT_IMAP_SCOPES,
+            )
+            .await?;
             crate::oauth::store_tokens(&account.id, &new)?;
             (new.access_token, true)
         } else {
@@ -287,7 +326,9 @@ pub async fn save_draft(
                 }
             }
             if !saved {
-                return Err(crate::error::Error::Other("Could not find Drafts folder".into()));
+                return Err(crate::error::Error::Other(
+                    "Could not find Drafts folder".into(),
+                ));
             }
             conn.logout();
             Ok(())
@@ -308,7 +349,8 @@ fn read_attachments(attachments: &[FileAttachment]) -> Result<Vec<smtp::Attachme
         // Reject relative paths
         if !path.is_absolute() {
             return Err(crate::error::Error::Other(format!(
-                "Attachment path must be absolute: '{}'", att.path
+                "Attachment path must be absolute: '{}'",
+                att.path
             )));
         }
 
@@ -316,7 +358,8 @@ fn read_attachments(attachments: &[FileAttachment]) -> Result<Vec<smtp::Attachme
         for component in path.components() {
             if matches!(component, std::path::Component::ParentDir) {
                 return Err(crate::error::Error::Other(format!(
-                    "Attachment path must not contain '..': '{}'", att.path
+                    "Attachment path must not contain '..': '{}'",
+                    att.path
                 )));
             }
         }
@@ -330,19 +373,24 @@ fn read_attachments(attachments: &[FileAttachment]) -> Result<Vec<smtp::Attachme
                 || path_str.starts_with("/var/tmp/")
         } else {
             // Windows
-            path_str.starts_with("C:\\Users\\")
-                || path_str.starts_with("C:\\Temp\\")
+            path_str.starts_with("C:\\Users\\") || path_str.starts_with("C:\\Temp\\")
         };
         if !is_typical {
             log::warn!("Attachment from unusual path: '{}'", att.path);
         }
 
-        let data = std::fs::read(&att.path)
-            .map_err(|e| crate::error::Error::Other(format!("Failed to read attachment '{}': {}", att.path, e)))?;
+        let data = std::fs::read(&att.path).map_err(|e| {
+            crate::error::Error::Other(format!("Failed to read attachment '{}': {}", att.path, e))
+        })?;
         let content_type = mime_guess::from_path(&att.name)
             .first_or_octet_stream()
             .to_string();
-        log::info!("Attachment: {} ({}, {} bytes)", att.name, content_type, data.len());
+        log::info!(
+            "Attachment: {} ({}, {} bytes)",
+            att.name,
+            content_type,
+            data.len()
+        );
         result.push(smtp::AttachmentData {
             name: att.name.clone(),
             content_type,

--- a/src-tauri/src/commands/contacts.rs
+++ b/src-tauri/src/commands/contacts.rs
@@ -24,19 +24,13 @@ pub async fn list_contact_books(
 // ---------------------------------------------------------------------------
 
 #[tauri::command]
-pub async fn list_contacts(
-    state: State<'_, AppState>,
-    book_id: String,
-) -> Result<Vec<Contact>> {
+pub async fn list_contacts(state: State<'_, AppState>, book_id: String) -> Result<Vec<Contact>> {
     let conn = state.db.reader();
     db::contacts::list_contacts(&conn, &book_id)
 }
 
 #[tauri::command]
-pub async fn get_contact(
-    state: State<'_, AppState>,
-    contact_id: String,
-) -> Result<Contact> {
+pub async fn get_contact(state: State<'_, AppState>, contact_id: String) -> Result<Contact> {
     let conn = state.db.reader();
     db::contacts::get_contact(&conn, &contact_id)
 }
@@ -79,11 +73,13 @@ pub async fn create_contact(
     log::info!("Created contact {} '{}'", id, c.display_name);
 
     // Push to Google People API if applicable
-    let book = conn.query_row(
-        "SELECT cb.sync_type, cb.account_id FROM contact_books cb WHERE cb.id = ?1",
-        rusqlite::params![c.book_id],
-        |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
-    ).ok();
+    let book = conn
+        .query_row(
+            "SELECT cb.sync_type, cb.account_id FROM contact_books cb WHERE cb.id = ?1",
+            rusqlite::params![c.book_id],
+            |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
+        )
+        .ok();
     drop(conn);
 
     if let Some((sync_type, account_id)) = book {
@@ -94,21 +90,37 @@ pub async fn create_contact(
                     "names": [{"givenName": c.display_name}],
                 });
                 if let Ok(emails) = serde_json::from_str::<Vec<serde_json::Value>>(&c.emails_json) {
-                    let ge: Vec<_> = emails.iter()
-                        .filter_map(|e| e["email"].as_str().map(|addr| serde_json::json!({"value": addr})))
+                    let ge: Vec<_> = emails
+                        .iter()
+                        .filter_map(|e| {
+                            e["email"]
+                                .as_str()
+                                .map(|addr| serde_json::json!({"value": addr}))
+                        })
                         .collect();
-                    if !ge.is_empty() { person["emailAddresses"] = serde_json::json!(ge); }
+                    if !ge.is_empty() {
+                        person["emailAddresses"] = serde_json::json!(ge);
+                    }
                 }
                 if let Ok(phones) = serde_json::from_str::<Vec<serde_json::Value>>(&c.phones_json) {
-                    let gp: Vec<_> = phones.iter()
-                        .filter_map(|p| p["number"].as_str().map(|n| serde_json::json!({"value": n})))
+                    let gp: Vec<_> = phones
+                        .iter()
+                        .filter_map(|p| {
+                            p["number"]
+                                .as_str()
+                                .map(|n| serde_json::json!({"value": n}))
+                        })
                         .collect();
-                    if !gp.is_empty() { person["phoneNumbers"] = serde_json::json!(gp); }
+                    if !gp.is_empty() {
+                        person["phoneNumbers"] = serde_json::json!(gp);
+                    }
                 }
-                match http.post("https://people.googleapis.com/v1/people:createContact")
+                match http
+                    .post("https://people.googleapis.com/v1/people:createContact")
                     .bearer_auth(&token)
                     .json(&person)
-                    .send().await
+                    .send()
+                    .await
                 {
                     Ok(resp) if resp.status().is_success() => {
                         if let Ok(data) = resp.json::<serde_json::Value>().await {
@@ -117,12 +129,16 @@ pub async fn create_contact(
                                 conn.execute(
                                     "UPDATE contacts SET remote_id = ?1 WHERE id = ?2",
                                     rusqlite::params![rn, id],
-                                ).ok();
+                                )
+                                .ok();
                                 log::info!("Created contact on Google: {}", rn);
                             }
                         }
                     }
-                    Ok(resp) => { let b = resp.text().await.unwrap_or_default(); log::error!("Google create contact failed: {}", b); }
+                    Ok(resp) => {
+                        let b = resp.text().await.unwrap_or_default();
+                        log::error!("Google create contact failed: {}", b);
+                    }
                     Err(e) => log::error!("Google create contact request failed: {}", e),
                 }
             }
@@ -133,31 +149,48 @@ pub async fn create_contact(
                     "displayName": c.display_name,
                 });
                 if let Ok(emails) = serde_json::from_str::<Vec<serde_json::Value>>(&c.emails_json) {
-                    let ge: Vec<_> = emails.iter()
-                        .filter_map(|e| e["email"].as_str().map(|addr| serde_json::json!({"address": addr, "name": ""})))
+                    let ge: Vec<_> = emails
+                        .iter()
+                        .filter_map(|e| {
+                            e["email"]
+                                .as_str()
+                                .map(|addr| serde_json::json!({"address": addr, "name": ""}))
+                        })
                         .collect();
-                    if !ge.is_empty() { gc["emailAddresses"] = serde_json::json!(ge); }
+                    if !ge.is_empty() {
+                        gc["emailAddresses"] = serde_json::json!(ge);
+                    }
                 }
                 if let Ok(phones) = serde_json::from_str::<Vec<serde_json::Value>>(&c.phones_json) {
-                    let mobile = phones.iter().find(|p| p["label"].as_str() == Some("mobile"));
+                    let mobile = phones
+                        .iter()
+                        .find(|p| p["label"].as_str() == Some("mobile"));
                     if let Some(m) = mobile.and_then(|p| p["number"].as_str()) {
                         gc["mobilePhone"] = serde_json::json!(m);
                     }
-                    let biz: Vec<&str> = phones.iter()
+                    let biz: Vec<&str> = phones
+                        .iter()
                         .filter(|p| p["label"].as_str() == Some("work"))
                         .filter_map(|p| p["number"].as_str())
                         .collect();
-                    if !biz.is_empty() { gc["businessPhones"] = serde_json::json!(biz); }
+                    if !biz.is_empty() {
+                        gc["businessPhones"] = serde_json::json!(biz);
+                    }
                 }
-                if let Some(ref org) = c.organization { gc["companyName"] = serde_json::json!(org); }
-                if let Some(ref t) = c.title { gc["jobTitle"] = serde_json::json!(t); }
+                if let Some(ref org) = c.organization {
+                    gc["companyName"] = serde_json::json!(org);
+                }
+                if let Some(ref t) = c.title {
+                    gc["jobTitle"] = serde_json::json!(t);
+                }
                 match graph.create_contact(&gc).await {
                     Ok(remote_id) => {
                         let conn = state.db.writer().await;
                         conn.execute(
                             "UPDATE contacts SET remote_id = ?1 WHERE id = ?2",
                             rusqlite::params![remote_id, id],
-                        ).ok();
+                        )
+                        .ok();
                         log::info!("Created contact on Graph: {}", remote_id);
                     }
                     Err(e) => log::error!("Graph create contact failed: {}", e),
@@ -170,7 +203,9 @@ pub async fn create_contact(
                     "SELECT remote_id FROM contact_books WHERE id = ?1",
                     rusqlite::params![c.book_id],
                     |row| row.get::<_, Option<String>>(0),
-                ).ok().flatten()
+                )
+                .ok()
+                .flatten()
             };
             if let Some(href) = book_href {
                 let account = {
@@ -178,22 +213,50 @@ pub async fn create_contact(
                     db::accounts::get_account_full(&conn, &account_id)?
                 };
                 match crate::mail::carddav::CardDavClient::connect(
-                    &account.caldav_url, &account.username, &account.password, &account.email,
-                ).await {
+                    &account.caldav_url,
+                    &account.username,
+                    &account.password,
+                    &account.email,
+                )
+                .await
+                {
                     Ok(client) => {
                         let uid = c.uid.as_deref().unwrap_or(&id);
-                        let emails: Vec<crate::mail::carddav::VCardEmail> = serde_json::from_str::<Vec<serde_json::Value>>(&c.emails_json)
-                            .unwrap_or_default().iter()
-                            .filter_map(|e| Some(crate::mail::carddav::VCardEmail { email: e["email"].as_str()?.to_string(), label: e["label"].as_str().unwrap_or("work").to_string() }))
-                            .collect();
-                        let phones: Vec<crate::mail::carddav::VCardPhone> = serde_json::from_str::<Vec<serde_json::Value>>(&c.phones_json)
-                            .unwrap_or_default().iter()
-                            .filter_map(|p| Some(crate::mail::carddav::VCardPhone { number: p["number"].as_str()?.to_string(), label: p["label"].as_str().unwrap_or("work").to_string() }))
-                            .collect();
-                        let vcard = crate::mail::carddav::generate_vcard(uid, &c.display_name, &emails, &phones, c.organization.as_deref(), c.title.as_deref(), c.notes.as_deref());
+                        let emails: Vec<crate::mail::carddav::VCardEmail> =
+                            serde_json::from_str::<Vec<serde_json::Value>>(&c.emails_json)
+                                .unwrap_or_default()
+                                .iter()
+                                .filter_map(|e| {
+                                    Some(crate::mail::carddav::VCardEmail {
+                                        email: e["email"].as_str()?.to_string(),
+                                        label: e["label"].as_str().unwrap_or("work").to_string(),
+                                    })
+                                })
+                                .collect();
+                        let phones: Vec<crate::mail::carddav::VCardPhone> =
+                            serde_json::from_str::<Vec<serde_json::Value>>(&c.phones_json)
+                                .unwrap_or_default()
+                                .iter()
+                                .filter_map(|p| {
+                                    Some(crate::mail::carddav::VCardPhone {
+                                        number: p["number"].as_str()?.to_string(),
+                                        label: p["label"].as_str().unwrap_or("work").to_string(),
+                                    })
+                                })
+                                .collect();
+                        let vcard = crate::mail::carddav::generate_vcard(
+                            uid,
+                            &c.display_name,
+                            &emails,
+                            &phones,
+                            c.organization.as_deref(),
+                            c.title.as_deref(),
+                            c.notes.as_deref(),
+                        );
                         match client.put_contact(&href, uid, &vcard).await {
                             Ok(etag) => {
-                                let remote_id = format!("{}/{}.vcf", href.trim_end_matches('/'), uid);
+                                let remote_id =
+                                    format!("{}/{}.vcf", href.trim_end_matches('/'), uid);
                                 let conn = state.db.writer().await;
                                 conn.execute("UPDATE contacts SET remote_id = ?1, etag = ?2, vcard_data = ?3 WHERE id = ?4", rusqlite::params![remote_id, etag, vcard, id]).ok();
                                 log::info!("Created contact on CardDAV: {}", remote_id);
@@ -211,10 +274,7 @@ pub async fn create_contact(
 }
 
 #[tauri::command]
-pub async fn update_contact(
-    state: State<'_, AppState>,
-    contact: Contact,
-) -> Result<()> {
+pub async fn update_contact(state: State<'_, AppState>, contact: Contact) -> Result<()> {
     let conn = state.db.writer().await;
     db::contacts::update_contact(&conn, &contact)?;
     log::info!("Updated contact {}", contact.id);
@@ -222,11 +282,13 @@ pub async fn update_contact(
     // Push to Google People API if applicable
     if let Some(ref remote_id) = contact.remote_id {
         if !remote_id.is_empty() {
-            let book_info = conn.query_row(
-                "SELECT cb.sync_type, cb.account_id FROM contact_books cb WHERE cb.id = ?1",
-                rusqlite::params![contact.book_id],
-                |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
-            ).ok();
+            let book_info = conn
+                .query_row(
+                    "SELECT cb.sync_type, cb.account_id FROM contact_books cb WHERE cb.id = ?1",
+                    rusqlite::params![contact.book_id],
+                    |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
+                )
+                .ok();
             drop(conn);
 
             if let Some((sync_type, account_id)) = book_info {
@@ -236,25 +298,52 @@ pub async fn update_contact(
                         let mut person = serde_json::json!({
                             "names": [{"givenName": contact.display_name}],
                         });
-                        if let Ok(emails) = serde_json::from_str::<Vec<serde_json::Value>>(&contact.emails_json) {
-                            let ge: Vec<_> = emails.iter()
-                                .filter_map(|e| e["email"].as_str().map(|a| serde_json::json!({"value": a})))
+                        if let Ok(emails) =
+                            serde_json::from_str::<Vec<serde_json::Value>>(&contact.emails_json)
+                        {
+                            let ge: Vec<_> = emails
+                                .iter()
+                                .filter_map(|e| {
+                                    e["email"].as_str().map(|a| serde_json::json!({"value": a}))
+                                })
                                 .collect();
-                            if !ge.is_empty() { person["emailAddresses"] = serde_json::json!(ge); }
+                            if !ge.is_empty() {
+                                person["emailAddresses"] = serde_json::json!(ge);
+                            }
                         }
-                        if let Ok(phones) = serde_json::from_str::<Vec<serde_json::Value>>(&contact.phones_json) {
-                            let gp: Vec<_> = phones.iter()
-                                .filter_map(|p| p["number"].as_str().map(|n| serde_json::json!({"value": n})))
+                        if let Ok(phones) =
+                            serde_json::from_str::<Vec<serde_json::Value>>(&contact.phones_json)
+                        {
+                            let gp: Vec<_> = phones
+                                .iter()
+                                .filter_map(|p| {
+                                    p["number"]
+                                        .as_str()
+                                        .map(|n| serde_json::json!({"value": n}))
+                                })
                                 .collect();
-                            if !gp.is_empty() { person["phoneNumbers"] = serde_json::json!(gp); }
+                            if !gp.is_empty() {
+                                person["phoneNumbers"] = serde_json::json!(gp);
+                            }
                         }
                         let url = format!(
                             "https://people.googleapis.com/v1/{}:updateContact?updatePersonFields=names,emailAddresses,phoneNumbers",
                             remote_id
                         );
-                        match http.patch(&url).bearer_auth(&token).json(&person).send().await {
-                            Ok(r) if r.status().is_success() => log::info!("Updated contact on Google: {}", remote_id),
-                            Ok(r) => { let b = r.text().await.unwrap_or_default(); log::warn!("Google update contact failed: {}", b); }
+                        match http
+                            .patch(&url)
+                            .bearer_auth(&token)
+                            .json(&person)
+                            .send()
+                            .await
+                        {
+                            Ok(r) if r.status().is_success() => {
+                                log::info!("Updated contact on Google: {}", remote_id)
+                            }
+                            Ok(r) => {
+                                let b = r.text().await.unwrap_or_default();
+                                log::warn!("Google update contact failed: {}", b);
+                            }
                             Err(e) => log::warn!("Google update contact request failed: {}", e),
                         }
                     }
@@ -264,25 +353,45 @@ pub async fn update_contact(
                         let mut gc = serde_json::json!({
                             "displayName": contact.display_name,
                         });
-                        if let Ok(emails) = serde_json::from_str::<Vec<serde_json::Value>>(&contact.emails_json) {
-                            let ge: Vec<_> = emails.iter()
-                                .filter_map(|e| e["email"].as_str().map(|addr| serde_json::json!({"address": addr, "name": ""})))
+                        if let Ok(emails) =
+                            serde_json::from_str::<Vec<serde_json::Value>>(&contact.emails_json)
+                        {
+                            let ge: Vec<_> = emails
+                                .iter()
+                                .filter_map(|e| {
+                                    e["email"].as_str().map(
+                                        |addr| serde_json::json!({"address": addr, "name": ""}),
+                                    )
+                                })
                                 .collect();
-                            if !ge.is_empty() { gc["emailAddresses"] = serde_json::json!(ge); }
+                            if !ge.is_empty() {
+                                gc["emailAddresses"] = serde_json::json!(ge);
+                            }
                         }
-                        if let Ok(phones) = serde_json::from_str::<Vec<serde_json::Value>>(&contact.phones_json) {
-                            let mobile = phones.iter().find(|p| p["label"].as_str() == Some("mobile"));
+                        if let Ok(phones) =
+                            serde_json::from_str::<Vec<serde_json::Value>>(&contact.phones_json)
+                        {
+                            let mobile = phones
+                                .iter()
+                                .find(|p| p["label"].as_str() == Some("mobile"));
                             if let Some(m) = mobile.and_then(|p| p["number"].as_str()) {
                                 gc["mobilePhone"] = serde_json::json!(m);
                             }
-                            let biz: Vec<&str> = phones.iter()
+                            let biz: Vec<&str> = phones
+                                .iter()
                                 .filter(|p| p["label"].as_str() == Some("work"))
                                 .filter_map(|p| p["number"].as_str())
                                 .collect();
-                            if !biz.is_empty() { gc["businessPhones"] = serde_json::json!(biz); }
+                            if !biz.is_empty() {
+                                gc["businessPhones"] = serde_json::json!(biz);
+                            }
                         }
-                        if let Some(ref org) = contact.organization { gc["companyName"] = serde_json::json!(org); }
-                        if let Some(ref t) = contact.title { gc["jobTitle"] = serde_json::json!(t); }
+                        if let Some(ref org) = contact.organization {
+                            gc["companyName"] = serde_json::json!(org);
+                        }
+                        if let Some(ref t) = contact.title {
+                            gc["jobTitle"] = serde_json::json!(t);
+                        }
                         match graph.update_contact(remote_id, &gc).await {
                             Ok(()) => log::info!("Updated contact on Graph: {}", remote_id),
                             Err(e) => log::warn!("Graph update contact failed: {}", e),
@@ -293,19 +402,23 @@ pub async fn update_contact(
                         let conn = state.db.reader();
                         db::accounts::get_account_full(&conn, &account_id)?
                     };
-                    let jmap_config = crate::commands::sync_cmd::build_jmap_config(&account).await?;
+                    let jmap_config =
+                        crate::commands::sync_cmd::build_jmap_config(&account).await?;
                     match crate::mail::jmap::JmapConnection::connect(&jmap_config).await {
                         Ok(conn_jmap) => {
-                            match conn_jmap.update_contact_card(
-                                &jmap_config,
-                                remote_id,
-                                &contact.display_name,
-                                &contact.emails_json,
-                                &contact.phones_json,
-                                contact.organization.as_deref(),
-                                contact.title.as_deref(),
-                                contact.notes.as_deref(),
-                            ).await {
+                            match conn_jmap
+                                .update_contact_card(
+                                    &jmap_config,
+                                    remote_id,
+                                    &contact.display_name,
+                                    &contact.emails_json,
+                                    &contact.phones_json,
+                                    contact.organization.as_deref(),
+                                    contact.title.as_deref(),
+                                    contact.notes.as_deref(),
+                                )
+                                .await
+                            {
                                 Ok(()) => log::info!("Updated contact on JMAP: {}", remote_id),
                                 Err(e) => log::warn!("JMAP update contact failed: {}", e),
                             }
@@ -318,23 +431,61 @@ pub async fn update_contact(
                         db::accounts::get_account_full(&conn, &account_id)?
                     };
                     match crate::mail::carddav::CardDavClient::connect(
-                        &account.caldav_url, &account.username, &account.password, &account.email,
-                    ).await {
+                        &account.caldav_url,
+                        &account.username,
+                        &account.password,
+                        &account.email,
+                    )
+                    .await
+                    {
                         Ok(client) => {
                             let uid = contact.uid.as_deref().unwrap_or(&contact.id);
                             let book_href = {
                                 let conn = state.db.reader();
-                                conn.query_row("SELECT remote_id FROM contact_books WHERE id = ?1", rusqlite::params![contact.book_id], |row| row.get::<_, Option<String>>(0)).ok().flatten().unwrap_or_default()
+                                conn.query_row(
+                                    "SELECT remote_id FROM contact_books WHERE id = ?1",
+                                    rusqlite::params![contact.book_id],
+                                    |row| row.get::<_, Option<String>>(0),
+                                )
+                                .ok()
+                                .flatten()
+                                .unwrap_or_default()
                             };
-                            let emails: Vec<crate::mail::carddav::VCardEmail> = serde_json::from_str::<Vec<serde_json::Value>>(&contact.emails_json)
-                                .unwrap_or_default().iter()
-                                .filter_map(|e| Some(crate::mail::carddav::VCardEmail { email: e["email"].as_str()?.to_string(), label: e["label"].as_str().unwrap_or("work").to_string() }))
+                            let emails: Vec<crate::mail::carddav::VCardEmail> =
+                                serde_json::from_str::<Vec<serde_json::Value>>(
+                                    &contact.emails_json,
+                                )
+                                .unwrap_or_default()
+                                .iter()
+                                .filter_map(|e| {
+                                    Some(crate::mail::carddav::VCardEmail {
+                                        email: e["email"].as_str()?.to_string(),
+                                        label: e["label"].as_str().unwrap_or("work").to_string(),
+                                    })
+                                })
                                 .collect();
-                            let phones: Vec<crate::mail::carddav::VCardPhone> = serde_json::from_str::<Vec<serde_json::Value>>(&contact.phones_json)
-                                .unwrap_or_default().iter()
-                                .filter_map(|p| Some(crate::mail::carddav::VCardPhone { number: p["number"].as_str()?.to_string(), label: p["label"].as_str().unwrap_or("work").to_string() }))
+                            let phones: Vec<crate::mail::carddav::VCardPhone> =
+                                serde_json::from_str::<Vec<serde_json::Value>>(
+                                    &contact.phones_json,
+                                )
+                                .unwrap_or_default()
+                                .iter()
+                                .filter_map(|p| {
+                                    Some(crate::mail::carddav::VCardPhone {
+                                        number: p["number"].as_str()?.to_string(),
+                                        label: p["label"].as_str().unwrap_or("work").to_string(),
+                                    })
+                                })
                                 .collect();
-                            let vcard = crate::mail::carddav::generate_vcard(uid, &contact.display_name, &emails, &phones, contact.organization.as_deref(), contact.title.as_deref(), contact.notes.as_deref());
+                            let vcard = crate::mail::carddav::generate_vcard(
+                                uid,
+                                &contact.display_name,
+                                &emails,
+                                &phones,
+                                contact.organization.as_deref(),
+                                contact.title.as_deref(),
+                                contact.notes.as_deref(),
+                            );
                             match client.put_contact(&book_href, uid, &vcard).await {
                                 Ok(etag) => {
                                     let conn = state.db.writer().await;
@@ -356,10 +507,7 @@ pub async fn update_contact(
 }
 
 #[tauri::command]
-pub async fn delete_contact(
-    state: State<'_, AppState>,
-    contact_id: String,
-) -> Result<()> {
+pub async fn delete_contact(state: State<'_, AppState>, contact_id: String) -> Result<()> {
     // Check if this contact has a Google remote_id before deleting
     let conn = state.db.writer().await;
     let remote_info = conn.query_row(
@@ -376,12 +524,18 @@ pub async fn delete_contact(
         if sync_type == "google" && !remote_id.is_empty() {
             if let Ok(token) = get_google_token(&account_id).await {
                 let http = reqwest::Client::new();
-                let url = format!("https://people.googleapis.com/v1/{}:deleteContact", remote_id);
+                let url = format!(
+                    "https://people.googleapis.com/v1/{}:deleteContact",
+                    remote_id
+                );
                 match http.delete(&url).bearer_auth(&token).send().await {
                     Ok(resp) if resp.status().is_success() => {
                         log::info!("Deleted contact from Google: {}", remote_id);
                     }
-                    Ok(resp) => { let b = resp.text().await.unwrap_or_default(); log::warn!("Google delete contact failed: {}", b); }
+                    Ok(resp) => {
+                        let b = resp.text().await.unwrap_or_default();
+                        log::warn!("Google delete contact failed: {}", b);
+                    }
                     Err(e) => log::warn!("Google delete contact request failed: {}", e),
                 }
             }
@@ -401,7 +555,10 @@ pub async fn delete_contact(
             let jmap_config = crate::commands::sync_cmd::build_jmap_config(&account).await?;
             match crate::mail::jmap::JmapConnection::connect(&jmap_config).await {
                 Ok(conn_jmap) => {
-                    match conn_jmap.delete_contact_card(&jmap_config, &remote_id).await {
+                    match conn_jmap
+                        .delete_contact_card(&jmap_config, &remote_id)
+                        .await
+                    {
                         Ok(()) => log::info!("Deleted contact from JMAP: {}", remote_id),
                         Err(e) => log::warn!("JMAP delete contact failed: {}", e),
                     }
@@ -414,14 +571,17 @@ pub async fn delete_contact(
                 db::accounts::get_account_full(&conn, &account_id)?
             };
             match crate::mail::carddav::CardDavClient::connect(
-                &account.caldav_url, &account.username, &account.password, &account.email,
-            ).await {
-                Ok(client) => {
-                    match client.delete_contact(&remote_id).await {
-                        Ok(()) => log::info!("Deleted contact from CardDAV: {}", remote_id),
-                        Err(e) => log::warn!("CardDAV delete contact failed: {}", e),
-                    }
-                }
+                &account.caldav_url,
+                &account.username,
+                &account.password,
+                &account.email,
+            )
+            .await
+            {
+                Ok(client) => match client.delete_contact(&remote_id).await {
+                    Ok(()) => log::info!("Deleted contact from CardDAV: {}", remote_id),
+                    Err(e) => log::warn!("CardDAV delete contact failed: {}", e),
+                },
                 Err(e) => log::warn!("CardDAV connect failed for contact delete: {}", e),
             }
         }
@@ -453,7 +613,10 @@ pub async fn sync_contacts(
         match sync_contacts_google(&state, &account_id, &account).await {
             Ok(()) => {}
             Err(e) => {
-                log::warn!("sync_contacts: Gmail CardDAV failed (OAuth may not be set up): {}", e);
+                log::warn!(
+                    "sync_contacts: Gmail CardDAV failed (OAuth may not be set up): {}",
+                    e
+                );
             }
         }
     } else if account.provider == "o365" {
@@ -467,7 +630,10 @@ pub async fn sync_contacts(
             }
         }
     } else {
-        log::debug!("sync_contacts: skipping account {} (no supported sync)", account_id);
+        log::debug!(
+            "sync_contacts: skipping account {} (no supported sync)",
+            account_id
+        );
     }
 
     // Notify frontend that contact data has changed
@@ -479,16 +645,18 @@ pub async fn sync_contacts(
 }
 
 async fn get_google_token(account_id: &str) -> Result<String> {
-    let tokens = crate::oauth::load_tokens(account_id)?
-        .ok_or_else(|| crate::error::Error::Other(
+    let tokens = crate::oauth::load_tokens(account_id)?.ok_or_else(|| {
+        crate::error::Error::Other(
             "No Google OAuth tokens. Please sign in with Google in Settings.".into(),
-        ))?;
+        )
+    })?;
 
     if !tokens.is_expired() {
         return Ok(tokens.access_token);
     }
 
-    let refresh_token = tokens.refresh_token
+    let refresh_token = tokens
+        .refresh_token
         .ok_or_else(|| crate::error::Error::Other("No refresh token".into()))?;
     match crate::oauth::refresh_access_token(&crate::oauth::GOOGLE, &refresh_token).await {
         Ok(new_tokens) => {
@@ -536,7 +704,10 @@ async fn sync_contacts_google(
         .get("https://people.googleapis.com/v1/people/me/connections")
         .bearer_auth(&access_token)
         .query(&[
-            ("personFields", "names,emailAddresses,phoneNumbers,organizations"),
+            (
+                "personFields",
+                "names,emailAddresses,phoneNumbers,organizations",
+            ),
             ("pageSize", "1000"),
         ])
         .send()
@@ -546,10 +717,15 @@ async fn sync_contacts_google(
     if !resp.status().is_success() {
         let status = resp.status();
         let body = resp.text().await.unwrap_or_default();
-        return Err(crate::error::Error::Other(format!("Google People API error {}: {}", status, body)));
+        return Err(crate::error::Error::Other(format!(
+            "Google People API error {}: {}",
+            status, body
+        )));
     }
 
-    let data: serde_json::Value = resp.json().await
+    let data: serde_json::Value = resp
+        .json()
+        .await
         .map_err(|e| crate::error::Error::Other(format!("Google People API parse error: {}", e)))?;
 
     let connections = data["connections"].as_array();
@@ -651,7 +827,10 @@ async fn sync_contacts_jmap(
 
     // Step 1: Fetch address books
     let address_books = jmap_conn.list_address_books(&jmap_config).await?;
-    log::info!("sync_contacts: fetched {} address books from JMAP", address_books.len());
+    log::info!(
+        "sync_contacts: fetched {} address books from JMAP",
+        address_books.len()
+    );
 
     let mut remote_to_local: std::collections::HashMap<String, String> =
         std::collections::HashMap::new();
@@ -691,12 +870,20 @@ async fn sync_contacts_jmap(
         let jmap_contacts = match jmap_conn.fetch_contacts(&jmap_config, Some(&ab.id)).await {
             Ok(c) => c,
             Err(e) => {
-                log::error!("sync_contacts: failed to fetch contacts for '{}': {}", ab.name, e);
+                log::error!(
+                    "sync_contacts: failed to fetch contacts for '{}': {}",
+                    ab.name,
+                    e
+                );
                 continue;
             }
         };
 
-        log::info!("sync_contacts: fetched {} contacts for '{}'", jmap_contacts.len(), ab.name);
+        log::info!(
+            "sync_contacts: fetched {} contacts for '{}'",
+            jmap_contacts.len(),
+            ab.name
+        );
 
         let local_book_id = remote_to_local.get(&ab.id).cloned().unwrap_or_default();
         let conn = state.db.writer().await;
@@ -743,16 +930,32 @@ async fn sync_contacts_jmap(
         let mut deleted = 0u32;
         for (local_id, remote_id) in &local_synced {
             if !server_ids.contains(remote_id) {
-                conn.execute("DELETE FROM contacts WHERE id = ?1", rusqlite::params![local_id]).ok();
+                conn.execute(
+                    "DELETE FROM contacts WHERE id = ?1",
+                    rusqlite::params![local_id],
+                )
+                .ok();
                 deleted += 1;
             }
         }
         if deleted > 0 {
-            log::info!("sync_contacts: removed {} server-deleted contacts from '{}'", deleted, ab.name);
+            log::info!(
+                "sync_contacts: removed {} server-deleted contacts from '{}'",
+                deleted,
+                ab.name
+            );
         }
 
         // Push local contacts (no remote_id) to server
-        type UnpushedRow = (String, String, String, String, Option<String>, Option<String>, Option<String>);
+        type UnpushedRow = (
+            String,
+            String,
+            String,
+            String,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+        );
         let unpushed: Vec<UnpushedRow> = conn
             .prepare(
                 "SELECT id, display_name, emails_json, phones_json, organization, title, notes
@@ -775,27 +978,39 @@ async fn sync_contacts_jmap(
             .unwrap_or_default();
 
         if !unpushed.is_empty() {
-            log::info!("sync_contacts: pushing {} local contacts to JMAP for '{}'", unpushed.len(), ab.name);
+            log::info!(
+                "sync_contacts: pushing {} local contacts to JMAP for '{}'",
+                unpushed.len(),
+                ab.name
+            );
             drop(conn); // Release lock for async calls
 
             for (local_id, name, emails, phones, org, title, notes) in &unpushed {
-                match jmap_conn.create_contact_card(
-                    &jmap_config,
-                    &ab.id,
-                    name,
-                    emails,
-                    phones,
-                    org.as_deref(),
-                    title.as_deref(),
-                    notes.as_deref(),
-                ).await {
+                match jmap_conn
+                    .create_contact_card(
+                        &jmap_config,
+                        &ab.id,
+                        name,
+                        emails,
+                        phones,
+                        org.as_deref(),
+                        title.as_deref(),
+                        notes.as_deref(),
+                    )
+                    .await
+                {
                     Ok(remote_id) => {
-                        log::info!("sync_contacts: pushed contact '{}' to JMAP, remote_id={}", name, remote_id);
+                        log::info!(
+                            "sync_contacts: pushed contact '{}' to JMAP, remote_id={}",
+                            name,
+                            remote_id
+                        );
                         let conn = state.db.writer().await;
                         conn.execute(
                             "UPDATE contacts SET remote_id = ?1 WHERE id = ?2",
                             rusqlite::params![remote_id, local_id],
-                        ).ok();
+                        )
+                        .ok();
                     }
                     Err(e) => {
                         log::error!("sync_contacts: failed to push contact '{}': {}", name, e);
@@ -813,7 +1028,7 @@ async fn sync_contacts_carddav(
     account_id: &str,
     account: &db::accounts::AccountFull,
 ) -> Result<()> {
-    use crate::mail::carddav::{CardDavClient, parse_vcard};
+    use crate::mail::carddav::{parse_vcard, CardDavClient};
 
     log::info!("sync_contacts_carddav: starting for account {}", account_id);
 
@@ -891,8 +1106,10 @@ async fn sync_contacts_carddav(
         for sc in &server_contacts {
             let parsed = parse_vcard(&sc.vcard_data);
 
-            let emails_json = serde_json::to_string(&parsed.emails).unwrap_or_else(|_| "[]".to_string());
-            let phones_json = serde_json::to_string(&parsed.phones).unwrap_or_else(|_| "[]".to_string());
+            let emails_json =
+                serde_json::to_string(&parsed.emails).unwrap_or_else(|_| "[]".to_string());
+            let phones_json =
+                serde_json::to_string(&parsed.phones).unwrap_or_else(|_| "[]".to_string());
 
             if let Some(existing) = local_by_uid.remove(&sc.uid) {
                 // Update if etag changed
@@ -949,7 +1166,10 @@ async fn sync_contacts_carddav(
         }
     }
 
-    log::info!("sync_contacts_carddav: completed for account {}", account_id);
+    log::info!(
+        "sync_contacts_carddav: completed for account {}",
+        account_id
+    );
     Ok(())
 }
 
@@ -958,10 +1178,7 @@ async fn sync_contacts_carddav(
 // ---------------------------------------------------------------------------
 
 #[tauri::command]
-pub async fn search_contacts(
-    state: State<'_, AppState>,
-    query: String,
-) -> Result<Vec<Contact>> {
+pub async fn search_contacts(state: State<'_, AppState>, query: String) -> Result<Vec<Contact>> {
     let conn = state.db.reader();
     db::contacts::search_all_contacts(&conn, &query)
 }
@@ -979,10 +1196,7 @@ pub async fn search_collected_contacts(
 // Microsoft Graph contacts sync
 // ---------------------------------------------------------------------------
 
-async fn sync_contacts_graph(
-    state: &State<'_, AppState>,
-    account_id: &str,
-) -> Result<()> {
+async fn sync_contacts_graph(state: &State<'_, AppState>, account_id: &str) -> Result<()> {
     log::info!("sync_contacts_graph: starting for account {}", account_id);
 
     let token = match crate::mail::graph::get_graph_token(account_id).await {
@@ -997,11 +1211,13 @@ async fn sync_contacts_graph(
     // 1. Ensure contact book exists
     let book_id = {
         let conn = state.db.writer().await;
-        let existing: Option<String> = conn.query_row(
-            "SELECT id FROM contact_books WHERE account_id = ?1 AND sync_type = 'o365'",
-            rusqlite::params![account_id],
-            |row| row.get(0),
-        ).ok();
+        let existing: Option<String> = conn
+            .query_row(
+                "SELECT id FROM contact_books WHERE account_id = ?1 AND sync_type = 'o365'",
+                rusqlite::params![account_id],
+                |row| row.get(0),
+            )
+            .ok();
 
         match existing {
             Some(id) => id,
@@ -1025,7 +1241,10 @@ async fn sync_contacts_graph(
             return Err(e);
         }
     };
-    log::info!("sync_contacts_graph: fetched {} contacts", graph_contacts.len());
+    log::info!(
+        "sync_contacts_graph: fetched {} contacts",
+        graph_contacts.len()
+    );
 
     let conn = state.db.writer().await;
 
@@ -1035,11 +1254,13 @@ async fn sync_contacts_graph(
 
     // 3. Upsert contacts
     for gc in &graph_contacts {
-        let existing: Option<String> = conn.query_row(
-            "SELECT id FROM contacts WHERE book_id = ?1 AND remote_id = ?2",
-            rusqlite::params![book_id, gc.id],
-            |row| row.get(0),
-        ).ok();
+        let existing: Option<String> = conn
+            .query_row(
+                "SELECT id FROM contacts WHERE book_id = ?1 AND remote_id = ?2",
+                rusqlite::params![book_id, gc.id],
+                |row| row.get(0),
+            )
+            .ok();
 
         match existing {
             Some(local_id) => {
@@ -1056,7 +1277,8 @@ async fn sync_contacts_graph(
                         gc.title,
                         local_id,
                     ],
-                ).ok();
+                )
+                .ok();
             }
             None => {
                 // Insert new contact
@@ -1093,12 +1315,19 @@ async fn sync_contacts_graph(
     let mut deleted = 0;
     for (local_id, remote_id) in &local_contacts {
         if !server_ids.contains(remote_id) {
-            conn.execute("DELETE FROM contacts WHERE id = ?1", rusqlite::params![local_id]).ok();
+            conn.execute(
+                "DELETE FROM contacts WHERE id = ?1",
+                rusqlite::params![local_id],
+            )
+            .ok();
             deleted += 1;
         }
     }
     if deleted > 0 {
-        log::info!("sync_contacts_graph: removed {} server-deleted contacts", deleted);
+        log::info!(
+            "sync_contacts_graph: removed {} server-deleted contacts",
+            deleted
+        );
     }
 
     log::info!("sync_contacts_graph: completed for account {}", account_id);

--- a/src-tauri/src/commands/filters.rs
+++ b/src-tauri/src/commands/filters.rs
@@ -24,11 +24,7 @@ pub async fn list_filters(
 /// Save (upsert) a filter rule. Inserts if the id is new, updates if it exists.
 #[tauri::command]
 pub async fn save_filter(state: State<'_, AppState>, rule: FilterRule) -> Result<()> {
-    log::info!(
-        "Save filter command: id={} name='{}'",
-        rule.id,
-        rule.name
-    );
+    log::info!("Save filter command: id={} name='{}'", rule.id, rule.name);
     let conn = state.db.writer().await;
 
     // Check if the rule already exists
@@ -97,11 +93,15 @@ pub async fn apply_filters_to_folder(
     let (imap_password, imap_xoauth2) = if account.provider == "o365" {
         let tokens = crate::oauth::load_tokens(&account_id)?
             .ok_or_else(|| Error::Other("No O365 tokens".into()))?;
-        let refresh = tokens.refresh_token
+        let refresh = tokens
+            .refresh_token
             .ok_or_else(|| Error::Other("No O365 refresh token".into()))?;
         let new = crate::oauth::refresh_with_scopes(
-            &crate::oauth::MICROSOFT, &refresh, crate::oauth::MICROSOFT_IMAP_SCOPES,
-        ).await?;
+            &crate::oauth::MICROSOFT,
+            &refresh,
+            crate::oauth::MICROSOFT_IMAP_SCOPES,
+        )
+        .await?;
         crate::oauth::store_tokens(&account_id, &new)?;
         (new.access_token, true)
     } else {
@@ -334,13 +334,23 @@ fn load_folder_messages(
         .collect::<std::result::Result<Vec<_>, _>>()?;
 
     let mut messages = Vec::with_capacity(rows.len());
-    for (id, uid, folder, from_name, from_email, to_json, cc_json, subject, size, has_attach, flags_json) in rows {
-        let to_addresses: Vec<AddressEntry> =
-            serde_json::from_str(&to_json).unwrap_or_default();
-        let cc_addresses: Vec<AddressEntry> =
-            serde_json::from_str(&cc_json).unwrap_or_default();
-        let flags: Vec<String> =
-            serde_json::from_str(&flags_json).unwrap_or_default();
+    for (
+        id,
+        uid,
+        folder,
+        from_name,
+        from_email,
+        to_json,
+        cc_json,
+        subject,
+        size,
+        has_attach,
+        flags_json,
+    ) in rows
+    {
+        let to_addresses: Vec<AddressEntry> = serde_json::from_str(&to_json).unwrap_or_default();
+        let cc_addresses: Vec<AddressEntry> = serde_json::from_str(&cc_json).unwrap_or_default();
+        let flags: Vec<String> = serde_json::from_str(&flags_json).unwrap_or_default();
 
         messages.push(MessageData {
             id,

--- a/src-tauri/src/commands/mail.rs
+++ b/src-tauri/src/commands/mail.rs
@@ -1,11 +1,10 @@
 use tauri::State;
 
+use crate::commands::events::{emit_folders_changed, emit_messages_changed};
 use crate::commands::sync_cmd::{
-    resume_imap_idle_for_account,
-    should_suspend_idle_for_imap_operation,
+    resume_imap_idle_for_account, should_suspend_idle_for_imap_operation,
     suspend_imap_idle_for_account,
 };
-use crate::commands::events::{emit_folders_changed, emit_messages_changed};
 use crate::db;
 use crate::db::messages::{MessageSummary, ThreadedPage};
 use crate::error::{Error, Result};
@@ -24,7 +23,8 @@ fn is_private_ip(ip: &std::net::IpAddr) -> bool {
             || v4.is_link_local()       // 169.254.0.0/16
             || v4.is_broadcast()        // 255.255.255.255
             || v4.is_unspecified()      // 0.0.0.0
-            || v4.octets()[0] == 100 && v4.octets()[1] >= 64 && v4.octets()[1] <= 127 // 100.64.0.0/10 (CGNAT)
+            || v4.octets()[0] == 100 && v4.octets()[1] >= 64 && v4.octets()[1] <= 127
+            // 100.64.0.0/10 (CGNAT)
         }
         std::net::IpAddr::V6(v6) => {
             v6.is_loopback()            // ::1
@@ -44,7 +44,11 @@ pub async fn list_folders(
     log::debug!("Listing folders for account {}", account_id);
     let conn = state.db.reader();
     let flat_folders = db::folders::list_folders(&conn, &account_id)?;
-    log::debug!("Found {} folders for account {}", flat_folders.len(), account_id);
+    log::debug!(
+        "Found {} folders for account {}",
+        flat_folders.len(),
+        account_id
+    );
     let tree = db::folders::build_folder_tree(flat_folders);
     Ok(tree)
 }
@@ -73,8 +77,16 @@ pub async fn get_messages(
         if asc { "asc" } else { "desc" }
     );
     let conn = state.db.reader();
-    let result =
-        db::messages::get_messages(&conn, &account_id, &folder_path, page, per_page, col, asc, &qf)?;
+    let result = db::messages::get_messages(
+        &conn,
+        &account_id,
+        &folder_path,
+        page,
+        per_page,
+        col,
+        asc,
+        &qf,
+    )?;
     log::debug!(
         "Returned {} messages (total={}) for folder {}",
         result.messages.len(),
@@ -118,7 +130,8 @@ pub async fn get_message_body(
             let graph_msg_id = if let Some(gid) = maildir_path.strip_prefix("graph:") {
                 gid.to_string()
             } else {
-                message_id.strip_prefix(&format!("{}_", account_id))
+                message_id
+                    .strip_prefix(&format!("{}_", account_id))
                     .unwrap_or(&message_id)
                     .to_string()
             };
@@ -130,10 +143,16 @@ pub async fn get_message_body(
             let maildir_base = data_dir.join(&account_id).join(&folder_dir);
             crate::mail::sync::create_maildir_dirs(&maildir_base)?;
 
-            let filename = format!("{}:2,{}", graph_msg_id, crate::mail::sync::flags_to_maildir_suffix(&flags));
+            let filename = format!(
+                "{}:2,{}",
+                graph_msg_id,
+                crate::mail::sync::flags_to_maildir_suffix(&flags)
+            );
             let msg_path = maildir_base.join("cur").join(&filename);
 
-            let bytes_written = client.download_mime_to_file(&graph_msg_id, &msg_path).await?;
+            let bytes_written = client
+                .download_mime_to_file(&graph_msg_id, &msg_path)
+                .await?;
             let rp = format!("{}/{}/cur/{}", account_id, folder_dir, filename);
             log::info!("Graph body streamed: {} ({} bytes)", rp, bytes_written);
             rp
@@ -171,11 +190,15 @@ pub async fn get_message_body(
             let (password, use_xoauth2) = if account.provider == "o365" {
                 let tokens = crate::oauth::load_tokens(&account_id)?
                     .ok_or_else(|| Error::Other("No O365 tokens".into()))?;
-                let refresh = tokens.refresh_token
+                let refresh = tokens
+                    .refresh_token
                     .ok_or_else(|| Error::Other("No O365 refresh token".into()))?;
                 let new = crate::oauth::refresh_with_scopes(
-                    &crate::oauth::MICROSOFT, &refresh, crate::oauth::MICROSOFT_IMAP_SCOPES,
-                ).await?;
+                    &crate::oauth::MICROSOFT,
+                    &refresh,
+                    crate::oauth::MICROSOFT_IMAP_SCOPES,
+                )
+                .await?;
                 crate::oauth::store_tokens(&account_id, &new)?;
                 (new.access_token, true)
             } else {
@@ -225,11 +248,7 @@ pub async fn get_message_body(
     let full_path = state.data_dir.join(&actual_maildir_path);
     log::debug!("Reading message from {}", full_path.display());
     let raw = std::fs::read(&full_path).map_err(|e| {
-        log::error!(
-            "Failed to read message file {}: {}",
-            full_path.display(),
-            e
-        );
+        log::error!("Failed to read message file {}: {}", full_path.display(), e);
         Error::Other(format!(
             "Failed to read message file {}: {}",
             full_path.display(),
@@ -276,13 +295,11 @@ pub async fn get_message_html_with_images(
     }
 
     let full_path = state.data_dir.join(&maildir_path);
-    let raw = std::fs::read(&full_path).map_err(|e| {
-        Error::Other(format!("Failed to read message file: {}", e))
-    })?;
+    let raw = std::fs::read(&full_path)
+        .map_err(|e| Error::Other(format!("Failed to read message file: {}", e)))?;
 
-    let html = parser::parse_html_with_images(&raw).ok_or_else(|| {
-        Error::MailParse("Failed to parse message HTML".to_string())
-    })?;
+    let html = parser::parse_html_with_images(&raw)
+        .ok_or_else(|| Error::MailParse("Failed to parse message HTML".to_string()))?;
 
     // Find all img src URLs and download them, replacing with data URIs.
     // This keeps the iframe sandbox at allow-scripts only (no allow-same-origin).
@@ -304,52 +321,67 @@ pub async fn get_message_html_with_images(
 
     // Download images in parallel (max 20 to avoid abuse)
     use base64::Engine;
-    let mut url_to_data: std::collections::HashMap<String, String> = std::collections::HashMap::new();
-    let futures: Vec<_> = urls.iter().take(20).map(|url| {
-        let client = client.clone();
-        let url = url.clone();
-        async move {
-            // SSRF protection: resolve hostname and reject private/internal IPs
-            if let Ok(parsed) = reqwest::Url::parse(&url) {
-                if let Some(host) = parsed.host_str() {
-                    // Block obvious private hostnames
-                    let h = host.to_lowercase();
-                    if h == "localhost" || h.ends_with(".local") || h.ends_with(".internal") {
-                        log::debug!("Image proxy: blocked private host {}", host);
-                        return None;
-                    }
-                    // Resolve DNS and check for private IPs
-                    if let Ok(addrs) = tokio::net::lookup_host(format!("{}:{}", host, parsed.port_or_known_default().unwrap_or(443))).await {
-                        for addr in addrs {
-                            let ip = addr.ip();
-                            if ip.is_loopback() || ip.is_unspecified() || is_private_ip(&ip) {
-                                log::debug!("Image proxy: blocked private IP {} for {}", ip, host);
-                                return None;
+    let mut url_to_data: std::collections::HashMap<String, String> =
+        std::collections::HashMap::new();
+    let futures: Vec<_> = urls
+        .iter()
+        .take(20)
+        .map(|url| {
+            let client = client.clone();
+            let url = url.clone();
+            async move {
+                // SSRF protection: resolve hostname and reject private/internal IPs
+                if let Ok(parsed) = reqwest::Url::parse(&url) {
+                    if let Some(host) = parsed.host_str() {
+                        // Block obvious private hostnames
+                        let h = host.to_lowercase();
+                        if h == "localhost" || h.ends_with(".local") || h.ends_with(".internal") {
+                            log::debug!("Image proxy: blocked private host {}", host);
+                            return None;
+                        }
+                        // Resolve DNS and check for private IPs
+                        if let Ok(addrs) = tokio::net::lookup_host(format!(
+                            "{}:{}",
+                            host,
+                            parsed.port_or_known_default().unwrap_or(443)
+                        ))
+                        .await
+                        {
+                            for addr in addrs {
+                                let ip = addr.ip();
+                                if ip.is_loopback() || ip.is_unspecified() || is_private_ip(&ip) {
+                                    log::debug!(
+                                        "Image proxy: blocked private IP {} for {}",
+                                        ip,
+                                        host
+                                    );
+                                    return None;
+                                }
                             }
                         }
                     }
                 }
-            }
 
-            let resp = client.get(&url).send().await.ok()?;
-            let content_type = resp
-                .headers()
-                .get("content-type")
-                .and_then(|v| v.to_str().ok())
-                .unwrap_or("image/png")
-                .to_string();
-            // Only allow image content types, max 5MB
-            if !content_type.starts_with("image/") {
-                return None;
+                let resp = client.get(&url).send().await.ok()?;
+                let content_type = resp
+                    .headers()
+                    .get("content-type")
+                    .and_then(|v| v.to_str().ok())
+                    .unwrap_or("image/png")
+                    .to_string();
+                // Only allow image content types, max 5MB
+                if !content_type.starts_with("image/") {
+                    return None;
+                }
+                let bytes = resp.bytes().await.ok()?;
+                if bytes.len() > 5 * 1024 * 1024 {
+                    return None;
+                }
+                let b64 = base64::engine::general_purpose::STANDARD.encode(&bytes);
+                Some((url, format!("data:{};base64,{}", content_type, b64)))
             }
-            let bytes = resp.bytes().await.ok()?;
-            if bytes.len() > 5 * 1024 * 1024 {
-                return None;
-            }
-            let b64 = base64::engine::general_purpose::STANDARD.encode(&bytes);
-            Some((url, format!("data:{};base64,{}", content_type, b64)))
-        }
-    }).collect();
+        })
+        .collect();
 
     let results = futures::future::join_all(futures).await;
     for result in results.into_iter().flatten() {
@@ -437,10 +469,7 @@ pub async fn get_thread_messages(
 }
 
 #[tauri::command]
-pub async fn unthread_message(
-    state: State<'_, AppState>,
-    message_id: String,
-) -> Result<()> {
+pub async fn unthread_message(state: State<'_, AppState>, message_id: String) -> Result<()> {
     log::info!("Unthreading message: {}", message_id);
     let conn = state.db.writer().await;
     db::messages::unthread_message(&conn, &message_id)?;
@@ -455,7 +484,11 @@ pub async fn create_folder(
     account_id: String,
     folder_path: String,
 ) -> Result<()> {
-    log::info!("Creating folder '{}' for account {}", folder_path, account_id);
+    log::info!(
+        "Creating folder '{}' for account {}",
+        folder_path,
+        account_id
+    );
 
     let account = {
         let conn = state.db.reader();
@@ -469,21 +502,34 @@ pub async fn create_folder(
         // For JMAP, folder_path is "parentId/name" (built by the frontend).
         // Split to get the parent mailbox ID and the new folder name.
         let (parent_id, mailbox_name) = if let Some((parent, name)) = folder_path.rsplit_once('/') {
-            (if parent.is_empty() { None } else { Some(parent) }, name)
+            (
+                if parent.is_empty() {
+                    None
+                } else {
+                    Some(parent)
+                },
+                name,
+            )
         } else {
             (None, folder_path.as_str())
         };
-        conn_jmap.create_mailbox(&jmap_config, mailbox_name, parent_id).await?;
+        conn_jmap
+            .create_mailbox(&jmap_config, mailbox_name, parent_id)
+            .await?;
     } else {
         // IMAP: CREATE (O365 uses XOAUTH2)
         let (imap_password, imap_xoauth2) = if account.provider == "o365" {
             let tokens = crate::oauth::load_tokens(&account_id)?
                 .ok_or_else(|| Error::Other("No O365 tokens".into()))?;
-            let refresh = tokens.refresh_token
+            let refresh = tokens
+                .refresh_token
                 .ok_or_else(|| Error::Other("No O365 refresh token".into()))?;
             let new = crate::oauth::refresh_with_scopes(
-                &crate::oauth::MICROSOFT, &refresh, crate::oauth::MICROSOFT_IMAP_SCOPES,
-            ).await?;
+                &crate::oauth::MICROSOFT,
+                &refresh,
+                crate::oauth::MICROSOFT_IMAP_SCOPES,
+            )
+            .await?;
             crate::oauth::store_tokens(&account_id, &new)?;
             (new.access_token, true)
         } else {
@@ -511,15 +557,16 @@ pub async fn create_folder(
     // Don't insert into local DB here — the next sync will discover the folder
     // with the correct server-side path/ID and register it properly.
 
-    log::info!("Folder '{}' created on server, will appear after sync", folder_path);
+    log::info!(
+        "Folder '{}' created on server, will appear after sync",
+        folder_path
+    );
     emit_folders_changed(&app, &account_id);
     Ok(())
 }
 
 /// System folder types that must never be deleted.
-const PROTECTED_FOLDER_TYPES: &[&str] = &[
-    "inbox", "sent", "drafts", "trash", "junk", "archive",
-];
+const PROTECTED_FOLDER_TYPES: &[&str] = &["inbox", "sent", "drafts", "trash", "junk", "archive"];
 
 /// Delete a folder on the mail server and remove it from local DB.
 /// Refuses to delete system folders (inbox, sent, drafts, trash, junk, archive).
@@ -530,7 +577,11 @@ pub async fn delete_folder(
     account_id: String,
     folder_path: String,
 ) -> Result<()> {
-    log::info!("Deleting folder '{}' for account {}", folder_path, account_id);
+    log::info!(
+        "Deleting folder '{}' for account {}",
+        folder_path,
+        account_id
+    );
 
     // Verify the folder exists in the local DB and is not a system folder
     let account = {
@@ -543,19 +594,25 @@ pub async fn delete_folder(
                 rusqlite::params![account_id, folder_path],
                 |row| row.get(0),
             )
-            .map_err(|_| Error::Other(format!(
-                "Folder '{}' not found for account {}", folder_path, account_id
-            )))?;
+            .map_err(|_| {
+                Error::Other(format!(
+                    "Folder '{}' not found for account {}",
+                    folder_path, account_id
+                ))
+            })?;
 
         // Reject deletion of system folders
         if let Some(ref ft) = folder_type {
             if PROTECTED_FOLDER_TYPES.contains(&ft.as_str()) {
                 log::warn!(
                     "Refusing to delete system folder '{}' (type={}) for account {}",
-                    folder_path, ft, account_id
+                    folder_path,
+                    ft,
+                    account_id
                 );
                 return Err(Error::Other(format!(
-                    "Cannot delete system folder '{}' ({})", folder_path, ft
+                    "Cannot delete system folder '{}' ({})",
+                    folder_path, ft
                 )));
             }
         }
@@ -579,25 +636,32 @@ pub async fn delete_folder(
         // JMAP: Mailbox/set destroy — folder_path is the mailbox ID
         let jmap_config = crate::commands::sync_cmd::build_jmap_config(&account).await?;
         let conn_jmap = crate::mail::jmap::JmapConnection::connect(&jmap_config).await?;
-        conn_jmap.destroy_mailbox(&jmap_config, &folder_path, true).await.map_err(|e| {
-            log::error!(
-                "Failed to delete JMAP folder '{}' for account {}: {}",
-                folder_path,
-                account_id,
+        conn_jmap
+            .destroy_mailbox(&jmap_config, &folder_path, true)
+            .await
+            .map_err(|e| {
+                log::error!(
+                    "Failed to delete JMAP folder '{}' for account {}: {}",
+                    folder_path,
+                    account_id,
+                    e
+                );
                 e
-            );
-            e
-        })?;
+            })?;
     } else {
         // IMAP: DELETE
         let (imap_password, imap_xoauth2) = if account.provider == "o365" {
             let tokens = crate::oauth::load_tokens(&account_id)?
                 .ok_or_else(|| Error::Other("No O365 tokens".into()))?;
-            let refresh = tokens.refresh_token
+            let refresh = tokens
+                .refresh_token
                 .ok_or_else(|| Error::Other("No O365 refresh token".into()))?;
             let new = crate::oauth::refresh_with_scopes(
-                &crate::oauth::MICROSOFT, &refresh, crate::oauth::MICROSOFT_IMAP_SCOPES,
-            ).await?;
+                &crate::oauth::MICROSOFT,
+                &refresh,
+                crate::oauth::MICROSOFT_IMAP_SCOPES,
+            )
+            .await?;
             crate::oauth::store_tokens(&account_id, &new)?;
             (new.access_token, true)
         } else {
@@ -628,7 +692,11 @@ pub async fn delete_folder(
         db::folders::delete_folder(&conn, &account_id, &folder_path)?;
     }
 
-    log::info!("Folder '{}' deleted for account {}", folder_path, account_id);
+    log::info!(
+        "Folder '{}' deleted for account {}",
+        folder_path,
+        account_id
+    );
     emit_folders_changed(&app, &account_id);
     emit_messages_changed(&app, &account_id);
     Ok(())
@@ -666,9 +734,8 @@ pub async fn save_attachment(
 
     // Extract attachment bytes first, before showing dialog
     let full_path = state.data_dir.join(&maildir_path);
-    let raw = std::fs::read(&full_path).map_err(|e| {
-        Error::Other(format!("Failed to read message file: {}", e))
-    })?;
+    let raw = std::fs::read(&full_path)
+        .map_err(|e| Error::Other(format!("Failed to read message file: {}", e)))?;
 
     let parsed = mail_parser::MessageParser::default()
         .parse(&raw)
@@ -694,9 +761,9 @@ pub async fn save_attachment(
         None => return Ok(()), // user cancelled
     };
 
-    let dest_path = dest.as_path().ok_or_else(|| {
-        Error::Other("Invalid save path".to_string())
-    })?;
+    let dest_path = dest
+        .as_path()
+        .ok_or_else(|| Error::Other("Invalid save path".to_string()))?;
 
     // Refuse to follow symlinks
     if let Ok(metadata) = std::fs::symlink_metadata(dest_path) {
@@ -708,12 +775,12 @@ pub async fn save_attachment(
     }
 
     // Write atomically: temp file + fsync + rename
-    let dest_dir = dest_path.parent().ok_or_else(|| {
-        Error::Other("Save path must have a parent directory".to_string())
-    })?;
-    let dest_name = dest_path.file_name().ok_or_else(|| {
-        Error::Other("Save path must include a file name".to_string())
-    })?;
+    let dest_dir = dest_path
+        .parent()
+        .ok_or_else(|| Error::Other("Save path must have a parent directory".to_string()))?;
+    let dest_name = dest_path
+        .file_name()
+        .ok_or_else(|| Error::Other("Save path must include a file name".to_string()))?;
     let unique_suffix = format!(
         "{}-{}",
         std::process::id(),

--- a/src-tauri/src/commands/oauth.rs
+++ b/src-tauri/src/commands/oauth.rs
@@ -53,22 +53,24 @@ fn get_provider(name: &str) -> Result<&'static oauth::OAuthProvider> {
 
 /// Start the OAuth2 flow for a provider. Returns the auth URL to open in the browser.
 #[tauri::command]
-pub async fn oauth_start(
-    provider: String,
-) -> Result<OAuthStartResult> {
+pub async fn oauth_start(provider: String) -> Result<OAuthStartResult> {
     let prov = get_provider(&provider)?;
 
     let (url, listener, code_verifier, state) = oauth::get_auth_url(prov)?;
-    let port = listener.local_addr()
+    let port = listener
+        .local_addr()
         .map_err(|e| Error::Other(format!("Failed to get port: {}", e)))?
         .port();
 
-    store_session(port, OAuthSession {
-        verifier: code_verifier,
-        state,
-        listener,
-        created_at: Instant::now(),
-    });
+    store_session(
+        port,
+        OAuthSession {
+            verifier: code_verifier,
+            state,
+            listener,
+            created_at: Instant::now(),
+        },
+    );
 
     log::info!("OAuth2: started {} flow on port {}", provider, port);
     Ok(OAuthStartResult { url, port })
@@ -91,20 +93,20 @@ pub async fn oauth_complete(
 ) -> Result<()> {
     let prov = get_provider(&provider)?;
 
-    let session = take_session(port)
-        .ok_or_else(|| Error::Other(format!(
-            "No OAuth session found for port {} (expired or never started)", port
-        )))?;
+    let session = take_session(port).ok_or_else(|| {
+        Error::Other(format!(
+            "No OAuth session found for port {} (expired or never started)",
+            port
+        ))
+    })?;
 
     let expected_state = session.state.clone();
     let code_verifier = session.verifier.clone();
 
     // Wait for callback in a blocking thread (TcpListener::accept blocks)
-    let result = tokio::task::spawn_blocking(move || {
-        oauth::wait_for_callback(session.listener)
-    })
-    .await
-    .map_err(|e| Error::Other(format!("OAuth callback task failed: {}", e)))??;
+    let result = tokio::task::spawn_blocking(move || oauth::wait_for_callback(session.listener))
+        .await
+        .map_err(|e| Error::Other(format!("OAuth callback task failed: {}", e)))??;
 
     // Validate CSRF state parameter
     match result.state {
@@ -130,16 +132,17 @@ pub async fn oauth_complete(
     // Store tokens in keyring
     oauth::store_tokens(&account_id, &tokens)?;
 
-    log::info!("OAuth2: completed {} flow for account {}", provider, account_id);
+    log::info!(
+        "OAuth2: completed {} flow for account {}",
+        provider,
+        account_id
+    );
     Ok(())
 }
 
 /// Get a valid access token for an account, refreshing if needed.
 #[tauri::command]
-pub async fn oauth_get_token(
-    provider: String,
-    account_id: String,
-) -> Result<String> {
+pub async fn oauth_get_token(provider: String, account_id: String) -> Result<String> {
     let prov = get_provider(&provider)?;
 
     let tokens = oauth::load_tokens(&account_id)?
@@ -150,7 +153,8 @@ pub async fn oauth_get_token(
     }
 
     // Need to refresh
-    let refresh_token = tokens.refresh_token
+    let refresh_token = tokens
+        .refresh_token
         .ok_or_else(|| Error::Other("No refresh token. Please sign in again.".into()))?;
 
     let new_tokens = oauth::refresh_access_token(prov, &refresh_token).await?;
@@ -161,34 +165,36 @@ pub async fn oauth_get_token(
 
 /// Check if an account has OAuth tokens stored.
 #[tauri::command]
-pub async fn oauth_has_tokens(
-    account_id: String,
-) -> Result<bool> {
+pub async fn oauth_has_tokens(account_id: String) -> Result<bool> {
     Ok(oauth::load_tokens(&account_id)?.is_some())
 }
 
 /// Fetch the user's profile (display name + email) from Microsoft Graph.
 #[tauri::command]
-pub async fn oauth_get_ms_profile(
-    account_id: String,
-) -> Result<MsProfile> {
+pub async fn oauth_get_ms_profile(account_id: String) -> Result<MsProfile> {
     let tokens = oauth::load_tokens(&account_id)?
         .ok_or_else(|| Error::Other("No tokens for profile fetch".into()))?;
 
-    let refresh_token = tokens.refresh_token.as_deref()
+    let refresh_token = tokens
+        .refresh_token
+        .as_deref()
         .ok_or_else(|| Error::Other("No refresh token for profile fetch".into()))?;
 
     let graph_tokens = oauth::refresh_with_scopes(
         &oauth::MICROSOFT,
         refresh_token,
         oauth::MICROSOFT_GRAPH_SCOPES,
-    ).await?;
+    )
+    .await?;
 
-    oauth::store_tokens(&account_id, &oauth::OAuthTokens {
-        access_token: tokens.access_token,
-        refresh_token: graph_tokens.refresh_token,
-        expires_at: tokens.expires_at,
-    })?;
+    oauth::store_tokens(
+        &account_id,
+        &oauth::OAuthTokens {
+            access_token: tokens.access_token,
+            refresh_token: graph_tokens.refresh_token,
+            expires_at: tokens.expires_at,
+        },
+    )?;
 
     let client = crate::mail::graph::GraphClient::new(&graph_tokens.access_token);
     let user = client.get_me().await?;
@@ -217,7 +223,8 @@ pub async fn jmap_oidc_start(
     let base_url = if !jmap_url.is_empty() {
         jmap_url.trim_end_matches('/').to_string()
     } else {
-        let domain = email.rsplit_once('@')
+        let domain = email
+            .rsplit_once('@')
             .map(|(_, d)| d)
             .ok_or_else(|| Error::Other(format!("Cannot extract domain from '{}'", email)))?;
         let candidates = [
@@ -227,7 +234,8 @@ pub async fn jmap_oidc_start(
         ];
         let http = reqwest::Client::builder()
             .timeout(std::time::Duration::from_secs(5))
-            .build().map_err(|e| Error::Other(format!("HTTP client error: {}", e)))?;
+            .build()
+            .map_err(|e| Error::Other(format!("HTTP client error: {}", e)))?;
         let mut found = None;
         for c in &candidates {
             let url = format!("{}/.well-known/openid-configuration", c);
@@ -238,18 +246,19 @@ pub async fn jmap_oidc_start(
                 }
             }
         }
-        found.ok_or_else(|| Error::Other(format!(
-            "OIDC auto-discovery failed for {} (tried {}, mail.{}, jmap.{})",
-            domain, domain, domain, domain
-        )))?
+        found.ok_or_else(|| {
+            Error::Other(format!(
+                "OIDC auto-discovery failed for {} (tried {}, mail.{}, jmap.{})",
+                domain, domain, domain, domain
+            ))
+        })?
     };
 
     let endpoints = crate::oauth::discover_oidc(&base_url).await?;
 
-    let device_auth_endpoint = endpoints.device_authorization_endpoint
-        .ok_or_else(|| Error::Other(
-            "Server does not support device authorization flow".into()
-        ))?;
+    let device_auth_endpoint = endpoints
+        .device_authorization_endpoint
+        .ok_or_else(|| Error::Other("Server does not support device authorization flow".into()))?;
 
     let effective_client_id = if !client_id.trim().is_empty() {
         client_id.trim().to_string()
@@ -261,7 +270,8 @@ pub async fn jmap_oidc_start(
         ));
     };
 
-    let device_resp = crate::oauth::device_auth_start(&device_auth_endpoint, &effective_client_id).await?;
+    let device_resp =
+        crate::oauth::device_auth_start(&device_auth_endpoint, &effective_client_id).await?;
 
     Ok(JmapOidcStartResult {
         verification_uri: device_resp.verification_uri.clone(),
@@ -303,10 +313,14 @@ pub async fn jmap_oidc_complete(
         interval,
         expires_in,
         &client_id,
-    ).await?;
+    )
+    .await?;
 
     crate::oauth::store_tokens(&account_id, &tokens)?;
 
-    log::info!("JMAP OIDC: device flow completed for account {}", account_id);
+    log::info!(
+        "JMAP OIDC: device flow completed for account {}",
+        account_id
+    );
     Ok(())
 }

--- a/src-tauri/src/commands/sync_cmd.rs
+++ b/src-tauri/src/commands/sync_cmd.rs
@@ -92,12 +92,9 @@ pub async fn refresh_jmap_oidc_token(
         return Ok(Some(tokens.access_token));
     }
 
-    let new_tokens = crate::oauth::refresh_token_dynamic(
-        oidc_token_endpoint,
-        &refresh_token,
-        oidc_client_id,
-    )
-    .await?;
+    let new_tokens =
+        crate::oauth::refresh_token_dynamic(oidc_token_endpoint, &refresh_token, oidc_client_id)
+            .await?;
     crate::oauth::store_tokens(account_id, &new_tokens)?;
 
     Ok(Some(new_tokens.access_token))
@@ -225,7 +222,11 @@ pub async fn trigger_sync(
     let account = match account_result {
         Ok(a) => a,
         Err(e) => {
-            app.emit("sync-error", serde_json::json!({"account_id": account_id, "error": e.to_string()})).ok();
+            app.emit(
+                "sync-error",
+                serde_json::json!({"account_id": account_id, "error": e.to_string()}),
+            )
+            .ok();
             return Err(e);
         }
     };
@@ -273,7 +274,8 @@ pub async fn trigger_sync(
             jmap_config.clone(),
             current_folder,
         )
-        .await {
+        .await
+        {
             Err(e)
         } else {
             // Calendar sync is now independent — triggered by its own interval,
@@ -291,21 +293,27 @@ pub async fn trigger_sync(
 
         // For O365 accounts, get an IMAP-scoped OAuth token
         let (password, use_xoauth2) = if account.provider == "o365" {
-            let tokens = crate::oauth::load_tokens(&account_id)?
-                .ok_or_else(|| Error::Other("No O365 OAuth tokens. Please sign in with Microsoft.".into()))?;
-            let refresh_token = tokens.refresh_token
+            let tokens = crate::oauth::load_tokens(&account_id)?.ok_or_else(|| {
+                Error::Other("No O365 OAuth tokens. Please sign in with Microsoft.".into())
+            })?;
+            let refresh_token = tokens
+                .refresh_token
                 .ok_or_else(|| Error::Other("No O365 refresh token.".into()))?;
             let imap_tokens = crate::oauth::refresh_with_scopes(
                 &crate::oauth::MICROSOFT,
                 &refresh_token,
                 crate::oauth::MICROSOFT_IMAP_SCOPES,
-            ).await?;
+            )
+            .await?;
             // Save the potentially rotated refresh token
-            crate::oauth::store_tokens(&account_id, &crate::oauth::OAuthTokens {
-                access_token: imap_tokens.access_token.clone(),
-                refresh_token: imap_tokens.refresh_token,
-                expires_at: imap_tokens.expires_at,
-            })?;
+            crate::oauth::store_tokens(
+                &account_id,
+                &crate::oauth::OAuthTokens {
+                    access_token: imap_tokens.access_token.clone(),
+                    refresh_token: imap_tokens.refresh_token,
+                    expires_at: imap_tokens.expires_at,
+                },
+            )?;
             (imap_tokens.access_token, true)
         } else {
             (account.password.clone(), false)
@@ -329,16 +337,22 @@ pub async fn trigger_sync(
             imap_config,
             current_folder,
         )
-        .await {
+        .await
+        {
             Err(e)
         } else {
             Ok(())
         }
     };
 
-    let resume_result = resume_imap_idle_for_account(&app, &state, &resume_account, suspended_idle).await;
+    let resume_result =
+        resume_imap_idle_for_account(&app, &state, &resume_account, suspended_idle).await;
     if let Err(e) = &sync_result {
-        app.emit("sync-error", serde_json::json!({"account_id": account_id, "error": e.to_string()})).ok();
+        app.emit(
+            "sync-error",
+            serde_json::json!({"account_id": account_id, "error": e.to_string()}),
+        )
+        .ok();
     }
     resume_result?;
 
@@ -356,7 +370,11 @@ pub async fn sync_folder(
         return Ok(0);
     };
 
-    log::info!("Single folder sync: account={} folder={}", account_id, folder_path);
+    log::info!(
+        "Single folder sync: account={} folder={}",
+        account_id,
+        folder_path
+    );
     let account = {
         let conn = state.db.reader();
         db::accounts::get_account_full(&conn, &account_id)?
@@ -369,7 +387,8 @@ pub async fn sync_folder(
             "account_id": account_id,
             "account_name": account.display_name,
         }),
-    ).ok();
+    )
+    .ok();
 
     let suspended_idle = if account.mail_protocol == "imap"
         && should_suspend_idle_for_imap_operation(&account.provider)
@@ -406,11 +425,15 @@ pub async fn sync_folder(
         let (password, use_xoauth2) = if account.provider == "o365" {
             let tokens = crate::oauth::load_tokens(&account_id)?
                 .ok_or_else(|| Error::Other("No O365 tokens".into()))?;
-            let refresh = tokens.refresh_token
+            let refresh = tokens
+                .refresh_token
                 .ok_or_else(|| Error::Other("No O365 refresh token".into()))?;
             let new = crate::oauth::refresh_with_scopes(
-                &crate::oauth::MICROSOFT, &refresh, crate::oauth::MICROSOFT_IMAP_SCOPES,
-            ).await?;
+                &crate::oauth::MICROSOFT,
+                &refresh,
+                crate::oauth::MICROSOFT_IMAP_SCOPES,
+            )
+            .await?;
             crate::oauth::store_tokens(&account_id, &new)?;
             (new.access_token, true)
         } else {
@@ -434,7 +457,10 @@ pub async fn sync_folder(
             let mut conn_imap = ImapConnection::connect(&imap_config)?;
             conn_imap.select_folder(&folder_clone)?;
             let count = mail_sync::sync_folder_envelopes_public(
-                &db, &account_id_clone, &mut conn_imap, &folder_clone,
+                &db,
+                &account_id_clone,
+                &mut conn_imap,
+                &folder_clone,
             )?;
             conn_imap.logout();
             Ok::<u32, Error>(count)
@@ -443,7 +469,8 @@ pub async fn sync_folder(
         .map_err(|e| Error::Sync(format!("Folder sync panicked: {}", e)))?
     };
 
-    let resume_result = resume_imap_idle_for_account(&app, &state, &resume_account, suspended_idle).await;
+    let resume_result =
+        resume_imap_idle_for_account(&app, &state, &resume_account, suspended_idle).await;
 
     match &sync_result {
         Ok(count) => {
@@ -453,7 +480,8 @@ pub async fn sync_folder(
                     "account_id": account_id,
                     "total_synced": count,
                 }),
-            ).ok();
+            )
+            .ok();
             emit_folders_changed(&app, &account_id);
             emit_messages_changed(&app, &account_id);
             log::info!("Single folder sync done: {} new in {}", count, folder_path);
@@ -465,7 +493,8 @@ pub async fn sync_folder(
                     "account_id": account_id,
                     "error": e.to_string(),
                 }),
-            ).ok();
+            )
+            .ok();
         }
     }
 
@@ -535,10 +564,7 @@ async fn sync_jmap_calendars(
             jcal.name
         );
 
-        let local_cal_id = remote_to_local
-            .get(&jcal.id)
-            .cloned()
-            .unwrap_or_default();
+        let local_cal_id = remote_to_local.get(&jcal.id).cloned().unwrap_or_default();
 
         let conn = db.writer().await;
         for ev in &events {
@@ -646,18 +672,23 @@ pub async fn prefetch_bodies(
     let (password, use_xoauth2) = if account.provider == "o365" {
         let tokens = crate::oauth::load_tokens(&account_id)?
             .ok_or_else(|| Error::Other("No O365 tokens for prefetch".into()))?;
-        let refresh_token = tokens.refresh_token
+        let refresh_token = tokens
+            .refresh_token
             .ok_or_else(|| Error::Other("No O365 refresh token for prefetch".into()))?;
         let imap_tokens = crate::oauth::refresh_with_scopes(
             &crate::oauth::MICROSOFT,
             &refresh_token,
             crate::oauth::MICROSOFT_IMAP_SCOPES,
-        ).await?;
-        crate::oauth::store_tokens(&account_id, &crate::oauth::OAuthTokens {
-            access_token: imap_tokens.access_token.clone(),
-            refresh_token: imap_tokens.refresh_token,
-            expires_at: imap_tokens.expires_at,
-        })?;
+        )
+        .await?;
+        crate::oauth::store_tokens(
+            &account_id,
+            &crate::oauth::OAuthTokens {
+                access_token: imap_tokens.access_token.clone(),
+                refresh_token: imap_tokens.refresh_token,
+                expires_at: imap_tokens.expires_at,
+            },
+        )?;
         (imap_tokens.access_token, true)
     } else {
         (account.password.clone(), false)
@@ -739,7 +770,11 @@ pub async fn prefetch_bodies(
                         let mut conn = match ImapConnection::connect(&imap_config) {
                             Ok(c) => c,
                             Err(e) => {
-                                log::error!("Prefetch thread {}: connect failed: {}", thread_idx, e);
+                                log::error!(
+                                    "Prefetch thread {}: connect failed: {}",
+                                    thread_idx,
+                                    e
+                                );
                                 return Err(e);
                             }
                         };
@@ -748,10 +783,17 @@ pub async fn prefetch_bodies(
                         for (folder_path, messages) in &folders {
                             log::info!(
                                 "Prefetch[{}]: folder '{}' ({} messages)",
-                                thread_idx, folder_path, messages.len()
+                                thread_idx,
+                                folder_path,
+                                messages.len()
                             );
                             if let Err(e) = conn.select_folder(folder_path) {
-                                log::error!("Prefetch[{}]: select '{}' failed: {}", thread_idx, folder_path, e);
+                                log::error!(
+                                    "Prefetch[{}]: select '{}' failed: {}",
+                                    thread_idx,
+                                    folder_path,
+                                    e
+                                );
                                 continue;
                             }
 
@@ -763,11 +805,16 @@ pub async fn prefetch_bodies(
                             }
 
                             for chunk in messages.chunks(100) {
-                                let batch_uids: Vec<u32> = chunk.iter().map(|(_, uid, _)| *uid).collect();
+                                let batch_uids: Vec<u32> =
+                                    chunk.iter().map(|(_, uid, _)| *uid).collect();
                                 let bodies = match conn.fetch_bodies_batch(&batch_uids) {
                                     Ok(b) => b,
                                     Err(e) => {
-                                        log::error!("Prefetch[{}]: batch fetch failed: {}", thread_idx, e);
+                                        log::error!(
+                                            "Prefetch[{}]: batch fetch failed: {}",
+                                            thread_idx,
+                                            e
+                                        );
                                         continue;
                                     }
                                 };
@@ -778,12 +825,16 @@ pub async fn prefetch_bodies(
                                         Some(b) => b,
                                         None => continue,
                                     };
-                                    let flags: Vec<String> = serde_json::from_str(flags_json).unwrap_or_default();
+                                    let flags: Vec<String> =
+                                        serde_json::from_str(flags_json).unwrap_or_default();
                                     let suffix = mail_sync::flags_to_maildir_suffix(&flags);
                                     let filename = format!("{}:2,{}", uid, suffix);
                                     let msg_path = maildir_base.join("cur").join(&filename);
-                                    if std::fs::write(&msg_path, body).is_err() { continue; }
-                                    let relative_path = format!("{}/{}/cur/{}", account_id, sanitized, filename);
+                                    if std::fs::write(&msg_path, body).is_err() {
+                                        continue;
+                                    }
+                                    let relative_path =
+                                        format!("{}/{}/cur/{}", account_id, sanitized, filename);
                                     db_updates.push((message_id.clone(), relative_path));
                                     count += 1;
                                 }
@@ -795,7 +846,12 @@ pub async fn prefetch_bodies(
                                         db::messages::update_maildir_path(&conn, msg_id, path).ok();
                                     }
                                     conn.execute_batch("COMMIT").ok();
-                                    log::info!("Prefetch[{}]: saved {} bodies in '{}'", thread_idx, db_updates.len(), folder_path);
+                                    log::info!(
+                                        "Prefetch[{}]: saved {} bodies in '{}'",
+                                        thread_idx,
+                                        db_updates.len(),
+                                        folder_path
+                                    );
                                 }
                             }
                         }
@@ -808,7 +864,10 @@ pub async fn prefetch_bodies(
 
             handles
                 .into_iter()
-                .map(|h| h.join().unwrap_or(Err(Error::Sync("Prefetch thread panicked".into()))))
+                .map(|h| {
+                    h.join()
+                        .unwrap_or(Err(Error::Sync("Prefetch thread panicked".into())))
+                })
                 .collect()
         });
 
@@ -838,7 +897,7 @@ async fn sync_graph_account(
     account_id: &str,
 ) -> Result<()> {
     use crate::mail::graph::{self, GraphClient};
-    use crate::mail::sync::{create_maildir_dirs, sanitize_folder_name, flags_to_maildir_suffix};
+    use crate::mail::sync::{create_maildir_dirs, flags_to_maildir_suffix, sanitize_folder_name};
 
     let data_dir = app.state::<AppState>().data_dir.clone();
 
@@ -847,14 +906,31 @@ async fn sync_graph_account(
 
     // Sync mail folders
     let graph_folders = client.list_mail_folders().await?;
-    log::info!("Graph sync: {} mail folders for account {}", graph_folders.len(), account_id);
+    log::info!(
+        "Graph sync: {} mail folders for account {}",
+        graph_folders.len(),
+        account_id
+    );
 
     {
         let conn = db_arc.writer().await;
         for gf in &graph_folders {
             let folder_type = graph::guess_folder_type(&gf.display_name);
-            db::folders::upsert_folder(&conn, account_id, &gf.display_name, &gf.id, folder_type, None)?;
-            db::folders::update_folder_counts(&conn, account_id, &gf.id, gf.unread_count, gf.total_count)?;
+            db::folders::upsert_folder(
+                &conn,
+                account_id,
+                &gf.display_name,
+                &gf.id,
+                folder_type,
+                None,
+            )?;
+            db::folders::update_folder_counts(
+                &conn,
+                account_id,
+                &gf.id,
+                gf.unread_count,
+                gf.total_count,
+            )?;
         }
     }
 
@@ -869,9 +945,9 @@ async fn sync_graph_account(
 
         let existing_ids = {
             let conn = db_arc.reader();
-            let mut stmt = conn.prepare(
-                "SELECT id FROM messages WHERE account_id = ?1 AND folder_path = ?2"
-            ).map_err(Error::Database)?;
+            let mut stmt = conn
+                .prepare("SELECT id FROM messages WHERE account_id = ?1 AND folder_path = ?2")
+                .map_err(Error::Database)?;
             let ids: std::collections::HashSet<String> = stmt
                 .query_map(rusqlite::params![account_id, gf.id], |row| row.get(0))
                 .map_err(Error::Database)?
@@ -902,13 +978,21 @@ async fn sync_graph_account(
         // Phase 1: Stream MIME bodies to disk (no DB lock — UI stays responsive)
         let mut downloaded: Vec<(&graph::GraphMessage, String)> = Vec::new();
         for msg in &new_messages {
-            let flags = if msg.is_read { vec!["seen".to_string()] } else { vec![] };
+            let flags = if msg.is_read {
+                vec!["seen".to_string()]
+            } else {
+                vec![]
+            };
             let filename = format!("{}:2,{}", msg.id, flags_to_maildir_suffix(&flags));
             let msg_path = maildir_base.join("cur").join(&filename);
 
             let maildir_path = match client.download_mime_to_file(&msg.id, &msg_path).await {
                 Ok(bytes_written) => {
-                    log::debug!("Graph sync: downloaded {} bytes for {}", bytes_written, msg.id);
+                    log::debug!(
+                        "Graph sync: downloaded {} bytes for {}",
+                        bytes_written,
+                        msg.id
+                    );
                     format!("{}/{}/cur/{}", account_id, folder_dir, filename)
                 }
                 Err(e) => {
@@ -928,7 +1012,11 @@ async fn sync_graph_account(
         let mut synced = 0u32;
         for (msg, maildir_path) in &downloaded {
             let id = format!("{}_{}", account_id, msg.id);
-            let flags = if msg.is_read { vec!["seen".to_string()] } else { vec![] };
+            let flags = if msg.is_read {
+                vec!["seen".to_string()]
+            } else {
+                vec![]
+            };
             let thread_id = msg.conversation_id.clone();
 
             let new_msg = db::messages::NewMessage {
@@ -941,7 +1029,10 @@ async fn sync_graph_account(
                 thread_id,
                 subject: msg.subject.clone(),
                 from_name: msg.from_name.clone(),
-                from_email: msg.from_email.clone().unwrap_or_else(|| "unknown".to_string()),
+                from_email: msg
+                    .from_email
+                    .clone()
+                    .unwrap_or_else(|| "unknown".to_string()),
                 to_addresses: msg.to_addresses.clone(),
                 cc_addresses: msg.cc_addresses.clone(),
                 date: msg.date.clone(),
@@ -961,35 +1052,46 @@ async fn sync_graph_account(
         drop(conn);
 
         if synced > 0 {
-            log::info!("Graph sync: {} new messages in '{}' (bodies streamed to disk)", synced, gf.display_name);
+            log::info!(
+                "Graph sync: {} new messages in '{}' (bodies streamed to disk)",
+                synced,
+                gf.display_name
+            );
             grand_total += synced;
         }
     }
 
-    app.emit("sync-complete", serde_json::json!({
-        "account_id": account_id,
-        "total_synced": grand_total,
-    })).ok();
+    app.emit(
+        "sync-complete",
+        serde_json::json!({
+            "account_id": account_id,
+            "total_synced": grand_total,
+        }),
+    )
+    .ok();
     emit_folders_changed(&app, account_id);
     emit_messages_changed(&app, account_id);
 
-    log::info!("Graph sync: completed for account {}, {} new messages", account_id, grand_total);
+    log::info!(
+        "Graph sync: completed for account {}, {} new messages",
+        account_id,
+        grand_total
+    );
     Ok(())
 }
 
 /// Start IMAP IDLE and JMAP push for all enabled accounts. Call on app startup.
 #[tauri::command]
-pub async fn start_idle(
-    app: AppHandle,
-    state: State<'_, AppState>,
-) -> Result<()> {
+pub async fn start_idle(app: AppHandle, state: State<'_, AppState>) -> Result<()> {
     let accounts = {
         let conn = state.db.reader();
         db::accounts::list_accounts(&conn)?
     };
 
     for account in &accounts {
-        if !account.enabled { continue; }
+        if !account.enabled {
+            continue;
+        }
 
         if account.mail_protocol == "imap" {
             start_imap_idle(&app, &state, account).await?;
@@ -1024,18 +1126,23 @@ async fn start_imap_idle(
     let (password, use_xoauth2) = if full_account.provider == "o365" {
         let tokens = crate::oauth::load_tokens(&account.id)?
             .ok_or_else(|| crate::error::Error::Other("No O365 tokens for IDLE".into()))?;
-        let refresh_token = tokens.refresh_token
+        let refresh_token = tokens
+            .refresh_token
             .ok_or_else(|| crate::error::Error::Other("No O365 refresh token for IDLE".into()))?;
         let imap_tokens = crate::oauth::refresh_with_scopes(
             &crate::oauth::MICROSOFT,
             &refresh_token,
             crate::oauth::MICROSOFT_IMAP_SCOPES,
-        ).await?;
-        crate::oauth::store_tokens(&account.id, &crate::oauth::OAuthTokens {
-            access_token: imap_tokens.access_token.clone(),
-            refresh_token: imap_tokens.refresh_token,
-            expires_at: imap_tokens.expires_at,
-        })?;
+        )
+        .await?;
+        crate::oauth::store_tokens(
+            &account.id,
+            &crate::oauth::OAuthTokens {
+                access_token: imap_tokens.access_token.clone(),
+                refresh_token: imap_tokens.refresh_token,
+                expires_at: imap_tokens.expires_at,
+            },
+        )?;
         (imap_tokens.access_token, true)
     } else {
         (full_account.password.clone(), false)
@@ -1060,17 +1167,15 @@ async fn start_imap_idle(
             config,
             account_id.clone(),
             stop_clone,
-            Box::new(move |event| {
-                match event {
-                    crate::mail::idle::IdleEvent::NewMail(aid) => {
-                        app_clone.emit("idle-new-mail", aid).ok();
-                    }
-                    crate::mail::idle::IdleEvent::Disconnected(aid) => {
-                        app_clone.emit("idle-disconnected", aid).ok();
-                    }
-                    crate::mail::idle::IdleEvent::Reconnected(aid) => {
-                        app_clone.emit("idle-reconnected", aid).ok();
-                    }
+            Box::new(move |event| match event {
+                crate::mail::idle::IdleEvent::NewMail(aid) => {
+                    app_clone.emit("idle-new-mail", aid).ok();
+                }
+                crate::mail::idle::IdleEvent::Disconnected(aid) => {
+                    app_clone.emit("idle-disconnected", aid).ok();
+                }
+                crate::mail::idle::IdleEvent::Reconnected(aid) => {
+                    app_clone.emit("idle-reconnected", aid).ok();
                 }
             }),
         );
@@ -1081,7 +1186,11 @@ async fn start_imap_idle(
         thread: Some(thread),
     };
 
-    state.idle_handles.lock().unwrap().insert(account.id.clone(), handle);
+    state
+        .idle_handles
+        .lock()
+        .unwrap()
+        .insert(account.id.clone(), handle);
     log::info!("Started IDLE loop for account {}", account.id);
     Ok(())
 }
@@ -1117,43 +1226,42 @@ async fn start_jmap_push(
             jmap_config,
             account_id.clone(),
             stop_clone,
-            std::sync::Arc::new(move |event| {
-                match event {
-                    crate::mail::jmap_push::PushEvent::StateChange(aid) => {
-                        app_clone.emit("idle-new-mail", &aid).ok();
-                    }
-                    crate::mail::jmap_push::PushEvent::Disconnected(aid) => {
-                        app_clone.emit("idle-disconnected", &aid).ok();
-                    }
-                    crate::mail::jmap_push::PushEvent::Reconnected(aid) => {
-                        app_clone.emit("idle-reconnected", &aid).ok();
-                    }
+            std::sync::Arc::new(move |event| match event {
+                crate::mail::jmap_push::PushEvent::StateChange(aid) => {
+                    app_clone.emit("idle-new-mail", &aid).ok();
+                }
+                crate::mail::jmap_push::PushEvent::Disconnected(aid) => {
+                    app_clone.emit("idle-disconnected", &aid).ok();
+                }
+                crate::mail::jmap_push::PushEvent::Reconnected(aid) => {
+                    app_clone.emit("idle-reconnected", &aid).ok();
                 }
             }),
         )
         .await;
     });
 
-    let handle = crate::state::JmapPushHandle {
-        stop_flag,
-        task,
-    };
+    let handle = crate::state::JmapPushHandle { stop_flag, task };
 
-    state.jmap_push_handles.lock().unwrap().insert(account.id.clone(), handle);
+    state
+        .jmap_push_handles
+        .lock()
+        .unwrap()
+        .insert(account.id.clone(), handle);
     log::info!("Started JMAP push for account {}", account.id);
     Ok(())
 }
 
 /// Stop all IMAP IDLE loops and JMAP push tasks.
 #[tauri::command]
-pub async fn stop_idle(
-    state: State<'_, AppState>,
-) -> Result<()> {
+pub async fn stop_idle(state: State<'_, AppState>) -> Result<()> {
     // Stop IMAP IDLE threads
     let mut handles = state.idle_handles.lock().unwrap();
     for (account_id, handle) in handles.drain() {
         log::info!("Stopping IDLE loop for account {}", account_id);
-        handle.stop_flag.store(true, std::sync::atomic::Ordering::Relaxed);
+        handle
+            .stop_flag
+            .store(true, std::sync::atomic::Ordering::Relaxed);
         if let Some(thread) = handle.thread {
             drop(thread);
         }
@@ -1164,7 +1272,9 @@ pub async fn stop_idle(
     let mut jmap_handles = state.jmap_push_handles.lock().unwrap();
     for (account_id, handle) in jmap_handles.drain() {
         log::info!("Stopping JMAP push for account {}", account_id);
-        handle.stop_flag.store(true, std::sync::atomic::Ordering::Relaxed);
+        handle
+            .stop_flag
+            .store(true, std::sync::atomic::Ordering::Relaxed);
         handle.task.abort();
     }
 

--- a/src-tauri/src/db/accounts.rs
+++ b/src-tauri/src/db/accounts.rs
@@ -120,7 +120,11 @@ pub fn get_account_full(conn: &Connection, id: &str) -> Result<AccountFull> {
     match crate::keyring::get_password(&account.id) {
         Ok(pw) => account.password = pw,
         Err(e) => {
-            log::warn!("Could not read password from keyring for account {}: {}", account.id, e);
+            log::warn!(
+                "Could not read password from keyring for account {}: {}",
+                account.id,
+                e
+            );
         }
     }
 

--- a/src-tauri/src/db/calendar.rs
+++ b/src-tauri/src/db/calendar.rs
@@ -116,7 +116,8 @@ pub fn set_calendar_subscribed(conn: &Connection, id: &str, subscribed: bool) ->
     )?;
     if rows == 0 {
         return Err(crate::error::Error::Other(format!(
-            "Calendar not found: {}", id
+            "Calendar not found: {}",
+            id
         )));
     }
     Ok(())
@@ -402,10 +403,7 @@ pub fn update_event(conn: &Connection, event: &CalendarEvent) -> Result<()> {
 }
 
 pub fn delete_event(conn: &Connection, id: &str) -> Result<()> {
-    conn.execute(
-        "DELETE FROM calendar_events WHERE id = ?1",
-        params![id],
-    )?;
+    conn.execute("DELETE FROM calendar_events WHERE id = ?1", params![id])?;
     Ok(())
 }
 
@@ -748,10 +746,9 @@ mod tests {
         let conn = setup_db();
 
         // First upsert creates a new calendar
-        let id1 = upsert_calendar_by_remote_id(
-            &conn, "acc1", "remote-cal", "Work", "#4285f4", true,
-        )
-        .unwrap();
+        let id1 =
+            upsert_calendar_by_remote_id(&conn, "acc1", "remote-cal", "Work", "#4285f4", true)
+                .unwrap();
 
         let cal = get_calendar(&conn, &id1).unwrap();
         assert_eq!(cal.name, "Work");
@@ -759,7 +756,12 @@ mod tests {
 
         // Second upsert with same remote_id updates
         let id2 = upsert_calendar_by_remote_id(
-            &conn, "acc1", "remote-cal", "Work Updated", "#ff0000", false,
+            &conn,
+            "acc1",
+            "remote-cal",
+            "Work Updated",
+            "#ff0000",
+            false,
         )
         .unwrap();
 
@@ -785,7 +787,10 @@ mod tests {
 
         delete_calendar(&conn, "cal1").unwrap();
 
-        assert!(get_event(&conn, "e1").is_err(), "Events should be deleted with calendar");
+        assert!(
+            get_event(&conn, "e1").is_err(),
+            "Events should be deleted with calendar"
+        );
     }
 
     #[test]
@@ -798,8 +803,10 @@ mod tests {
         insert_event(&conn, &make_event("e3", "C", Some("remote-c"))).unwrap();
 
         // Server only has A and B
-        let server_ids: std::collections::HashSet<String> =
-            ["remote-a", "remote-b"].iter().map(|s| s.to_string()).collect();
+        let server_ids: std::collections::HashSet<String> = ["remote-a", "remote-b"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
 
         // Find local events with remote_id
         let local_synced: Vec<(String, String)> = conn

--- a/src-tauri/src/db/contacts.rs
+++ b/src-tauri/src/db/contacts.rs
@@ -70,7 +70,13 @@ pub fn insert_contact_book(conn: &Connection, book: &ContactBook) -> Result<()> 
     conn.execute(
         "INSERT INTO contact_books (id, account_id, name, remote_id, sync_type)
          VALUES (?1, ?2, ?3, ?4, ?5)",
-        params![book.id, book.account_id, book.name, book.remote_id, book.sync_type],
+        params![
+            book.id,
+            book.account_id,
+            book.name,
+            book.remote_id,
+            book.sync_type
+        ],
     )?;
     Ok(())
 }
@@ -232,7 +238,12 @@ pub fn search_all_contacts(conn: &Connection, query: &str) -> Result<Vec<Contact
 // ---------------------------------------------------------------------------
 
 /// Upsert a collected contact — increment use_count if exists, insert if not.
-pub fn collect_contact(conn: &Connection, account_id: &str, email: &str, name: Option<&str>) -> Result<()> {
+pub fn collect_contact(
+    conn: &Connection,
+    account_id: &str,
+    email: &str,
+    name: Option<&str>,
+) -> Result<()> {
     let existing: Option<i64> = conn
         .query_row(
             "SELECT id FROM collected_contacts WHERE account_id = ?1 AND email = ?2",
@@ -333,7 +344,10 @@ mod tests {
             book_id: book_id.to_string(),
             uid: None,
             display_name: name.to_string(),
-            emails_json: format!("[{{\"email\":\"{}@example.com\",\"label\":\"work\"}}]", name.to_lowercase().replace(' ', ".")),
+            emails_json: format!(
+                "[{{\"email\":\"{}@example.com\",\"label\":\"work\"}}]",
+                name.to_lowercase().replace(' ', ".")
+            ),
             phones_json: "[]".to_string(),
             addresses_json: "[]".to_string(),
             organization: None,
@@ -459,7 +473,10 @@ mod tests {
 
         let results = search_collected_contacts(&conn, "example").unwrap();
         assert_eq!(results.len(), 2);
-        assert_eq!(results[0].email, "frequent@example.com", "Most used should be first");
+        assert_eq!(
+            results[0].email, "frequent@example.com",
+            "Most used should be first"
+        );
         assert_eq!(results[0].use_count, 6);
     }
 

--- a/src-tauri/src/db/filters.rs
+++ b/src-tauri/src/db/filters.rs
@@ -1,7 +1,7 @@
 use rusqlite::{params, Connection};
 
 use crate::error::{Error, Result};
-use crate::filters::rules::{FilterAction, FilterRule, MatchType, Condition};
+use crate::filters::rules::{Condition, FilterAction, FilterRule, MatchType};
 
 /// List all filter rules, optionally filtered by account_id.
 /// If account_id is None, returns all rules (including global ones).
@@ -65,10 +65,8 @@ pub fn list_filters(conn: &Connection, account_id: Option<&str>) -> Result<Vec<F
             "any" => MatchType::Any,
             _ => MatchType::All,
         };
-        let conditions: Vec<Condition> =
-            serde_json::from_str(&cond_json).unwrap_or_default();
-        let actions: Vec<FilterAction> =
-            serde_json::from_str(&act_json).unwrap_or_default();
+        let conditions: Vec<Condition> = serde_json::from_str(&cond_json).unwrap_or_default();
+        let actions: Vec<FilterAction> = serde_json::from_str(&act_json).unwrap_or_default();
 
         rules.push(FilterRule {
             id,
@@ -121,10 +119,8 @@ pub fn get_filter(conn: &Connection, id: &str) -> Result<FilterRule> {
         "any" => MatchType::Any,
         _ => MatchType::All,
     };
-    let conditions: Vec<Condition> =
-        serde_json::from_str(&cond_json).unwrap_or_default();
-    let actions: Vec<FilterAction> =
-        serde_json::from_str(&act_json).unwrap_or_default();
+    let conditions: Vec<Condition> = serde_json::from_str(&cond_json).unwrap_or_default();
+    let actions: Vec<FilterAction> = serde_json::from_str(&act_json).unwrap_or_default();
 
     Ok(FilterRule {
         id,

--- a/src-tauri/src/db/folders.rs
+++ b/src-tauri/src/db/folders.rs
@@ -128,16 +128,15 @@ pub fn build_folder_tree(mut folders: Vec<Folder>) -> Vec<Folder> {
 
     for parent_path in parent_paths {
         if let Some(child_indices) = children_map.remove(&parent_path) {
-            let children: Vec<Folder> = child_indices.iter()
-                .map(|&i| folders[i].clone())
-                .collect();
+            let children: Vec<Folder> = child_indices.iter().map(|&i| folders[i].clone()).collect();
             if let Some(&parent_idx) = by_path.get(&parent_path) {
                 folders[parent_idx].children = children;
             }
         }
     }
 
-    folders.into_iter()
+    folders
+        .into_iter()
         .enumerate()
         .filter(|(i, _)| !is_child[*i])
         .map(|(_, f)| f)
@@ -203,7 +202,11 @@ pub fn delete_folder(conn: &Connection, account_id: &str, path: &str) -> Result<
         }
     }
 
-    log::info!("Deleted folder '{}' from local DB for account {}", path, account_id);
+    log::info!(
+        "Deleted folder '{}' from local DB for account {}",
+        path,
+        account_id
+    );
     Ok(())
 }
 
@@ -244,7 +247,12 @@ pub fn get_folder_sync_state(
     let result = conn.query_row(
         "SELECT uid_next, total_count FROM folders WHERE account_id = ?1 AND path = ?2",
         params![account_id, path],
-        |row| Ok((row.get::<_, u32>(0).unwrap_or(0), row.get::<_, i64>(1).unwrap_or(0))),
+        |row| {
+            Ok((
+                row.get::<_, u32>(0).unwrap_or(0),
+                row.get::<_, i64>(1).unwrap_or(0),
+            ))
+        },
     );
     Ok(result.unwrap_or((0, 0)))
 }
@@ -467,10 +475,18 @@ mod tests {
         let inbox = tree.iter().find(|f| f.path == "INBOX").unwrap();
         assert_eq!(inbox.children.len(), 2);
 
-        let ietf = inbox.children.iter().find(|f| f.path == "INBOX/IETF").unwrap();
+        let ietf = inbox
+            .children
+            .iter()
+            .find(|f| f.path == "INBOX/IETF")
+            .unwrap();
         assert_eq!(ietf.children.len(), 1);
 
-        let infra = inbox.children.iter().find(|f| f.path == "INBOX/Infra").unwrap();
+        let infra = inbox
+            .children
+            .iter()
+            .find(|f| f.path == "INBOX/Infra")
+            .unwrap();
         assert_eq!(infra.children.len(), 1);
     }
 

--- a/src-tauri/src/db/messages.rs
+++ b/src-tauri/src/db/messages.rs
@@ -172,15 +172,23 @@ fn build_filter_clauses(filter: &QuickFilter, account_id: &str, use_fts: bool) -
 
         if use_fts {
             // FTS5 for fast full-text matching
-            let escaped = text
-                .replace('"', "\"\"")
-                .replace('\'', "''");
+            let escaped = text.replace('"', "\"\"").replace('\'', "''");
 
             let mut fts_columns = Vec::new();
-            if search_sender { fts_columns.push("from_name"); fts_columns.push("from_email"); }
-            if search_recipients { fts_columns.push("to_addresses"); fts_columns.push("cc_addresses"); }
-            if search_subject { fts_columns.push("subject"); }
-            if search_body { fts_columns.push("snippet"); }
+            if search_sender {
+                fts_columns.push("from_name");
+                fts_columns.push("from_email");
+            }
+            if search_recipients {
+                fts_columns.push("to_addresses");
+                fts_columns.push("cc_addresses");
+            }
+            if search_subject {
+                fts_columns.push("subject");
+            }
+            if search_body {
+                fts_columns.push("snippet");
+            }
 
             if !fts_columns.is_empty() {
                 let col_filter = format!("{{{}}}", fts_columns.join(" "));
@@ -203,8 +211,14 @@ fn build_filter_clauses(filter: &QuickFilter, account_id: &str, use_fts: bool) -
                 like_clauses.push(format!("from_email LIKE '%{}%' ESCAPE '\\'", like_escaped));
             }
             if search_recipients {
-                like_clauses.push(format!("to_addresses LIKE '%{}%' ESCAPE '\\'", like_escaped));
-                like_clauses.push(format!("cc_addresses LIKE '%{}%' ESCAPE '\\'", like_escaped));
+                like_clauses.push(format!(
+                    "to_addresses LIKE '%{}%' ESCAPE '\\'",
+                    like_escaped
+                ));
+                like_clauses.push(format!(
+                    "cc_addresses LIKE '%{}%' ESCAPE '\\'",
+                    like_escaped
+                ));
             }
             if search_subject {
                 like_clauses.push(format!("subject LIKE '%{}%' ESCAPE '\\'", like_escaped));
@@ -236,11 +250,31 @@ pub fn get_messages(
 ) -> Result<MessagePage> {
     // Try FTS5 first; on failure (bad query syntax), fall back to LIKE
     let has_text = !filter.text.trim().is_empty();
-    match get_messages_inner(conn, account_id, folder_path, page, per_page, sort_column, sort_asc, filter, true) {
+    match get_messages_inner(
+        conn,
+        account_id,
+        folder_path,
+        page,
+        per_page,
+        sort_column,
+        sort_asc,
+        filter,
+        true,
+    ) {
         Ok(page) => Ok(page),
         Err(e) if has_text => {
             log::warn!("FTS5 query failed, retrying with LIKE fallback: {}", e);
-            get_messages_inner(conn, account_id, folder_path, page, per_page, sort_column, sort_asc, filter, false)
+            get_messages_inner(
+                conn,
+                account_id,
+                folder_path,
+                page,
+                per_page,
+                sort_column,
+                sort_asc,
+                filter,
+                false,
+            )
         }
         Err(e) => Err(e),
     }
@@ -292,8 +326,7 @@ fn get_messages_inner(
     let messages = stmt
         .query_map(params![account_id, folder_path, per_page, offset], |row| {
             let flags_json: String = row.get(5)?;
-            let flags: Vec<String> =
-                serde_json::from_str(&flags_json).unwrap_or_default();
+            let flags: Vec<String> = serde_json::from_str(&flags_json).unwrap_or_default();
             Ok(MessageSummary {
                 id: row.get(0)?,
                 subject: row.get(1)?,
@@ -347,7 +380,12 @@ pub fn get_message_metadata(
     })
 }
 
-pub fn message_exists(conn: &Connection, account_id: &str, folder_path: &str, uid: u32) -> Result<bool> {
+pub fn message_exists(
+    conn: &Connection,
+    account_id: &str,
+    folder_path: &str,
+    uid: u32,
+) -> Result<bool> {
     let count: i64 = conn.query_row(
         "SELECT COUNT(*) FROM messages WHERE account_id = ?1 AND folder_path = ?2 AND uid = ?3",
         params![account_id, folder_path, uid],
@@ -533,7 +571,10 @@ pub fn sync_flags_by_uid(
     )?;
     let local: std::collections::HashMap<u32, (String, String)> = stmt
         .query_map(params![account_id, folder_path], |row| {
-            Ok((row.get::<_, u32>(0)?, (row.get::<_, String>(1)?, row.get::<_, String>(2)?)))
+            Ok((
+                row.get::<_, u32>(0)?,
+                (row.get::<_, String>(1)?, row.get::<_, String>(2)?),
+            ))
         })?
         .filter_map(|r| r.ok())
         .collect();
@@ -640,7 +681,8 @@ pub fn compute_thread_id(
     if let Some(subj) = subject {
         let trimmed = subj.trim();
         let lower = trimmed.to_lowercase();
-        let is_reply = lower.starts_with("re:") || lower.starts_with("fwd:") || lower.starts_with("fw:");
+        let is_reply =
+            lower.starts_with("re:") || lower.starts_with("fwd:") || lower.starts_with("fw:");
         if is_reply {
             let normalized = normalize_subject(trimmed);
             if !normalized.is_empty() {
@@ -736,11 +778,31 @@ pub fn get_threaded_messages(
     filter: &QuickFilter,
 ) -> Result<ThreadedPage> {
     let has_text = !filter.text.trim().is_empty();
-    match get_threaded_messages_inner(conn, account_id, folder_path, page, per_page, sort_column, sort_asc, filter, true) {
+    match get_threaded_messages_inner(
+        conn,
+        account_id,
+        folder_path,
+        page,
+        per_page,
+        sort_column,
+        sort_asc,
+        filter,
+        true,
+    ) {
         Ok(page) => Ok(page),
         Err(e) if has_text => {
             log::warn!("FTS5 threaded query failed, retrying with LIKE: {}", e);
-            get_threaded_messages_inner(conn, account_id, folder_path, page, per_page, sort_column, sort_asc, filter, false)
+            get_threaded_messages_inner(
+                conn,
+                account_id,
+                folder_path,
+                page,
+                per_page,
+                sort_column,
+                sort_asc,
+                filter,
+                false,
+            )
         }
         Err(e) => Err(e),
     }
@@ -835,10 +897,7 @@ fn get_threaded_messages_inner(
                 .and_then(|f| serde_json::from_str(f).ok())
                 .unwrap_or_default();
 
-            let message_ids: Vec<String> = all_ids_str
-                .split("||")
-                .map(|s| s.to_string())
-                .collect();
+            let message_ids: Vec<String> = all_ids_str.split("||").map(|s| s.to_string()).collect();
 
             Ok(ThreadSummary {
                 thread_id: tid,
@@ -897,8 +956,7 @@ pub fn get_thread_messages(
     let messages = stmt
         .query_map(params![account_id, folder_path, thread_id], |row| {
             let flags_json: String = row.get(5)?;
-            let flags: Vec<String> =
-                serde_json::from_str(&flags_json).unwrap_or_default();
+            let flags: Vec<String> = serde_json::from_str(&flags_json).unwrap_or_default();
             Ok(MessageSummary {
                 id: row.get(0)?,
                 subject: row.get(1)?,
@@ -925,7 +983,10 @@ pub fn get_thread_messages(
 /// Remove a message from its thread by setting its thread_id to its own message_id,
 /// effectively making it a standalone thread.
 pub fn unthread_message(conn: &Connection, message_id: &str) -> Result<()> {
-    log::info!("unthread_message: removing message '{}' from its thread", message_id);
+    log::info!(
+        "unthread_message: removing message '{}' from its thread",
+        message_id
+    );
 
     // Get the message's own message_id (the RFC 822 Message-ID header, stored in message_id column)
     let own_message_id: Option<String> = conn
@@ -1013,8 +1074,14 @@ mod tests {
 
         assert_eq!(paths.len(), 2);
         let map: std::collections::HashMap<_, _> = paths.into_iter().collect();
-        assert_eq!(map.get("msg1").map(String::as_str), Some("acc1/INBOX/cur/1:2,S"));
-        assert_eq!(map.get("msg3").map(String::as_str), Some("acc1/INBOX/cur/3:2,S"));
+        assert_eq!(
+            map.get("msg1").map(String::as_str),
+            Some("acc1/INBOX/cur/1:2,S")
+        );
+        assert_eq!(
+            map.get("msg3").map(String::as_str),
+            Some("acc1/INBOX/cur/3:2,S")
+        );
     }
 
     #[test]

--- a/src-tauri/src/db/pool.rs
+++ b/src-tauri/src/db/pool.rs
@@ -62,9 +62,7 @@ impl DbPool {
     /// `std::sync::Mutex` never yields to the async executor.
     pub fn reader(&self) -> PooledReader<'_> {
         let idx = self.next_reader.fetch_add(1, Ordering::Relaxed) % self.readers.len();
-        let guard = self.readers[idx]
-            .lock()
-            .unwrap_or_else(|e| e.into_inner());
+        let guard = self.readers[idx].lock().unwrap_or_else(|e| e.into_inner());
         PooledReader { guard }
     }
 }

--- a/src-tauri/src/db/schema.rs
+++ b/src-tauri/src/db/schema.rs
@@ -229,9 +229,7 @@ fn run_migrations(conn: &Connection) -> Result<()> {
         .is_ok();
     if !has_caldav_url {
         log::info!("Migration: adding caldav_url column to accounts table");
-        conn.execute_batch(
-            "ALTER TABLE accounts ADD COLUMN caldav_url TEXT NOT NULL DEFAULT '';",
-        )?;
+        conn.execute_batch("ALTER TABLE accounts ADD COLUMN caldav_url TEXT NOT NULL DEFAULT '';")?;
     }
 
     // Add signature column if it doesn't exist
@@ -240,9 +238,7 @@ fn run_migrations(conn: &Connection) -> Result<()> {
         .is_ok();
     if !has_signature {
         log::info!("Migration: adding signature column to accounts table");
-        conn.execute_batch(
-            "ALTER TABLE accounts ADD COLUMN signature TEXT NOT NULL DEFAULT '';",
-        )?;
+        conn.execute_batch("ALTER TABLE accounts ADD COLUMN signature TEXT NOT NULL DEFAULT '';")?;
     }
 
     // Add jmap_auth_method column if it doesn't exist
@@ -290,9 +286,7 @@ fn run_migrations(conn: &Connection) -> Result<()> {
     }
 
     // Add uid_next column to folders for IMAP preflight sync optimization
-    let has_uid_next: bool = conn
-        .prepare("SELECT uid_next FROM folders LIMIT 0")
-        .is_ok();
+    let has_uid_next: bool = conn.prepare("SELECT uid_next FROM folders LIMIT 0").is_ok();
     if !has_uid_next {
         log::info!("Migration: adding uid_next column to folders table");
         conn.execute_batch("ALTER TABLE folders ADD COLUMN uid_next INTEGER DEFAULT 0;")?;

--- a/src-tauri/src/filters/engine.rs
+++ b/src-tauri/src/filters/engine.rs
@@ -1,9 +1,7 @@
 use regex::RegexBuilder;
 use serde::{Deserialize, Serialize};
 
-use super::rules::{
-    Condition, ConditionField, ConditionOp, FilterAction, FilterRule, MatchType,
-};
+use super::rules::{Condition, ConditionField, ConditionOp, FilterAction, FilterRule, MatchType};
 
 /// Lightweight struct holding the message fields needed for filter matching.
 /// Constructed from DB row data before running the filter engine.
@@ -115,16 +113,15 @@ fn eval_string_op(op: &ConditionOp, haystack: &str, needle: &str) -> bool {
         ConditionOp::NotContains => !h.contains(&n),
         ConditionOp::Equals => h == n,
         ConditionOp::NotEquals => h != n,
-        ConditionOp::MatchesRegex => match RegexBuilder::new(needle)
-            .size_limit(1_000_000)
-            .build()
-        {
-            Ok(re) => re.is_match(haystack),
-            Err(e) => {
-                log::warn!("Invalid or too complex regex '{}': {}", needle, e);
-                false
+        ConditionOp::MatchesRegex => {
+            match RegexBuilder::new(needle).size_limit(1_000_000).build() {
+                Ok(re) => re.is_match(haystack),
+                Err(e) => {
+                    log::warn!("Invalid or too complex regex '{}': {}", needle, e);
+                    false
+                }
             }
-        },
+        }
         ConditionOp::GreaterThan | ConditionOp::LessThan => {
             // Numeric ops don't apply to strings; always false
             false
@@ -167,33 +164,21 @@ fn eval_address_list_op(op: &ConditionOp, addrs: &[AddressEntry], value: &str) -
         ConditionOp::NotContains => {
             // True if no address contains the value
             !addrs.iter().any(|a| {
-                let combined = format!(
-                    "{} {}",
-                    a.name.as_deref().unwrap_or(""),
-                    a.email
-                );
+                let combined = format!("{} {}", a.name.as_deref().unwrap_or(""), a.email);
                 eval_string_op(&ConditionOp::Contains, &combined, value)
             })
         }
         ConditionOp::NotEquals => {
             // True if no address equals the value
             !addrs.iter().any(|a| {
-                let combined = format!(
-                    "{} {}",
-                    a.name.as_deref().unwrap_or(""),
-                    a.email
-                );
+                let combined = format!("{} {}", a.name.as_deref().unwrap_or(""), a.email);
                 eval_string_op(&ConditionOp::Equals, &combined, value)
             })
         }
         _ => {
             // For Contains, Equals, MatchesRegex: true if any address matches
             addrs.iter().any(|a| {
-                let combined = format!(
-                    "{} {}",
-                    a.name.as_deref().unwrap_or(""),
-                    a.email
-                );
+                let combined = format!("{} {}", a.name.as_deref().unwrap_or(""), a.email);
                 eval_string_op(op, &combined, value)
             })
         }

--- a/src-tauri/src/filters/engine.rs
+++ b/src-tauri/src/filters/engine.rs
@@ -43,7 +43,7 @@ pub fn matches_message(rule: &FilterRule, msg: &MessageData) -> bool {
 /// evaluating further rules.
 pub fn apply_filters(rules: &[FilterRule], msg: &MessageData) -> Vec<FilterAction> {
     let mut sorted: Vec<&FilterRule> = rules.iter().filter(|r| r.enabled).collect();
-    sorted.sort_by(|a, b| b.priority.cmp(&a.priority));
+    sorted.sort_by_key(|r| std::cmp::Reverse(r.priority));
 
     let mut collected_actions: Vec<FilterAction> = Vec::new();
 

--- a/src-tauri/src/mail/caldav.rs
+++ b/src-tauri/src/mail/caldav.rs
@@ -166,7 +166,11 @@ impl CalDavClient {
 
         log::info!("caldav: connected to {}", base_url);
 
-        Ok(Self { http, base_url, auth })
+        Ok(Self {
+            http,
+            base_url,
+            auth,
+        })
     }
 
     /// Create a CalDAV client with OAuth2 bearer token authentication.
@@ -175,7 +179,9 @@ impl CalDavClient {
 
         let http = crate::mail::dav_http::build_client()?;
 
-        let auth = DavAuth::Bearer { token: token.to_string() };
+        let auth = DavAuth::Bearer {
+            token: token.to_string(),
+        };
 
         log::info!("caldav: connected with OAuth to {}", caldav_url);
 
@@ -202,11 +208,7 @@ impl CalDavClient {
     }
 
     /// Auto-discover CalDAV URL by trying `.well-known/caldav` on the email domain.
-    async fn auto_discover(
-        http: &reqwest::Client,
-        auth: &DavAuth,
-        email: &str,
-    ) -> Result<String> {
+    async fn auto_discover(http: &reqwest::Client, auth: &DavAuth, email: &str) -> Result<String> {
         let domain = email
             .rsplit('@')
             .next()
@@ -224,11 +226,11 @@ impl CalDavClient {
                 http.request(reqwest::Method::from_bytes(b"PROPFIND").unwrap(), url),
                 auth,
             )
-                .header("Depth", "0")
-                .header("Content-Type", "application/xml; charset=utf-8")
-                .body(PROPFIND_CURRENT_USER_PRINCIPAL)
-                .send()
-                .await
+            .header("Depth", "0")
+            .header("Content-Type", "application/xml; charset=utf-8")
+            .body(PROPFIND_CURRENT_USER_PRINCIPAL)
+            .send()
+            .await
             {
                 Ok(resp) => {
                     let status = resp.status();
@@ -275,10 +277,9 @@ impl CalDavClient {
             .propfind(&self.base_url, "0", PROPFIND_CURRENT_USER_PRINCIPAL)
             .await?;
 
-        let principal = parse_href_from_xml(&resp, "current-user-principal")
-            .ok_or_else(|| {
-                Error::Other("CalDAV: could not find current-user-principal in response".to_string())
-            })?;
+        let principal = parse_href_from_xml(&resp, "current-user-principal").ok_or_else(|| {
+            Error::Other("CalDAV: could not find current-user-principal in response".to_string())
+        })?;
 
         let principal_url = self.resolve_url(&principal)?;
         log::info!("caldav: principal URL: {}", principal_url);
@@ -292,12 +293,9 @@ impl CalDavClient {
             .propfind(principal_url, "0", PROPFIND_CALENDAR_HOME_SET)
             .await?;
 
-        let home = parse_href_from_xml(&resp, "calendar-home-set")
-            .ok_or_else(|| {
-                Error::Other(
-                    "CalDAV: could not find calendar-home-set in response".to_string(),
-                )
-            })?;
+        let home = parse_href_from_xml(&resp, "calendar-home-set").ok_or_else(|| {
+            Error::Other("CalDAV: could not find calendar-home-set in response".to_string())
+        })?;
 
         let home_url = self.resolve_url(&home)?;
         log::info!("caldav: calendar home URL: {}", home_url);
@@ -339,9 +337,11 @@ impl CalDavClient {
         let url = self.resolve_url(calendar_href)?;
         log::debug!("caldav: fetching events from {}", url);
 
-        let resp = self.apply_auth(
-            self.http
-                .request(reqwest::Method::from_bytes(b"REPORT").unwrap(), &url))
+        let resp = self
+            .apply_auth(
+                self.http
+                    .request(reqwest::Method::from_bytes(b"REPORT").unwrap(), &url),
+            )
             .header("Depth", "1")
             .header("Content-Type", "application/xml; charset=utf-8")
             .body(REPORT_CALENDAR_QUERY)
@@ -380,14 +380,11 @@ impl CalDavClient {
         ical_data: &str,
     ) -> Result<String> {
         let calendar_url = self.resolve_url(calendar_href)?;
-        let event_url = format!(
-            "{}/{}.ics",
-            calendar_url.trim_end_matches('/'),
-            uid
-        );
+        let event_url = format!("{}/{}.ics", calendar_url.trim_end_matches('/'), uid);
         log::info!("caldav: PUT event to {}", event_url);
 
-        let resp = self.apply_auth(self.http.put(&event_url))
+        let resp = self
+            .apply_auth(self.http.put(&event_url))
             .header("Content-Type", "text/calendar; charset=utf-8")
             .body(ical_data.to_string())
             .send()
@@ -424,7 +421,8 @@ impl CalDavClient {
         let url = self.resolve_url(event_href)?;
         log::info!("caldav: DELETE event at {}", url);
 
-        let resp = self.apply_auth(self.http.delete(&url))
+        let resp = self
+            .apply_auth(self.http.delete(&url))
             .send()
             .await
             .map_err(|e| Error::Other(format!("CalDAV DELETE failed: {}", e)))?;
@@ -452,8 +450,11 @@ impl CalDavClient {
 
     /// Send a PROPFIND request and return the response body.
     async fn propfind(&self, url: &str, depth: &str, body: &str) -> Result<String> {
-        let resp = self.apply_auth(
-            self.http.request(reqwest::Method::from_bytes(b"PROPFIND").unwrap(), url))
+        let resp = self
+            .apply_auth(
+                self.http
+                    .request(reqwest::Method::from_bytes(b"PROPFIND").unwrap(), url),
+            )
             .header("Depth", depth)
             .header("Content-Type", "application/xml; charset=utf-8")
             .body(body.to_string())
@@ -497,10 +498,7 @@ impl CalDavClient {
         } else if let Ok(base) = url::Url::parse(&self.base_url) {
             let scheme = base.scheme();
             let host = base.host_str().unwrap_or("");
-            let port_str = base
-                .port()
-                .map(|p| format!(":{}", p))
-                .unwrap_or_default();
+            let port_str = base.port().map(|p| format!(":{}", p)).unwrap_or_default();
             format!("{}://{}{}{}", scheme, host, port_str, href)
         } else {
             // Fallback: just concatenate
@@ -639,13 +637,15 @@ fn parse_calendars_from_xml(xml: &str) -> Vec<CalDavCalendar> {
         }
 
         let resourcetypes = find_elements(&doc, *response, "resourcetype");
-        let is_calendar = resourcetypes.iter().any(|rt| has_descendant(&doc, *rt, "calendar"));
+        let is_calendar = resourcetypes
+            .iter()
+            .any(|rt| has_descendant(&doc, *rt, "calendar"));
         if !is_calendar {
             continue;
         }
 
-        let name = find_text_in(&doc, *response, "displayname")
-            .unwrap_or_else(|| "Calendar".to_string());
+        let name =
+            find_text_in(&doc, *response, "displayname").unwrap_or_else(|| "Calendar".to_string());
 
         let color = find_text_in(&doc, *response, "calendar-color").map(|c| {
             let c = c.trim().to_string();
@@ -687,7 +687,12 @@ fn parse_events_from_xml(xml: &str) -> Vec<CalDavEvent> {
         }
 
         let uid = extract_uid_from_ical(&ical_data).unwrap_or_else(|| href.clone());
-        events.push(CalDavEvent { href, etag, uid, ical_data });
+        events.push(CalDavEvent {
+            href,
+            etag,
+            uid,
+            ical_data,
+        });
     }
 
     events
@@ -786,13 +791,19 @@ pub fn utc_to_local(utc_datetime: &str, tzid: &str) -> String {
     let dt = utc_datetime.trim();
     if let Ok(tz) = tzid.parse::<chrono_tz::Tz>() {
         if let Ok(utc) = chrono::DateTime::parse_from_rfc3339(dt) {
-            return utc.with_timezone(&tz).format("%Y-%m-%dT%H:%M:%S").to_string();
+            return utc
+                .with_timezone(&tz)
+                .format("%Y-%m-%dT%H:%M:%S")
+                .to_string();
         }
         let bare = dt.trim_end_matches('Z');
         if let Ok(naive) = chrono::NaiveDateTime::parse_from_str(bare, "%Y-%m-%dT%H:%M:%S") {
             use chrono::TimeZone;
             let utc = chrono::Utc.from_utc_datetime(&naive);
-            return utc.with_timezone(&tz).format("%Y-%m-%dT%H:%M:%S").to_string();
+            return utc
+                .with_timezone(&tz)
+                .format("%Y-%m-%dT%H:%M:%S")
+                .to_string();
         }
     }
     dt.trim_end_matches('Z').to_string()

--- a/src-tauri/src/mail/carddav.rs
+++ b/src-tauri/src/mail/carddav.rs
@@ -88,7 +88,11 @@ impl CardDavClient {
         };
 
         log::info!("carddav: connected to {}", base_url);
-        Ok(Self { http, base_url, auth })
+        Ok(Self {
+            http,
+            base_url,
+            auth,
+        })
     }
 
     fn apply_auth(&self, req: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
@@ -153,7 +157,9 @@ impl CardDavClient {
 
     /// Discover the current user's principal URL.
     pub async fn discover_principal(&self) -> Result<String> {
-        let resp = self.propfind(&self.base_url, "0", PROPFIND_PRINCIPAL).await?;
+        let resp = self
+            .propfind(&self.base_url, "0", PROPFIND_PRINCIPAL)
+            .await?;
         let principal = parse_href_from_xml(&resp, "current-user-principal")
             .ok_or_else(|| Error::Other("CardDAV: no current-user-principal".to_string()))?;
         self.resolve_url(&principal)
@@ -175,7 +181,9 @@ impl CardDavClient {
         let home = self.discover_addressbook_home(&principal).await?;
         log::debug!("carddav: listing address books at {}", home);
 
-        let resp = self.propfind(&home, "1", PROPFIND_LIST_ADDRESSBOOKS).await?;
+        let resp = self
+            .propfind(&home, "1", PROPFIND_LIST_ADDRESSBOOKS)
+            .await?;
         let books = parse_addressbooks_from_xml(&resp);
         log::info!("carddav: found {} address books", books.len());
         Ok(books)
@@ -213,12 +221,21 @@ impl CardDavClient {
         }
 
         let contacts = parse_contacts_from_xml(&body);
-        log::info!("carddav: fetched {} contacts from {}", contacts.len(), book_href);
+        log::info!(
+            "carddav: fetched {} contacts from {}",
+            contacts.len(),
+            book_href
+        );
         Ok(contacts)
     }
 
     /// PUT a vCard to the server. Returns the new etag.
-    pub async fn put_contact(&self, book_href: &str, uid: &str, vcard_data: &str) -> Result<String> {
+    pub async fn put_contact(
+        &self,
+        book_href: &str,
+        uid: &str,
+        vcard_data: &str,
+    ) -> Result<String> {
         let book_url = self.resolve_url(book_href)?;
         let url = format!("{}/{}.vcf", book_url.trim_end_matches('/'), uid);
         log::info!("carddav: PUT contact to {}", url);
@@ -234,21 +251,37 @@ impl CardDavClient {
         let status = resp.status();
         if !status.is_success() {
             let body = resp.text().await.unwrap_or_default();
-            return Err(Error::Other(format!("CardDAV PUT returned {}: {}", status, body.chars().take(500).collect::<String>())));
+            return Err(Error::Other(format!(
+                "CardDAV PUT returned {}: {}",
+                status,
+                body.chars().take(500).collect::<String>()
+            )));
         }
 
-        Ok(resp.headers().get("etag").and_then(|v| v.to_str().ok()).unwrap_or("").to_string())
+        Ok(resp
+            .headers()
+            .get("etag")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("")
+            .to_string())
     }
 
     /// DELETE a contact from the server.
     pub async fn delete_contact(&self, contact_href: &str) -> Result<()> {
         let url = self.resolve_url(contact_href)?;
-        let resp = self.apply_auth(self.http.delete(&url)).send().await
+        let resp = self
+            .apply_auth(self.http.delete(&url))
+            .send()
+            .await
             .map_err(|e| Error::Other(format!("CardDAV DELETE failed: {}", e)))?;
         let status = resp.status();
         if !status.is_success() && status.as_u16() != 204 {
             let body = resp.text().await.unwrap_or_default();
-            return Err(Error::Other(format!("CardDAV DELETE returned {}: {}", status, body.chars().take(500).collect::<String>())));
+            return Err(Error::Other(format!(
+                "CardDAV DELETE returned {}: {}",
+                status,
+                body.chars().take(500).collect::<String>()
+            )));
         }
         Ok(())
     }
@@ -360,11 +393,18 @@ fn parse_addressbooks_from_xml(xml: &str) -> Vec<CardDavAddressBook> {
     let root = doc.root();
     for response in &find_elements(&doc, root, "response") {
         let href = find_text_in(&doc, *response, "href").unwrap_or_default();
-        if href.is_empty() { continue; }
+        if href.is_empty() {
+            continue;
+        }
         let resourcetypes = find_elements(&doc, *response, "resourcetype");
-        let is_addressbook = resourcetypes.iter().any(|rt| has_descendant(&doc, *rt, "addressbook"));
-        if !is_addressbook { continue; }
-        let name = find_text_in(&doc, *response, "displayname").unwrap_or_else(|| "Address Book".to_string());
+        let is_addressbook = resourcetypes
+            .iter()
+            .any(|rt| has_descendant(&doc, *rt, "addressbook"));
+        if !is_addressbook {
+            continue;
+        }
+        let name = find_text_in(&doc, *response, "displayname")
+            .unwrap_or_else(|| "Address Book".to_string());
         books.push(CardDavAddressBook { href, name });
     }
     books
@@ -386,9 +426,16 @@ fn parse_contacts_from_xml(xml: &str) -> Vec<CardDavContact> {
             .map(|e| e.trim_matches('"').to_string())
             .unwrap_or_default();
         let vcard_data = find_text_in(&doc, *response, "address-data").unwrap_or_default();
-        if vcard_data.is_empty() { continue; }
+        if vcard_data.is_empty() {
+            continue;
+        }
         let uid = extract_uid_from_vcard(&vcard_data).unwrap_or_else(|| href.clone());
-        contacts.push(CardDavContact { href, etag, uid, vcard_data });
+        contacts.push(CardDavContact {
+            href,
+            etag,
+            uid,
+            vcard_data,
+        });
     }
     contacts
 }
@@ -435,19 +482,36 @@ pub fn parse_vcard(vcard: &str) -> ParsedVCard {
         } else if prop_upper == "UID" {
             result.uid = Some(value.to_string());
         } else if prop_upper.starts_with("EMAIL") {
-            let label = if params_lower.contains("work") { "work" }
-                else if params_lower.contains("home") { "home" }
-                else { "other" };
-            result.emails.push(VCardEmail { email: value.to_string(), label: label.to_string() });
+            let label = if params_lower.contains("work") {
+                "work"
+            } else if params_lower.contains("home") {
+                "home"
+            } else {
+                "other"
+            };
+            result.emails.push(VCardEmail {
+                email: value.to_string(),
+                label: label.to_string(),
+            });
         } else if prop_upper.starts_with("TEL") {
-            let label = if params_lower.contains("cell") || params_lower.contains("mobile") { "mobile" }
-                else if params_lower.contains("work") { "work" }
-                else if params_lower.contains("home") { "home" }
-                else { "other" };
-            result.phones.push(VCardPhone { number: value.to_string(), label: label.to_string() });
+            let label = if params_lower.contains("cell") || params_lower.contains("mobile") {
+                "mobile"
+            } else if params_lower.contains("work") {
+                "work"
+            } else if params_lower.contains("home") {
+                "home"
+            } else {
+                "other"
+            };
+            result.phones.push(VCardPhone {
+                number: value.to_string(),
+                label: label.to_string(),
+            });
         } else if prop_upper == "ORG" || prop_upper.starts_with("ORG;") {
             let org = value.split(';').next().unwrap_or(value).trim();
-            if !org.is_empty() { result.organization = Some(org.to_string()); }
+            if !org.is_empty() {
+                result.organization = Some(org.to_string());
+            }
         } else if (prop_upper == "TITLE" || prop_upper.starts_with("TITLE;")) && !value.is_empty() {
             result.title = Some(value.to_string());
         } else if (prop_upper == "NOTE" || prop_upper.starts_with("NOTE;")) && !value.is_empty() {
@@ -467,7 +531,12 @@ pub fn parse_vcard(vcard: &str) -> ParsedVCard {
                 let last = parts.first().unwrap_or(&"").trim();
                 let first = parts.get(1).unwrap_or(&"").trim();
                 let middle = parts.get(2).unwrap_or(&"").trim();
-                result.display_name = [first, middle, last].iter().filter(|s| !s.is_empty()).copied().collect::<Vec<_>>().join(" ");
+                result.display_name = [first, middle, last]
+                    .iter()
+                    .filter(|s| !s.is_empty())
+                    .copied()
+                    .collect::<Vec<_>>()
+                    .join(" ");
                 break;
             }
         }
@@ -494,20 +563,45 @@ pub fn generate_vcard(
     ];
 
     let parts: Vec<&str> = display_name.splitn(2, ' ').collect();
-    let (first, last) = if parts.len() == 2 { (parts[0], parts[1]) } else { (display_name, "") };
+    let (first, last) = if parts.len() == 2 {
+        (parts[0], parts[1])
+    } else {
+        (display_name, "")
+    };
     lines.push(format!("N:{};{};;;", last, first));
 
     for e in emails {
-        let t = match e.label.as_str() { "work" => "WORK", "home" => "HOME", _ => "OTHER" };
+        let t = match e.label.as_str() {
+            "work" => "WORK",
+            "home" => "HOME",
+            _ => "OTHER",
+        };
         lines.push(format!("EMAIL;TYPE={}:{}", t, e.email));
     }
     for p in phones {
-        let t = match p.label.as_str() { "mobile" => "CELL", "work" => "WORK", "home" => "HOME", _ => "OTHER" };
+        let t = match p.label.as_str() {
+            "mobile" => "CELL",
+            "work" => "WORK",
+            "home" => "HOME",
+            _ => "OTHER",
+        };
         lines.push(format!("TEL;TYPE={}:{}", t, p.number));
     }
-    if let Some(org) = organization { if !org.is_empty() { lines.push(format!("ORG:{}", org)); } }
-    if let Some(t) = title { if !t.is_empty() { lines.push(format!("TITLE:{}", t)); } }
-    if let Some(n) = note { if !n.is_empty() { lines.push(format!("NOTE:{}", n)); } }
+    if let Some(org) = organization {
+        if !org.is_empty() {
+            lines.push(format!("ORG:{}", org));
+        }
+    }
+    if let Some(t) = title {
+        if !t.is_empty() {
+            lines.push(format!("TITLE:{}", t));
+        }
+    }
+    if let Some(n) = note {
+        if !n.is_empty() {
+            lines.push(format!("NOTE:{}", n));
+        }
+    }
 
     lines.push("END:VCARD".to_string());
     lines.join("\r\n")
@@ -523,13 +617,8 @@ mod connect_tests {
 
     #[tokio::test]
     async fn connect_rejects_http_url() {
-        let msg = match CardDavClient::connect(
-            "http://example.com/dav/",
-            "u",
-            "p",
-            "u@example.com",
-        )
-        .await
+        let msg = match CardDavClient::connect("http://example.com/dav/", "u", "p", "u@example.com")
+            .await
         {
             Ok(_) => String::new(),
             Err(e) => e.to_string(),
@@ -591,7 +680,8 @@ mod tests {
 
     #[test]
     fn test_parse_vcard_fallback_to_n() {
-        let vcard = "BEGIN:VCARD\r\nVERSION:3.0\r\nN:Doe;John;M;;\r\nEMAIL:john@example.com\r\nEND:VCARD";
+        let vcard =
+            "BEGIN:VCARD\r\nVERSION:3.0\r\nN:Doe;John;M;;\r\nEMAIL:john@example.com\r\nEND:VCARD";
         let parsed = parse_vcard(vcard);
         assert_eq!(parsed.display_name, "John M Doe");
         assert_eq!(parsed.emails[0].label, "other");
@@ -610,17 +700,37 @@ mod tests {
     fn test_parse_vcard_folded_lines() {
         let vcard = "BEGIN:VCARD\r\nFN:Alice\r\nNOTE:This is a long note\r\n  that continues here\r\nEND:VCARD";
         let parsed = parse_vcard(vcard);
-        assert_eq!(parsed.note, Some("This is a long note that continues here".to_string()));
+        assert_eq!(
+            parsed.note,
+            Some("This is a long note that continues here".to_string())
+        );
     }
 
     #[test]
     fn test_generate_vcard_roundtrip() {
         let emails = vec![
-            VCardEmail { email: "a@work.com".to_string(), label: "work".to_string() },
-            VCardEmail { email: "a@home.com".to_string(), label: "home".to_string() },
+            VCardEmail {
+                email: "a@work.com".to_string(),
+                label: "work".to_string(),
+            },
+            VCardEmail {
+                email: "a@home.com".to_string(),
+                label: "home".to_string(),
+            },
         ];
-        let phones = vec![VCardPhone { number: "+1-555".to_string(), label: "mobile".to_string() }];
-        let vcard = generate_vcard("uid-1", "Alice Smith", &emails, &phones, Some("Acme"), Some("CTO"), None);
+        let phones = vec![VCardPhone {
+            number: "+1-555".to_string(),
+            label: "mobile".to_string(),
+        }];
+        let vcard = generate_vcard(
+            "uid-1",
+            "Alice Smith",
+            &emails,
+            &phones,
+            Some("Acme"),
+            Some("CTO"),
+            None,
+        );
         let parsed = parse_vcard(&vcard);
         assert_eq!(parsed.display_name, "Alice Smith");
         assert_eq!(parsed.emails.len(), 2);

--- a/src-tauri/src/mail/graph.rs
+++ b/src-tauri/src/mail/graph.rs
@@ -27,7 +27,8 @@ impl GraphClient {
 
     async fn get(&self, path: &str, params: &[(&str, &str)]) -> Result<serde_json::Value> {
         let url = format!("{}{}", GRAPH_BASE, path);
-        let resp = self.http
+        let resp = self
+            .http
             .get(&url)
             .bearer_auth(&self.access_token)
             .query(params)
@@ -38,7 +39,12 @@ impl GraphClient {
         let status = resp.status();
         let body = resp.text().await.unwrap_or_default();
         if !status.is_success() {
-            return Err(Error::Other(format!("Graph GET {} returned {}: {}", path, status, truncate(&body, 500))));
+            return Err(Error::Other(format!(
+                "Graph GET {} returned {}: {}",
+                path,
+                status,
+                truncate(&body, 500)
+            )));
         }
 
         serde_json::from_str(&body)
@@ -52,7 +58,8 @@ impl GraphClient {
         use tokio::io::AsyncWriteExt;
 
         let url = format!("{}{}", GRAPH_BASE, path);
-        let resp = self.http
+        let resp = self
+            .http
             .get(&url)
             .bearer_auth(&self.access_token)
             .send()
@@ -62,24 +69,32 @@ impl GraphClient {
         let status = resp.status();
         if !status.is_success() {
             let body = resp.text().await.unwrap_or_default();
-            return Err(Error::Other(format!("Graph GET {} returned {}: {}", path, status, truncate(&body, 500))));
+            return Err(Error::Other(format!(
+                "Graph GET {} returned {}: {}",
+                path,
+                status,
+                truncate(&body, 500)
+            )));
         }
 
-        let mut file = tokio::fs::File::create(dest).await
-            .map_err(|e| Error::Other(format!("Failed to create file {}: {}", dest.display(), e)))?;
+        let mut file = tokio::fs::File::create(dest).await.map_err(|e| {
+            Error::Other(format!("Failed to create file {}: {}", dest.display(), e))
+        })?;
         let mut stream = resp.bytes_stream();
         let mut total: u64 = 0;
 
         use futures::StreamExt;
         while let Some(chunk) = stream.next().await {
-            let chunk = chunk
-                .map_err(|e| Error::Other(format!("Graph stream read failed: {}", e)))?;
-            file.write_all(&chunk).await
-                .map_err(|e| Error::Other(format!("Failed to write to {}: {}", dest.display(), e)))?;
+            let chunk =
+                chunk.map_err(|e| Error::Other(format!("Graph stream read failed: {}", e)))?;
+            file.write_all(&chunk).await.map_err(|e| {
+                Error::Other(format!("Failed to write to {}: {}", dest.display(), e))
+            })?;
             total += chunk.len() as u64;
         }
 
-        file.flush().await
+        file.flush()
+            .await
             .map_err(|e| Error::Other(format!("Failed to flush {}: {}", dest.display(), e)))?;
 
         Ok(total)
@@ -87,7 +102,8 @@ impl GraphClient {
 
     async fn post_json(&self, path: &str, body: &serde_json::Value) -> Result<serde_json::Value> {
         let url = format!("{}{}", GRAPH_BASE, path);
-        let resp = self.http
+        let resp = self
+            .http
             .post(&url)
             .bearer_auth(&self.access_token)
             .json(body)
@@ -98,7 +114,12 @@ impl GraphClient {
         let status = resp.status();
         let text = resp.text().await.unwrap_or_default();
         if !status.is_success() {
-            return Err(Error::Other(format!("Graph POST {} returned {}: {}", path, status, truncate(&text, 500))));
+            return Err(Error::Other(format!(
+                "Graph POST {} returned {}: {}",
+                path,
+                status,
+                truncate(&text, 500)
+            )));
         }
 
         if text.is_empty() {
@@ -111,7 +132,8 @@ impl GraphClient {
 
     async fn patch_json(&self, path: &str, body: &serde_json::Value) -> Result<()> {
         let url = format!("{}{}", GRAPH_BASE, path);
-        let resp = self.http
+        let resp = self
+            .http
             .patch(&url)
             .bearer_auth(&self.access_token)
             .json(body)
@@ -122,14 +144,20 @@ impl GraphClient {
         let status = resp.status();
         if !status.is_success() {
             let text = resp.text().await.unwrap_or_default();
-            return Err(Error::Other(format!("Graph PATCH {} returned {}: {}", path, status, truncate(&text, 500))));
+            return Err(Error::Other(format!(
+                "Graph PATCH {} returned {}: {}",
+                path,
+                status,
+                truncate(&text, 500)
+            )));
         }
         Ok(())
     }
 
     async fn delete(&self, path: &str) -> Result<()> {
         let url = format!("{}{}", GRAPH_BASE, path);
-        let resp = self.http
+        let resp = self
+            .http
             .delete(&url)
             .bearer_auth(&self.access_token)
             .send()
@@ -139,7 +167,12 @@ impl GraphClient {
         let status = resp.status();
         if !status.is_success() && status.as_u16() != 204 {
             let text = resp.text().await.unwrap_or_default();
-            return Err(Error::Other(format!("Graph DELETE {} returned {}: {}", path, status, truncate(&text, 500))));
+            return Err(Error::Other(format!(
+                "Graph DELETE {} returned {}: {}",
+                path,
+                status,
+                truncate(&text, 500)
+            )));
         }
         Ok(())
     }
@@ -150,25 +183,38 @@ impl GraphClient {
 
     /// Get the signed-in user's profile (email, display name).
     pub async fn get_me(&self) -> Result<GraphUser> {
-        let resp = self.get("/me", &[("$select", "id,displayName,userPrincipalName,mail")]).await?;
+        let resp = self
+            .get(
+                "/me",
+                &[("$select", "id,displayName,userPrincipalName,mail")],
+            )
+            .await?;
 
         let display_name = resp["displayName"].as_str().unwrap_or("").to_string();
-        let mut email = resp["mail"].as_str()
+        let mut email = resp["mail"]
+            .as_str()
             .or_else(|| resp["userPrincipalName"].as_str())
             .unwrap_or("")
             .to_string();
 
         let login_email = email.clone();
-        log::info!("Graph /me: displayName={}, login_email={}", display_name, login_email);
+        log::info!(
+            "Graph /me: displayName={}, login_email={}",
+            display_name,
+            login_email
+        );
 
         // For personal Microsoft accounts, the login email (e.g., gmail.com) may differ
         // from the actual Outlook mailbox address. Try multiple sources:
 
         // 1. Check To address of inbox messages (catches user-configured aliases like chithiapp@outlook.com)
-        if let Ok(inbox_resp) = self.get(
-            "/me/mailFolders('Inbox')/messages",
-            &[("$top", "1"), ("$select", "toRecipients")],
-        ).await {
+        if let Ok(inbox_resp) = self
+            .get(
+                "/me/mailFolders('Inbox')/messages",
+                &[("$top", "1"), ("$select", "toRecipients")],
+            )
+            .await
+        {
             if let Some(to_addr) = inbox_resp["value"]
                 .as_array()
                 .and_then(|a| a.first())
@@ -176,7 +222,11 @@ impl GraphClient {
                 .and_then(|r| r.first())
                 .and_then(|r| r["emailAddress"]["address"].as_str())
             {
-                if to_addr != email && (to_addr.contains("outlook.") || to_addr.contains("hotmail.") || to_addr.contains("live.")) {
+                if to_addr != email
+                    && (to_addr.contains("outlook.")
+                        || to_addr.contains("hotmail.")
+                        || to_addr.contains("live."))
+                {
                     log::info!("Graph: mailbox email from Inbox To: {}", to_addr);
                     email = to_addr.to_string();
                 }
@@ -185,10 +235,13 @@ impl GraphClient {
 
         // 2. Fallback: check From address of sent messages
         if email == login_email {
-            if let Ok(sent_resp) = self.get(
-                "/me/mailFolders('SentItems')/messages",
-                &[("$top", "1"), ("$select", "from")],
-            ).await {
+            if let Ok(sent_resp) = self
+                .get(
+                    "/me/mailFolders('SentItems')/messages",
+                    &[("$top", "1"), ("$select", "from")],
+                )
+                .await
+            {
                 if let Some(from_addr) = sent_resp["value"]
                     .as_array()
                     .and_then(|a| a.first())
@@ -219,11 +272,19 @@ impl GraphClient {
         let mut url = "/me/mailFolders".to_string();
 
         loop {
-            let resp = self.get(&url, &[
-                ("$select", "id,displayName,totalItemCount,unreadItemCount,parentFolderId"),
-                ("$top", "100"),
-                ("includeHiddenFolders", "true"),
-            ]).await?;
+            let resp = self
+                .get(
+                    &url,
+                    &[
+                        (
+                            "$select",
+                            "id,displayName,totalItemCount,unreadItemCount,parentFolderId",
+                        ),
+                        ("$top", "100"),
+                        ("includeHiddenFolders", "true"),
+                    ],
+                )
+                .await?;
 
             if let Some(values) = resp["value"].as_array() {
                 for f in values {
@@ -249,10 +310,15 @@ impl GraphClient {
         // Also fetch child folders (Graph only returns top-level by default)
         let top_ids: Vec<String> = folders.iter().map(|f| f.id.clone()).collect();
         for parent_id in &top_ids {
-            let child_resp = self.get(
-                &format!("/me/mailFolders/{}/childFolders", parent_id),
-                &[("$select", "id,displayName,totalItemCount,unreadItemCount,parentFolderId")],
-            ).await;
+            let child_resp = self
+                .get(
+                    &format!("/me/mailFolders/{}/childFolders", parent_id),
+                    &[(
+                        "$select",
+                        "id,displayName,totalItemCount,unreadItemCount,parentFolderId",
+                    )],
+                )
+                .await;
             if let Ok(resp) = child_resp {
                 if let Some(values) = resp["value"].as_array() {
                     for f in values {
@@ -308,10 +374,12 @@ impl GraphClient {
 
     /// Fetch the full body of a message.
     pub async fn get_message_body(&self, message_id: &str) -> Result<GraphMessageBody> {
-        let resp = self.get(
-            &format!("/me/messages/{}", message_id),
-            &[("$select", "body,uniqueBody")],
-        ).await?;
+        let resp = self
+            .get(
+                &format!("/me/messages/{}", message_id),
+                &[("$select", "body,uniqueBody")],
+            )
+            .await?;
 
         let content_type = resp["body"]["contentType"].as_str().unwrap_or("text");
         let content = resp["body"]["content"].as_str().unwrap_or("").to_string();
@@ -322,11 +390,16 @@ impl GraphClient {
         })
     }
 
-    pub async fn get_attachments(&self, message_id: &str) -> Result<Vec<crate::db::messages::Attachment>> {
-        let resp = self.get(
-            &format!("/me/messages/{}/attachments", message_id),
-            &[("$select", "id,name,contentType,size")],
-        ).await?;
+    pub async fn get_attachments(
+        &self,
+        message_id: &str,
+    ) -> Result<Vec<crate::db::messages::Attachment>> {
+        let resp = self
+            .get(
+                &format!("/me/messages/{}/attachments", message_id),
+                &[("$select", "id,name,contentType,size")],
+            )
+            .await?;
 
         let mut attachments = Vec::new();
         if let Some(values) = resp["value"].as_array() {
@@ -334,7 +407,10 @@ impl GraphClient {
                 attachments.push(crate::db::messages::Attachment {
                     index: i as u32,
                     filename: att["name"].as_str().map(|s| s.to_string()),
-                    content_type: att["contentType"].as_str().unwrap_or("application/octet-stream").to_string(),
+                    content_type: att["contentType"]
+                        .as_str()
+                        .unwrap_or("application/octet-stream")
+                        .to_string(),
                     size: att["size"].as_u64().unwrap_or(0),
                 });
             }
@@ -349,10 +425,8 @@ impl GraphClient {
         message_id: &str,
         dest: &std::path::Path,
     ) -> Result<u64> {
-        self.stream_to_file(
-            &format!("/me/messages/{}/$value", message_id),
-            dest,
-        ).await
+        self.stream_to_file(&format!("/me/messages/{}/$value", message_id), dest)
+            .await
     }
 
     pub async fn save_draft(&self, message: &GraphSendMessage) -> Result<()> {
@@ -408,7 +482,8 @@ impl GraphClient {
     /// Move a message to a different folder.
     pub async fn move_message(&self, message_id: &str, dest_folder_id: &str) -> Result<()> {
         let body = serde_json::json!({ "destinationId": dest_folder_id });
-        self.post_json(&format!("/me/messages/{}/move", message_id), &body).await?;
+        self.post_json(&format!("/me/messages/{}/move", message_id), &body)
+            .await?;
         Ok(())
     }
 
@@ -423,23 +498,32 @@ impl GraphClient {
     }
 
     /// Update message properties (isRead, flag, etc).
-    pub async fn update_message(&self, message_id: &str, updates: &serde_json::Value) -> Result<()> {
-        self.patch_json(&format!("/me/messages/{}", message_id), updates).await
+    pub async fn update_message(
+        &self,
+        message_id: &str,
+        updates: &serde_json::Value,
+    ) -> Result<()> {
+        self.patch_json(&format!("/me/messages/{}", message_id), updates)
+            .await
     }
 
     /// Mark messages as read or unread.
     pub async fn set_read_status(&self, message_ids: &[String], is_read: bool) -> Result<()> {
         // Batch up to 20 requests per $batch call (Graph API limit)
         for chunk in message_ids.chunks(20) {
-            let requests: Vec<serde_json::Value> = chunk.iter().enumerate().map(|(i, id)| {
-                serde_json::json!({
-                    "id": format!("{}", i),
-                    "method": "PATCH",
-                    "url": format!("/me/messages/{}", id),
-                    "headers": { "Content-Type": "application/json" },
-                    "body": { "isRead": is_read }
+            let requests: Vec<serde_json::Value> = chunk
+                .iter()
+                .enumerate()
+                .map(|(i, id)| {
+                    serde_json::json!({
+                        "id": format!("{}", i),
+                        "method": "PATCH",
+                        "url": format!("/me/messages/{}", id),
+                        "headers": { "Content-Type": "application/json" },
+                        "body": { "isRead": is_read }
+                    })
                 })
-            }).collect();
+                .collect();
 
             let batch_body = serde_json::json!({ "requests": requests });
             self.post_json("/$batch", &batch_body).await?;
@@ -453,14 +537,22 @@ impl GraphClient {
 
     /// List all calendars for the signed-in user.
     pub async fn list_calendars(&self) -> Result<Vec<GraphCalendar>> {
-        let resp = self.get("/me/calendars", &[("$select", "id,name,color,isDefaultCalendar")]).await?;
+        let resp = self
+            .get(
+                "/me/calendars",
+                &[("$select", "id,name,color,isDefaultCalendar")],
+            )
+            .await?;
         let items = resp["value"].as_array().cloned().unwrap_or_default();
-        Ok(items.iter().map(|c| GraphCalendar {
-            id: c["id"].as_str().unwrap_or("").to_string(),
-            name: c["name"].as_str().unwrap_or("Calendar").to_string(),
-            color: graph_color_to_hex(c["color"].as_str().unwrap_or("")),
-            is_default: c["isDefaultCalendar"].as_bool().unwrap_or(false),
-        }).collect())
+        Ok(items
+            .iter()
+            .map(|c| GraphCalendar {
+                id: c["id"].as_str().unwrap_or("").to_string(),
+                name: c["name"].as_str().unwrap_or("Calendar").to_string(),
+                color: graph_color_to_hex(c["color"].as_str().unwrap_or("")),
+                is_default: c["isDefaultCalendar"].as_bool().unwrap_or(false),
+            })
+            .collect())
     }
 
     /// Fetch events in a time range via calendarView.
@@ -472,7 +564,8 @@ impl GraphClient {
             let resp: serde_json::Value = match next_path.take() {
                 Some(path) => {
                     // Pagination: next link is a full URL, fetch directly with UTC preference
-                    let resp = self.http
+                    let resp = self
+                        .http
                         .get(&path)
                         .bearer_auth(&self.access_token)
                         .header("Prefer", "outlook.timezone=\"UTC\"")
@@ -482,7 +575,11 @@ impl GraphClient {
                     let status = resp.status();
                     let body = resp.text().await.unwrap_or_default();
                     if !status.is_success() {
-                        return Err(Error::Other(format!("Graph GET returned {}: {}", status, truncate(&body, 500))));
+                        return Err(Error::Other(format!(
+                            "Graph GET returned {}: {}",
+                            status,
+                            truncate(&body, 500)
+                        )));
                     }
                     serde_json::from_str(&body)
                         .map_err(|e| Error::Other(format!("Graph JSON parse failed: {}", e)))?
@@ -506,7 +603,11 @@ impl GraphClient {
                     let status = resp.status();
                     let body = resp.text().await.unwrap_or_default();
                     if !status.is_success() {
-                        return Err(Error::Other(format!("Graph GET /me/calendarView returned {}: {}", status, truncate(&body, 500))));
+                        return Err(Error::Other(format!(
+                            "Graph GET /me/calendarView returned {}: {}",
+                            status,
+                            truncate(&body, 500)
+                        )));
                     }
                     serde_json::from_str(&body)
                         .map_err(|e| Error::Other(format!("Graph JSON parse failed: {}", e)))?
@@ -517,7 +618,9 @@ impl GraphClient {
                     events.push(parse_graph_event(e));
                 }
             }
-            let next_link = resp["@odata.nextLink"].as_str().map(|s: &str| s.to_string());
+            let next_link = resp["@odata.nextLink"]
+                .as_str()
+                .map(|s: &str| s.to_string());
             match next_link {
                 Some(next) => {
                     next_path = Some(next);
@@ -530,7 +633,10 @@ impl GraphClient {
 
     /// Create a calendar event.
     /// Create a calendar event. Returns (graph_id, iCalUid).
-    pub async fn create_event(&self, event: &serde_json::Value) -> Result<(String, Option<String>)> {
+    pub async fn create_event(
+        &self,
+        event: &serde_json::Value,
+    ) -> Result<(String, Option<String>)> {
         let resp = self.post_json("/me/events", event).await?;
         let id = resp["id"].as_str().unwrap_or("").to_string();
         let ical_uid = resp["iCalUId"].as_str().map(|s| s.to_string());
@@ -539,7 +645,8 @@ impl GraphClient {
 
     /// Update a calendar event.
     pub async fn update_event(&self, event_id: &str, updates: &serde_json::Value) -> Result<()> {
-        self.patch_json(&format!("/me/events/{}", event_id), updates).await
+        self.patch_json(&format!("/me/events/{}", event_id), updates)
+            .await
     }
 
     /// Delete a calendar event.
@@ -553,7 +660,10 @@ impl GraphClient {
         let escaped_uid = ical_uid.replace('\'', "''");
         let filter = format!("iCalUId eq '{}'", escaped_uid);
         let resp = self
-            .get("/me/events", &[("$filter", filter.as_str()), ("$select", "id")])
+            .get(
+                "/me/events",
+                &[("$filter", filter.as_str()), ("$select", "id")],
+            )
             .await?;
         Ok(resp["value"]
             .as_array()
@@ -574,7 +684,8 @@ impl GraphClient {
             "comment": comment,
             "sendResponse": true,
         });
-        self.post_json(&format!("/me/events/{}/{}", event_id, action), &body).await?;
+        self.post_json(&format!("/me/events/{}/{}", event_id, action), &body)
+            .await?;
         Ok(())
     }
 
@@ -619,9 +730,13 @@ impl GraphClient {
                     contacts.push(parse_graph_contact(c));
                 }
             }
-            let next_link = resp["@odata.nextLink"].as_str().map(|s: &str| s.to_string());
+            let next_link = resp["@odata.nextLink"]
+                .as_str()
+                .map(|s: &str| s.to_string());
             match next_link {
-                Some(next) => { next_path = Some(next); }
+                Some(next) => {
+                    next_path = Some(next);
+                }
                 None => break,
             }
         }
@@ -635,8 +750,13 @@ impl GraphClient {
     }
 
     /// Update a contact.
-    pub async fn update_contact(&self, contact_id: &str, updates: &serde_json::Value) -> Result<()> {
-        self.patch_json(&format!("/me/contacts/{}", contact_id), updates).await
+    pub async fn update_contact(
+        &self,
+        contact_id: &str,
+        updates: &serde_json::Value,
+    ) -> Result<()> {
+        self.patch_json(&format!("/me/contacts/{}", contact_id), updates)
+            .await
     }
 
     /// Delete a contact.
@@ -745,7 +865,8 @@ fn parse_graph_message(m: &serde_json::Value) -> GraphMessage {
     let to_addresses = parse_recipients(&m["toRecipients"]);
     let cc_addresses = parse_recipients(&m["ccRecipients"]);
 
-    let date = m["receivedDateTime"].as_str()
+    let date = m["receivedDateTime"]
+        .as_str()
         .and_then(|d| chrono::DateTime::parse_from_rfc3339(d).ok())
         .map(|dt| dt.with_timezone(&chrono::Utc).to_rfc3339())
         .unwrap_or_default();
@@ -767,19 +888,28 @@ fn parse_graph_message(m: &serde_json::Value) -> GraphMessage {
 }
 
 fn parse_recipients(arr: &serde_json::Value) -> String {
-    let addrs: Vec<serde_json::Value> = arr.as_array()
-        .map(|a| a.iter().map(|r| {
-            serde_json::json!({
-                "name": r["emailAddress"]["name"].as_str().unwrap_or(""),
-                "email": r["emailAddress"]["address"].as_str().unwrap_or(""),
-            })
-        }).collect())
+    let addrs: Vec<serde_json::Value> = arr
+        .as_array()
+        .map(|a| {
+            a.iter()
+                .map(|r| {
+                    serde_json::json!({
+                        "name": r["emailAddress"]["name"].as_str().unwrap_or(""),
+                        "email": r["emailAddress"]["address"].as_str().unwrap_or(""),
+                    })
+                })
+                .collect()
+        })
         .unwrap_or_default();
     serde_json::to_string(&addrs).unwrap_or_else(|_| "[]".to_string())
 }
 
 fn truncate(s: &str, max: usize) -> &str {
-    if s.len() <= max { s } else { &s[..max] }
+    if s.len() <= max {
+        s
+    } else {
+        &s[..max]
+    }
 }
 
 /// Map well-known Graph folder display names to our folder_type.
@@ -804,23 +934,40 @@ fn parse_graph_event(e: &serde_json::Value) -> GraphCalendarEvent {
     let start_tz = start_obj["timeZone"].as_str().unwrap_or("UTC");
 
     let start = if all_day {
-        start_obj["dateTime"].as_str().unwrap_or("").split('T').next().unwrap_or("").to_string()
+        start_obj["dateTime"]
+            .as_str()
+            .unwrap_or("")
+            .split('T')
+            .next()
+            .unwrap_or("")
+            .to_string()
     } else {
         let dt = start_obj["dateTime"].as_str().unwrap_or("");
         crate::calendar::timezone::to_utc(dt, start_tz)
     };
 
     let end = if all_day {
-        end_obj["dateTime"].as_str().unwrap_or("").split('T').next().unwrap_or("").to_string()
+        end_obj["dateTime"]
+            .as_str()
+            .unwrap_or("")
+            .split('T')
+            .next()
+            .unwrap_or("")
+            .to_string()
     } else {
         let dt = end_obj["dateTime"].as_str().unwrap_or("");
         let end_tz = end_obj["timeZone"].as_str().unwrap_or("UTC");
         crate::calendar::timezone::to_utc(dt, end_tz)
     };
 
-    let timezone = if all_day { None } else { Some(start_tz.to_string()) };
+    let timezone = if all_day {
+        None
+    } else {
+        Some(start_tz.to_string())
+    };
 
-    let location = e["location"]["displayName"].as_str()
+    let location = e["location"]["displayName"]
+        .as_str()
         .filter(|s| !s.is_empty())
         .map(|s| s.to_string());
 
@@ -829,13 +976,16 @@ fn parse_graph_event(e: &serde_json::Value) -> GraphCalendarEvent {
         .map(|s| s.to_string());
 
     let attendees_json = e["attendees"].as_array().map(|atts| {
-        let parsed: Vec<serde_json::Value> = atts.iter().map(|a| {
-            serde_json::json!({
-                "name": a["emailAddress"]["name"].as_str().unwrap_or(""),
-                "email": a["emailAddress"]["address"].as_str().unwrap_or(""),
-                "status": a["status"]["response"].as_str().unwrap_or("none"),
+        let parsed: Vec<serde_json::Value> = atts
+            .iter()
+            .map(|a| {
+                serde_json::json!({
+                    "name": a["emailAddress"]["name"].as_str().unwrap_or(""),
+                    "email": a["emailAddress"]["address"].as_str().unwrap_or(""),
+                    "status": a["status"]["response"].as_str().unwrap_or("none"),
+                })
             })
-        }).collect();
+            .collect();
         serde_json::to_string(&parsed).unwrap_or_else(|_| "[]".to_string())
     });
 
@@ -859,22 +1009,32 @@ fn parse_graph_contact(c: &serde_json::Value) -> GraphContact {
     let display_name = c["displayName"].as_str().unwrap_or("").to_string();
     let given_name = c["givenName"].as_str().map(|s| s.to_string());
     let surname = c["surname"].as_str().map(|s| s.to_string());
-    let organization = c["companyName"].as_str()
+    let organization = c["companyName"]
+        .as_str()
         .filter(|s| !s.is_empty())
         .map(|s| s.to_string());
-    let title = c["jobTitle"].as_str()
+    let title = c["jobTitle"]
+        .as_str()
         .filter(|s| !s.is_empty())
         .map(|s| s.to_string());
 
     // Parse emails — Graph's "name" field is a display label, not work/home.
     // Use index-based labeling: first = "work", rest = "other".
-    let emails: Vec<serde_json::Value> = c["emailAddresses"].as_array()
-        .map(|arr| arr.iter().enumerate().filter_map(|(i, e)| {
-            let addr = e["address"].as_str()?;
-            if addr.is_empty() { return None; }
-            let label = if i == 0 { "work" } else { "other" };
-            Some(serde_json::json!({"email": addr, "label": label}))
-        }).collect())
+    let emails: Vec<serde_json::Value> = c["emailAddresses"]
+        .as_array()
+        .map(|arr| {
+            arr.iter()
+                .enumerate()
+                .filter_map(|(i, e)| {
+                    let addr = e["address"].as_str()?;
+                    if addr.is_empty() {
+                        return None;
+                    }
+                    let label = if i == 0 { "work" } else { "other" };
+                    Some(serde_json::json!({"email": addr, "label": label}))
+                })
+                .collect()
+        })
         .unwrap_or_default();
     let emails_json = serde_json::to_string(&emails).unwrap_or_else(|_| "[]".to_string());
 
@@ -932,10 +1092,12 @@ fn graph_color_to_hex(color: &str) -> String {
 /// Always refreshes with Graph-specific scopes because the stored token
 /// may be IMAP-scoped (both share the same keyring entry and refresh token).
 pub async fn get_graph_token(account_id: &str) -> Result<String> {
-    let tokens = crate::oauth::load_tokens(account_id)?
-        .ok_or_else(|| Error::Other("No O365 OAuth tokens. Please sign in with Microsoft.".into()))?;
+    let tokens = crate::oauth::load_tokens(account_id)?.ok_or_else(|| {
+        Error::Other("No O365 OAuth tokens. Please sign in with Microsoft.".into())
+    })?;
 
-    let refresh_token = tokens.refresh_token
+    let refresh_token = tokens
+        .refresh_token
         .ok_or_else(|| Error::Other("No refresh token for O365. Please sign in again.".into()))?;
 
     // Always refresh with Graph scopes — the cached token is likely IMAP-scoped
@@ -943,15 +1105,19 @@ pub async fn get_graph_token(account_id: &str) -> Result<String> {
         &crate::oauth::MICROSOFT,
         &refresh_token,
         crate::oauth::MICROSOFT_GRAPH_SCOPES,
-    ).await?;
+    )
+    .await?;
     // Don't overwrite the stored tokens — IMAP sync needs the IMAP-scoped token.
     // The refresh_token may rotate, so save that part only.
     if new_tokens.refresh_token.is_some() {
-        crate::oauth::store_tokens(account_id, &crate::oauth::OAuthTokens {
-            access_token: tokens.access_token, // Keep the IMAP token as stored
-            refresh_token: new_tokens.refresh_token,
-            expires_at: tokens.expires_at,
-        })?;
+        crate::oauth::store_tokens(
+            account_id,
+            &crate::oauth::OAuthTokens {
+                access_token: tokens.access_token, // Keep the IMAP token as stored
+                refresh_token: new_tokens.refresh_token,
+                expires_at: tokens.expires_at,
+            },
+        )?;
     }
 
     Ok(new_tokens.access_token)

--- a/src-tauri/src/mail/idle.rs
+++ b/src-tauri/src/mail/idle.rs
@@ -50,13 +50,24 @@ pub fn run_idle_loop(
             Ok(c) => c,
             Err(e) => {
                 if !was_disconnected {
-                    log::error!("IDLE: connection failed for {} ({}): {}", account_id, config.username, e);
+                    log::error!(
+                        "IDLE: connection failed for {} ({}): {}",
+                        account_id,
+                        config.username,
+                        e
+                    );
                     on_event(IdleEvent::Disconnected(&account_id));
                     was_disconnected = true;
                 }
-                if stop.load(Ordering::Relaxed) { break; }
+                if stop.load(Ordering::Relaxed) {
+                    break;
+                }
                 // Exponential backoff with jitter
-                log::debug!("IDLE: retrying in {}s for {}", backoff.as_secs(), account_id);
+                log::debug!(
+                    "IDLE: retrying in {}s for {}",
+                    backoff.as_secs(),
+                    account_id
+                );
                 sleep_interruptible(&stop, backoff);
                 backoff = (backoff * 2).min(MAX_RECONNECT_DELAY);
                 continue;
@@ -65,7 +76,12 @@ pub fn run_idle_loop(
 
         // Select INBOX
         if let Err(e) = conn.select_folder("INBOX") {
-            log::warn!("IDLE: failed to select INBOX for {} ({}): {}, will retry", account_id, config.username, e);
+            log::warn!(
+                "IDLE: failed to select INBOX for {} ({}): {}, will retry",
+                account_id,
+                config.username,
+                e
+            );
             sleep_interruptible(&stop, backoff);
             backoff = (backoff * 2).min(MAX_RECONNECT_DELAY);
             continue;
@@ -81,12 +97,17 @@ pub fn run_idle_loop(
             on_event(IdleEvent::NewMail(&account_id));
             was_disconnected = false;
         } else {
-            log::info!("IDLE: connected and selected INBOX for account {}", account_id);
+            log::info!(
+                "IDLE: connected and selected INBOX for account {}",
+                account_id
+            );
         }
 
         // IDLE loop — stay on this connection until it breaks
         loop {
-            if stop.load(Ordering::Relaxed) { break; }
+            if stop.load(Ordering::Relaxed) {
+                break;
+            }
 
             match conn.idle_wait(IDLE_TIMEOUT) {
                 Ok(had_notification) => {
@@ -121,7 +142,9 @@ pub fn run_idle_loop(
 fn sleep_interruptible(stop: &AtomicBool, duration: Duration) {
     let steps = duration.as_secs();
     for _ in 0..steps {
-        if stop.load(Ordering::Relaxed) { return; }
+        if stop.load(Ordering::Relaxed) {
+            return;
+        }
         std::thread::sleep(Duration::from_secs(1));
     }
 }

--- a/src-tauri/src/mail/imap.rs
+++ b/src-tauri/src/mail/imap.rs
@@ -67,31 +67,44 @@ pub struct ImapConnection {
 impl ImapConnection {
     /// Connect and authenticate. Must be called from a blocking context.
     pub fn connect(config: &ImapConfig) -> Result<Self> {
-        log::info!("IMAP connecting to {}:{} (tls={})", config.host, config.port, config.use_tls);
+        log::info!(
+            "IMAP connecting to {}:{} (tls={})",
+            config.host,
+            config.port,
+            config.use_tls
+        );
 
-        let tls = native_tls::TlsConnector::builder()
-            .build()
-            .map_err(|e| {
-                log::error!("TLS connector build failed: {}", e);
-                Error::Imap(e.to_string())
-            })?;
+        let tls = native_tls::TlsConnector::builder().build().map_err(|e| {
+            log::error!("TLS connector build failed: {}", e);
+            Error::Imap(e.to_string())
+        })?;
 
         // Port 993 = implicit TLS (entire connection wrapped in TLS from start)
         // Port 143 = STARTTLS (connect plain, send STARTTLS command, upgrade to TLS)
         let client = if config.port == 993 {
             log::debug!("IMAP using implicit TLS");
-            imap::connect((&*config.host, config.port), &config.host, &tls)
-                .map_err(|e| {
-                    log::error!("IMAP TLS connection failed to {}:{}: {}", config.host, config.port, e);
-                    Error::Imap(e.to_string())
-                })?
+            imap::connect((&*config.host, config.port), &config.host, &tls).map_err(|e| {
+                log::error!(
+                    "IMAP TLS connection failed to {}:{}: {}",
+                    config.host,
+                    config.port,
+                    e
+                );
+                Error::Imap(e.to_string())
+            })?
         } else {
             log::debug!("IMAP using STARTTLS");
-            imap::connect_starttls((&*config.host, config.port), &config.host, &tls)
-                .map_err(|e| {
-                    log::error!("IMAP STARTTLS failed for {}:{}: {}", config.host, config.port, e);
+            imap::connect_starttls((&*config.host, config.port), &config.host, &tls).map_err(
+                |e| {
+                    log::error!(
+                        "IMAP STARTTLS failed for {}:{}: {}",
+                        config.host,
+                        config.port,
+                        e
+                    );
                     Error::Imap(e.to_string())
-                })?
+                },
+            )?
         };
 
         log::debug!("IMAP connected, authenticating as {}", config.username);
@@ -102,12 +115,10 @@ impl ImapConnection {
                 user: config.username.clone(),
                 token: config.password.clone(),
             };
-            client
-                .authenticate("XOAUTH2", &auth)
-                .map_err(|e| {
-                    log::error!("IMAP XOAUTH2 auth failed for {}: {}", config.username, e.0);
-                    Error::Imap(format!("XOAUTH2 auth failed: {}", e.0))
-                })?
+            client.authenticate("XOAUTH2", &auth).map_err(|e| {
+                log::error!("IMAP XOAUTH2 auth failed for {}: {}", config.username, e.0);
+                Error::Imap(format!("XOAUTH2 auth failed: {}", e.0))
+            })?
         } else {
             client
                 .login(&config.username, &config.password)
@@ -123,13 +134,10 @@ impl ImapConnection {
 
     pub fn list_folders(&mut self) -> Result<Vec<(String, String)>> {
         log::debug!("IMAP listing folders");
-        let mailboxes = self
-            .session
-            .list(None, Some("*"))
-            .map_err(|e| {
-                log::error!("IMAP LIST failed: {}", e);
-                Error::Imap(e.to_string())
-            })?;
+        let mailboxes = self.session.list(None, Some("*")).map_err(|e| {
+            log::error!("IMAP LIST failed: {}", e);
+            Error::Imap(e.to_string())
+        })?;
 
         let mut folders = Vec::new();
         for mb in mailboxes.iter() {
@@ -154,13 +162,10 @@ impl ImapConnection {
     /// SELECT a folder. Returns (exists, uid_validity, uid_next).
     pub fn select_folder(&mut self, folder: &str) -> Result<(u32, u32, u32)> {
         log::debug!("IMAP SELECT {}", folder);
-        let mailbox = self
-            .session
-            .select(folder)
-            .map_err(|e| {
-                log::error!("IMAP SELECT {} failed: {}", folder, e);
-                Error::Imap(e.to_string())
-            })?;
+        let mailbox = self.session.select(folder).map_err(|e| {
+            log::error!("IMAP SELECT {} failed: {}", folder, e);
+            Error::Imap(e.to_string())
+        })?;
         let exists = mailbox.exists;
         let uid_validity = mailbox.uid_validity.unwrap_or(0);
         let uid_next = mailbox.uid_next.unwrap_or(0);
@@ -183,13 +188,10 @@ impl ImapConnection {
         };
         log::debug!("IMAP UID FETCH {} (since_uid={})", range, since_uid);
 
-        let messages = self
-            .session
-            .uid_fetch(&range, "UID")
-            .map_err(|e| {
-                log::error!("IMAP UID FETCH failed: {}", e);
-                Error::Imap(e.to_string())
-            })?;
+        let messages = self.session.uid_fetch(&range, "UID").map_err(|e| {
+            log::error!("IMAP UID FETCH failed: {}", e);
+            Error::Imap(e.to_string())
+        })?;
 
         let uids: Vec<u32> = messages
             .iter()
@@ -241,10 +243,7 @@ impl ImapConnection {
             let envelope = fetch.envelope();
             let (subject, from_name, from_email, to_json, cc_json, date_str, msg_id, in_reply_to) =
                 if let Some(env) = envelope {
-                    let subject = env
-                        .subject
-                        .as_ref()
-                        .map(|s| decode_imap_str(s));
+                    let subject = env.subject.as_ref().map(|s| decode_imap_str(s));
 
                     let (fname, femail) = env
                         .from
@@ -253,16 +252,14 @@ impl ImapConnection {
                         .map(|a| {
                             (
                                 a.name.as_ref().map(|n| decode_imap_str(n)),
-                                a.mailbox
-                                    .as_ref()
-                                    .map(|m| {
-                                        let mb = decode_imap_str(m);
-                                        if let Some(host) = a.host.as_ref() {
-                                            format!("{}@{}", mb, decode_imap_str(host))
-                                        } else {
-                                            mb
-                                        }
-                                    }),
+                                a.mailbox.as_ref().map(|m| {
+                                    let mb = decode_imap_str(m);
+                                    if let Some(host) = a.host.as_ref() {
+                                        format!("{}@{}", mb, decode_imap_str(host))
+                                    } else {
+                                        mb
+                                    }
+                                }),
                             )
                         })
                         .unwrap_or((None, None));
@@ -276,7 +273,16 @@ impl ImapConnection {
 
                     (subject, fname, femail, to_list, cc_list, date, mid, irt)
                 } else {
-                    (None, None, None, "[]".to_string(), "[]".to_string(), None, None, None)
+                    (
+                        None,
+                        None,
+                        None,
+                        "[]".to_string(),
+                        "[]".to_string(),
+                        None,
+                        None,
+                        None,
+                    )
                 };
 
             // Check for attachments from BODYSTRUCTURE
@@ -299,10 +305,7 @@ impl ImapConnection {
                 has_attachments,
             });
         }
-        log::info!(
-            "IMAP envelope batch: {} envelopes fetched",
-            results.len()
-        );
+        log::info!("IMAP envelope batch: {} envelopes fetched", results.len());
         Ok(results)
     }
 
@@ -331,22 +334,26 @@ impl ImapConnection {
 
     /// Fetch bodies for multiple UIDs in a single IMAP command.
     /// Returns a map of UID → body bytes.
-    pub fn fetch_bodies_batch(&mut self, uids: &[u32]) -> Result<std::collections::HashMap<u32, Vec<u8>>> {
+    pub fn fetch_bodies_batch(
+        &mut self,
+        uids: &[u32],
+    ) -> Result<std::collections::HashMap<u32, Vec<u8>>> {
         if uids.is_empty() {
             return Ok(std::collections::HashMap::new());
         }
 
-        let uid_set: String = uids.iter().map(|u| u.to_string()).collect::<Vec<_>>().join(",");
+        let uid_set: String = uids
+            .iter()
+            .map(|u| u.to_string())
+            .collect::<Vec<_>>()
+            .join(",");
 
         log::debug!("IMAP batch fetching {} bodies", uids.len());
 
-        let fetches = self
-            .session
-            .uid_fetch(&uid_set, "BODY[]")
-            .map_err(|e| {
-                log::error!("IMAP batch FETCH bodies failed: {}", e);
-                Error::Imap(e.to_string())
-            })?;
+        let fetches = self.session.uid_fetch(&uid_set, "BODY[]").map_err(|e| {
+            log::error!("IMAP batch FETCH bodies failed: {}", e);
+            Error::Imap(e.to_string())
+        })?;
 
         let mut results = std::collections::HashMap::new();
         for msg in fetches.iter() {
@@ -363,7 +370,11 @@ impl ImapConnection {
     pub fn create_folder(&mut self, folder_path: &str) -> Result<()> {
         // Encode UTF-8 folder name to IMAP Modified UTF-7 (RFC 3501 §5.1.3)
         let encoded = utf7_imap::encode_utf7_imap(folder_path.to_string());
-        log::info!("IMAP creating folder: {} (encoded: {})", folder_path, encoded);
+        log::info!(
+            "IMAP creating folder: {} (encoded: {})",
+            folder_path,
+            encoded
+        );
         self.session.create(&encoded).map_err(|e| {
             log::error!("IMAP CREATE folder '{}' failed: {}", folder_path, e);
             Error::Imap(e.to_string())
@@ -401,12 +412,10 @@ impl ImapConnection {
         );
 
         // 1. Copy messages to destination
-        self.session
-            .uid_copy(&uid_set, dest_folder)
-            .map_err(|e| {
-                log::error!("IMAP UID COPY to '{}' failed: {}", dest_folder, e);
-                Error::Imap(format!("COPY to '{}' failed: {}", dest_folder, e))
-            })?;
+        self.session.uid_copy(&uid_set, dest_folder).map_err(|e| {
+            log::error!("IMAP UID COPY to '{}' failed: {}", dest_folder, e);
+            Error::Imap(format!("COPY to '{}' failed: {}", dest_folder, e))
+        })?;
         log::debug!("IMAP COPY to '{}' succeeded", dest_folder);
 
         // 2. Mark originals as deleted
@@ -423,7 +432,11 @@ impl ImapConnection {
             log::error!("IMAP EXPUNGE failed: {}", e);
             Error::Imap(format!("EXPUNGE failed: {}", e))
         })?;
-        log::info!("IMAP move complete: {} messages moved to '{}'", uids.len(), dest_folder);
+        log::info!(
+            "IMAP move complete: {} messages moved to '{}'",
+            uids.len(),
+            dest_folder
+        );
 
         Ok(())
     }
@@ -483,12 +496,10 @@ impl ImapConnection {
             &uid_set[..uid_set.len().min(80)]
         );
 
-        self.session
-            .uid_store(&uid_set, &store_cmd)
-            .map_err(|e| {
-                log::error!("IMAP UID STORE {} failed: {}", store_cmd, e);
-                Error::Imap(format!("STORE {} failed: {}", store_cmd, e))
-            })?;
+        self.session.uid_store(&uid_set, &store_cmd).map_err(|e| {
+            log::error!("IMAP UID STORE {} failed: {}", store_cmd, e);
+            Error::Imap(format!("STORE {} failed: {}", store_cmd, e))
+        })?;
 
         log::info!(
             "IMAP flags updated: {} {} on {} messages",
@@ -513,13 +524,10 @@ impl ImapConnection {
     /// Fetch current flags for all messages in the selected folder.
     /// Returns a map of UID → flags vec. Uses `1:*` to get everything.
     pub fn fetch_all_flags(&mut self) -> Result<Vec<(u32, Vec<String>)>> {
-        let fetches = self
-            .session
-            .uid_fetch("1:*", "(UID FLAGS)")
-            .map_err(|e| {
-                log::error!("IMAP UID FETCH FLAGS failed: {}", e);
-                Error::Imap(format!("FETCH FLAGS failed: {}", e))
-            })?;
+        let fetches = self.session.uid_fetch("1:*", "(UID FLAGS)").map_err(|e| {
+            log::error!("IMAP UID FETCH FLAGS failed: {}", e);
+            Error::Imap(format!("FETCH FLAGS failed: {}", e))
+        })?;
 
         let mut results = Vec::new();
         for fetch in fetches.iter() {
@@ -547,12 +555,10 @@ impl ImapConnection {
             dest_folder
         );
 
-        self.session
-            .uid_copy(&uid_set, dest_folder)
-            .map_err(|e| {
-                log::error!("IMAP UID COPY to '{}' failed: {}", dest_folder, e);
-                Error::Imap(format!("COPY to '{}' failed: {}", dest_folder, e))
-            })?;
+        self.session.uid_copy(&uid_set, dest_folder).map_err(|e| {
+            log::error!("IMAP UID COPY to '{}' failed: {}", dest_folder, e);
+            Error::Imap(format!("COPY to '{}' failed: {}", dest_folder, e))
+        })?;
 
         log::info!(
             "IMAP copy complete: {} messages copied to '{}'",
@@ -565,9 +571,17 @@ impl ImapConnection {
 
     /// Append a raw RFC5322 message to a folder (used for saving drafts).
     pub fn append_message(&mut self, folder: &str, message: &[u8]) -> Result<()> {
-        log::info!("IMAP appending message ({} bytes) to folder '{}'", message.len(), folder);
+        log::info!(
+            "IMAP appending message ({} bytes) to folder '{}'",
+            message.len(),
+            folder
+        );
         self.session
-            .append_with_flags(folder, message, &[imap::types::Flag::Seen, imap::types::Flag::Draft])
+            .append_with_flags(
+                folder,
+                message,
+                &[imap::types::Flag::Seen, imap::types::Flag::Draft],
+            )
             .map_err(|e| Error::Imap(format!("IMAP APPEND failed: {}", e)))?;
         log::info!("IMAP message appended to '{}'", folder);
         Ok(())
@@ -577,7 +591,11 @@ impl ImapConnection {
     /// (no extra flags). Used for cross-account moves where we want to keep
     /// the message as-is.
     pub fn append_message_raw(&mut self, folder: &str, message: &[u8]) -> Result<()> {
-        log::info!("IMAP appending raw message ({} bytes) to folder '{}'", message.len(), folder);
+        log::info!(
+            "IMAP appending raw message ({} bytes) to folder '{}'",
+            message.len(),
+            folder
+        );
         self.session
             .append(folder, message)
             .map_err(|e| Error::Imap(format!("IMAP APPEND failed: {}", e)))?;
@@ -590,7 +608,10 @@ impl ImapConnection {
     /// or the timeout expires. Returns true if there was a server notification.
     pub fn idle_wait(&mut self, timeout: std::time::Duration) -> Result<bool> {
         log::debug!("IMAP entering IDLE (timeout={}s)", timeout.as_secs());
-        let mut idle = self.session.idle().map_err(|e| Error::Imap(format!("IDLE setup failed: {}", e)))?;
+        let mut idle = self
+            .session
+            .idle()
+            .map_err(|e| Error::Imap(format!("IDLE setup failed: {}", e)))?;
         idle.set_keepalive(std::time::Duration::from_secs(300)); // 5 min keepalive
         let result = idle.wait_with_timeout(timeout);
         let had_notification = result.is_ok();

--- a/src-tauri/src/mail/jmap.rs
+++ b/src-tauri/src/mail/jmap.rs
@@ -20,7 +20,7 @@ pub struct JmapCalendarEvent {
     pub title: String,
     pub description: Option<String>,
     pub location: Option<String>,
-    pub start: String,      // ISO 8601
+    pub start: String, // ISO 8601
     pub end: String,
     pub all_day: bool,
     pub timezone: Option<String>,
@@ -144,8 +144,13 @@ impl JmapConnection {
             url
         } else {
             // Auto-discover
-            let domain = config.email.rsplit_once('@').map(|(_, d)| d)
-                .ok_or_else(|| Error::Other(format!("Cannot extract domain from '{}'", config.email)))?;
+            let domain = config
+                .email
+                .rsplit_once('@')
+                .map(|(_, d)| d)
+                .ok_or_else(|| {
+                    Error::Other(format!("Cannot extract domain from '{}'", config.email))
+                })?;
             let candidates = [
                 format!("https://{}", domain),
                 format!("https://mail.{}", domain),
@@ -153,7 +158,8 @@ impl JmapConnection {
             ];
             let http = reqwest::Client::builder()
                 .timeout(std::time::Duration::from_secs(5))
-                .build().map_err(|e| Error::Other(e.to_string()))?;
+                .build()
+                .map_err(|e| Error::Other(e.to_string()))?;
             let mut found = None;
             for c in &candidates {
                 let url = format!("{}/.well-known/jmap", c);
@@ -164,19 +170,23 @@ impl JmapConnection {
                     }
                 }
             }
-            found.ok_or_else(|| Error::Other(format!("JMAP auto-discovery failed for {}", domain)))?
+            found
+                .ok_or_else(|| Error::Other(format!("JMAP auto-discovery failed for {}", domain)))?
         };
 
         log::info!("JMAP connecting to {} as {}", base_url, config.username);
 
         let http = reqwest::Client::builder()
             .timeout(std::time::Duration::from_secs(30))
-            .build().map_err(|e| Error::Other(e.to_string()))?;
+            .build()
+            .map_err(|e| Error::Other(e.to_string()))?;
 
         // Fetch session with authentication
         let well_known = format!("{}/.well-known/jmap", base_url);
-        let resp = config.apply_auth(http.get(&well_known))
-            .send().await
+        let resp = config
+            .apply_auth(http.get(&well_known))
+            .send()
+            .await
             .map_err(|e| Error::Other(format!("JMAP session fetch failed: {}", e)))?;
 
         if !resp.status().is_success() {
@@ -185,12 +195,16 @@ impl JmapConnection {
             return Err(Error::Other(format!("JMAP session: {} {}", status, body)));
         }
 
-        let session: JmapSession = resp.json().await
+        let session: JmapSession = resp
+            .json()
+            .await
             .map_err(|e| Error::Other(format!("JMAP session parse failed: {}", e)))?;
 
         // Get the default account ID
-        let account_id = session.primary_accounts
-            .values().next()
+        let account_id = session
+            .primary_accounts
+            .values()
+            .next()
             .cloned()
             .ok_or_else(|| Error::Other("No primary account in JMAP session".into()))?;
 
@@ -199,11 +213,17 @@ impl JmapConnection {
         let api_url = rewrite_url(&session.api_url, &base_url);
         let download_url = rewrite_url(&session.download_url, &base_url);
         let upload_url = rewrite_url(&session.upload_url, &base_url);
-        let event_source_url = session.event_source_url
+        let event_source_url = session
+            .event_source_url
             .as_deref()
             .map(|u| rewrite_url(u, &base_url));
 
-        log::info!("JMAP connected: account={}, api={}, eventSource={:?}", account_id, api_url, event_source_url);
+        log::info!(
+            "JMAP connected: account={}, api={}, eventSource={:?}",
+            account_id,
+            api_url,
+            event_source_url
+        );
 
         Ok(Self {
             http,
@@ -231,10 +251,16 @@ impl JmapConnection {
     }
 
     /// Send a JMAP API request and return the response JSON.
-    async fn api_request(&self, body: &serde_json::Value, config: &JmapConfig) -> Result<serde_json::Value> {
-        let resp = config.apply_auth(self.http.post(&self.api_url))
+    async fn api_request(
+        &self,
+        body: &serde_json::Value,
+        config: &JmapConfig,
+    ) -> Result<serde_json::Value> {
+        let resp = config
+            .apply_auth(self.http.post(&self.api_url))
             .json(body)
-            .send().await
+            .send()
+            .await
             .map_err(|e| Error::Other(format!("JMAP request failed: {}", e)))?;
 
         if !resp.status().is_success() {
@@ -243,10 +269,15 @@ impl JmapConnection {
             return Err(Error::Other(format!("JMAP API error {}: {}", status, body)));
         }
 
-        resp.json().await.map_err(|e| Error::Other(format!("JMAP response parse error: {}", e)))
+        resp.json()
+            .await
+            .map_err(|e| Error::Other(format!("JMAP response parse error: {}", e)))
     }
 
-    pub async fn list_folders(&self, config: &JmapConfig) -> Result<Vec<(String, String, Option<&'static str>, Option<String>)>> {
+    pub async fn list_folders(
+        &self,
+        config: &JmapConfig,
+    ) -> Result<Vec<(String, String, Option<&'static str>, Option<String>)>> {
         log::debug!("JMAP listing mailboxes");
         let request = serde_json::json!({
             "using": ["urn:ietf:params:jmap:core", "urn:ietf:params:jmap:mail"],
@@ -279,7 +310,13 @@ impl JmapConnection {
                 _ => None,
             };
             let parent_id = mb["parentId"].as_str().map(|s| s.to_string());
-            log::debug!("  mailbox: {} ({}) role={:?} parentId={:?}", name, id, role, parent_id);
+            log::debug!(
+                "  mailbox: {} ({}) role={:?} parentId={:?}",
+                name,
+                id,
+                role,
+                parent_id
+            );
             folders.push((name, id, folder_type, parent_id));
         }
         log::info!("JMAP found {} mailboxes", folders.len());
@@ -357,7 +394,11 @@ impl JmapConnection {
             position += page_count;
         }
 
-        log::info!("JMAP fetched {} emails from mailbox {}", all_emails.len(), mailbox_id);
+        log::info!(
+            "JMAP fetched {} emails from mailbox {}",
+            all_emails.len(),
+            mailbox_id
+        );
         Ok((all_emails, state))
     }
 
@@ -366,27 +407,33 @@ impl JmapConnection {
         let id = e["id"].as_str().unwrap_or("").to_string();
         let subject = e["subject"].as_str().map(|s| s.to_string());
 
-        let (from_name, from_email) = e["from"].as_array()
+        let (from_name, from_email) = e["from"]
+            .as_array()
             .and_then(|a| a.first())
-            .map(|f| (
-                f["name"].as_str().map(|s| s.to_string()),
-                f["email"].as_str().map(|s| s.to_string()),
-            ))
+            .map(|f| {
+                (
+                    f["name"].as_str().map(|s| s.to_string()),
+                    f["email"].as_str().map(|s| s.to_string()),
+                )
+            })
             .unwrap_or((None, None));
 
         let to_addresses = addresses_to_json(e["to"].as_array());
         let cc_addresses = addresses_to_json(e["cc"].as_array());
 
-        let date = e["receivedAt"].as_str()
+        let date = e["receivedAt"]
+            .as_str()
             .and_then(|d| chrono::DateTime::parse_from_rfc3339(d).ok())
             .map(|dt| dt.with_timezone(&chrono::Utc).to_rfc3339())
             .unwrap_or_default();
         let size = e["size"].as_u64().unwrap_or(0);
-        let message_id = e["messageId"].as_array()
+        let message_id = e["messageId"]
+            .as_array()
             .and_then(|a| a.first())
             .and_then(|v| v.as_str())
             .map(|s| format!("<{}>", s));
-        let in_reply_to = e["inReplyTo"].as_array()
+        let in_reply_to = e["inReplyTo"]
+            .as_array()
             .and_then(|a| a.first())
             .and_then(|v| v.as_str())
             .map(|s| format!("<{}>", s));
@@ -396,16 +443,34 @@ impl JmapConnection {
         let keywords = e["keywords"].as_object();
         let mut flags = Vec::new();
         if let Some(kw) = keywords {
-            if kw.contains_key("$seen") { flags.push("seen".to_string()); }
-            if kw.contains_key("$flagged") { flags.push("flagged".to_string()); }
-            if kw.contains_key("$answered") { flags.push("answered".to_string()); }
-            if kw.contains_key("$draft") { flags.push("draft".to_string()); }
+            if kw.contains_key("$seen") {
+                flags.push("seen".to_string());
+            }
+            if kw.contains_key("$flagged") {
+                flags.push("flagged".to_string());
+            }
+            if kw.contains_key("$answered") {
+                flags.push("answered".to_string());
+            }
+            if kw.contains_key("$draft") {
+                flags.push("draft".to_string());
+            }
         }
 
         JmapEmail {
-            id, subject, from_name, from_email,
-            to_addresses, cc_addresses, date, message_id,
-            in_reply_to, size, has_attachments, flags, preview,
+            id,
+            subject,
+            from_name,
+            from_email,
+            to_addresses,
+            cc_addresses,
+            date,
+            message_id,
+            in_reply_to,
+            size,
+            has_attachments,
+            flags,
+            preview,
         }
     }
 
@@ -434,24 +499,36 @@ impl JmapConnection {
             .ok_or_else(|| Error::Other(format!("No blobId for email {}", email_id)))?;
 
         // Download the blob
-        let download_url = self.download_url_template
+        let download_url = self
+            .download_url_template
             .replace("{accountId}", &self.account_id)
             .replace("{blobId}", blob_id)
             .replace("{name}", "message.eml")
             .replace("{type}", "application/octet-stream");
 
         log::debug!("JMAP downloading blob from {}", download_url);
-        let resp = config.apply_auth(self.http.get(&download_url))
-            .send().await
+        let resp = config
+            .apply_auth(self.http.get(&download_url))
+            .send()
+            .await
             .map_err(|e| Error::Other(format!("JMAP download failed: {}", e)))?;
 
         if !resp.status().is_success() {
-            return Err(Error::Other(format!("JMAP download error: {}", resp.status())));
+            return Err(Error::Other(format!(
+                "JMAP download error: {}",
+                resp.status()
+            )));
         }
 
-        let bytes = resp.bytes().await
+        let bytes = resp
+            .bytes()
+            .await
             .map_err(|e| Error::Other(format!("JMAP download read error: {}", e)))?;
-        log::debug!("JMAP downloaded {} bytes for email {}", bytes.len(), email_id);
+        log::debug!(
+            "JMAP downloaded {} bytes for email {}",
+            bytes.len(),
+            email_id
+        );
         Ok(Some(bytes.to_vec()))
     }
 
@@ -462,7 +539,12 @@ impl JmapConnection {
         flags: &[&str],
         add: bool,
     ) -> Result<()> {
-        log::debug!("JMAP set_flags: {:?} add={} on {} emails", flags, add, email_ids.len());
+        log::debug!(
+            "JMAP set_flags: {:?} add={} on {} emails",
+            flags,
+            add,
+            email_ids.len()
+        );
 
         let mut update = serde_json::Map::new();
         for id in email_ids {
@@ -470,7 +552,14 @@ impl JmapConnection {
             for flag in flags {
                 let keyword = flag_to_keyword(flag);
                 let key = format!("keywords/{}", keyword);
-                patch.insert(key, if add { serde_json::json!(true) } else { serde_json::json!(null) });
+                patch.insert(
+                    key,
+                    if add {
+                        serde_json::json!(true)
+                    } else {
+                        serde_json::json!(null)
+                    },
+                );
             }
             update.insert(id.clone(), serde_json::Value::Object(patch));
         }
@@ -511,13 +600,21 @@ impl JmapConnection {
         from_mailbox: &str,
         to_mailbox: &str,
     ) -> Result<()> {
-        log::debug!("JMAP moving {} emails from {} to {}", email_ids.len(), from_mailbox, to_mailbox);
+        log::debug!(
+            "JMAP moving {} emails from {} to {}",
+            email_ids.len(),
+            from_mailbox,
+            to_mailbox
+        );
         let mut update = serde_json::Map::new();
         for id in email_ids {
-            update.insert(id.clone(), serde_json::json!({
-                format!("mailboxIds/{}", from_mailbox): null,
-                format!("mailboxIds/{}", to_mailbox): true,
-            }));
+            update.insert(
+                id.clone(),
+                serde_json::json!({
+                    format!("mailboxIds/{}", from_mailbox): null,
+                    format!("mailboxIds/{}", to_mailbox): true,
+                }),
+            );
         }
         let request = serde_json::json!({
             "using": ["urn:ietf:params:jmap:core", "urn:ietf:params:jmap:mail"],
@@ -549,23 +646,32 @@ impl JmapConnection {
             mailbox_id
         );
 
-        let upload_url = self.upload_url_template
+        let upload_url = self
+            .upload_url_template
             .replace("{accountId}", &self.account_id);
-        let resp = config.apply_auth(self.http.post(&upload_url))
+        let resp = config
+            .apply_auth(self.http.post(&upload_url))
             .header("Content-Type", "message/rfc822")
             .body(raw_message.to_vec())
-            .send().await
+            .send()
+            .await
             .map_err(|e| Error::Other(format!("JMAP upload failed: {}", e)))?;
 
         if !resp.status().is_success() {
             let status = resp.status();
             let body = resp.text().await.unwrap_or_default();
-            return Err(Error::Other(format!("JMAP upload error {}: {}", status, body)));
+            return Err(Error::Other(format!(
+                "JMAP upload error {}: {}",
+                status, body
+            )));
         }
 
-        let upload_resp: serde_json::Value = resp.json().await
+        let upload_resp: serde_json::Value = resp
+            .json()
+            .await
             .map_err(|e| Error::Other(format!("JMAP upload response parse error: {}", e)))?;
-        let blob_id = upload_resp["blobId"].as_str()
+        let blob_id = upload_resp["blobId"]
+            .as_str()
             .ok_or_else(|| Error::Other("No blobId in upload response".into()))?
             .to_string();
 
@@ -602,31 +708,42 @@ impl JmapConnection {
         log::info!("JMAP sending email ({} bytes)", raw_message.len());
 
         // Step 1: Upload the raw message as a blob
-        let upload_url = self.upload_url_template
+        let upload_url = self
+            .upload_url_template
             .replace("{accountId}", &self.account_id);
         log::debug!("JMAP uploading blob to {}", upload_url);
 
-        let resp = config.apply_auth(self.http.post(&upload_url))
+        let resp = config
+            .apply_auth(self.http.post(&upload_url))
             .header("Content-Type", "message/rfc822")
             .body(raw_message.to_vec())
-            .send().await
+            .send()
+            .await
             .map_err(|e| Error::Other(format!("JMAP upload failed: {}", e)))?;
 
         if !resp.status().is_success() {
             let status = resp.status();
             let body = resp.text().await.unwrap_or_default();
-            return Err(Error::Other(format!("JMAP upload error {}: {}", status, body)));
+            return Err(Error::Other(format!(
+                "JMAP upload error {}: {}",
+                status, body
+            )));
         }
 
-        let upload_resp: serde_json::Value = resp.json().await
+        let upload_resp: serde_json::Value = resp
+            .json()
+            .await
             .map_err(|e| Error::Other(format!("JMAP upload response parse error: {}", e)))?;
-        let blob_id = upload_resp["blobId"].as_str()
+        let blob_id = upload_resp["blobId"]
+            .as_str()
             .ok_or_else(|| Error::Other("No blobId in upload response".into()))?
             .to_string();
         log::debug!("JMAP blob uploaded: {}", blob_id);
 
         // Step 2: Find the Sent mailbox (or Inbox as fallback) to store the email
-        let sent_mailbox_id = self.find_mailbox_by_role(config, "sent").await?
+        let sent_mailbox_id = self
+            .find_mailbox_by_role(config, "sent")
+            .await?
             .or(self.find_mailbox_by_role(config, "inbox").await?)
             .ok_or_else(|| Error::Other("No Sent or Inbox mailbox found".into()))?;
         log::debug!("JMAP using mailbox {} for sent email", sent_mailbox_id);
@@ -672,11 +789,17 @@ impl JmapConnection {
         });
 
         let resp = self.api_request(&request, config).await?;
-        log::debug!("JMAP send response: {}", serde_json::to_string_pretty(&resp).unwrap_or_default());
+        log::debug!(
+            "JMAP send response: {}",
+            serde_json::to_string_pretty(&resp).unwrap_or_default()
+        );
 
         // Check for import errors
         if let Some(err) = resp["methodResponses"][0][1]["notCreated"]["draft"].as_object() {
-            let desc = err.get("description").and_then(|d| d.as_str()).unwrap_or("Unknown error");
+            let desc = err
+                .get("description")
+                .and_then(|d| d.as_str())
+                .unwrap_or("Unknown error");
             return Err(Error::Other(format!("JMAP email import failed: {}", desc)));
         }
 
@@ -686,13 +809,24 @@ impl JmapConnection {
             .map(|s| s.to_string());
 
         // Check for submission errors — clean up imported email on failure
-        let submission_failed = if resp["methodResponses"].as_array().map(|a| a.len()).unwrap_or(0) > 1 {
+        let submission_failed = if resp["methodResponses"]
+            .as_array()
+            .map(|a| a.len())
+            .unwrap_or(0)
+            > 1
+        {
             if resp["methodResponses"][1][0].as_str() == Some("error") {
                 let desc = resp["methodResponses"][1][1]["description"]
-                    .as_str().unwrap_or("Unknown error");
+                    .as_str()
+                    .unwrap_or("Unknown error");
                 Some(format!("JMAP submission failed: {}", desc))
-            } else if let Some(err) = resp["methodResponses"][1][1]["notCreated"]["sub1"].as_object() {
-                let desc = err.get("description").and_then(|d| d.as_str()).unwrap_or("Unknown error");
+            } else if let Some(err) =
+                resp["methodResponses"][1][1]["notCreated"]["sub1"].as_object()
+            {
+                let desc = err
+                    .get("description")
+                    .and_then(|d| d.as_str())
+                    .unwrap_or("Unknown error");
                 Some(format!("JMAP submission failed: {}", desc))
             } else {
                 None
@@ -704,7 +838,10 @@ impl JmapConnection {
         if let Some(error_msg) = submission_failed {
             // Clean up the imported email that wasn't submitted
             if let Some(ref email_id) = imported_id {
-                log::warn!("JMAP cleaning up imported email {} after submission failure", email_id);
+                log::warn!(
+                    "JMAP cleaning up imported email {} after submission failure",
+                    email_id
+                );
                 let cleanup = serde_json::json!({
                     "using": ["urn:ietf:params:jmap:core", "urn:ietf:params:jmap:mail"],
                     "methodCalls": [
@@ -728,29 +865,40 @@ impl JmapConnection {
         log::info!("JMAP saving draft ({} bytes)", raw_message.len());
 
         // Upload the raw message as a blob
-        let upload_url = self.upload_url_template
+        let upload_url = self
+            .upload_url_template
             .replace("{accountId}", &self.account_id);
 
-        let resp = config.apply_auth(self.http.post(&upload_url))
+        let resp = config
+            .apply_auth(self.http.post(&upload_url))
             .header("Content-Type", "message/rfc822")
             .body(raw_message.to_vec())
-            .send().await
+            .send()
+            .await
             .map_err(|e| Error::Other(format!("JMAP draft upload failed: {}", e)))?;
 
         if !resp.status().is_success() {
             let status = resp.status();
             let body = resp.text().await.unwrap_or_default();
-            return Err(Error::Other(format!("JMAP draft upload error {}: {}", status, body)));
+            return Err(Error::Other(format!(
+                "JMAP draft upload error {}: {}",
+                status, body
+            )));
         }
 
-        let upload_resp: serde_json::Value = resp.json().await
+        let upload_resp: serde_json::Value = resp
+            .json()
+            .await
             .map_err(|e| Error::Other(format!("JMAP draft upload parse error: {}", e)))?;
-        let blob_id = upload_resp["blobId"].as_str()
+        let blob_id = upload_resp["blobId"]
+            .as_str()
             .ok_or_else(|| Error::Other("No blobId in draft upload response".into()))?
             .to_string();
 
         // Find the Drafts mailbox
-        let drafts_mailbox_id = self.find_mailbox_by_role(config, "drafts").await?
+        let drafts_mailbox_id = self
+            .find_mailbox_by_role(config, "drafts")
+            .await?
             .ok_or_else(|| Error::Other("No Drafts mailbox found".into()))?;
 
         // Import into Drafts with $draft keyword
@@ -773,7 +921,10 @@ impl JmapConnection {
         let resp = self.api_request(&request, config).await?;
 
         if let Some(err) = resp["methodResponses"][0][1]["notImported"]["draft"].as_object() {
-            let desc = err.get("description").and_then(|d| d.as_str()).unwrap_or("Unknown error");
+            let desc = err
+                .get("description")
+                .and_then(|d| d.as_str())
+                .unwrap_or("Unknown error");
             return Err(Error::Other(format!("JMAP draft import failed: {}", desc)));
         }
 
@@ -880,11 +1031,16 @@ impl JmapConnection {
         });
 
         let resp = self.api_request(&request, config).await?;
-        log::debug!("JMAP CalendarEvent response: {}", serde_json::to_string(&resp).unwrap_or_default());
+        log::debug!(
+            "JMAP CalendarEvent response: {}",
+            serde_json::to_string(&resp).unwrap_or_default()
+        );
 
         // Check if the query returned an error
         if resp["methodResponses"][0][0].as_str() == Some("error") {
-            let desc = resp["methodResponses"][0][1]["description"].as_str().unwrap_or("Unknown");
+            let desc = resp["methodResponses"][0][1]["description"]
+                .as_str()
+                .unwrap_or("Unknown");
             log::error!("JMAP CalendarEvent/query error: {}", desc);
             return Ok(vec![]);
         }
@@ -932,10 +1088,18 @@ impl JmapConnection {
             let duration_str = ev["duration"].as_str().unwrap_or("PT1H");
             let end = {
                 let e = compute_end_from_duration(start.trim_end_matches('Z'), duration_str);
-                if start.ends_with('Z') && !e.ends_with('Z') { format!("{}Z", e) } else { e }
+                if start.ends_with('Z') && !e.ends_with('Z') {
+                    format!("{}Z", e)
+                } else {
+                    e
+                }
             };
 
-            let event_tz_opt = if event_tz.is_empty() { None } else { Some(event_tz) };
+            let event_tz_opt = if event_tz.is_empty() {
+                None
+            } else {
+                Some(event_tz)
+            };
 
             // Recurrence rules: JSCalendar uses an array of recurrence rule objects
             let recurrence_rule = ev["recurrenceRules"]
@@ -949,15 +1113,22 @@ impl JmapConnection {
             if let Some(participants) = ev["participants"].as_object() {
                 for (_pid, p) in participants {
                     // Try calendarAddress (JSCalendar-bis), then sendTo.imip (old), then email
-                    let email = p["calendarAddress"].as_str()
+                    let email = p["calendarAddress"]
+                        .as_str()
                         .map(|s| s.trim_start_matches("mailto:").to_string())
-                        .or_else(|| p["sendTo"].as_object()
-                            .and_then(|s| s.get("imip"))
-                            .and_then(|v| v.as_str())
-                            .map(|s| s.trim_start_matches("mailto:").to_string()))
+                        .or_else(|| {
+                            p["sendTo"]
+                                .as_object()
+                                .and_then(|s| s.get("imip"))
+                                .and_then(|v| v.as_str())
+                                .map(|s| s.trim_start_matches("mailto:").to_string())
+                        })
                         .or_else(|| p["email"].as_str().map(|s| s.to_string()));
                     let name = p["name"].as_str().map(|s| s.to_string());
-                    let mut status = p["participationStatus"].as_str().unwrap_or("needs-action").to_string();
+                    let mut status = p["participationStatus"]
+                        .as_str()
+                        .unwrap_or("needs-action")
+                        .to_string();
                     let roles = p["roles"].as_object();
                     let is_owner = roles.map(|r| r.contains_key("owner")).unwrap_or(false);
 
@@ -977,11 +1148,20 @@ impl JmapConnection {
                     }
                 }
             }
-            let attendees_json = if attendees.is_empty() { None } else {
+            let attendees_json = if attendees.is_empty() {
+                None
+            } else {
                 Some(serde_json::to_string(&attendees).unwrap_or_default())
             };
 
-            log::debug!("  event: {} ({}) start={} end={} attendees={}", title, id, start, end, attendees.len());
+            log::debug!(
+                "  event: {} ({}) start={} end={} attendees={}",
+                title,
+                id,
+                start,
+                end,
+                attendees.len()
+            );
             events.push(JmapCalendarEvent {
                 id,
                 calendar_id: cal_id,
@@ -1001,7 +1181,10 @@ impl JmapConnection {
 
         // Client-side filter by calendar if requested
         let filtered = if let Some(cal_id) = calendar_id {
-            events.into_iter().filter(|e| e.calendar_id == cal_id).collect()
+            events
+                .into_iter()
+                .filter(|e| e.calendar_id == cal_id)
+                .collect()
         } else {
             events
         };
@@ -1017,12 +1200,17 @@ impl JmapConnection {
         config: &JmapConfig,
         event: &JmapCalendarEvent,
     ) -> Result<String> {
-        log::info!("JMAP creating calendar event: '{}' organizer={:?} attendees={:?}",
-            event.title, event.organizer_email, event.attendees_json);
+        log::info!(
+            "JMAP creating calendar event: '{}' organizer={:?} attendees={:?}",
+            event.title,
+            event.organizer_email,
+            event.attendees_json
+        );
 
-        let uid = event.uid.clone().unwrap_or_else(|| {
-            format!("{}@chithi", uuid::Uuid::new_v4())
-        });
+        let uid = event
+            .uid
+            .clone()
+            .unwrap_or_else(|| format!("{}@chithi", uuid::Uuid::new_v4()));
 
         let duration = compute_duration(&event.start, &event.end);
 
@@ -1057,13 +1245,16 @@ impl JmapConnection {
         let mut participants = serde_json::Map::new();
         if let Some(ref org_email) = event.organizer_email {
             if !org_email.is_empty() {
-                participants.insert("organizer".to_string(), serde_json::json!({
-                    "@type": "Participant",
-                    "calendarAddress": format!("mailto:{}", org_email),
-                    "roles": {"owner": true, "attendee": true},
-                    "participationStatus": "accepted",
-                    "expectReply": false,
-                }));
+                participants.insert(
+                    "organizer".to_string(),
+                    serde_json::json!({
+                        "@type": "Participant",
+                        "calendarAddress": format!("mailto:{}", org_email),
+                        "roles": {"owner": true, "attendee": true},
+                        "participationStatus": "accepted",
+                        "expectReply": false,
+                    }),
+                );
             }
         }
         if let Some(ref att_json) = event.attendees_json {
@@ -1072,13 +1263,16 @@ impl JmapConnection {
                     let email = att["email"].as_str().unwrap_or_default();
                     if !email.is_empty() {
                         let status = att["status"].as_str().unwrap_or("needs-action");
-                        participants.insert(format!("att{}", i), serde_json::json!({
-                            "@type": "Participant",
-                            "calendarAddress": format!("mailto:{}", email),
-                            "roles": {"attendee": true},
-                            "participationStatus": status,
-                            "expectReply": true,
-                        }));
+                        participants.insert(
+                            format!("att{}", i),
+                            serde_json::json!({
+                                "@type": "Participant",
+                                "calendarAddress": format!("mailto:{}", email),
+                                "roles": {"attendee": true},
+                                "participationStatus": status,
+                                "expectReply": true,
+                            }),
+                        );
                     }
                 }
             }
@@ -1106,8 +1300,14 @@ impl JmapConnection {
 
         // Check for creation errors
         if let Some(err) = resp["methodResponses"][0][1]["notCreated"]["new1"].as_object() {
-            let desc = err.get("description").and_then(|d| d.as_str()).unwrap_or("Unknown error");
-            return Err(Error::Other(format!("JMAP create calendar event failed: {}", desc)));
+            let desc = err
+                .get("description")
+                .and_then(|d| d.as_str())
+                .unwrap_or("Unknown error");
+            return Err(Error::Other(format!(
+                "JMAP create calendar event failed: {}",
+                desc
+            )));
         }
 
         let created_id = resp["methodResponses"][0][1]["created"]["new1"]["id"]
@@ -1170,8 +1370,14 @@ impl JmapConnection {
         let resp = self.api_request(&request, config).await?;
 
         if let Some(err) = resp["methodResponses"][0][1]["notUpdated"][event_id].as_object() {
-            let desc = err.get("description").and_then(|d| d.as_str()).unwrap_or("Unknown error");
-            return Err(Error::Other(format!("JMAP update calendar event failed: {}", desc)));
+            let desc = err
+                .get("description")
+                .and_then(|d| d.as_str())
+                .unwrap_or("Unknown error");
+            return Err(Error::Other(format!(
+                "JMAP update calendar event failed: {}",
+                desc
+            )));
         }
 
         log::info!("JMAP updated calendar event id={}", event_id);
@@ -1187,7 +1393,12 @@ impl JmapConnection {
         participant_key: &str,
         status: &str,
     ) -> Result<()> {
-        log::info!("JMAP updating participant {} status to {} on event {}", participant_key, status, event_id);
+        log::info!(
+            "JMAP updating participant {} status to {} on event {}",
+            participant_key,
+            status,
+            event_id
+        );
 
         let patch_key = format!("participants/{}/participationStatus", participant_key);
         let mut patch = serde_json::Map::new();
@@ -1209,8 +1420,14 @@ impl JmapConnection {
         let resp = self.api_request(&request, config).await?;
 
         if let Some(err) = resp["methodResponses"][0][1]["notUpdated"][event_id].as_object() {
-            let desc = err.get("description").and_then(|d| d.as_str()).unwrap_or("Unknown error");
-            return Err(Error::Other(format!("JMAP update participant failed: {}", desc)));
+            let desc = err
+                .get("description")
+                .and_then(|d| d.as_str())
+                .unwrap_or("Unknown error");
+            return Err(Error::Other(format!(
+                "JMAP update participant failed: {}",
+                desc
+            )));
         }
 
         log::info!("JMAP updated participant status on event {}", event_id);
@@ -1218,11 +1435,7 @@ impl JmapConnection {
     }
 
     /// Delete a calendar event on the server via CalendarEvent/set.
-    pub async fn delete_calendar_event(
-        &self,
-        config: &JmapConfig,
-        event_id: &str,
-    ) -> Result<()> {
+    pub async fn delete_calendar_event(&self, config: &JmapConfig, event_id: &str) -> Result<()> {
         log::info!("JMAP deleting calendar event: id={}", event_id);
 
         let request = serde_json::json!({
@@ -1241,8 +1454,14 @@ impl JmapConnection {
         let resp = self.api_request(&request, config).await?;
 
         if let Some(err) = resp["methodResponses"][0][1]["notDestroyed"][event_id].as_object() {
-            let desc = err.get("description").and_then(|d| d.as_str()).unwrap_or("Unknown error");
-            return Err(Error::Other(format!("JMAP delete calendar event failed: {}", desc)));
+            let desc = err
+                .get("description")
+                .and_then(|d| d.as_str())
+                .unwrap_or("Unknown error");
+            return Err(Error::Other(format!(
+                "JMAP delete calendar event failed: {}",
+                desc
+            )));
         }
 
         log::info!("JMAP deleted calendar event id={}", event_id);
@@ -1250,7 +1469,11 @@ impl JmapConnection {
     }
 
     /// Find a mailbox by its JMAP role (inbox, sent, drafts, trash, junk).
-    async fn find_mailbox_by_role(&self, config: &JmapConfig, role: &str) -> Result<Option<String>> {
+    async fn find_mailbox_by_role(
+        &self,
+        config: &JmapConfig,
+        role: &str,
+    ) -> Result<Option<String>> {
         let request = serde_json::json!({
             "using": ["urn:ietf:params:jmap:core", "urn:ietf:params:jmap:mail"],
             "methodCalls": [
@@ -1271,7 +1494,12 @@ impl JmapConnection {
         Ok(None)
     }
     /// Create a new mailbox on the JMAP server.
-    pub async fn create_mailbox(&self, config: &JmapConfig, name: &str, parent_id: Option<&str>) -> Result<String> {
+    pub async fn create_mailbox(
+        &self,
+        config: &JmapConfig,
+        name: &str,
+        parent_id: Option<&str>,
+    ) -> Result<String> {
         log::info!("JMAP creating mailbox: {} (parent={:?})", name, parent_id);
         let create_id = "new-folder";
         let mut mailbox = serde_json::json!({ "name": name });
@@ -1298,14 +1526,26 @@ impl JmapConnection {
             let err = resp["methodResponses"][0][1]["notCreated"][create_id]["description"]
                 .as_str()
                 .unwrap_or("Unknown error");
-            return Err(Error::Other(format!("JMAP Mailbox/set create failed: {}", err)));
+            return Err(Error::Other(format!(
+                "JMAP Mailbox/set create failed: {}",
+                err
+            )));
         }
         log::info!("JMAP mailbox created: id={}", created_id);
         Ok(created_id)
     }
 
-    pub async fn destroy_mailbox(&self, config: &JmapConfig, mailbox_id: &str, remove_messages: bool) -> Result<()> {
-        log::info!("JMAP destroying mailbox: {} (remove_messages={})", mailbox_id, remove_messages);
+    pub async fn destroy_mailbox(
+        &self,
+        config: &JmapConfig,
+        mailbox_id: &str,
+        remove_messages: bool,
+    ) -> Result<()> {
+        log::info!(
+            "JMAP destroying mailbox: {} (remove_messages={})",
+            mailbox_id,
+            remove_messages
+        );
         let request = serde_json::json!({
             "using": ["urn:ietf:params:jmap:core", "urn:ietf:params:jmap:mail"],
             "methodCalls": [
@@ -1317,7 +1557,9 @@ impl JmapConnection {
             ]
         });
         let resp = self.api_request(&request, config).await?;
-        let method_name = resp["methodResponses"][0][0].as_str().unwrap_or("<unknown>");
+        let method_name = resp["methodResponses"][0][0]
+            .as_str()
+            .unwrap_or("<unknown>");
         if method_name != "Mailbox/set" {
             log::error!("Unexpected JMAP response to mailbox destroy: {}", resp);
             return Err(Error::Other(format!(
@@ -1335,7 +1577,10 @@ impl JmapConnection {
                 .as_str()
                 .unwrap_or("Unknown error");
             log::error!("JMAP mailbox destroy failed for {}: {}", mailbox_id, err);
-            return Err(Error::Other(format!("JMAP Mailbox/set destroy failed: {}", err)));
+            return Err(Error::Other(format!(
+                "JMAP Mailbox/set destroy failed: {}",
+                err
+            )));
         }
         log::info!("JMAP mailbox destroyed: {}", mailbox_id);
         Ok(())
@@ -1365,7 +1610,11 @@ impl JmapConnection {
                 let id = ab["id"].as_str().unwrap_or_default().to_string();
                 let name = ab["name"].as_str().unwrap_or("Contacts").to_string();
                 let is_default = ab["isDefault"].as_bool().unwrap_or(false);
-                books.push(JmapAddressBook { id, name, is_default });
+                books.push(JmapAddressBook {
+                    id,
+                    name,
+                    is_default,
+                });
             }
         }
 
@@ -1374,7 +1623,11 @@ impl JmapConnection {
     }
 
     /// Fetch contacts from a JMAP address book.
-    pub async fn fetch_contacts(&self, config: &JmapConfig, address_book_id: Option<&str>) -> Result<Vec<JmapContact>> {
+    pub async fn fetch_contacts(
+        &self,
+        config: &JmapConfig,
+        address_book_id: Option<&str>,
+    ) -> Result<Vec<JmapContact>> {
         log::debug!("JMAP fetching contacts (addressBook={:?})", address_book_id);
 
         let request = serde_json::json!({
@@ -1387,7 +1640,10 @@ impl JmapConnection {
         });
 
         let resp = self.api_request(&request, config).await?;
-        log::debug!("JMAP ContactCard response: {}", serde_json::to_string(&resp).unwrap_or_default());
+        log::debug!(
+            "JMAP ContactCard response: {}",
+            serde_json::to_string(&resp).unwrap_or_default()
+        );
 
         let mut contacts = Vec::new();
 
@@ -1405,7 +1661,9 @@ impl JmapConnection {
                         full.to_string()
                     }
                     // Try "components" array (Stalwart JSContact format)
-                    else if let Some(components) = name_obj.get("components").and_then(|c| c.as_array()) {
+                    else if let Some(components) =
+                        name_obj.get("components").and_then(|c| c.as_array())
+                    {
                         let mut given = String::new();
                         let mut middle = String::new();
                         let mut surname = String::new();
@@ -1423,14 +1681,25 @@ impl JmapConnection {
                             .into_iter()
                             .filter(|s| !s.is_empty())
                             .collect();
-                        if parts.is_empty() { "(No name)".to_string() } else { parts.join(" ") }
+                        if parts.is_empty() {
+                            "(No name)".to_string()
+                        } else {
+                            parts.join(" ")
+                        }
                     }
                     // Try direct given/surname
                     else {
                         let given = name_obj.get("given").and_then(|g| g.as_str()).unwrap_or("");
-                        let surname = name_obj.get("surname").and_then(|s| s.as_str()).unwrap_or("");
+                        let surname = name_obj
+                            .get("surname")
+                            .and_then(|s| s.as_str())
+                            .unwrap_or("");
                         let name = format!("{} {}", given, surname).trim().to_string();
-                        if name.is_empty() { "(No name)".to_string() } else { name }
+                        if name.is_empty() {
+                            "(No name)".to_string()
+                        } else {
+                            name
+                        }
                     }
                 } else {
                     "(No name)".to_string()
@@ -1442,8 +1711,14 @@ impl JmapConnection {
                     for (_key, em) in emails_obj {
                         let addr = em["address"].as_str().unwrap_or_default().to_string();
                         // Try label, then contexts keys, then default to "work"
-                        let label = em["label"].as_str().map(|s| s.to_string())
-                            .or_else(|| em["contexts"].as_object().and_then(|c| c.keys().next().cloned()))
+                        let label = em["label"]
+                            .as_str()
+                            .map(|s| s.to_string())
+                            .or_else(|| {
+                                em["contexts"]
+                                    .as_object()
+                                    .and_then(|c| c.keys().next().cloned())
+                            })
                             .unwrap_or_else(|| "work".to_string());
                         if !addr.is_empty() {
                             emails.push(serde_json::json!({"email": addr, "label": label}));
@@ -1464,23 +1739,27 @@ impl JmapConnection {
                 }
 
                 // Parse organization
-                let organization = card["organizations"].as_object()
+                let organization = card["organizations"]
+                    .as_object()
                     .and_then(|orgs| orgs.values().next())
                     .and_then(|org| org["name"].as_str())
                     .map(|s| s.to_string());
 
-                let title = card["titles"].as_object()
+                let title = card["titles"]
+                    .as_object()
                     .and_then(|titles| titles.values().next())
                     .and_then(|t| t["name"].as_str())
                     .map(|s| s.to_string());
 
-                let notes = card["notes"].as_object()
+                let notes = card["notes"]
+                    .as_object()
                     .and_then(|n| n.values().next())
                     .and_then(|note| note["note"].as_str())
                     .map(|s| s.to_string());
 
                 // Determine which address book this belongs to
-                let ab_id = card["addressBookIds"].as_object()
+                let ab_id = card["addressBookIds"]
+                    .as_object()
                     .and_then(|abs| abs.keys().next())
                     .map(|s| s.to_string());
 
@@ -1497,8 +1776,10 @@ impl JmapConnection {
                     id,
                     uid,
                     display_name,
-                    emails_json: serde_json::to_string(&emails).unwrap_or_else(|_| "[]".to_string()),
-                    phones_json: serde_json::to_string(&phones).unwrap_or_else(|_| "[]".to_string()),
+                    emails_json: serde_json::to_string(&emails)
+                        .unwrap_or_else(|_| "[]".to_string()),
+                    phones_json: serde_json::to_string(&phones)
+                        .unwrap_or_else(|_| "[]".to_string()),
                     organization,
                     title,
                     notes,
@@ -1531,11 +1812,12 @@ impl JmapConnection {
             components.push(serde_json::json!({"kind": "given", "value": first}));
         }
         if name_parts.len() > 2 {
-            let middle = name_parts[1..name_parts.len()-1].join(" ");
+            let middle = name_parts[1..name_parts.len() - 1].join(" ");
             components.push(serde_json::json!({"kind": "given2", "value": middle}));
         }
         if name_parts.len() >= 2 {
-            components.push(serde_json::json!({"kind": "surname", "value": name_parts.last().unwrap()}));
+            components
+                .push(serde_json::json!({"kind": "surname", "value": name_parts.last().unwrap()}));
         }
 
         let mut card = serde_json::json!({
@@ -1612,8 +1894,14 @@ impl JmapConnection {
         let resp = self.api_request(&request, config).await?;
 
         if let Some(err) = resp["methodResponses"][0][1]["notCreated"]["new1"].as_object() {
-            let desc = err.get("description").and_then(|d| d.as_str()).unwrap_or("Unknown error");
-            return Err(Error::Other(format!("JMAP create contact failed: {}", desc)));
+            let desc = err
+                .get("description")
+                .and_then(|d| d.as_str())
+                .unwrap_or("Unknown error");
+            return Err(Error::Other(format!(
+                "JMAP create contact failed: {}",
+                desc
+            )));
         }
 
         let remote_id = resp["methodResponses"][0][1]["created"]["new1"]["id"]
@@ -1646,11 +1934,12 @@ impl JmapConnection {
             components.push(serde_json::json!({"kind": "given", "value": first}));
         }
         if name_parts.len() > 2 {
-            let middle = name_parts[1..name_parts.len()-1].join(" ");
+            let middle = name_parts[1..name_parts.len() - 1].join(" ");
             components.push(serde_json::json!({"kind": "given2", "value": middle}));
         }
         if name_parts.len() >= 2 {
-            components.push(serde_json::json!({"kind": "surname", "value": name_parts.last().unwrap()}));
+            components
+                .push(serde_json::json!({"kind": "surname", "value": name_parts.last().unwrap()}));
         }
 
         let mut updates = serde_json::json!({
@@ -1715,8 +2004,14 @@ impl JmapConnection {
         let resp = self.api_request(&request, config).await?;
 
         if let Some(err) = resp["methodResponses"][0][1]["notUpdated"][remote_id].as_object() {
-            let desc = err.get("description").and_then(|d| d.as_str()).unwrap_or("Unknown error");
-            return Err(Error::Other(format!("JMAP update contact failed: {}", desc)));
+            let desc = err
+                .get("description")
+                .and_then(|d| d.as_str())
+                .unwrap_or("Unknown error");
+            return Err(Error::Other(format!(
+                "JMAP update contact failed: {}",
+                desc
+            )));
         }
 
         log::info!("JMAP updated contact '{}'", remote_id);
@@ -1724,11 +2019,7 @@ impl JmapConnection {
     }
 
     /// Delete a contact on the JMAP server via ContactCard/set destroy.
-    pub async fn delete_contact_card(
-        &self,
-        config: &JmapConfig,
-        remote_id: &str,
-    ) -> Result<()> {
+    pub async fn delete_contact_card(&self, config: &JmapConfig, remote_id: &str) -> Result<()> {
         log::info!("JMAP deleting contact: {}", remote_id);
 
         let request = serde_json::json!({
@@ -1805,7 +2096,7 @@ struct AddrJson {
 /// Handles simple cases like PT1H, PT30M, P1D, PT1H30M, etc.
 /// Falls back to start + 1 hour if parsing fails.
 fn compute_end_from_duration(start: &str, duration: &str) -> String {
-    use chrono::{NaiveDateTime, NaiveDate, Duration};
+    use chrono::{Duration, NaiveDate, NaiveDateTime};
 
     let total_seconds = parse_iso8601_duration_seconds(duration);
 
@@ -1881,44 +2172,54 @@ fn parse_iso8601_duration_seconds(dur: &str) -> i64 {
 
     for ch in dur.chars() {
         match ch {
-            'P' => {},
-            'T' => { in_time = true; },
-            '0'..='9' => { num_buf.push(ch); },
+            'P' => {}
+            'T' => {
+                in_time = true;
+            }
+            '0'..='9' => {
+                num_buf.push(ch);
+            }
             'D' => {
                 if let Ok(n) = num_buf.parse::<i64>() {
                     total += n * 86400;
                 }
                 num_buf.clear();
-            },
+            }
             'H' if in_time => {
                 if let Ok(n) = num_buf.parse::<i64>() {
                     total += n * 3600;
                 }
                 num_buf.clear();
-            },
+            }
             'M' if in_time => {
                 if let Ok(n) = num_buf.parse::<i64>() {
                     total += n * 60;
                 }
                 num_buf.clear();
-            },
+            }
             'S' if in_time => {
                 if let Ok(n) = num_buf.parse::<i64>() {
                     total += n;
                 }
                 num_buf.clear();
-            },
+            }
             'W' => {
                 if let Ok(n) = num_buf.parse::<i64>() {
                     total += n * 604800;
                 }
                 num_buf.clear();
-            },
-            _ => { num_buf.clear(); },
+            }
+            _ => {
+                num_buf.clear();
+            }
         }
     }
 
-    if total == 0 { 3600 } else { total } // default 1 hour
+    if total == 0 {
+        3600
+    } else {
+        total
+    } // default 1 hour
 }
 
 fn addresses_to_json(addrs: Option<&Vec<serde_json::Value>>) -> String {

--- a/src-tauri/src/mail/jmap_push.rs
+++ b/src-tauri/src/mail/jmap_push.rs
@@ -60,7 +60,9 @@ pub async fn run_push_loop(
                 &account_id,
                 &config.oidc_token_endpoint,
                 &config.oidc_client_id,
-            ).await {
+            )
+            .await
+            {
                 Ok(Some(new_token)) => config.access_token = Some(new_token),
                 Ok(None) => {}
                 Err(e) => log::warn!("JMAP push: token refresh failed for {}: {}", account_id, e),
@@ -72,10 +74,7 @@ pub async fn run_push_loop(
             Ok(v) => v,
             Err(e) => {
                 if !was_disconnected {
-                    log::error!(
-                        "JMAP push: connection failed for {}: {}",
-                        account_id, e
-                    );
+                    log::error!("JMAP push: connection failed for {}: {}", account_id, e);
                     on_event(PushEvent::Disconnected(account_id.clone()));
                     was_disconnected = true;
                 }
@@ -126,7 +125,8 @@ pub async fn run_push_loop(
             Err(e) => {
                 log::warn!(
                     "JMAP push: stream error for {}: {}, reconnecting...",
-                    account_id, e
+                    account_id,
+                    e
                 );
                 on_event(PushEvent::Disconnected(account_id.clone()));
                 was_disconnected = true;
@@ -197,7 +197,8 @@ async fn stream_events(
         .build()
         .map_err(|e| format!("HTTP client build error: {}", e))?;
 
-    let response = auth.apply_auth(client.get(url))
+    let response = auth
+        .apply_auth(client.get(url))
         .header("Accept", "text/event-stream")
         // Prevent reverse proxies (nginx) from buffering SSE responses.
         .header("Cache-Control", "no-cache")
@@ -276,12 +277,7 @@ async fn stream_events(
 
 /// Process a single SSE event. JMAP EventSource sends `state` events
 /// with a JSON payload containing changed type→state mappings.
-fn handle_sse_event(
-    account_id: &str,
-    event_type: &str,
-    data: &str,
-    on_event: &dyn Fn(PushEvent),
-) {
+fn handle_sse_event(account_id: &str, event_type: &str, data: &str, on_event: &dyn Fn(PushEvent)) {
     match event_type {
         "state" => {
             // RFC 8620 §7.3: The data is a StateChange object with

--- a/src-tauri/src/mail/jmap_sync.rs
+++ b/src-tauri/src/mail/jmap_sync.rs
@@ -55,9 +55,14 @@ pub async fn sync_jmap_account(
     )
     .ok();
 
-    let result =
-        sync_jmap_account_inner(&app, &db, &account_id, &jmap_config, current_folder.as_deref())
-            .await;
+    let result = sync_jmap_account_inner(
+        &app,
+        &db,
+        &account_id,
+        &jmap_config,
+        current_folder.as_deref(),
+    )
+    .await;
 
     match &result {
         Ok(total) => {
@@ -146,7 +151,16 @@ async fn sync_jmap_account_inner(
         )
         .ok();
 
-        match sync_jmap_folder(db, account_id, &conn_jmap, jmap_config, mailbox_id, folder_name).await {
+        match sync_jmap_folder(
+            db,
+            account_id,
+            &conn_jmap,
+            jmap_config,
+            mailbox_id,
+            folder_name,
+        )
+        .await
+        {
             Ok(count) => {
                 grand_total += count;
                 if count > 0 {
@@ -239,11 +253,7 @@ async fn sync_jmap_folder(
                 email.subject.as_deref(),
             );
             if let Some(ref tid) = thread_id {
-                log::debug!(
-                    "JMAP assigned thread_id '{}' to email {}",
-                    tid,
-                    email.id
-                );
+                log::debug!("JMAP assigned thread_id '{}' to email {}", tid, email.id);
             }
 
             let new_msg = db::messages::NewMessage {
@@ -283,44 +293,58 @@ async fn sync_jmap_folder(
 
     // Remove local messages that no longer exist on the server.
     // Build a set of JMAP email IDs from the server response.
-    let server_ids: std::collections::HashSet<String> = emails.iter().map(|e| e.id.clone()).collect();
+    let server_ids: std::collections::HashSet<String> =
+        emails.iter().map(|e| e.id.clone()).collect();
     {
         let conn = db.writer().await;
         // Get all local message IDs for this folder
-        let mut stmt = conn.prepare(
-            "SELECT id FROM messages WHERE account_id = ?1 AND folder_path = ?2"
-        ).map_err(Error::Database)?;
-        let local_ids: Vec<String> = stmt.query_map(
-            rusqlite::params![account_id, mailbox_id],
-            |row| row.get(0),
-        ).map_err(Error::Database)?
-        .filter_map(|r| r.ok())
-        .collect();
+        let mut stmt = conn
+            .prepare("SELECT id FROM messages WHERE account_id = ?1 AND folder_path = ?2")
+            .map_err(Error::Database)?;
+        let local_ids: Vec<String> = stmt
+            .query_map(rusqlite::params![account_id, mailbox_id], |row| row.get(0))
+            .map_err(Error::Database)?
+            .filter_map(|r| r.ok())
+            .collect();
 
         let _prefix = format!("{}_{}_{}", account_id, mailbox_id, "");
         let mut deleted = 0u32;
         for local_id in &local_ids {
             // Extract the JMAP email ID from the composite local ID
-            let jmap_id = local_id.strip_prefix(&format!("{}_{}_", account_id, mailbox_id))
+            let jmap_id = local_id
+                .strip_prefix(&format!("{}_{}_", account_id, mailbox_id))
                 .unwrap_or(local_id);
             if !server_ids.contains(jmap_id) {
                 conn.execute(
                     "DELETE FROM messages WHERE id = ?1",
                     rusqlite::params![local_id],
-                ).ok();
+                )
+                .ok();
                 deleted += 1;
             }
         }
         if deleted > 0 {
-            log::info!("JMAP removed {} locally deleted messages from {}", deleted, folder_name);
+            log::info!(
+                "JMAP removed {} locally deleted messages from {}",
+                deleted,
+                folder_name
+            );
         }
     }
 
     // Update folder counts
     {
         let conn = db.writer().await;
-        let page =
-            db::messages::get_messages(&conn, account_id, mailbox_id, 0, 1, "date", false, &Default::default())?;
+        let page = db::messages::get_messages(
+            &conn,
+            account_id,
+            mailbox_id,
+            0,
+            1,
+            "date",
+            false,
+            &Default::default(),
+        )?;
         let unread = count_unread(&conn, account_id, mailbox_id)?;
         db::folders::update_folder_counts(&conn, account_id, mailbox_id, unread, page.total)?;
     }
@@ -374,7 +398,15 @@ pub async fn sync_jmap_folder_public(
 
     let conn_jmap = JmapConnection::connect(&jmap_config).await?;
     let folder_name = mailbox_id.clone();
-    let result = sync_jmap_folder(&db, &account_id, &conn_jmap, &jmap_config, &mailbox_id, &folder_name).await;
+    let result = sync_jmap_folder(
+        &db,
+        &account_id,
+        &conn_jmap,
+        &jmap_config,
+        &mailbox_id,
+        &folder_name,
+    )
+    .await;
 
     match &result {
         Ok(count) => {
@@ -427,7 +459,9 @@ pub async fn fetch_and_store_jmap_body(
     let body = conn_jmap
         .fetch_email_body(jmap_config, jmap_email_id)
         .await?
-        .ok_or_else(|| Error::Other(format!("JMAP no body returned for email {}", jmap_email_id)))?;
+        .ok_or_else(|| {
+            Error::Other(format!("JMAP no body returned for email {}", jmap_email_id))
+        })?;
 
     // Write to Maildir structure for parsing
     let maildir_base = data_dir
@@ -446,11 +480,7 @@ pub async fn fetch_and_store_jmap_body(
         filename
     );
 
-    log::info!(
-        "JMAP body saved: {} ({} bytes)",
-        relative_path,
-        body.len()
-    );
+    log::info!("JMAP body saved: {} ({} bytes)", relative_path, body.len());
 
     Ok(relative_path)
 }

--- a/src-tauri/src/mail/mod.rs
+++ b/src-tauri/src/mail/mod.rs
@@ -7,7 +7,7 @@ pub mod imap;
 pub mod jmap;
 pub mod jmap_push;
 pub mod jmap_sync;
+pub mod parser;
 pub mod smtp;
 pub mod sync;
-pub mod parser;
 pub mod url_validation;

--- a/src-tauri/src/mail/parser.rs
+++ b/src-tauri/src/mail/parser.rs
@@ -8,7 +8,11 @@ fn mail_address_to_list(addr: &MailAddress<'_>) -> Vec<Address> {
             .iter()
             .map(|a| Address {
                 name: a.name.as_ref().map(|s| s.to_string()),
-                email: a.address.as_ref().map(|s| s.to_string()).unwrap_or_default(),
+                email: a
+                    .address
+                    .as_ref()
+                    .map(|s| s.to_string())
+                    .unwrap_or_default(),
             })
             .collect(),
         MailAddress::Group(groups) => groups
@@ -16,7 +20,11 @@ fn mail_address_to_list(addr: &MailAddress<'_>) -> Vec<Address> {
             .flat_map(|g| {
                 g.addresses.iter().map(|a| Address {
                     name: a.name.as_ref().map(|s| s.to_string()),
-                    email: a.address.as_ref().map(|s| s.to_string()).unwrap_or_default(),
+                    email: a
+                        .address
+                        .as_ref()
+                        .map(|s| s.to_string())
+                        .unwrap_or_default(),
                 })
             })
             .collect(),
@@ -75,16 +83,12 @@ pub fn parse_envelope(
     let is_encrypted = parsed
         .content_type()
         .map(|ct| {
-            ct.ctype() == "multipart"
-                && ct.subtype().map(|s| s == "encrypted").unwrap_or(false)
+            ct.ctype() == "multipart" && ct.subtype().map(|s| s == "encrypted").unwrap_or(false)
         })
         .unwrap_or(false);
     let is_signed = parsed
         .content_type()
-        .map(|ct| {
-            ct.ctype() == "multipart"
-                && ct.subtype().map(|s| s == "signed").unwrap_or(false)
-        })
+        .map(|ct| ct.ctype() == "multipart" && ct.subtype().map(|s| s == "signed").unwrap_or(false))
         .unwrap_or(false);
 
     let id = format!("{}_{}_{}", account_id, folder_path, uid);
@@ -140,10 +144,7 @@ pub fn parse_message_body(
     let flags: Vec<String> = serde_json::from_str(flags_json).unwrap_or_default();
 
     let subject = parsed.subject().map(|s| s.to_string());
-    let date = parsed
-        .date()
-        .map(|d| d.to_rfc3339())
-        .unwrap_or_default();
+    let date = parsed.date().map(|d| d.to_rfc3339()).unwrap_or_default();
 
     // Grab raw HTML once for both image detection and sanitization
     let raw_html = parsed.body_html(0);
@@ -151,19 +152,25 @@ pub fn parse_message_body(
     // Check for remote images before sanitization strips <img> tags.
     // Only match https:// to align with the loading pipeline (parse_html_with_images
     // only allows https URL scheme).
-    let has_remote_images = raw_html.as_ref().map(|s| {
-        use std::sync::LazyLock;
-        static RE: LazyLock<regex::Regex> = LazyLock::new(|| {
-            regex::Regex::new(r#"(?i)<img\b[^>]*\bsrc\s*=\s*["']https://"#).unwrap()
-        });
-        RE.is_match(s)
-    }).unwrap_or(false);
+    let has_remote_images = raw_html
+        .as_ref()
+        .map(|s| {
+            use std::sync::LazyLock;
+            static RE: LazyLock<regex::Regex> = LazyLock::new(|| {
+                regex::Regex::new(r#"(?i)<img\b[^>]*\bsrc\s*=\s*["']https://"#).unwrap()
+            });
+            RE.is_match(s)
+        })
+        .unwrap_or(false);
 
     let body_html = raw_html.map(|s| {
         let url_schemes = std::collections::HashSet::from(["http", "https", "mailto"]);
         ammonia::Builder::default()
             .add_generic_attributes(&["style"])
-            .rm_tags(&["img", "object", "embed", "iframe", "form", "input", "button", "textarea", "select", "video", "audio", "source", "svg", "math"])
+            .rm_tags(&[
+                "img", "object", "embed", "iframe", "form", "input", "button", "textarea",
+                "select", "video", "audio", "source", "svg", "math",
+            ])
             .url_schemes(url_schemes)
             .clean(&s)
             .to_string()
@@ -177,13 +184,7 @@ pub fn parse_message_body(
             let filename = att.attachment_name().map(|s| s.to_string());
             let content_type = att
                 .content_type()
-                .map(|ct| {
-                    format!(
-                        "{}/{}",
-                        ct.ctype(),
-                        ct.subtype().unwrap_or("octet-stream")
-                    )
-                })
+                .map(|ct| format!("{}/{}", ct.ctype(), ct.subtype().unwrap_or("octet-stream")))
                 .unwrap_or_else(|| "application/octet-stream".to_string());
             Attachment {
                 index: i as u32,
@@ -229,7 +230,10 @@ pub fn parse_html_with_images(raw: &[u8]) -> Option<String> {
             .add_generic_attributes(&["style"])
             .add_tags(&["img"])
             .add_tag_attributes("img", &["src", "alt", "width", "height", "style"])
-            .rm_tags(&["object", "embed", "iframe", "form", "input", "button", "textarea", "select", "video", "audio", "source", "svg", "math"])
+            .rm_tags(&[
+                "object", "embed", "iframe", "form", "input", "button", "textarea", "select",
+                "video", "audio", "source", "svg", "math",
+            ])
             .url_schemes(url_schemes)
             .clean(&s)
             .to_string()

--- a/src-tauri/src/mail/smtp.rs
+++ b/src-tauri/src/mail/smtp.rs
@@ -1,4 +1,4 @@
-use lettre::message::{header::ContentType, Attachment, MultiPart, SinglePart, Mailbox};
+use lettre::message::{header::ContentType, Attachment, Mailbox, MultiPart, SinglePart};
 use lettre::transport::smtp::authentication::{Credentials, Mechanism};
 use lettre::{AsyncSmtpTransport, AsyncTransport, Message, Tokio1Executor};
 
@@ -46,8 +46,7 @@ fn build_body(
     let mut mixed = MultiPart::mixed().multipart(text_part);
     for att in attachments {
         let ct = ContentType::parse(&att.content_type).unwrap_or(ContentType::TEXT_PLAIN);
-        let attachment = Attachment::new(att.name.clone())
-            .body(att.data.clone(), ct);
+        let attachment = Attachment::new(att.name.clone()).body(att.data.clone(), ct);
         mixed = mixed.singlepart(attachment);
     }
 
@@ -73,16 +72,18 @@ pub async fn send_message(
 ) -> Result<()> {
     log::info!(
         "SMTP sending message from {} to {:?} via {}:{} ({} attachments)",
-        from, to, smtp_host, smtp_port, attachments.len()
+        from,
+        to,
+        smtp_host,
+        smtp_port,
+        attachments.len()
     );
 
     let from_mailbox: Mailbox = from
         .parse()
         .map_err(|e| Error::Other(format!("Invalid 'from' address '{}': {}", from, e)))?;
 
-    let mut builder = Message::builder()
-        .from(from_mailbox)
-        .subject(subject);
+    let mut builder = Message::builder().from(from_mailbox).subject(subject);
 
     for addr in to {
         let mailbox: Mailbox = addr

--- a/src-tauri/src/mail/sync.rs
+++ b/src-tauri/src/mail/sync.rs
@@ -61,7 +61,14 @@ pub async fn sync_account(
 
     let current_folder_clone = current_folder;
     let result = tokio::task::spawn_blocking(move || {
-        sync_account_blocking(&app_clone, db, &data_dir, &account_id_clone, &imap_config, current_folder_clone.as_deref())
+        sync_account_blocking(
+            &app_clone,
+            db,
+            &data_dir,
+            &account_id_clone,
+            &imap_config,
+            current_folder_clone.as_deref(),
+        )
     })
     .await
     .map_err(|e| Error::Sync(format!("Sync task panicked: {}", e)))?;
@@ -124,22 +131,24 @@ fn sync_account_blocking(
     // but keep them in the DB (they're needed for move/delete operations).
     // [Gmail]/All Mail contains every email, [Gmail]/Important is a virtual view.
     // [Gmail] itself is not a selectable mailbox.
-    let skip_sync_folders: &[&str] = &[
-        "[Gmail]/All Mail",
-        "[Gmail]/Important",
-        "[Gmail]",
-    ];
+    let skip_sync_folders: &[&str] = &["[Gmail]/All Mail", "[Gmail]/Important", "[Gmail]"];
 
     // Sync order: priority folders first (current, INBOX), then rest in parallel.
     // Folders in skip_sync_folders are registered in DB (above) but not synced.
     let mut priority: Vec<String> = Vec::new();
     let mut others: Vec<String> = Vec::new();
     for (_, path) in &imap_folders {
-        if skip_sync_folders.iter().any(|skip| path.eq_ignore_ascii_case(skip)) {
+        if skip_sync_folders
+            .iter()
+            .any(|skip| path.eq_ignore_ascii_case(skip))
+        {
             log::debug!("Skipping envelope sync for Gmail virtual folder: {}", path);
             continue;
         }
-        if current_folder.map(|cf| cf == path.as_str()).unwrap_or(false) {
+        if current_folder
+            .map(|cf| cf == path.as_str())
+            .unwrap_or(false)
+        {
             priority.insert(0, path.clone());
         } else if path.to_uppercase() == "INBOX" {
             priority.push(path.clone());
@@ -199,7 +208,8 @@ fn sync_account_blocking(
             parallel_count
         );
 
-        let mut thread_folders: Vec<Vec<String>> = (0..parallel_count).map(|_| Vec::new()).collect();
+        let mut thread_folders: Vec<Vec<String>> =
+            (0..parallel_count).map(|_| Vec::new()).collect();
         for (i, folder) in others.iter().enumerate() {
             thread_folders[i % parallel_count].push(folder.clone());
         }
@@ -222,13 +232,20 @@ fn sync_account_blocking(
                         let mut conn = match ImapConnection::connect(&imap_config) {
                             Ok(c) => c,
                             Err(e) => {
-                                log::error!("Parallel sync thread {}: connect failed: {}", thread_idx, e);
+                                log::error!(
+                                    "Parallel sync thread {}: connect failed: {}",
+                                    thread_idx,
+                                    e
+                                );
                                 return Err(e);
                             }
                         };
                         let mut thread_total = 0u32;
                         for folder in &folders {
-                            let folder_idx = priority_count + thread_idx + (folders.iter().position(|f| f == folder).unwrap_or(0) * parallel_count);
+                            let folder_idx = priority_count
+                                + thread_idx
+                                + (folders.iter().position(|f| f == folder).unwrap_or(0)
+                                    * parallel_count);
                             app.emit(
                                 "sync-progress",
                                 SyncProgress {
@@ -244,10 +261,16 @@ fn sync_account_blocking(
                                 Ok(count) => {
                                     thread_total += count;
                                     if count > 0 {
-                                        log::info!("Parallel sync: {} envelopes in {}", count, folder);
+                                        log::info!(
+                                            "Parallel sync: {} envelopes in {}",
+                                            count,
+                                            folder
+                                        );
                                     }
                                 }
-                                Err(e) => log::warn!("Parallel sync: skipping folder '{}': {}", folder, e),
+                                Err(e) => {
+                                    log::warn!("Parallel sync: skipping folder '{}': {}", folder, e)
+                                }
                             }
                         }
                         conn.logout();
@@ -256,7 +279,13 @@ fn sync_account_blocking(
                 })
                 .collect();
 
-            handles.into_iter().map(|h| h.join().unwrap_or(Err(Error::Sync("Thread panicked".into())))).collect()
+            handles
+                .into_iter()
+                .map(|h| {
+                    h.join()
+                        .unwrap_or(Err(Error::Sync("Thread panicked".into())))
+                })
+                .collect()
         });
 
         for count in results.into_iter().flatten() {
@@ -302,10 +331,16 @@ fn sync_folder_envelopes(
     // folder is unchanged — skip deletion reconciliation, flag sync, and
     // envelope fetch entirely. Most folders are dormant, so this skips ~80%
     // of folders on a typical sync cycle.
-    if last_uid > 0 && stored_uid_next > 0 && uid_next == stored_uid_next && exists as i64 == stored_total {
+    if last_uid > 0
+        && stored_uid_next > 0
+        && uid_next == stored_uid_next
+        && exists as i64 == stored_total
+    {
         log::debug!(
             "Folder '{}' unchanged (uidnext={}, exists={}), skipping",
-            folder_path, uid_next, exists
+            folder_path,
+            uid_next,
+            exists
         );
         return Ok(0);
     }
@@ -313,8 +348,7 @@ fn sync_folder_envelopes(
     // Reconcile deletions — skip on first sync (last_uid == 0) since the local DB is empty.
     if last_uid > 0 {
         let all_server_uids = conn_imap.fetch_uids(0)?;
-        let server_uid_set: std::collections::HashSet<u32> =
-            all_server_uids.into_iter().collect();
+        let server_uid_set: std::collections::HashSet<u32> = all_server_uids.into_iter().collect();
 
         let rt = tokio::runtime::Handle::current();
         let conn = rt.block_on(db.writer());
@@ -383,8 +417,16 @@ fn sync_folder_envelopes(
     if new_uids.is_empty() {
         let rt = tokio::runtime::Handle::current();
         let conn = rt.block_on(db.writer());
-        let page =
-            db::messages::get_messages(&conn, account_id, folder_path, 0, 1, "date", false, &Default::default())?;
+        let page = db::messages::get_messages(
+            &conn,
+            account_id,
+            folder_path,
+            0,
+            1,
+            "date",
+            false,
+            &Default::default(),
+        )?;
         let unread = count_unread(&conn, account_id, folder_path)?;
         db::folders::update_folder_counts(&conn, account_id, folder_path, unread, page.total)?;
         if uid_next > 0 {
@@ -515,8 +557,16 @@ fn sync_folder_envelopes(
     {
         let rt = tokio::runtime::Handle::current();
         let conn = rt.block_on(db.writer());
-        let page =
-            db::messages::get_messages(&conn, account_id, folder_path, 0, 1, "date", false, &Default::default())?;
+        let page = db::messages::get_messages(
+            &conn,
+            account_id,
+            folder_path,
+            0,
+            1,
+            "date",
+            false,
+            &Default::default(),
+        )?;
         let unread = count_unread(&conn, account_id, folder_path)?;
         db::folders::update_folder_counts(&conn, account_id, folder_path, unread, page.total)?;
         // Store uid_next for preflight optimization on next sync
@@ -554,9 +604,7 @@ pub fn fetch_and_store_body(
 
     // Write to Maildir — validate path components before creating directories
     let sanitized = sanitize_folder_name(folder_path);
-    let maildir_base = data_dir
-        .join(account_id)
-        .join(&sanitized);
+    let maildir_base = data_dir.join(account_id).join(&sanitized);
 
     // Reject any remaining ".." or absolute components before touching the filesystem
     for component in maildir_base.components() {
@@ -571,12 +619,10 @@ pub fn fetch_and_store_body(
     create_maildir_dirs(&maildir_base)?;
 
     // Post-creation canonical check as defence-in-depth (catches symlink attacks)
-    let canonical_data_dir = std::fs::canonicalize(data_dir)
-        .unwrap_or_else(|_| data_dir.to_path_buf());
+    let canonical_data_dir =
+        std::fs::canonicalize(data_dir).unwrap_or_else(|_| data_dir.to_path_buf());
     let canonical_maildir = std::fs::canonicalize(&maildir_base)
-        .map_err(|e| Error::Other(format!(
-            "Failed to resolve maildir path: {}", e
-        )))?;
+        .map_err(|e| Error::Other(format!("Failed to resolve maildir path: {}", e)))?;
     if !canonical_maildir.starts_with(&canonical_data_dir) {
         // Clean up the directory we just created since it's outside our tree
         let _ = std::fs::remove_dir_all(&canonical_maildir);
@@ -597,11 +643,7 @@ pub fn fetch_and_store_body(
         filename
     );
 
-    log::info!(
-        "Body saved: {} ({} bytes)",
-        relative_path,
-        body.len()
-    );
+    log::info!("Body saved: {} ({} bytes)", relative_path, body.len());
 
     Ok(relative_path)
 }
@@ -621,7 +663,11 @@ pub(crate) fn sanitize_folder_name(name: &str) -> String {
         .filter_map(|c| match c {
             std::path::Component::Normal(part) => {
                 let s = part.to_string_lossy().replace('.', "_");
-                if s.is_empty() { None } else { Some(s) }
+                if s.is_empty() {
+                    None
+                } else {
+                    Some(s)
+                }
             }
             // Strip ., .., /, and prefix components
             _ => None,
@@ -906,11 +952,22 @@ fn load_messages_by_ids(
         .collect::<std::result::Result<Vec<_>, _>>()?;
 
     let mut messages = Vec::with_capacity(rows.len());
-    for (id, uid, folder, from_name, from_email, to_json, cc_json, subject, size, has_attach, flags_json) in rows {
-        let to_addresses: Vec<AddressEntry> =
-            serde_json::from_str(&to_json).unwrap_or_default();
-        let cc_addresses: Vec<AddressEntry> =
-            serde_json::from_str(&cc_json).unwrap_or_default();
+    for (
+        id,
+        uid,
+        folder,
+        from_name,
+        from_email,
+        to_json,
+        cc_json,
+        subject,
+        size,
+        has_attach,
+        flags_json,
+    ) in rows
+    {
+        let to_addresses: Vec<AddressEntry> = serde_json::from_str(&to_json).unwrap_or_default();
+        let cc_addresses: Vec<AddressEntry> = serde_json::from_str(&cc_json).unwrap_or_default();
         let flags: Vec<String> = serde_json::from_str(&flags_json).unwrap_or_default();
 
         messages.push(MessageData {

--- a/src-tauri/src/mail/url_validation.rs
+++ b/src-tauri/src/mail/url_validation.rs
@@ -22,8 +22,7 @@ fn redact_url(url: &str) -> String {
 /// development against test servers. Release builds reject all cleartext
 /// URLs unconditionally.
 pub fn require_https(url: &str) -> Result<()> {
-    let parsed = url::Url::parse(url)
-        .map_err(|e| Error::Other(format!("Invalid URL: {}", e)))?;
+    let parsed = url::Url::parse(url).map_err(|e| Error::Other(format!("Invalid URL: {}", e)))?;
 
     match parsed.scheme() {
         "https" => Ok(()),
@@ -118,7 +117,11 @@ mod tests {
             .to_string();
         assert!(!err.contains("secret"), "password leaked in error: {}", err);
         assert!(!err.contains("user:"), "userinfo leaked in error: {}", err);
-        assert!(err.contains("example.com"), "expected host in error: {}", err);
+        assert!(
+            err.contains("example.com"),
+            "expected host in error: {}",
+            err
+        );
     }
 
     #[test]

--- a/src-tauri/src/oauth.rs
+++ b/src-tauri/src/oauth.rs
@@ -55,7 +55,8 @@ pub const MICROSOFT: OAuthProvider = OAuthProvider {
 };
 
 /// Microsoft Graph scopes — used for a separate token refresh for calendar/contacts.
-pub const MICROSOFT_GRAPH_SCOPES: &str = "User.Read Calendars.ReadWrite Contacts.ReadWrite offline_access";
+pub const MICROSOFT_GRAPH_SCOPES: &str =
+    "User.Read Calendars.ReadWrite Contacts.ReadWrite offline_access";
 
 /// Microsoft IMAP/SMTP scopes — used for token refresh for mail access.
 /// Uses outlook.office.com (works for both personal and work/school accounts).
@@ -114,10 +115,13 @@ impl OAuthTokens {
 /// The listener is kept open to prevent port hijacking between URL
 /// generation and callback handling (TOCTOU). The state parameter
 /// provides CSRF protection and must be validated in the callback.
-pub fn get_auth_url(provider: &OAuthProvider) -> Result<(String, TcpListener, Option<String>, String)> {
+pub fn get_auth_url(
+    provider: &OAuthProvider,
+) -> Result<(String, TcpListener, Option<String>, String)> {
     let listener = TcpListener::bind("127.0.0.1:0")
         .map_err(|e| Error::Other(format!("Failed to bind local server: {}", e)))?;
-    let port = listener.local_addr()
+    let port = listener
+        .local_addr()
         .map_err(|e| Error::Other(format!("Failed to get port: {}", e)))?
         .port();
 
@@ -177,10 +181,14 @@ pub fn wait_for_callback(listener: TcpListener) -> Result<CallbackResult> {
 
     let timeout = Duration::from_secs(300);
     let deadline = Instant::now() + timeout;
-    listener.set_nonblocking(true)
+    listener
+        .set_nonblocking(true)
         .map_err(|e| Error::Other(format!("Failed to set non-blocking: {}", e)))?;
 
-    log::info!("OAuth2: waiting for callback (timeout={}s)", timeout.as_secs());
+    log::info!(
+        "OAuth2: waiting for callback (timeout={}s)",
+        timeout.as_secs()
+    );
 
     let (mut stream, _) = loop {
         match listener.accept() {
@@ -200,11 +208,15 @@ pub fn wait_for_callback(listener: TcpListener) -> Result<CallbackResult> {
         }
     };
 
-    let mut reader = BufReader::new(stream.try_clone()
-        .map_err(|e| Error::Other(format!("Stream clone failed: {}", e)))?);
+    let mut reader = BufReader::new(
+        stream
+            .try_clone()
+            .map_err(|e| Error::Other(format!("Stream clone failed: {}", e)))?,
+    );
 
     let mut request_line = String::new();
-    reader.read_line(&mut request_line)
+    reader
+        .read_line(&mut request_line)
         .map_err(|e| Error::Other(format!("Failed to read request: {}", e)))?;
 
     // Parse query parameters from: GET /?code=xxx&state=yyy HTTP/1.1
@@ -213,7 +225,8 @@ pub fn wait_for_callback(listener: TcpListener) -> Result<CallbackResult> {
         .nth(1)
         .and_then(|path| path.split('?').nth(1))
         .map(|query| {
-            query.split('&')
+            query
+                .split('&')
                 .filter_map(|param| {
                     let mut parts = param.splitn(2, '=');
                     let key = parts.next()?;
@@ -229,7 +242,8 @@ pub fn wait_for_callback(listener: TcpListener) -> Result<CallbackResult> {
         .unwrap_or_default();
 
     let code = query_params.get("code").cloned().ok_or_else(|| {
-        let error = query_params.get("error")
+        let error = query_params
+            .get("error")
             .cloned()
             .unwrap_or_else(|| "unknown".to_string());
         Error::Other(format!("OAuth2 authorization failed: {}", error))
@@ -287,7 +301,9 @@ pub async fn exchange_code(
         return Err(Error::Other(format!("Token exchange error: {}", body)));
     }
 
-    let token_resp: serde_json::Value = resp.json().await
+    let token_resp: serde_json::Value = resp
+        .json()
+        .await
         .map_err(|e| Error::Other(format!("Token parse failed: {}", e)))?;
 
     let access_token = token_resp["access_token"]
@@ -295,14 +311,15 @@ pub async fn exchange_code(
         .ok_or_else(|| Error::Other("No access_token in response".into()))?
         .to_string();
 
-    let refresh_token = token_resp["refresh_token"]
-        .as_str()
-        .map(|s| s.to_string());
+    let refresh_token = token_resp["refresh_token"].as_str().map(|s| s.to_string());
 
     let expires_in = token_resp["expires_in"].as_i64().unwrap_or(3600);
     let expires_at = chrono::Utc::now().timestamp() + expires_in;
 
-    log::info!("OAuth2: token exchange successful, expires in {}s", expires_in);
+    log::info!(
+        "OAuth2: token exchange successful, expires in {}s",
+        expires_in
+    );
 
     Ok(OAuthTokens {
         access_token,
@@ -338,7 +355,9 @@ pub async fn refresh_access_token(
         return Err(Error::Other(format!("Token refresh error: {}", body)));
     }
 
-    let token_resp: serde_json::Value = resp.json().await
+    let token_resp: serde_json::Value = resp
+        .json()
+        .await
         .map_err(|e| Error::Other(format!("Token refresh parse failed: {}", e)))?;
 
     let access_token = token_resp["access_token"]
@@ -394,7 +413,9 @@ pub async fn refresh_with_scopes(
         return Err(Error::Other(format!("Token refresh error: {}", body)));
     }
 
-    let token_resp: serde_json::Value = resp.json().await
+    let token_resp: serde_json::Value = resp
+        .json()
+        .await
         .map_err(|e| Error::Other(format!("Token refresh parse failed: {}", e)))?;
 
     let access_token = token_resp["access_token"]
@@ -411,7 +432,10 @@ pub async fn refresh_with_scopes(
         .map(|s| s.to_string())
         .unwrap_or_else(|| refresh_token.to_string());
 
-    log::info!("OAuth2: token refreshed with scopes, expires in {}s", expires_in);
+    log::info!(
+        "OAuth2: token refreshed with scopes, expires in {}s",
+        expires_in
+    );
 
     Ok(OAuthTokens {
         access_token,
@@ -434,7 +458,10 @@ pub struct OidcEndpoints {
 /// Discover OIDC endpoints from a JMAP server's .well-known/openid-configuration.
 /// `base_url` should be like "https://mail.example.com".
 pub async fn discover_oidc(base_url: &str) -> Result<OidcEndpoints> {
-    let url = format!("{}/.well-known/openid-configuration", base_url.trim_end_matches('/'));
+    let url = format!(
+        "{}/.well-known/openid-configuration",
+        base_url.trim_end_matches('/')
+    );
     log::info!("OIDC: discovering endpoints from {}", url);
 
     let client = reqwest::Client::builder()
@@ -442,17 +469,23 @@ pub async fn discover_oidc(base_url: &str) -> Result<OidcEndpoints> {
         .build()
         .map_err(|e| Error::Other(format!("HTTP client build error: {}", e)))?;
 
-    let resp = client.get(&url).send().await
+    let resp = client
+        .get(&url)
+        .send()
+        .await
         .map_err(|e| Error::Other(format!("OIDC discovery failed: {}", e)))?;
 
     if !resp.status().is_success() {
         let status = resp.status();
         return Err(Error::Other(format!(
-            "OIDC discovery returned {}: server may not support OIDC", status
+            "OIDC discovery returned {}: server may not support OIDC",
+            status
         )));
     }
 
-    let config: serde_json::Value = resp.json().await
+    let config: serde_json::Value = resp
+        .json()
+        .await
         .map_err(|e| Error::Other(format!("OIDC discovery parse error: {}", e)))?;
 
     let token_endpoint = config["token_endpoint"]
@@ -462,7 +495,8 @@ pub async fn discover_oidc(base_url: &str) -> Result<OidcEndpoints> {
 
     if !token_endpoint.starts_with("https://") {
         return Err(Error::Other(format!(
-            "OIDC: token_endpoint must use HTTPS, got: {}", token_endpoint
+            "OIDC: token_endpoint must use HTTPS, got: {}",
+            token_endpoint
         )));
     }
 
@@ -473,7 +507,8 @@ pub async fn discover_oidc(base_url: &str) -> Result<OidcEndpoints> {
     if let Some(ref ep) = device_authorization_endpoint {
         if !ep.starts_with("https://") {
             return Err(Error::Other(format!(
-                "OIDC: device_authorization_endpoint must use HTTPS, got: {}", ep
+                "OIDC: device_authorization_endpoint must use HTTPS, got: {}",
+                ep
             )));
         }
     }
@@ -485,13 +520,18 @@ pub async fn discover_oidc(base_url: &str) -> Result<OidcEndpoints> {
     if let Some(ref ep) = registration_endpoint {
         if !ep.starts_with("https://") {
             return Err(Error::Other(format!(
-                "OIDC: registration_endpoint must use HTTPS, got: {}", ep
+                "OIDC: registration_endpoint must use HTTPS, got: {}",
+                ep
             )));
         }
     }
 
-    log::info!("OIDC: discovered token={}, device_auth={:?}, registration={:?}",
-        token_endpoint, device_authorization_endpoint, registration_endpoint);
+    log::info!(
+        "OIDC: discovered token={}, device_auth={:?}, registration={:?}",
+        token_endpoint,
+        device_authorization_endpoint,
+        registration_endpoint
+    );
 
     Ok(OidcEndpoints {
         token_endpoint,
@@ -529,11 +569,14 @@ pub async fn register_oidc_client(registration_endpoint: &str) -> Result<String>
         let status = resp.status();
         let resp_body = resp.text().await.unwrap_or_default();
         return Err(Error::Other(format!(
-            "OIDC client registration returned {}: {}", status, resp_body
+            "OIDC client registration returned {}: {}",
+            status, resp_body
         )));
     }
 
-    let reg_resp: serde_json::Value = resp.json().await
+    let reg_resp: serde_json::Value = resp
+        .json()
+        .await
         .map_err(|e| Error::Other(format!("OIDC registration parse error: {}", e)))?;
 
     let client_id = reg_resp["client_id"]
@@ -566,8 +609,12 @@ pub struct DeviceAuthResponse {
     pub expires_in: u64,
 }
 
-fn default_interval() -> u64 { 5 }
-fn default_expires_in() -> u64 { 600 }
+fn default_interval() -> u64 {
+    5
+}
+fn default_expires_in() -> u64 {
+    600
+}
 
 /// Start the device authorization flow — POST to the device authorization endpoint.
 /// Returns the device code, user code, and verification URL to show to the user.
@@ -576,10 +623,15 @@ pub async fn device_auth_start(
     client_id: &str,
 ) -> Result<DeviceAuthResponse> {
     if client_id.trim().is_empty() {
-        return Err(Error::Other("Device authorization requires a client_id".into()));
+        return Err(Error::Other(
+            "Device authorization requires a client_id".into(),
+        ));
     }
 
-    log::info!("OIDC device flow: requesting device code from {}", device_auth_endpoint);
+    log::info!(
+        "OIDC device flow: requesting device code from {}",
+        device_auth_endpoint
+    );
 
     let mut params = HashMap::new();
     params.insert("client_id", client_id.to_string());
@@ -600,15 +652,20 @@ pub async fn device_auth_start(
         let status = resp.status();
         let body = resp.text().await.unwrap_or_default();
         return Err(Error::Other(format!(
-            "Device auth endpoint returned {}: {}", status, body
+            "Device auth endpoint returned {}: {}",
+            status, body
         )));
     }
 
-    let auth_resp: DeviceAuthResponse = resp.json().await
+    let auth_resp: DeviceAuthResponse = resp
+        .json()
+        .await
         .map_err(|e| Error::Other(format!("Device auth response parse error: {}", e)))?;
 
-    log::info!("OIDC device flow: received user_code, verification_uri={}",
-        auth_resp.verification_uri);
+    log::info!(
+        "OIDC device flow: received user_code, verification_uri={}",
+        auth_resp.verification_uri
+    );
 
     Ok(auth_resp)
 }
@@ -633,7 +690,9 @@ pub async fn device_auth_poll(
 
     loop {
         if std::time::Instant::now() >= deadline {
-            return Err(Error::Other("Device authorization timed out — user did not complete sign-in".into()));
+            return Err(Error::Other(
+                "Device authorization timed out — user did not complete sign-in".into(),
+            ));
         }
 
         // Sleep before polling (skip on first attempt per RFC 8628 §3.5)
@@ -644,7 +703,10 @@ pub async fn device_auth_poll(
         }
 
         let mut params = HashMap::new();
-        params.insert("grant_type", "urn:ietf:params:oauth:grant-type:device_code".to_string());
+        params.insert(
+            "grant_type",
+            "urn:ietf:params:oauth:grant-type:device_code".to_string(),
+        );
         params.insert("device_code", device_code.to_string());
         if !client_id.is_empty() {
             params.insert("client_id", client_id.to_string());
@@ -658,7 +720,9 @@ pub async fn device_auth_poll(
             .map_err(|e| Error::Other(format!("Device token poll failed: {}", e)))?;
 
         if resp.status().is_success() {
-            let token_resp: serde_json::Value = resp.json().await
+            let token_resp: serde_json::Value = resp
+                .json()
+                .await
                 .map_err(|e| Error::Other(format!("Device token parse failed: {}", e)))?;
 
             let access_token = token_resp["access_token"]
@@ -666,14 +730,15 @@ pub async fn device_auth_poll(
                 .ok_or_else(|| Error::Other("No access_token in device token response".into()))?
                 .to_string();
 
-            let refresh_token = token_resp["refresh_token"]
-                .as_str()
-                .map(|s| s.to_string());
+            let refresh_token = token_resp["refresh_token"].as_str().map(|s| s.to_string());
 
             let expires_in = token_resp["expires_in"].as_i64().unwrap_or(3600);
             let expires_at = chrono::Utc::now().timestamp() + expires_in;
 
-            log::info!("OIDC device flow: authorization complete, expires in {}s", expires_in);
+            log::info!(
+                "OIDC device flow: authorization complete, expires in {}s",
+                expires_in
+            );
 
             return Ok(OAuthTokens {
                 access_token,
@@ -694,18 +759,26 @@ pub async fn device_auth_poll(
             "slow_down" => {
                 // RFC 8628 §3.5: increase interval by 5 seconds
                 current_interval += std::time::Duration::from_secs(5);
-                log::debug!("OIDC device flow: slow_down, interval now {}s", current_interval.as_secs());
+                log::debug!(
+                    "OIDC device flow: slow_down, interval now {}s",
+                    current_interval.as_secs()
+                );
                 continue;
             }
             "access_denied" => {
                 return Err(Error::Other("Device authorization denied by user".into()));
             }
             "expired_token" => {
-                return Err(Error::Other("Device code expired — please try again".into()));
+                return Err(Error::Other(
+                    "Device code expired — please try again".into(),
+                ));
             }
             _ => {
                 let desc = body["error_description"].as_str().unwrap_or("");
-                return Err(Error::Other(format!("Device auth error: {} {}", error, desc)));
+                return Err(Error::Other(format!(
+                    "Device auth error: {} {}",
+                    error, desc
+                )));
             }
         }
     }
@@ -739,7 +812,9 @@ pub async fn refresh_token_dynamic(
         return Err(Error::Other(format!("OIDC token refresh error: {}", body)));
     }
 
-    let token_resp: serde_json::Value = resp.json().await
+    let token_resp: serde_json::Value = resp
+        .json()
+        .await
         .map_err(|e| Error::Other(format!("OIDC token refresh parse failed: {}", e)))?;
 
     let access_token = token_resp["access_token"]
@@ -784,14 +859,18 @@ pub fn store_tokens(account_id: &str, tokens: &OAuthTokens) -> Result<()> {
         // Drop the stale credential and retry once with a fresh CreateItem.
         log::warn!(
             "OAuth2: keyring set_password failed for {} ({}); attempting recovery",
-            account_id, first,
+            account_id,
+            first,
         );
         let _ = entry.delete_credential();
         entry.set_password(&json).map_err(|e| {
             Error::Keyring(format!("Failed to store tokens (after recovery): {}", e))
         })?;
     }
-    log::info!("OAuth2: tokens stored in keyring for account {}", account_id);
+    log::info!(
+        "OAuth2: tokens stored in keyring for account {}",
+        account_id
+    );
     Ok(())
 }
 
@@ -830,8 +909,16 @@ mod tests {
     fn test_pkce_verifier_is_valid_length() {
         let verifier = generate_code_verifier();
         // RFC 7636: 43-128 characters
-        assert!(verifier.len() >= 43, "verifier too short: {}", verifier.len());
-        assert!(verifier.len() <= 128, "verifier too long: {}", verifier.len());
+        assert!(
+            verifier.len() >= 43,
+            "verifier too short: {}",
+            verifier.len()
+        );
+        assert!(
+            verifier.len() <= 128,
+            "verifier too long: {}",
+            verifier.len()
+        );
     }
 
     #[test]
@@ -841,7 +928,8 @@ mod tests {
         for c in verifier.chars() {
             assert!(
                 c.is_ascii_alphanumeric() || c == '-' || c == '_',
-                "invalid char in verifier: '{}'", c
+                "invalid char in verifier: '{}'",
+                c
             );
         }
     }
@@ -868,7 +956,8 @@ mod tests {
         for c in challenge.chars() {
             assert!(
                 c.is_ascii_alphanumeric() || c == '-' || c == '_',
-                "invalid char in challenge: '{}'", c
+                "invalid char in challenge: '{}'",
+                c
             );
         }
         // No padding

--- a/src-tauri/src/ops/coalesce.rs
+++ b/src-tauri/src/ops/coalesce.rs
@@ -33,9 +33,7 @@ pub fn coalesce(mut ops: Vec<OpEntry>) -> Vec<OpEntry> {
                 by_folder,
                 target_folder,
             } => {
-                let moves = pending_moves
-                    .entry(target_folder)
-                    .or_default();
+                let moves = pending_moves.entry(target_folder).or_default();
                 merge_by_folder(moves, by_folder);
             }
             MailOp::SetFlags {

--- a/src-tauri/src/ops/offline.rs
+++ b/src-tauri/src/ops/offline.rs
@@ -159,10 +159,9 @@ pub fn mail_op_to_outbox(op: &MailOp) -> Option<(&'static str, serde_json::Value
                 "target_folder": target_folder,
             }),
         )),
-        MailOp::DeleteMessages { by_folder } => Some((
-            "delete",
-            serde_json::json!({ "by_folder": by_folder }),
-        )),
+        MailOp::DeleteMessages { by_folder } => {
+            Some(("delete", serde_json::json!({ "by_folder": by_folder })))
+        }
         MailOp::SetFlags {
             by_folder,
             flags,
@@ -193,9 +192,9 @@ pub fn mail_op_to_outbox(op: &MailOp) -> Option<(&'static str, serde_json::Value
 /// Validate that a folder path doesn't contain characters that could be
 /// injected into IMAP commands (null bytes, bare newlines).
 fn validate_folder_paths(by_folder: &std::collections::HashMap<String, Vec<u32>>) -> bool {
-    by_folder.keys().all(|path| {
-        !path.contains('\0') && !path.contains('\n') && !path.contains('\r')
-    })
+    by_folder
+        .keys()
+        .all(|path| !path.contains('\0') && !path.contains('\n') && !path.contains('\r'))
 }
 
 /// Convert an outbox entry back to a MailOp for replay.

--- a/src-tauri/src/ops/queue.rs
+++ b/src-tauri/src/ops/queue.rs
@@ -5,13 +5,9 @@ use std::collections::HashMap;
 pub enum MailOp {
     // --- Sync (lower priority) ---
     /// Full account sync. The worker delegates to the existing sync engine.
-    SyncAll {
-        current_folder: Option<String>,
-    },
+    SyncAll { current_folder: Option<String> },
     /// Sync a single folder.
-    SyncFolder {
-        folder_path: String,
-    },
+    SyncFolder { folder_path: String },
 
     // --- User operations (higher priority) ---
     /// Move messages by IMAP UID, grouped by source folder.

--- a/src-tauri/src/ops/worker.rs
+++ b/src-tauri/src/ops/worker.rs
@@ -109,7 +109,8 @@ impl AccountWorker {
 
             let mut sync_succeeded = false;
             for entry in ops {
-                let is_sync = matches!(entry.op, MailOp::SyncAll { .. } | MailOp::SyncFolder { .. });
+                let is_sync =
+                    matches!(entry.op, MailOp::SyncAll { .. } | MailOp::SyncFolder { .. });
                 match self.execute(entry.op).await {
                     Ok(()) => {
                         if is_sync {
@@ -117,11 +118,7 @@ impl AccountWorker {
                         }
                     }
                     Err(e) => {
-                        log::error!(
-                            "Worker op failed for account {}: {}",
-                            self.account_id,
-                            e
-                        );
+                        log::error!("Worker op failed for account {}: {}", self.account_id, e);
                         // Don't break the loop — continue processing remaining ops
                     }
                 }
@@ -244,22 +241,23 @@ impl AccountWorker {
 
         // Serialize the op for outbox before executing (we move op into execute_*)
         let outbox_data = if !is_sync {
-            super::offline::mail_op_to_outbox(&op)
-                .map(|(t, p)| (t.to_string(), p))
+            super::offline::mail_op_to_outbox(&op).map(|(t, p)| (t.to_string(), p))
         } else {
             None
         };
 
         let result = match &op {
-            MailOp::SyncAll { .. } | MailOp::SyncFolder { .. } => {
-                self.execute_sync(op).await
-            }
+            MailOp::SyncAll { .. } | MailOp::SyncFolder { .. } => self.execute_sync(op).await,
             _ => match self.protocol.as_str() {
                 "imap" => self.execute_imap(op).await,
                 "jmap" => self.execute_jmap(op).await,
                 "graph" => self.execute_graph(op).await,
                 _ => {
-                    log::warn!("Worker: unknown protocol '{}' for account {}", self.protocol, self.account_id);
+                    log::warn!(
+                        "Worker: unknown protocol '{}' for account {}",
+                        self.protocol,
+                        self.account_id
+                    );
                     Ok(())
                 }
             },
@@ -399,11 +397,7 @@ impl AccountWorker {
         let mut imap_state = self.imap_state.take().unwrap();
 
         let (result, state_back) = tokio::task::spawn_blocking(move || {
-            let result = execute_imap_op(
-                &mut imap_state.conn,
-                &mut imap_state.selected_folder,
-                op,
-            );
+            let result = execute_imap_op(&mut imap_state.conn, &mut imap_state.selected_folder, op);
             (result, imap_state)
         })
         .await
@@ -433,13 +427,12 @@ impl AccountWorker {
         if self.imap_state.is_none() || stale {
             // Exponential backoff: 1s, 2s, 4s, 8s, ... max 60s
             if self.consecutive_failures > 0 {
-                let delay_secs = std::cmp::min(
-                    1u64 << (self.consecutive_failures - 1),
-                    60,
-                );
+                let delay_secs = std::cmp::min(1u64 << (self.consecutive_failures - 1), 60);
                 log::info!(
                     "Worker: backoff {}s before reconnect (failures={}) for account {}",
-                    delay_secs, self.consecutive_failures, self.account_id
+                    delay_secs,
+                    self.consecutive_failures,
+                    self.account_id
                 );
                 tokio::time::sleep(std::time::Duration::from_secs(delay_secs)).await;
             }

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -81,12 +81,7 @@ impl AppState {
         }
 
         let (tx, rx) = tokio::sync::mpsc::channel::<OpEntry>(256);
-        let worker = AccountWorker::new(
-            account_id.to_string(),
-            rx,
-            self.db.clone(),
-            app.clone(),
-        );
+        let worker = AccountWorker::new(account_id.to_string(), rx, self.db.clone(), app.clone());
         tokio::spawn(worker.run());
         senders.insert(account_id.to_string(), tx.clone());
         tx


### PR DESCRIPTION
Closes #62.

## Summary

- **`.github/workflows/ci.yml`**: on PRs to `main` and pushes to `main`
  - Frontend: `pnpm install`, `vue-tsc --noEmit`, `pnpm test` (Vitest)
  - Rust: installs Tauri system deps, then `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --all-targets`
- **`.github/workflows/security.yml`**: daily `cargo audit` via `rustsec/audit-check` (06:17 UTC), plus on `Cargo.{toml,lock}` changes and `workflow_dispatch`
- **`SECURITY.md`**: private reporting channel (kushal@sunet.se, kano@sunet.se), scope, pre-1.0 support statement
- All third-party actions pinned by commit SHA; the version tag resolved at pin time is preserved as a trailing comment

## Also in this PR

- Commit 1: `chore(rust): apply cargo fmt --all`. `cargo fmt --check` failed on `main` as-is (pre-existing drift). Running fmt first keeps CI green when the workflow lands. No semantic changes.

## Local verification

All steps the CI workflow will run pass locally on this branch:

- `pnpm test`: 200 passed
- `pnpm exec vue-tsc --noEmit`: clean
- `cargo fmt --all -- --check`: clean
- `cargo clippy --all-targets -- -D warnings`: clean
- `cargo test --all-targets`: 154 passed

## Test plan

- [ ] Draft PR triggers `CI / frontend` and `CI / rust` checks and both go green
- [ ] Review rendered `SECURITY.md` on GitHub
- [ ] After merge, confirm `Security audit` workflow appears in Actions and can be invoked via `workflow_dispatch`