### PR TITLE
security(imap): drop escaped-path cleanup on traversal detection

### DIFF
--- a/src-tauri/src/mail/sync.rs
+++ b/src-tauri/src/mail/sync.rs
@@ -624,8 +624,10 @@ pub fn fetch_and_store_body(
     let canonical_maildir = std::fs::canonicalize(&maildir_base)
         .map_err(|e| Error::Other(format!("Failed to resolve maildir path: {}", e)))?;
     if !canonical_maildir.starts_with(&canonical_data_dir) {
-        // Clean up the directory we just created since it's outside our tree
-        let _ = std::fs::remove_dir_all(&canonical_maildir);
+        // Do NOT attempt to clean up: the canonical path is, by construction,
+        // outside our data tree, and removing it would follow the symlink an
+        // attacker used to cause the escape and recursively delete arbitrary
+        // user data. Leaving the stray dir is the safer failure mode.
         return Err(Error::Other(format!(
             "Path traversal detected: maildir path '{}' escapes data directory",
             maildir_base.display()


### PR DESCRIPTION
## Summary
- Mirror the JMAP hardening from #105 on the IMAP body-fetch path in `src-tauri/src/mail/sync.rs`.
- `remove_dir_all` on a canonical path we have just proven is outside `data_dir` is a footgun: if an attacker used a symlink to cause the escape, the cleanup would follow it and recursively delete arbitrary user data. Leaving the stray dir is the safer failure mode.
- The IMAP path uses a numeric UID as the filename, so there is no attacker-controlled string driving traversal in the first place; this is defence-in-depth consistency with the JMAP side.

Closes #106.

## Test plan
- [x] `cargo build --all-targets` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] IMAP account still syncs bodies normally (one-line change on an error-only branch, so the happy path is untouched; low-risk to test locally before merge)