### PR TITLE
feat(accounts): per-account calendar sync toggle

### DIFF
--- a/src-tauri/src/commands/accounts.rs
+++ b/src-tauri/src/commands/accounts.rs
@@ -91,6 +91,7 @@ pub async fn get_account_config(
         jmap_auth_method: full.jmap_auth_method,
         oidc_token_endpoint: full.oidc_token_endpoint,
         oidc_client_id: full.oidc_client_id,
+        calendar_sync_enabled: full.calendar_sync_enabled,
     })
 }
 

--- a/src-tauri/src/commands/calendar.rs
+++ b/src-tauri/src/commands/calendar.rs
@@ -691,6 +691,14 @@ pub async fn sync_calendars(
         db::accounts::get_account_full(&conn, &account_id)?
     };
 
+    if !account.calendar_sync_enabled {
+        log::info!(
+            "sync_calendars: skipping account {} (calendar sync disabled)",
+            account_id
+        );
+        return Ok(());
+    }
+
     if account.mail_protocol == "jmap" {
         sync_calendars_jmap(&state, &account_id, &account).await?;
     } else if account.provider == "gmail" {

--- a/src-tauri/src/commands/calendar.rs
+++ b/src-tauri/src/commands/calendar.rs
@@ -668,6 +668,22 @@ pub async fn sync_calendars(
 ) -> Result<()> {
     log::info!("sync_calendars: account={}", account_id);
 
+    let account = {
+        let conn = state.db.reader();
+        db::accounts::get_account_full(&conn, &account_id)?
+    };
+
+    // Gate on the per-account toggle before any side effects. Running the
+    // force_full_sync token-clearing below for a disabled account would
+    // make the *next* sync after re-enabling do an unnecessary full sync.
+    if !account.calendar_sync_enabled {
+        log::info!(
+            "sync_calendars: skipping account {} (calendar sync disabled)",
+            account_id
+        );
+        return Ok(());
+    }
+
     // When force_full_sync is true (manual Sync button), clear Google/O365
     // sync tokens to force a full sync that reconciles server-side deletions.
     if force_full_sync.unwrap_or(false) {
@@ -684,19 +700,6 @@ pub async fn sync_calendars(
             "sync_calendars: cleared sync tokens for full sync (account={})",
             account_id
         );
-    }
-
-    let account = {
-        let conn = state.db.reader();
-        db::accounts::get_account_full(&conn, &account_id)?
-    };
-
-    if !account.calendar_sync_enabled {
-        log::info!(
-            "sync_calendars: skipping account {} (calendar sync disabled)",
-            account_id
-        );
-        return Ok(());
     }
 
     if account.mail_protocol == "jmap" {

--- a/src-tauri/src/db/accounts.rs
+++ b/src-tauri/src/db/accounts.rs
@@ -36,10 +36,16 @@ pub struct AccountConfig {
     pub oidc_token_endpoint: String,
     #[serde(default)]
     pub oidc_client_id: String,
+    #[serde(default = "default_true")]
+    pub calendar_sync_enabled: bool,
 }
 
 fn default_basic() -> String {
     "basic".to_string()
+}
+
+fn default_true() -> bool {
+    true
 }
 
 #[derive(Debug, Clone)]
@@ -63,6 +69,7 @@ pub struct AccountFull {
     pub jmap_auth_method: String,
     pub oidc_token_endpoint: String,
     pub oidc_client_id: String,
+    pub calendar_sync_enabled: bool,
 }
 
 pub fn list_accounts(conn: &Connection) -> Result<Vec<Account>> {
@@ -86,7 +93,7 @@ pub fn list_accounts(conn: &Connection) -> Result<Vec<Account>> {
 
 pub fn get_account_full(conn: &Connection, id: &str) -> Result<AccountFull> {
     let mut account = conn.query_row(
-        "SELECT id, display_name, email, provider, mail_protocol, imap_host, imap_port, smtp_host, smtp_port, jmap_url, caldav_url, username, use_tls, enabled, signature, jmap_auth_method, oidc_token_endpoint, oidc_client_id FROM accounts WHERE id = ?1",
+        "SELECT id, display_name, email, provider, mail_protocol, imap_host, imap_port, smtp_host, smtp_port, jmap_url, caldav_url, username, use_tls, enabled, signature, jmap_auth_method, oidc_token_endpoint, oidc_client_id, calendar_sync_enabled FROM accounts WHERE id = ?1",
         params![id],
         |row| {
             Ok(AccountFull {
@@ -109,6 +116,7 @@ pub fn get_account_full(conn: &Connection, id: &str) -> Result<AccountFull> {
                 jmap_auth_method: row.get(15)?,
                 oidc_token_endpoint: row.get(16)?,
                 oidc_client_id: row.get(17)?,
+                calendar_sync_enabled: row.get(18)?,
             })
         },
     ).map_err(|e| match e {
@@ -141,8 +149,8 @@ pub fn insert_account(conn: &Connection, id: &str, config: &AccountConfig) -> Re
     }
 
     conn.execute(
-        "INSERT INTO accounts (id, display_name, email, provider, mail_protocol, imap_host, imap_port, smtp_host, smtp_port, jmap_url, caldav_url, username, use_tls, signature, jmap_auth_method, oidc_token_endpoint, oidc_client_id)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17)",
+        "INSERT INTO accounts (id, display_name, email, provider, mail_protocol, imap_host, imap_port, smtp_host, smtp_port, jmap_url, caldav_url, username, use_tls, signature, jmap_auth_method, oidc_token_endpoint, oidc_client_id, calendar_sync_enabled)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18)",
         params![
             id,
             config.display_name,
@@ -161,6 +169,7 @@ pub fn insert_account(conn: &Connection, id: &str, config: &AccountConfig) -> Re
             config.jmap_auth_method,
             config.oidc_token_endpoint,
             config.oidc_client_id,
+            config.calendar_sync_enabled,
         ],
     )?;
     Ok(())
@@ -180,8 +189,9 @@ pub fn update_account(conn: &Connection, id: &str, config: &AccountConfig) -> Re
          imap_host=?5, imap_port=?6, smtp_host=?7, smtp_port=?8, jmap_url=?9,
          caldav_url=?10, username=?11, use_tls=?12, signature=?13,
          jmap_auth_method=?14, oidc_token_endpoint=?15, oidc_client_id=?16,
+         calendar_sync_enabled=?17,
          updated_at=CURRENT_TIMESTAMP
-         WHERE id=?17",
+         WHERE id=?18",
         params![
             config.display_name,
             config.email,
@@ -199,6 +209,7 @@ pub fn update_account(conn: &Connection, id: &str, config: &AccountConfig) -> Re
             config.jmap_auth_method,
             config.oidc_token_endpoint,
             config.oidc_client_id,
+            config.calendar_sync_enabled,
             id,
         ],
     )?;
@@ -246,6 +257,7 @@ mod tests {
                 jmap_auth_method TEXT NOT NULL DEFAULT 'basic',
                 oidc_token_endpoint TEXT NOT NULL DEFAULT '',
                 oidc_client_id TEXT NOT NULL DEFAULT '',
+                calendar_sync_enabled INTEGER NOT NULL DEFAULT 1,
                 created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
                 updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
             );
@@ -278,6 +290,7 @@ mod tests {
             jmap_auth_method: "basic".to_string(),
             oidc_token_endpoint: String::new(),
             oidc_client_id: String::new(),
+            calendar_sync_enabled: true,
         }
     }
 
@@ -414,6 +427,26 @@ mod tests {
 
         let full = get_account_full(&conn, &id).unwrap();
         assert_eq!(full.signature, "-- \nAlice S.");
+        crate::keyring::delete_password(&id).ok();
+    }
+
+    #[test]
+    fn test_calendar_sync_enabled_defaults_true_and_persists_toggle() {
+        let conn = setup_db();
+        let id = unique_id();
+        let config = make_config("alice@example.com", "Alice");
+        assert!(config.calendar_sync_enabled);
+        insert_account(&conn, &id, &config).unwrap();
+
+        let full = get_account_full(&conn, &id).unwrap();
+        assert!(full.calendar_sync_enabled);
+
+        let mut updated = config.clone();
+        updated.calendar_sync_enabled = false;
+        update_account(&conn, &id, &updated).unwrap();
+
+        let full = get_account_full(&conn, &id).unwrap();
+        assert!(!full.calendar_sync_enabled);
         crate::keyring::delete_password(&id).ok();
     }
 

--- a/src-tauri/src/db/accounts.rs
+++ b/src-tauri/src/db/accounts.rs
@@ -431,6 +431,30 @@ mod tests {
     }
 
     #[test]
+    fn test_calendar_sync_enabled_serde_default_true() {
+        // Older renderers may send AccountConfig payloads without the new
+        // calendar_sync_enabled field; the serde default must yield true so
+        // existing accounts keep syncing calendars.
+        let json = r#"{
+            "display_name": "Alice",
+            "email": "a@example.com",
+            "provider": "generic",
+            "mail_protocol": "imap",
+            "imap_host": "imap.example.com",
+            "imap_port": 993,
+            "smtp_host": "smtp.example.com",
+            "smtp_port": 587,
+            "jmap_url": "",
+            "caldav_url": "",
+            "username": "u",
+            "password": "p",
+            "use_tls": true
+        }"#;
+        let cfg: AccountConfig = serde_json::from_str(json).unwrap();
+        assert!(cfg.calendar_sync_enabled);
+    }
+
+    #[test]
     fn test_calendar_sync_enabled_defaults_true_and_persists_toggle() {
         let conn = setup_db();
         let id = unique_id();

--- a/src-tauri/src/db/schema.rs
+++ b/src-tauri/src/db/schema.rs
@@ -292,6 +292,17 @@ fn run_migrations(conn: &Connection) -> Result<()> {
         conn.execute_batch("ALTER TABLE folders ADD COLUMN uid_next INTEGER DEFAULT 0;")?;
     }
 
+    // Add calendar_sync_enabled column for per-account calendar-sync toggle
+    let has_calendar_sync_enabled: bool = conn
+        .prepare("SELECT calendar_sync_enabled FROM accounts LIMIT 0")
+        .is_ok();
+    if !has_calendar_sync_enabled {
+        log::info!("Migration: adding calendar_sync_enabled column to accounts table");
+        conn.execute_batch(
+            "ALTER TABLE accounts ADD COLUMN calendar_sync_enabled INTEGER NOT NULL DEFAULT 1;",
+        )?;
+    }
+
     // Populate FTS index for existing messages (one-time migration)
     if !has_migration(conn, "fts5_initial_populate") {
         log::info!("Migration: populating FTS5 index for existing messages");

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -121,6 +121,7 @@ export interface AccountConfig {
   jmap_auth_method: "basic" | "oidc";
   oidc_token_endpoint: string;
   oidc_client_id: string;
+  calendar_sync_enabled: boolean;
 }
 
 export interface FilterRule {

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -43,6 +43,7 @@ const defaultForm = (): AccountConfig => ({
   jmap_auth_method: "basic",
   oidc_token_endpoint: "",
   oidc_client_id: "",
+  calendar_sync_enabled: true,
 });
 
 const form = ref<AccountConfig>(defaultForm());
@@ -562,6 +563,20 @@ async function doDelete() {
                 placeholder="-- &#10;Your Name&#10;Your Title"
               ></textarea>
             </div>
+
+            <div class="form-group form-group-checkbox">
+              <label class="checkbox-label">
+                <input
+                  v-model="form.calendar_sync_enabled"
+                  type="checkbox"
+                  data-testid="calendar-sync-enabled"
+                />
+                Enable calendar sync for this account
+              </label>
+              <p class="form-help">
+                When off, calendars and events are not fetched from the server. Existing calendar data remains available offline.
+              </p>
+            </div>
           </div>
           <div class="modal-footer">
             <button class="btn-secondary" @click="cancelForm">Cancel</button>
@@ -914,6 +929,29 @@ async function doDelete() {
   border-radius: 6px;
   font-size: 12px;
   color: var(--color-text-muted);
+}
+
+.form-group-checkbox .checkbox-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--color-text);
+  margin-bottom: 4px;
+}
+
+.form-group-checkbox .checkbox-label input[type="checkbox"] {
+  width: auto;
+  height: auto;
+  margin: 0;
+}
+
+.form-group-checkbox .form-help {
+  margin: 0 0 0 24px;
+  font-size: 12px;
+  color: var(--color-text-muted);
+  line-height: 1.4;
 }
 
 .btn-primary {

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -670,7 +670,7 @@ async function doDelete() {
   border: 1px solid var(--color-border);
   border-left: 4px solid var(--acct-color, var(--color-accent));
   border-radius: var(--radius);
-  background: #fff;
+  background: var(--color-bg-secondary);
   box-shadow: var(--shadow-sm);
   min-height: 100px;
 }


### PR DESCRIPTION
## Summary
- Add an **Enable calendar sync** checkbox to the account settings form. When off, `commands::calendar::sync_calendars` returns early for that account; events already in the DB stay visible.
- Schema: new `calendar_sync_enabled` column with `DEFAULT 1`, added through the existing probe-then-ALTER migration path in `schema.rs::run_migrations`. Existing accounts keep current behaviour.
- Rust `AccountConfig` / `AccountFull` and TS `AccountConfig` gain matching fields. `#[serde(default = "default_true")]` on the Rust side so a frontend that omits the field (older renderer talking to newer backend) defaults to enabled.
- Checkbox carries `data-testid="calendar-sync-enabled"` for automated testing.
- Also bundles a drive-by fix: `.account-card { background: #fff }` was hardcoded and broke dark mode on the settings account list. Swapped to `var(--color-bg-secondary)`.

Closes #42.

## Test plan
- [x] `cargo test db::accounts` 11 passed (new test covers default-true + toggle persistence)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `pnpm test` 229 passed
- [x] `pnpm exec vue-tsc --noEmit` clean
- [x] Manual: checkbox renders in Settings, toggle persists across app restart, account cards now follow dark mode