### PR TITLE
fix(oauth/microsoft): align authorize-time scopes with refresh-time scopes

### DIFF
--- a/src-tauri/src/oauth.rs
+++ b/src-tauri/src/oauth.rs
@@ -158,9 +158,9 @@ pub fn get_auth_url(
         url.push_str("&access_type=offline&prompt=consent");
     }
 
-    // Microsoft needs prompt=consent for first-time consent
+    // Microsoft: show account picker but honor existing consent (admin or user).
     if provider.name == "microsoft" {
-        url.push_str("&prompt=consent");
+        url.push_str("&prompt=select_account");
     }
 
     Ok((url, listener, code_verifier, state))

--- a/src-tauri/src/oauth.rs
+++ b/src-tauri/src/oauth.rs
@@ -43,9 +43,15 @@ pub const MICROSOFT: OAuthProvider = OAuthProvider {
     // Request all scopes during authorization for consent.
     // IMAP/SMTP use outlook.office.com (not office365.com) for personal accounts.
     // Graph scopes use short form (resolved to graph.microsoft.com automatically).
+    // All Graph scopes here must also appear in MICROSOFT_GRAPH_SCOPES or token
+    // refresh will fail with AADSTS65001 (consent_required).
     scopes: &[
         "https://outlook.office.com/IMAP.AccessAsUser.All",
         "https://outlook.office.com/SMTP.Send",
+        "User.Read",
+        "Mail.ReadWrite",
+        "Calendars.ReadWrite",
+        "Contacts.ReadWrite",
         "offline_access",
         "openid",
         "profile",
@@ -56,7 +62,7 @@ pub const MICROSOFT: OAuthProvider = OAuthProvider {
 
 /// Microsoft Graph scopes — used for a separate token refresh for calendar/contacts.
 pub const MICROSOFT_GRAPH_SCOPES: &str =
-    "User.Read Calendars.ReadWrite Contacts.ReadWrite offline_access";
+    "User.Read Mail.ReadWrite Calendars.ReadWrite Contacts.ReadWrite offline_access";
 
 /// Microsoft IMAP/SMTP scopes — used for token refresh for mail access.
 /// Uses outlook.office.com (works for both personal and work/school accounts).


### PR DESCRIPTION
## Summary

Two fixes for Microsoft 365 / Entra ID sign-in:

- **`prompt=select_account` instead of `prompt=consent`** — users with already-granted consent (including admin-granted tenant consent) are no longer re-prompted on every sign-in. They still get an account picker so they can disambiguate between multiple MS accounts.
- **Request all Graph scopes at authorize time** — the initial authorize request now includes `User.Read`, `Mail.ReadWrite`, `Calendars.ReadWrite`, and `Contacts.ReadWrite` (in addition to the existing IMAP/SMTP/OpenID ones). `Mail.ReadWrite` is also added to `MICROSOFT_GRAPH_SCOPES`.

### Why

Chithi's `MICROSOFT.scopes` (the authorize request) and `MICROSOFT_GRAPH_SCOPES` (the refresh request for Graph-scoped tokens) were out of sync:

- Admin consent only ever showed IMAP/SMTP + OpenID scopes.
- First Graph-scoped refresh after sign-in → `AADSTS65001 consent_required` because Calendars/Contacts were never consented.
- After that was fixed, `GET /me/mailFolders` returned `403 ErrorAccessDenied` because O365 mailbox access via Graph (chithi uses Graph, not IMAP, for mail on O365 per ADR-0025) requires `Mail.ReadWrite` — which wasn't in either scope set.

After this change, admin consent covers every scope chithi will ever refresh for, and mail sync on O365 works end-to-end.

### Admin impact

Existing tenants that previously granted admin consent will see one new consent prompt listing the added delegated scopes (`Mail.ReadWrite`, `Calendars.ReadWrite`, `Contacts.ReadWrite`, `User.Read`). After re-consent, existing users should sign out + back in so their refresh token is issued against the expanded scope set.

## Test plan

- [x] `cargo check` passes
- [x] Verified end-to-end sign-in on a live sunet.se M365 tenant after admin re-consent: token exchange OK, `Graph /me` profile OK, `/me/mailFolders` returns 200, folders populate.
- [x] Sign-in on an already-consented tenant no longer re-shows the consent dialog, just the account picker.