### PR TITLE
feat(search): server-side email search per backend

### DIFF
--- a/src-tauri/src/commands/mail.rs
+++ b/src-tauri/src/commands/mail.rs
@@ -184,6 +184,13 @@ pub async fn import_search_hit(
     account_id: String,
     hit: SearchHit,
 ) -> Result<String> {
+    if hit.account_id != account_id {
+        return Err(Error::Other(format!(
+            "search hit account_id mismatch: command got {:?}, hit was tagged {:?}",
+            account_id, hit.account_id
+        )));
+    }
+
     let account = {
         let conn = state.db.reader();
         db::accounts::get_account_full(&conn, &account_id)?

--- a/src-tauri/src/commands/mail.rs
+++ b/src-tauri/src/commands/mail.rs
@@ -171,6 +171,87 @@ pub async fn search_messages_server(
     Ok(hits)
 }
 
+/// Insert (or upsert) a server-search hit into the local messages table so
+/// the existing `get_message_body` flow can fetch and render it. Returns the
+/// synthetic database id, which the frontend then passes to `loadMessage`.
+///
+/// We don't have the full envelope (size, to/cc, encryption flags) from the
+/// search response, so we fill in reasonable defaults — the next sync of
+/// that folder will reconcile them.
+#[tauri::command]
+pub async fn import_search_hit(
+    state: State<'_, AppState>,
+    account_id: String,
+    hit: SearchHit,
+) -> Result<String> {
+    let account = {
+        let conn = state.db.reader();
+        db::accounts::get_account_full(&conn, &account_id)?
+    };
+
+    let (id, uid, maildir_path) = if account.mail_protocol == "graph" {
+        // Format matches sync_cmd::sync_graph_account: `{account_id}_{graph_id}`,
+        // and `graph:{graph_id}` in maildir_path triggers the on-demand stream
+        // path in get_message_body.
+        let id = format!("{}_{}", account_id, hit.backend_id);
+        let maildir = format!("graph:{}", hit.backend_id);
+        (id, 0u32, maildir)
+    } else if account.mail_protocol == "jmap" {
+        // Format matches jmap_sync: `{account_id}_{mailbox_id}_{email_id}`.
+        let id = format!("{}_{}_{}", account_id, hit.folder_path, hit.backend_id);
+        (id, 0u32, String::new())
+    } else {
+        // IMAP: `{account_id}_{folder_path}_{uid}`.
+        let uid = hit
+            .uid
+            .ok_or_else(|| Error::Other("IMAP search hit is missing UID".into()))?;
+        let id = format!("{}_{}_{}", account_id, hit.folder_path, uid);
+        (id, uid, String::new())
+    };
+
+    let date_str = if hit.date > 0 {
+        chrono::DateTime::<chrono::Utc>::from_timestamp(hit.date, 0)
+            .map(|dt| dt.to_rfc3339())
+            .unwrap_or_default()
+    } else {
+        chrono::Utc::now().to_rfc3339()
+    };
+
+    let new_msg = db::messages::NewMessage {
+        id: id.clone(),
+        account_id: account_id.clone(),
+        folder_path: hit.folder_path,
+        uid,
+        message_id: hit.message_id,
+        in_reply_to: None,
+        thread_id: None,
+        subject: if hit.subject.is_empty() {
+            None
+        } else {
+            Some(hit.subject)
+        },
+        from_name: hit.from_name,
+        from_email: hit.from_email.unwrap_or_else(|| "unknown".to_string()),
+        to_addresses: "[]".to_string(),
+        cc_addresses: "[]".to_string(),
+        date: date_str,
+        size: 0,
+        has_attachments: false,
+        is_encrypted: false,
+        is_signed: false,
+        flags: "[]".to_string(),
+        maildir_path,
+        snippet: hit.snippet,
+    };
+
+    {
+        let conn = state.db.writer().await;
+        db::messages::insert_message(&conn, &new_msg)?;
+    }
+
+    Ok(id)
+}
+
 #[tauri::command]
 pub async fn get_message_body(
     app: tauri::AppHandle,

--- a/src-tauri/src/commands/mail.rs
+++ b/src-tauri/src/commands/mail.rs
@@ -11,6 +11,7 @@ use crate::error::{Error, Result};
 use crate::mail::imap::ImapConfig;
 use crate::mail::jmap_sync;
 use crate::mail::parser;
+use crate::mail::search::{SearchHit, SearchQuery};
 use crate::mail::sync as mail_sync;
 use crate::state::AppState;
 
@@ -94,6 +95,80 @@ pub async fn get_messages(
         folder_path
     );
     Ok(result)
+}
+
+/// Run a server-side search across all folders of an account.
+/// Dispatches to the IMAP, JMAP, or Graph backend based on `mail_protocol`.
+#[tauri::command]
+pub async fn search_messages_server(
+    state: State<'_, AppState>,
+    account_id: String,
+    query: SearchQuery,
+) -> Result<Vec<SearchHit>> {
+    log::info!(
+        "Server search: account={} text={:?} fields={:?}",
+        account_id,
+        query.text,
+        query.fields,
+    );
+
+    let account = {
+        let conn = state.db.reader();
+        db::accounts::get_account_full(&conn, &account_id)?
+    };
+
+    let hits = if account.mail_protocol == "graph" {
+        let token = crate::mail::graph::get_graph_token(&account_id).await?;
+        let client = crate::mail::graph::GraphClient::new(&token);
+        client.search_messages(&account_id, &query).await?
+    } else if account.mail_protocol == "jmap" {
+        let jmap_config = crate::commands::sync_cmd::build_jmap_config(&account).await?;
+        let conn_jmap = crate::mail::jmap::JmapConnection::connect(&jmap_config).await?;
+        conn_jmap
+            .search_account(&jmap_config, &account_id, &query)
+            .await?
+    } else {
+        let (password, use_xoauth2) = if account.provider == "o365" {
+            let tokens = crate::oauth::load_tokens(&account_id)?
+                .ok_or_else(|| Error::Other("No O365 tokens".into()))?;
+            let refresh = tokens
+                .refresh_token
+                .ok_or_else(|| Error::Other("No O365 refresh token".into()))?;
+            let new = crate::oauth::refresh_with_scopes(
+                &crate::oauth::MICROSOFT,
+                &refresh,
+                crate::oauth::MICROSOFT_IMAP_SCOPES,
+            )
+            .await?;
+            crate::oauth::store_tokens(&account_id, &new)?;
+            (new.access_token, true)
+        } else {
+            (account.password.clone(), false)
+        };
+        let imap_config = ImapConfig {
+            host: account.imap_host.clone(),
+            port: account.imap_port,
+            username: account.username.clone(),
+            password,
+            use_tls: account.use_tls,
+            use_xoauth2,
+        };
+
+        let account_id_for_blocking = account_id.clone();
+        let query_for_blocking = query.clone();
+        tokio::task::spawn_blocking(move || {
+            crate::mail::imap::search_account_blocking(
+                &imap_config,
+                &account_id_for_blocking,
+                &query_for_blocking,
+            )
+        })
+        .await
+        .map_err(|e| Error::Other(format!("IMAP search task panicked: {}", e)))??
+    };
+
+    log::info!("Server search returned {} hits", hits.len());
+    Ok(hits)
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/mail.rs
+++ b/src-tauri/src/commands/mail.rs
@@ -106,10 +106,10 @@ pub async fn search_messages_server(
     query: SearchQuery,
 ) -> Result<Vec<SearchHit>> {
     log::info!(
-        "Server search: account={} text={:?} fields={:?}",
+        "Server search: account={} fields={:?} text_len={}",
         account_id,
-        query.text,
         query.fields,
+        query.text.len(),
     );
 
     let account = {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -46,6 +46,7 @@ pub fn run() {
             commands::accounts::delete_account,
             commands::mail::list_folders,
             commands::mail::get_messages,
+            commands::mail::search_messages_server,
             commands::mail::get_message_body,
             commands::mail::get_message_html_with_images,
             commands::mail::get_threaded_messages,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -47,6 +47,7 @@ pub fn run() {
             commands::mail::list_folders,
             commands::mail::get_messages,
             commands::mail::search_messages_server,
+            commands::mail::import_search_hit,
             commands::mail::get_message_body,
             commands::mail::get_message_html_with_images,
             commands::mail::get_threaded_messages,

--- a/src-tauri/src/mail/graph.rs
+++ b/src-tauri/src/mail/graph.rs
@@ -422,6 +422,9 @@ impl GraphClient {
                     .and_then(|s| s.parse::<u64>().ok())
                     .unwrap_or(2)
                     .min(10);
+                // Drain the body so reqwest can return the connection to the
+                // pool; otherwise the next request opens a fresh socket.
+                let _ = resp.bytes().await;
                 log::warn!("Graph $search throttled, retrying after {}s", retry_after);
                 tokio::time::sleep(std::time::Duration::from_secs(retry_after)).await;
                 continue;

--- a/src-tauri/src/mail/graph.rs
+++ b/src-tauri/src/mail/graph.rs
@@ -4,6 +4,7 @@
 //! Bearer token authentication. No IMAP/SMTP needed for O365 accounts.
 
 use crate::error::{Error, Result};
+use crate::mail::search::{build_graph_kql, SearchHit, SearchQuery};
 use serde::{Deserialize, Serialize};
 
 const GRAPH_BASE: &str = "https://graph.microsoft.com/v1.0";
@@ -370,6 +371,83 @@ impl GraphClient {
         }
 
         Ok((messages, total))
+    }
+
+    /// Search messages across all folders using `$search` (KQL).
+    /// Graph requires `ConsistencyLevel: eventual` for `$search`. Cannot be
+    /// combined with `$orderby` or `$filter`. On HTTP 429 (throttled),
+    /// honors `Retry-After` once and returns whatever was retrieved.
+    pub async fn search_messages(
+        &self,
+        account_id: &str,
+        query: &SearchQuery,
+    ) -> Result<Vec<SearchHit>> {
+        let kql = match build_graph_kql(query) {
+            Some(k) => k,
+            None => return Ok(vec![]),
+        };
+
+        let url = format!("{}/me/messages", GRAPH_BASE);
+        // Graph $search REQUIRES the value to be wrapped in double quotes,
+        // exactly once. `build_graph_kql` returns the bare KQL.
+        let search_value = format!("\"{}\"", kql);
+        let params = [
+            (
+                "$select",
+                "id,subject,from,receivedDateTime,bodyPreview,internetMessageId,parentFolderId",
+            ),
+            ("$top", "50"),
+            ("$search", search_value.as_str()),
+        ];
+
+        let mut attempts = 0u8;
+        let body = loop {
+            attempts += 1;
+            let resp = self
+                .http
+                .get(&url)
+                .bearer_auth(&self.access_token)
+                .header("ConsistencyLevel", "eventual")
+                .query(&params)
+                .send()
+                .await
+                .map_err(|e| Error::Other(format!("Graph $search failed: {}", e)))?;
+
+            let status = resp.status();
+            if status.as_u16() == 429 && attempts < 2 {
+                let retry_after = resp
+                    .headers()
+                    .get("retry-after")
+                    .and_then(|v| v.to_str().ok())
+                    .and_then(|s| s.parse::<u64>().ok())
+                    .unwrap_or(2)
+                    .min(10);
+                log::warn!("Graph $search throttled, retrying after {}s", retry_after);
+                tokio::time::sleep(std::time::Duration::from_secs(retry_after)).await;
+                continue;
+            }
+
+            let text = resp.text().await.unwrap_or_default();
+            if !status.is_success() {
+                return Err(Error::Other(format!(
+                    "Graph $search returned {}: {}",
+                    status,
+                    truncate(&text, 500)
+                )));
+            }
+            break text;
+        };
+
+        let resp: serde_json::Value = serde_json::from_str(&body)
+            .map_err(|e| Error::Other(format!("Graph $search parse failed: {}", e)))?;
+
+        let mut hits = Vec::new();
+        if let Some(values) = resp["value"].as_array() {
+            for m in values {
+                hits.push(parse_graph_search_hit(account_id, m));
+            }
+        }
+        Ok(hits)
     }
 
     /// Fetch the full body of a message.
@@ -864,6 +942,37 @@ pub struct GraphCalendarEvent {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+fn parse_graph_search_hit(account_id: &str, m: &serde_json::Value) -> SearchHit {
+    let id = m["id"].as_str().unwrap_or("").to_string();
+    let subject = m["subject"].as_str().unwrap_or("").to_string();
+    let from = &m["from"]["emailAddress"];
+    let from_name = from["name"].as_str().map(|s| s.to_string());
+    let from_email = from["address"].as_str().map(|s| s.to_string());
+
+    let date = m["receivedDateTime"]
+        .as_str()
+        .and_then(|d| chrono::DateTime::parse_from_rfc3339(d).ok())
+        .map(|dt| dt.timestamp())
+        .unwrap_or(0);
+
+    let snippet = m["bodyPreview"].as_str().map(|s| s.to_string());
+    let folder_path = m["parentFolderId"].as_str().unwrap_or("").to_string();
+    let message_id = m["internetMessageId"].as_str().map(|s| s.to_string());
+
+    SearchHit {
+        account_id: account_id.to_string(),
+        folder_path,
+        uid: None,
+        message_id,
+        backend_id: id,
+        subject,
+        from_name,
+        from_email,
+        date,
+        snippet,
+    }
+}
 
 fn parse_graph_message(m: &serde_json::Value) -> GraphMessage {
     let from = &m["from"]["emailAddress"];

--- a/src-tauri/src/mail/imap.rs
+++ b/src-tauri/src/mail/imap.rs
@@ -695,8 +695,12 @@ pub fn search_account_blocking(
             continue;
         }
 
+        // UIDs are server-assigned monotonically per mailbox, so the tail of
+        // the SEARCH response is the most recent slice — match the
+        // newest-first ordering used by the JMAP and Graph providers.
         let take_n = uids.len().min(SEARCH_PER_FOLDER_LIMIT);
-        let envelopes = match conn.fetch_envelopes_batch(&uids[..take_n]) {
+        let recent_uids = &uids[uids.len() - take_n..];
+        let envelopes = match conn.fetch_envelopes_batch(recent_uids) {
             Ok(e) => e,
             Err(e) => {
                 log::warn!("IMAP search: envelope fetch in {} failed: {}", path, e);

--- a/src-tauri/src/mail/imap.rs
+++ b/src-tauri/src/mail/imap.rs
@@ -3,6 +3,7 @@ use native_tls::TlsStream;
 use std::net::TcpStream;
 
 use crate::error::{Error, Result};
+use crate::mail::search::{build_imap_search, SearchHit, SearchQuery};
 
 #[derive(Clone)]
 pub struct ImapConfig {
@@ -623,9 +624,117 @@ impl ImapConnection {
         Ok(had_notification)
     }
 
+    /// Issue a `UID SEARCH` command against the currently selected mailbox
+    /// and return matching UIDs. The query string is the raw search key
+    /// (e.g., `CHARSET UTF-8 SUBJECT "foo"`).
+    pub fn uid_search(&mut self, query: &str) -> Result<Vec<u32>> {
+        log::debug!("IMAP UID SEARCH {}", query);
+        let uids = self.session.uid_search(query).map_err(|e| {
+            log::error!("IMAP UID SEARCH failed: {}", e);
+            Error::Imap(e.to_string())
+        })?;
+        Ok(uids.into_iter().collect())
+    }
+
     pub fn logout(mut self) {
         log::debug!("IMAP logging out");
         self.session.logout().ok();
+    }
+}
+
+/// Folders that contain duplicate copies of mail (Gmail virtual folders).
+/// Skipping them avoids returning the same hit multiple times.
+const SEARCH_SKIP_FOLDERS: &[&str] = &["[Gmail]/All Mail", "[Gmail]/Important", "[Gmail]"];
+
+/// Cap on per-folder search hits, to bound work on huge mailboxes.
+const SEARCH_PER_FOLDER_LIMIT: usize = 200;
+/// Cap on total hits returned across all folders for one query.
+const SEARCH_TOTAL_LIMIT: usize = 500;
+
+/// Search across every folder of an IMAP account. Runs synchronously inside
+/// a `spawn_blocking` because the `imap` crate uses a blocking session.
+pub fn search_account_blocking(
+    config: &ImapConfig,
+    account_id: &str,
+    query: &SearchQuery,
+) -> Result<Vec<SearchHit>> {
+    let search_arg = match build_imap_search(query) {
+        Some(s) => s,
+        None => return Ok(vec![]),
+    };
+
+    let mut conn = ImapConnection::connect(config)?;
+    let folders = conn.list_folders()?;
+
+    let mut hits: Vec<SearchHit> = Vec::new();
+    for (_display, path) in folders {
+        if hits.len() >= SEARCH_TOTAL_LIMIT {
+            break;
+        }
+        if SEARCH_SKIP_FOLDERS
+            .iter()
+            .any(|skip| path.eq_ignore_ascii_case(skip))
+        {
+            continue;
+        }
+
+        if let Err(e) = conn.select_folder(&path) {
+            log::warn!("IMAP search: SELECT {} failed: {}", path, e);
+            continue;
+        }
+
+        let uids = match conn.uid_search(&search_arg) {
+            Ok(u) => u,
+            Err(e) => {
+                log::warn!("IMAP search: UID SEARCH in {} failed: {}", path, e);
+                continue;
+            }
+        };
+
+        if uids.is_empty() {
+            continue;
+        }
+
+        let take_n = uids.len().min(SEARCH_PER_FOLDER_LIMIT);
+        let envelopes = match conn.fetch_envelopes_batch(&uids[..take_n]) {
+            Ok(e) => e,
+            Err(e) => {
+                log::warn!("IMAP search: envelope fetch in {} failed: {}", path, e);
+                continue;
+            }
+        };
+
+        for env in envelopes {
+            if hits.len() >= SEARCH_TOTAL_LIMIT {
+                break;
+            }
+            hits.push(envelope_to_hit(account_id, &path, env));
+        }
+    }
+
+    conn.logout();
+    Ok(hits)
+}
+
+fn envelope_to_hit(account_id: &str, folder_path: &str, env: EnvelopeData) -> SearchHit {
+    let date_secs = env
+        .date
+        .as_deref()
+        .and_then(|d| chrono::DateTime::parse_from_rfc2822(d).ok())
+        .map(|dt| dt.timestamp())
+        .unwrap_or(0);
+
+    SearchHit {
+        account_id: account_id.to_string(),
+        folder_path: folder_path.to_string(),
+        uid: Some(env.uid),
+        message_id: env.message_id,
+        backend_id: format!("{}:{}", folder_path, env.uid),
+        subject: env.subject.unwrap_or_default(),
+        from_name: env.from_name,
+        from_email: env.from_email,
+        date: date_secs,
+        snippet: None,
     }
 }
 

--- a/src-tauri/src/mail/imap.rs
+++ b/src-tauri/src/mail/imap.rs
@@ -628,7 +628,9 @@ impl ImapConnection {
     /// and return matching UIDs. The query string is the raw search key
     /// (e.g., `CHARSET UTF-8 SUBJECT "foo"`).
     pub fn uid_search(&mut self, query: &str) -> Result<Vec<u32>> {
-        log::debug!("IMAP UID SEARCH {}", query);
+        // The query string carries user-provided search text; log only its
+        // shape so debug output is safe to share.
+        log::debug!("IMAP UID SEARCH (query_len={})", query.len());
         let uids = self.session.uid_search(query).map_err(|e| {
             log::error!("IMAP UID SEARCH failed: {}", e);
             Error::Imap(e.to_string())

--- a/src-tauri/src/mail/jmap.rs
+++ b/src-tauri/src/mail/jmap.rs
@@ -1,4 +1,5 @@
 use crate::error::{Error, Result};
+use crate::mail::search::{build_jmap_filter, SearchHit, SearchQuery};
 use serde::{Deserialize, Serialize};
 
 // ---------------------------------------------------------------------------
@@ -591,6 +592,49 @@ impl JmapConnection {
         });
         self.api_request(&request, config).await?;
         Ok(())
+    }
+
+    /// Search emails across the account using `Email/query` + `Email/get`.
+    /// Folder scope: account-wide (no `inMailbox` filter). Cap: 200 hits.
+    pub async fn search_account(
+        &self,
+        config: &JmapConfig,
+        account_id: &str,
+        query: &SearchQuery,
+    ) -> Result<Vec<SearchHit>> {
+        let filter = match build_jmap_filter(query) {
+            Some(f) => f,
+            None => return Ok(vec![]),
+        };
+
+        let request = serde_json::json!({
+            "using": ["urn:ietf:params:jmap:core", "urn:ietf:params:jmap:mail"],
+            "methodCalls": [
+                ["Email/query", {
+                    "accountId": self.account_id,
+                    "filter": filter,
+                    "sort": [{ "property": "receivedAt", "isAscending": false }],
+                    "limit": 200u64,
+                }, "sq"],
+                ["Email/get", {
+                    "#ids": { "resultOf": "sq", "name": "Email/query", "path": "/ids" },
+                    "accountId": self.account_id,
+                    "properties": ["id", "subject", "from", "receivedAt", "preview", "messageId", "mailboxIds"]
+                }, "sg"]
+            ]
+        });
+
+        let resp = self.api_request(&request, config).await?;
+
+        let emails = resp["methodResponses"][1][1]["list"]
+            .as_array()
+            .ok_or_else(|| Error::Other("Invalid Email/get response in search".into()))?;
+
+        let mut hits = Vec::with_capacity(emails.len());
+        for e in emails {
+            hits.push(parse_jmap_search_hit(account_id, e));
+        }
+        Ok(hits)
     }
 
     pub async fn move_emails(
@@ -2279,4 +2323,55 @@ fn addresses_to_json(addrs: Option<&Vec<serde_json::Value>>) -> String {
         })
         .collect();
     serde_json::to_string(&list).unwrap_or_else(|_| "[]".to_string())
+}
+
+fn parse_jmap_search_hit(account_id: &str, e: &serde_json::Value) -> SearchHit {
+    let id = e["id"].as_str().unwrap_or("").to_string();
+    let subject = e["subject"].as_str().unwrap_or("").to_string();
+
+    let (from_name, from_email) = e["from"]
+        .as_array()
+        .and_then(|a| a.first())
+        .map(|f| {
+            (
+                f["name"].as_str().map(|s| s.to_string()),
+                f["email"].as_str().map(|s| s.to_string()),
+            )
+        })
+        .unwrap_or((None, None));
+
+    let date = e["receivedAt"]
+        .as_str()
+        .and_then(|d| chrono::DateTime::parse_from_rfc3339(d).ok())
+        .map(|dt| dt.timestamp())
+        .unwrap_or(0);
+
+    let snippet = e["preview"].as_str().map(|s| s.to_string());
+
+    let message_id = e["messageId"]
+        .as_array()
+        .and_then(|a| a.first())
+        .and_then(|v| v.as_str())
+        .map(|s| format!("<{}>", s));
+
+    // mailboxIds is an object whose keys are mailbox IDs that are true.
+    // Pick the first one as the canonical folder for this hit.
+    let folder_path = e["mailboxIds"]
+        .as_object()
+        .and_then(|m| m.iter().find(|(_, v)| v.as_bool().unwrap_or(false)))
+        .map(|(k, _)| k.to_string())
+        .unwrap_or_default();
+
+    SearchHit {
+        account_id: account_id.to_string(),
+        folder_path,
+        uid: None,
+        message_id,
+        backend_id: id,
+        subject,
+        from_name,
+        from_email,
+        date,
+        snippet,
+    }
 }

--- a/src-tauri/src/mail/mod.rs
+++ b/src-tauri/src/mail/mod.rs
@@ -8,6 +8,7 @@ pub mod jmap;
 pub mod jmap_push;
 pub mod jmap_sync;
 pub mod parser;
+pub mod search;
 pub mod smtp;
 pub mod sync;
 pub mod url_validation;

--- a/src-tauri/src/mail/search.rs
+++ b/src-tauri/src/mail/search.rs
@@ -42,7 +42,7 @@ impl SearchFields {
     }
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SearchHit {
     pub account_id: String,
     pub folder_path: String,

--- a/src-tauri/src/mail/search.rs
+++ b/src-tauri/src/mail/search.rs
@@ -1,0 +1,377 @@
+//! Shared types for server-side mail search across IMAP / JMAP / Graph.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct SearchQuery {
+    pub text: String,
+    #[serde(default)]
+    pub fields: SearchFields,
+    #[serde(default)]
+    pub has_attachment: Option<bool>,
+    #[serde(default)]
+    pub since_days: Option<u32>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct SearchFields {
+    pub subject: bool,
+    pub from: bool,
+    pub to: bool,
+    pub body: bool,
+}
+
+impl Default for SearchFields {
+    fn default() -> Self {
+        Self {
+            subject: true,
+            from: true,
+            to: true,
+            body: true,
+        }
+    }
+}
+
+impl SearchFields {
+    pub fn all_enabled(&self) -> bool {
+        self.subject && self.from && self.to && self.body
+    }
+
+    pub fn any_enabled(&self) -> bool {
+        self.subject || self.from || self.to || self.body
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SearchHit {
+    pub account_id: String,
+    pub folder_path: String,
+    pub uid: Option<u32>,
+    pub message_id: Option<String>,
+    pub backend_id: String,
+    pub subject: String,
+    pub from_name: Option<String>,
+    pub from_email: Option<String>,
+    pub date: i64,
+    pub snippet: Option<String>,
+}
+
+/// Build an IMAP `UID SEARCH` argument from a query.
+///
+/// Quotes are doubled rather than escaped (IMAP atoms don't support backslash
+/// escapes inside quoted strings except for `\` and `"` themselves).
+/// Returns `None` if no fields are enabled or the text is empty.
+pub fn build_imap_search(query: &SearchQuery) -> Option<String> {
+    let text = query.text.trim();
+    if text.is_empty() || !query.fields.any_enabled() {
+        return None;
+    }
+    let escaped = text.replace('\\', "\\\\").replace('"', "\\\"");
+
+    let mut keys: Vec<String> = Vec::new();
+    if query.fields.subject {
+        keys.push(format!("SUBJECT \"{}\"", escaped));
+    }
+    if query.fields.from {
+        keys.push(format!("FROM \"{}\"", escaped));
+    }
+    if query.fields.to {
+        keys.push(format!("TO \"{}\"", escaped));
+    }
+    if query.fields.body {
+        keys.push(format!("BODY \"{}\"", escaped));
+    }
+
+    let combined = match keys.len() {
+        1 => keys.remove(0),
+        n => {
+            let mut acc = keys.pop().unwrap();
+            for _ in 1..n {
+                let next = keys.pop().unwrap();
+                acc = format!("OR {} {}", next, acc);
+            }
+            acc
+        }
+    };
+
+    let mut full = format!("CHARSET UTF-8 {}", combined);
+    if let Some(days) = query.since_days {
+        if days > 0 {
+            full.push_str(&format!(" SINCE {}", imap_since_date(days)));
+        }
+    }
+    Some(full)
+}
+
+fn imap_since_date(days_ago: u32) -> String {
+    let now = chrono::Utc::now();
+    let dt = now - chrono::Duration::days(days_ago as i64);
+    dt.format("%d-%b-%Y").to_string()
+}
+
+/// Build a JMAP `Email/query` FilterCondition for a search query.
+///
+/// When all fields are enabled, uses the single `text` filter (RFC 8621
+/// defines it to cover headers + body). Otherwise OR-combines individual
+/// per-field filters.
+pub fn build_jmap_filter(query: &SearchQuery) -> Option<serde_json::Value> {
+    let text = query.text.trim();
+    if text.is_empty() {
+        return None;
+    }
+    let mut conditions: Vec<serde_json::Value> = Vec::new();
+
+    if query.fields.all_enabled() {
+        conditions.push(serde_json::json!({ "text": text }));
+    } else {
+        let mut field_conds: Vec<serde_json::Value> = Vec::new();
+        if query.fields.subject {
+            field_conds.push(serde_json::json!({ "subject": text }));
+        }
+        if query.fields.from {
+            field_conds.push(serde_json::json!({ "from": text }));
+        }
+        if query.fields.to {
+            field_conds.push(serde_json::json!({ "to": text }));
+        }
+        if query.fields.body {
+            field_conds.push(serde_json::json!({ "body": text }));
+        }
+        if field_conds.is_empty() {
+            return None;
+        }
+        if field_conds.len() == 1 {
+            conditions.push(field_conds.remove(0));
+        } else {
+            conditions.push(serde_json::json!({
+                "operator": "OR",
+                "conditions": field_conds,
+            }));
+        }
+    }
+
+    if let Some(true) = query.has_attachment {
+        conditions.push(serde_json::json!({ "hasAttachment": true }));
+    }
+    if let Some(days) = query.since_days {
+        if days > 0 {
+            let after = chrono::Utc::now() - chrono::Duration::days(days as i64);
+            conditions.push(serde_json::json!({ "after": after.to_rfc3339() }));
+        }
+    }
+
+    if conditions.len() == 1 {
+        Some(conditions.remove(0))
+    } else {
+        Some(serde_json::json!({
+            "operator": "AND",
+            "conditions": conditions,
+        }))
+    }
+}
+
+/// Build a Microsoft Graph `$search` KQL expression for a search query.
+///
+/// Returns the bare KQL — the caller must wrap it as `$search="..."` exactly
+/// once. Quotes inside the user's text are stripped because KQL field-value
+/// quoting cannot be reliably escaped through a URL query parameter.
+///
+/// When all fields are enabled, omits field prefixes (Graph's default search
+/// covers subject + body + from). For multi-word values restricted to a
+/// specific field, wraps the value in parens so each term stays scoped to
+/// that field (e.g. `subject:(tax 2024)` matches when both `tax` and `2024`
+/// appear in the subject).
+pub fn build_graph_kql(query: &SearchQuery) -> Option<String> {
+    let text = query.text.trim();
+    if text.is_empty() || !query.fields.any_enabled() {
+        return None;
+    }
+    let safe = text.replace('"', "");
+    if safe.is_empty() {
+        return None;
+    }
+
+    let core = if query.fields.all_enabled() {
+        safe.clone()
+    } else {
+        let value = if safe.contains(' ') {
+            format!("({})", safe)
+        } else {
+            safe.clone()
+        };
+        let mut parts: Vec<String> = Vec::new();
+        if query.fields.subject {
+            parts.push(format!("subject:{}", value));
+        }
+        if query.fields.from {
+            parts.push(format!("from:{}", value));
+        }
+        if query.fields.to {
+            parts.push(format!("to:{}", value));
+        }
+        if query.fields.body {
+            parts.push(format!("body:{}", value));
+        }
+        if parts.is_empty() {
+            return None;
+        }
+        parts.join(" OR ")
+    };
+
+    let mut kql = core;
+    if let Some(true) = query.has_attachment {
+        kql = format!("({}) AND hasAttachments:true", kql);
+    }
+    Some(kql)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn q(text: &str) -> SearchQuery {
+        SearchQuery {
+            text: text.into(),
+            fields: SearchFields::default(),
+            has_attachment: None,
+            since_days: None,
+        }
+    }
+
+    fn q_fields(text: &str, fields: SearchFields) -> SearchQuery {
+        SearchQuery {
+            text: text.into(),
+            fields,
+            has_attachment: None,
+            since_days: None,
+        }
+    }
+
+    #[test]
+    fn imap_all_fields_or_combines() {
+        let s = build_imap_search(&q("foo")).unwrap();
+        assert!(s.starts_with("CHARSET UTF-8 OR "));
+        assert!(s.contains("SUBJECT \"foo\""));
+        assert!(s.contains("FROM \"foo\""));
+        assert!(s.contains("TO \"foo\""));
+        assert!(s.contains("BODY \"foo\""));
+    }
+
+    #[test]
+    fn imap_single_field_no_or() {
+        let s = build_imap_search(&q_fields(
+            "foo",
+            SearchFields {
+                subject: true,
+                from: false,
+                to: false,
+                body: false,
+            },
+        ))
+        .unwrap();
+        assert_eq!(s, "CHARSET UTF-8 SUBJECT \"foo\"");
+    }
+
+    #[test]
+    fn imap_quote_escape() {
+        let s = build_imap_search(&q("a\"b")).unwrap();
+        assert!(s.contains("\\\""));
+    }
+
+    #[test]
+    fn imap_empty_returns_none() {
+        assert!(build_imap_search(&q("")).is_none());
+        assert!(build_imap_search(&q("   ")).is_none());
+    }
+
+    #[test]
+    fn imap_no_fields_returns_none() {
+        let none_fields = SearchFields {
+            subject: false,
+            from: false,
+            to: false,
+            body: false,
+        };
+        assert!(build_imap_search(&q_fields("foo", none_fields)).is_none());
+    }
+
+    #[test]
+    fn jmap_all_fields_uses_text_shortcut() {
+        let f = build_jmap_filter(&q("foo")).unwrap();
+        assert_eq!(f, serde_json::json!({ "text": "foo" }));
+    }
+
+    #[test]
+    fn jmap_partial_uses_or_operator() {
+        let f = build_jmap_filter(&q_fields(
+            "foo",
+            SearchFields {
+                subject: true,
+                from: true,
+                to: false,
+                body: false,
+            },
+        ))
+        .unwrap();
+        assert_eq!(f["operator"], "OR");
+        assert_eq!(f["conditions"].as_array().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn jmap_attachment_wraps_in_and() {
+        let mut query = q("foo");
+        query.has_attachment = Some(true);
+        let f = build_jmap_filter(&query).unwrap();
+        assert_eq!(f["operator"], "AND");
+    }
+
+    #[test]
+    fn graph_all_fields_bare() {
+        let s = build_graph_kql(&q("foo")).unwrap();
+        assert_eq!(s, "foo");
+    }
+
+    #[test]
+    fn graph_partial_uses_prefixed_or() {
+        let s = build_graph_kql(&q_fields(
+            "foo",
+            SearchFields {
+                subject: true,
+                body: true,
+                from: false,
+                to: false,
+            },
+        ))
+        .unwrap();
+        assert_eq!(s, "subject:foo OR body:foo");
+    }
+
+    #[test]
+    fn graph_partial_multi_word_uses_parens() {
+        let s = build_graph_kql(&q_fields(
+            "tax 2024",
+            SearchFields {
+                subject: true,
+                body: false,
+                from: false,
+                to: false,
+            },
+        ))
+        .unwrap();
+        assert_eq!(s, "subject:(tax 2024)");
+    }
+
+    #[test]
+    fn graph_strips_quotes() {
+        let s = build_graph_kql(&q("a\"b")).unwrap();
+        assert_eq!(s, "ab");
+    }
+
+    #[test]
+    fn graph_attachment_wraps_in_and() {
+        let mut query = q("foo");
+        query.has_attachment = Some(true);
+        let s = build_graph_kql(&query).unwrap();
+        assert_eq!(s, "(foo) AND hasAttachments:true");
+    }
+}

--- a/src-tauri/src/mail/search.rs
+++ b/src-tauri/src/mail/search.rs
@@ -58,15 +58,21 @@ pub struct SearchHit {
 
 /// Build an IMAP `UID SEARCH` argument from a query.
 ///
-/// Quotes are doubled rather than escaped (IMAP atoms don't support backslash
-/// escapes inside quoted strings except for `\` and `"` themselves).
+/// Inside an IMAP quoted string only `"` and `\` are special and are escaped
+/// with a leading backslash (RFC 3501 §4.3). Control characters (CR, LF, NUL)
+/// are forbidden in quoted strings and would break command framing if a user
+/// query contained them, so they are stripped before quoting.
 /// Returns `None` if no fields are enabled or the text is empty.
 pub fn build_imap_search(query: &SearchQuery) -> Option<String> {
     let text = query.text.trim();
     if text.is_empty() || !query.fields.any_enabled() {
         return None;
     }
-    let escaped = text.replace('\\', "\\\\").replace('"', "\\\"");
+    let cleaned: String = text.chars().filter(|c| !c.is_control()).collect();
+    if cleaned.is_empty() {
+        return None;
+    }
+    let escaped = cleaned.replace('\\', "\\\\").replace('"', "\\\"");
 
     let mut keys: Vec<String> = Vec::new();
     if query.fields.subject {
@@ -282,6 +288,19 @@ mod tests {
     fn imap_empty_returns_none() {
         assert!(build_imap_search(&q("")).is_none());
         assert!(build_imap_search(&q("   ")).is_none());
+    }
+
+    #[test]
+    fn imap_strips_control_chars() {
+        let s = build_imap_search(&q("foo\r\nA001 LOGOUT")).unwrap();
+        assert!(!s.contains('\r'));
+        assert!(!s.contains('\n'));
+        assert!(s.contains("fooA001 LOGOUT"));
+    }
+
+    #[test]
+    fn imap_only_control_chars_returns_none() {
+        assert!(build_imap_search(&q("\r\n\t")).is_none());
     }
 
     #[test]

--- a/src/__tests__/server-search.test.ts
+++ b/src/__tests__/server-search.test.ts
@@ -26,6 +26,7 @@ vi.mock("@/lib/tauri", () => ({
   }),
   getThreadMessages: vi.fn().mockResolvedValue([]),
   getMessageBody: vi.fn().mockResolvedValue(null),
+  importSearchHit: vi.fn(),
   setMessageFlags: vi.fn().mockResolvedValue(undefined),
   deleteMessages: vi.fn().mockResolvedValue(undefined),
   backfillThreads: vi.fn().mockResolvedValue(0),
@@ -205,6 +206,48 @@ describe("server-side search", () => {
     await messagesStore.runServerSearch();
 
     expect(messagesStore.serverSearchError).toBe("server unreachable");
+  });
+
+  it("opening a hit imports it then loads the message body", async () => {
+    withActiveAccount();
+    const importMock = vi.mocked(api.importSearchHit);
+    const bodyMock = vi.mocked(api.getMessageBody);
+    importMock.mockResolvedValueOnce("acc1_INBOX_42");
+    bodyMock.mockResolvedValueOnce({
+      id: "acc1_INBOX_42",
+      subject: "hello",
+      from: { name: null, email: "x@y" },
+      to: [],
+      cc: [],
+      date: "",
+      flags: [],
+      body_html: null,
+      body_text: "hi",
+      attachments: [],
+      is_encrypted: false,
+      is_signed: false,
+      list_id: null,
+      has_remote_images: false,
+    });
+
+    const messagesStore = useMessagesStore();
+    await messagesStore.openServerHit({
+      account_id: "acc1",
+      folder_path: "INBOX",
+      uid: 42,
+      message_id: null,
+      backend_id: "INBOX:42",
+      subject: "hello",
+      from_name: null,
+      from_email: "x@y",
+      date: 1_700_000_000,
+      snippet: null,
+    });
+
+    expect(importMock).toHaveBeenCalledTimes(1);
+    expect(importMock.mock.calls[0][1].backend_id).toBe("INBOX:42");
+    expect(bodyMock).toHaveBeenCalledWith("acc1", "acc1_INBOX_42");
+    expect(messagesStore.activeMessageId).toBe("acc1_INBOX_42");
   });
 
   it("clears prior hits as soon as the user types again", async () => {

--- a/src/__tests__/server-search.test.ts
+++ b/src/__tests__/server-search.test.ts
@@ -159,6 +159,54 @@ describe("server-side search", () => {
     expect(messagesStore.serverSearchError).toContain("timeout");
   });
 
+  it("drops stale results when filter text changes mid-flight", async () => {
+    withActiveAccount();
+    let resolveSearch: ((hits: unknown[]) => void) | undefined;
+    mockedSearch.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveSearch = resolve as (hits: unknown[]) => void;
+        }),
+    );
+
+    const messagesStore = useMessagesStore();
+    messagesStore.quickFilterText = "old";
+    const search = messagesStore.runServerSearch();
+
+    // User types again before the in-flight search resolves.
+    messagesStore.onFilterTextChange();
+
+    // Now the late response arrives with stale data — must NOT repopulate.
+    resolveSearch!([
+      {
+        account_id: "acc1",
+        folder_path: "INBOX",
+        uid: 1,
+        message_id: null,
+        backend_id: "stale",
+        subject: "stale",
+        from_name: null,
+        from_email: null,
+        date: 0,
+        snippet: null,
+      },
+    ]);
+    await search;
+    expect(messagesStore.serverHits).toHaveLength(0);
+    expect(messagesStore.serverSearchLoading).toBe(false);
+  });
+
+  it("uses Error.message for human-readable error display", async () => {
+    withActiveAccount();
+    mockedSearch.mockRejectedValueOnce(new Error("server unreachable"));
+
+    const messagesStore = useMessagesStore();
+    messagesStore.quickFilterText = "hi";
+    await messagesStore.runServerSearch();
+
+    expect(messagesStore.serverSearchError).toBe("server unreachable");
+  });
+
   it("clears prior hits as soon as the user types again", async () => {
     withActiveAccount();
     const messagesStore = useMessagesStore();

--- a/src/__tests__/server-search.test.ts
+++ b/src/__tests__/server-search.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+
+const { listenMock } = vi.hoisted(() => ({
+  listenMock: vi.fn(() => Promise.resolve(() => {})),
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: listenMock,
+}));
+
+vi.mock("@/lib/tauri", () => ({
+  listAccounts: vi.fn().mockResolvedValue([]),
+  listFolders: vi.fn().mockResolvedValue([]),
+  triggerSync: vi.fn().mockResolvedValue(undefined),
+  getMessages: vi
+    .fn()
+    .mockResolvedValue({ messages: [], total: 0, page: 0, per_page: 100 }),
+  getThreadedMessages: vi.fn().mockResolvedValue({
+    threads: [],
+    total_threads: 0,
+    total_messages: 0,
+    page: 0,
+    per_page: 100,
+  }),
+  getThreadMessages: vi.fn().mockResolvedValue([]),
+  getMessageBody: vi.fn().mockResolvedValue(null),
+  setMessageFlags: vi.fn().mockResolvedValue(undefined),
+  deleteMessages: vi.fn().mockResolvedValue(undefined),
+  backfillThreads: vi.fn().mockResolvedValue(0),
+  prefetchBodies: vi.fn().mockResolvedValue(0),
+  searchMessagesServer: vi.fn(),
+}));
+
+import * as api from "@/lib/tauri";
+import { useAccountsStore } from "@/stores/accounts";
+import { useMessagesStore } from "@/stores/messages";
+import QuickFilterBar from "@/components/mail/QuickFilterBar.vue";
+
+const mockedSearch = vi.mocked(api.searchMessagesServer);
+
+function withActiveAccount() {
+  const accountsStore = useAccountsStore();
+  accountsStore.accounts = [
+    {
+      id: "acc1",
+      display_name: "Test",
+      email: "test@example.com",
+      provider: "generic",
+      mail_protocol: "imap" as const,
+      enabled: true,
+    },
+  ];
+  accountsStore.activeAccountId = "acc1";
+}
+
+describe("server-side search", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    listenMock.mockClear();
+    mockedSearch.mockReset();
+  });
+
+  it("hides the trigger when filter text is empty", () => {
+    const wrapper = mount(QuickFilterBar);
+    expect(wrapper.find('[data-testid="search-server-trigger"]').exists()).toBe(
+      false,
+    );
+  });
+
+  it("shows the trigger when filter text is non-empty", async () => {
+    const messagesStore = useMessagesStore();
+    messagesStore.quickFilterText = "report";
+    const wrapper = mount(QuickFilterBar);
+    expect(wrapper.find('[data-testid="search-server-trigger"]').exists()).toBe(
+      true,
+    );
+    expect(wrapper.text()).toContain("Search server for");
+    expect(wrapper.text()).toContain("report");
+  });
+
+  it("dispatches a SearchQuery built from filter text + field toggles", async () => {
+    withActiveAccount();
+    mockedSearch.mockResolvedValueOnce([]);
+
+    const messagesStore = useMessagesStore();
+    messagesStore.quickFilterText = "invoice";
+    messagesStore.quickFilterFields = ["subject"];
+
+    const wrapper = mount(QuickFilterBar);
+    await wrapper.find('[data-testid="search-server-trigger"]').trigger("click");
+    await Promise.resolve();
+
+    expect(mockedSearch).toHaveBeenCalledTimes(1);
+    const [accountId, query] = mockedSearch.mock.calls[0];
+    expect(accountId).toBe("acc1");
+    expect(query.text).toBe("invoice");
+    expect(query.fields).toEqual({
+      subject: true,
+      from: false,
+      to: false,
+      body: false,
+    });
+  });
+
+  it("uses all fields when no field toggle has been set", async () => {
+    withActiveAccount();
+    mockedSearch.mockResolvedValueOnce([]);
+
+    const messagesStore = useMessagesStore();
+    messagesStore.quickFilterText = "invoice";
+    messagesStore.quickFilterFields = [];
+
+    await messagesStore.runServerSearch();
+    expect(mockedSearch.mock.calls[0][1].fields).toEqual({
+      subject: true,
+      from: true,
+      to: true,
+      body: true,
+    });
+  });
+
+  it("populates serverHits on a successful search", async () => {
+    withActiveAccount();
+    mockedSearch.mockResolvedValueOnce([
+      {
+        account_id: "acc1",
+        folder_path: "INBOX",
+        uid: 42,
+        message_id: "<x@y>",
+        backend_id: "INBOX:42",
+        subject: "Hi there",
+        from_name: "Alice",
+        from_email: "alice@example.com",
+        date: 1_700_000_000,
+        snippet: "preview text",
+      },
+    ]);
+
+    const messagesStore = useMessagesStore();
+    messagesStore.quickFilterText = "hi";
+    await messagesStore.runServerSearch();
+
+    expect(messagesStore.serverHits).toHaveLength(1);
+    expect(messagesStore.serverSearchLoading).toBe(false);
+    expect(messagesStore.serverSearchError).toBeNull();
+  });
+
+  it("captures errors and clears hits", async () => {
+    withActiveAccount();
+    mockedSearch.mockRejectedValueOnce(new Error("timeout"));
+
+    const messagesStore = useMessagesStore();
+    messagesStore.quickFilterText = "hi";
+    await messagesStore.runServerSearch();
+
+    expect(messagesStore.serverHits).toHaveLength(0);
+    expect(messagesStore.serverSearchError).toContain("timeout");
+  });
+
+  it("clears prior hits as soon as the user types again", async () => {
+    withActiveAccount();
+    const messagesStore = useMessagesStore();
+    messagesStore.serverHits = [
+      {
+        account_id: "acc1",
+        folder_path: "INBOX",
+        uid: null,
+        message_id: null,
+        backend_id: "x",
+        subject: "old",
+        from_name: null,
+        from_email: null,
+        date: 0,
+        snippet: null,
+      },
+    ];
+    messagesStore.serverSearchError = "stale";
+
+    messagesStore.onFilterTextChange();
+    expect(messagesStore.serverHits).toHaveLength(0);
+    expect(messagesStore.serverSearchError).toBeNull();
+  });
+});

--- a/src/components/mail/MessageList.vue
+++ b/src/components/mail/MessageList.vue
@@ -460,12 +460,15 @@ function formatHitDate(secs: number): string {
 }
 
 // JMAP and Graph hits report the backend's folder/mailbox ID, which is
-// opaque to the user. Resolve to the folder's display name when we have it
-// in the tree; fall back to the raw path otherwise.
+// opaque to the user. Build a path -> name index once per folder-tree
+// change so rendering N hits stays O(N) instead of O(N * folder_count).
+const folderNameByPath = computed(
+  () => new Map(foldersStore.getFlatFolders().map((f) => [f.path, f.name])),
+);
+
 function resolveFolderName(path: string): string {
   if (!path) return "(unknown folder)";
-  const folder = foldersStore.getFlatFolders().find((f) => f.path === path);
-  return folder?.name ?? path;
+  return folderNameByPath.value.get(path) ?? path;
 }
 </script>
 

--- a/src/components/mail/MessageList.vue
+++ b/src/components/mail/MessageList.vue
@@ -605,6 +605,11 @@ function resolveFolderName(path: string): string {
         :key="hit.backend_id"
         class="server-hit-row"
         data-testid="server-hit-row"
+        role="button"
+        tabindex="0"
+        @click="messagesStore.openServerHit(hit)"
+        @keydown.enter.prevent="messagesStore.openServerHit(hit)"
+        @keydown.space.prevent="messagesStore.openServerHit(hit)"
       >
         <div class="hit-line">
           <span class="hit-from">{{ hit.from_name || hit.from_email || "(unknown sender)" }}</span>
@@ -858,6 +863,14 @@ function resolveFolderName(path: string): string {
   padding: 8px 12px;
   border-bottom: 1px solid var(--color-border);
   font-size: 12px;
+  cursor: pointer;
+  transition: background 0.12s;
+}
+
+.server-hit-row:hover,
+.server-hit-row:focus-visible {
+  background: var(--color-bg-hover);
+  outline: none;
 }
 
 .hit-line {

--- a/src/components/mail/MessageList.vue
+++ b/src/components/mail/MessageList.vue
@@ -458,6 +458,15 @@ function formatHitDate(secs: number): string {
   if (!secs) return "";
   return new Date(secs * 1000).toLocaleDateString();
 }
+
+// JMAP and Graph hits report the backend's folder/mailbox ID, which is
+// opaque to the user. Resolve to the folder's display name when we have it
+// in the tree; fall back to the raw path otherwise.
+function resolveFolderName(path: string): string {
+  if (!path) return "(unknown folder)";
+  const folder = foldersStore.getFlatFolders().find((f) => f.path === path);
+  return folder?.name ?? path;
+}
 </script>
 
 <template>
@@ -603,7 +612,7 @@ function formatHitDate(secs: number): string {
         </div>
         <div class="hit-subject">{{ hit.subject || "(no subject)" }}</div>
         <div v-if="hit.snippet" class="hit-snippet">{{ hit.snippet }}</div>
-        <div class="hit-folder">in {{ hit.folder_path || "(unknown folder)" }}</div>
+        <div class="hit-folder">in {{ resolveFolderName(hit.folder_path) }}</div>
       </div>
     </div>
 

--- a/src/components/mail/MessageList.vue
+++ b/src/components/mail/MessageList.vue
@@ -453,6 +453,11 @@ const displayedCount = () => {
   }
   return `${messagesStore.messages.length} of ${messagesStore.total}`;
 };
+
+function formatHitDate(secs: number): string {
+  if (!secs) return "";
+  return new Date(secs * 1000).toLocaleDateString();
+}
 </script>
 
 <template>
@@ -575,6 +580,31 @@ const displayedCount = () => {
         />
       </div>
       <div v-if="messagesStore.loadingMore" class="loading-more">Loading more...</div>
+    </div>
+
+    <!-- Server-side search results: rendered after local list when present -->
+    <div
+      v-if="messagesStore.serverHits.length > 0"
+      class="server-results"
+      data-testid="server-results"
+    >
+      <div class="server-results-header">
+        Server results ({{ messagesStore.serverHits.length }})
+      </div>
+      <div
+        v-for="hit in messagesStore.serverHits"
+        :key="hit.backend_id"
+        class="server-hit-row"
+        data-testid="server-hit-row"
+      >
+        <div class="hit-line">
+          <span class="hit-from">{{ hit.from_name || hit.from_email || "(unknown sender)" }}</span>
+          <span class="hit-date">{{ formatHitDate(hit.date) }}</span>
+        </div>
+        <div class="hit-subject">{{ hit.subject || "(no subject)" }}</div>
+        <div v-if="hit.snippet" class="hit-snippet">{{ hit.snippet }}</div>
+        <div class="hit-folder">in {{ hit.folder_path || "(unknown folder)" }}</div>
+      </div>
     </div>
 
     <div class="list-footer">
@@ -795,6 +825,76 @@ const displayedCount = () => {
   font-size: 11px;
   color: var(--color-text-muted);
   flex-shrink: 0;
+}
+
+.server-results {
+  border-top: 2px solid var(--color-border);
+  background: var(--color-bg-secondary);
+  max-height: 40vh;
+  overflow-y: auto;
+  flex-shrink: 0;
+}
+
+.server-results-header {
+  padding: 6px 12px;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.server-hit-row {
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--color-border);
+  font-size: 12px;
+}
+
+.hit-line {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  color: var(--color-text);
+}
+
+.hit-from {
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.hit-date {
+  color: var(--color-text-muted);
+  font-size: 11px;
+  flex-shrink: 0;
+}
+
+.hit-subject {
+  color: var(--color-text);
+  margin-top: 2px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.hit-snippet {
+  color: var(--color-text-muted);
+  font-size: 11px;
+  margin-top: 2px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
+.hit-folder {
+  color: var(--color-text-muted);
+  font-size: 10px;
+  margin-top: 4px;
+  font-style: italic;
 }
 
 .quick-filter-toggle {

--- a/src/components/mail/QuickFilterBar.vue
+++ b/src/components/mail/QuickFilterBar.vue
@@ -97,6 +97,23 @@ function onTextInput() {
         @click="messagesStore.toggleTextField('body')"
       >Body</button>
     </div>
+    <div v-if="messagesStore.quickFilterText.trim()" class="server-row">
+      <button
+        class="server-btn"
+        data-testid="search-server-trigger"
+        :disabled="messagesStore.serverSearchLoading"
+        @click="messagesStore.runServerSearch()"
+      >
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+        <span v-if="messagesStore.serverSearchLoading" data-testid="search-server-loading">Searching server&hellip;</span>
+        <span v-else>Search server for &ldquo;{{ messagesStore.quickFilterText.trim() }}&rdquo;</span>
+      </button>
+      <span
+        v-if="messagesStore.serverSearchError"
+        class="server-error"
+        data-testid="search-server-error"
+      >{{ messagesStore.serverSearchError }}</span>
+    </div>
   </div>
 </template>
 
@@ -228,5 +245,42 @@ function onTextInput() {
 .field-btn.active {
   border-color: var(--color-accent);
   color: var(--color-accent);
+}
+
+.server-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 2px 8px 6px;
+}
+
+.server-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  background: var(--color-bg);
+  color: var(--color-text-secondary);
+  font-size: 11px;
+  cursor: pointer;
+  transition: all 0.12s;
+}
+
+.server-btn:hover:not(:disabled) {
+  background: var(--color-bg-hover);
+  color: var(--color-text);
+  border-color: var(--color-accent);
+}
+
+.server-btn:disabled {
+  opacity: 0.6;
+  cursor: progress;
+}
+
+.server-error {
+  font-size: 11px;
+  color: var(--color-danger);
 }
 </style>

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -74,6 +74,13 @@ export async function searchMessagesServer(
   return invoke("search_messages_server", { accountId, query });
 }
 
+export async function importSearchHit(
+  accountId: string,
+  hit: SearchHit,
+): Promise<string> {
+  return invoke("import_search_hit", { accountId, hit });
+}
+
 export async function getMessageHtmlWithImages(
   accountId: string,
   messageId: string,

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -7,6 +7,8 @@ import type {
   MessageBody,
   SyncStatus,
   QuickFilter,
+  SearchQuery,
+  SearchHit,
 } from "./types";
 
 export async function listAccounts(): Promise<Account[]> {
@@ -63,6 +65,13 @@ export async function getMessageBody(
   messageId: string,
 ): Promise<MessageBody> {
   return invoke("get_message_body", { accountId, messageId });
+}
+
+export async function searchMessagesServer(
+  accountId: string,
+  query: SearchQuery,
+): Promise<SearchHit[]> {
+  return invoke("search_messages_server", { accountId, query });
 }
 
 export async function getMessageHtmlWithImages(

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -16,6 +16,33 @@ export interface QuickFilter {
   text_fields?: string[];
 }
 
+export interface SearchFields {
+  subject: boolean;
+  from: boolean;
+  to: boolean;
+  body: boolean;
+}
+
+export interface SearchQuery {
+  text: string;
+  fields: SearchFields;
+  has_attachment?: boolean;
+  since_days?: number;
+}
+
+export interface SearchHit {
+  account_id: string;
+  folder_path: string;
+  uid: number | null;
+  message_id: string | null;
+  backend_id: string;
+  subject: string;
+  from_name: string | null;
+  from_email: string | null;
+  date: number;
+  snippet: string | null;
+}
+
 export interface Folder {
   name: string;
   path: string;

--- a/src/stores/messages.ts
+++ b/src/stores/messages.ts
@@ -162,6 +162,24 @@ export const useMessagesStore = defineStore("messages", () => {
     serverSearchError.value = null;
   }
 
+  /**
+   * Open a server-search hit. The hit may not be in the local messages
+   * table yet, so we first ask the backend to upsert a stub row (the
+   * existing get_message_body flow then fetches the body on demand) and
+   * then drive the regular load-and-display path.
+   */
+  async function openServerHit(hit: SearchHit) {
+    const accountId = accountsStore.activeAccountId;
+    if (!accountId) return;
+    try {
+      const messageId = await api.importSearchHit(accountId, hit);
+      await loadMessage(messageId);
+    } catch (e) {
+      console.error("Failed to open server hit:", e);
+      serverSearchError.value = e instanceof Error ? e.message : String(e);
+    }
+  }
+
   async function runServerSearch() {
     const accountId = accountsStore.activeAccountId;
     const text = quickFilterText.value.trim();
@@ -752,5 +770,6 @@ export const useMessagesStore = defineStore("messages", () => {
     serverSearchError,
     runServerSearch,
     clearServerSearch,
+    openServerHit,
   };
 });

--- a/src/stores/messages.ts
+++ b/src/stores/messages.ts
@@ -1,7 +1,15 @@
 import { defineStore } from "pinia";
 import { ref, computed, watch, onScopeDispose } from "vue";
 import { listen } from "@tauri-apps/api/event";
-import type { MessageSummary, MessageBody, ThreadSummary, QuickFilter } from "@/lib/types";
+import type {
+  MessageSummary,
+  MessageBody,
+  ThreadSummary,
+  QuickFilter,
+  SearchHit,
+  SearchQuery,
+  SearchFields,
+} from "@/lib/types";
 import * as api from "@/lib/tauri";
 import { useAccountsStore } from "./accounts";
 import { useFoldersStore } from "./folders";
@@ -52,6 +60,11 @@ export const useMessagesStore = defineStore("messages", () => {
   const quickFilterText = ref("");
   const quickFilterVisible = ref(false);
   const quickFilterFields = ref<string[]>([]); // empty = all fields
+
+  // Server-side search state (separate from local quick-filter)
+  const serverHits = ref<SearchHit[]>([]);
+  const serverSearchLoading = ref(false);
+  const serverSearchError = ref<string | null>(null);
 
   const accountsStore = useAccountsStore();
   const foldersStore = useFoldersStore();
@@ -105,6 +118,9 @@ export const useMessagesStore = defineStore("messages", () => {
   let textSearchTimer: ReturnType<typeof setTimeout> | null = null;
   function onFilterTextChange() {
     if (textSearchTimer) clearTimeout(textSearchTimer);
+    // The server-search results are tied to the *previous* query, so clear
+    // them as soon as the user changes the input.
+    clearServerSearch();
     textSearchTimer = setTimeout(() => {
       fetchMessages(true);
     }, 300);
@@ -115,7 +131,53 @@ export const useMessagesStore = defineStore("messages", () => {
     quickFilterText.value = "";
     quickFilterFields.value = [];
     if (textSearchTimer) clearTimeout(textSearchTimer);
+    clearServerSearch();
     fetchMessages(true);
+  }
+
+  function fieldsForServerSearch(): SearchFields {
+    // QuickFilterBar uses `quickFilterFields` with values 'sender', 'recipients',
+    // 'subject', 'body'. Empty array means "all fields" (matches the bar's UI).
+    const f = quickFilterFields.value;
+    if (f.length === 0) {
+      return { subject: true, from: true, to: true, body: true };
+    }
+    return {
+      subject: f.includes("subject"),
+      from: f.includes("sender"),
+      to: f.includes("recipients"),
+      body: f.includes("body"),
+    };
+  }
+
+  function clearServerSearch() {
+    serverHits.value = [];
+    serverSearchLoading.value = false;
+    serverSearchError.value = null;
+  }
+
+  async function runServerSearch() {
+    const accountId = accountsStore.activeAccountId;
+    const text = quickFilterText.value.trim();
+    if (!accountId || !text) return;
+
+    const query: SearchQuery = {
+      text,
+      fields: fieldsForServerSearch(),
+      has_attachment: quickFilter.value.has_attachment ? true : undefined,
+    };
+
+    serverSearchLoading.value = true;
+    serverSearchError.value = null;
+    try {
+      serverHits.value = await api.searchMessagesServer(accountId, query);
+    } catch (e) {
+      console.error("Server search failed:", e);
+      serverSearchError.value = String(e);
+      serverHits.value = [];
+    } finally {
+      serverSearchLoading.value = false;
+    }
   }
 
   // Computed for quick lookup
@@ -558,6 +620,7 @@ export const useMessagesStore = defineStore("messages", () => {
       activeMessageId.value = null;
       selectedIds.value = [];
       lastClickedId.value = null;
+      clearServerSearch();
       fetchMessages();
     },
   );
@@ -671,5 +734,10 @@ export const useMessagesStore = defineStore("messages", () => {
     markAsUnread,
     setReadStatus,
     subjectForMessage,
+    serverHits,
+    serverSearchLoading,
+    serverSearchError,
+    runServerSearch,
+    clearServerSearch,
   };
 });

--- a/src/stores/messages.ts
+++ b/src/stores/messages.ts
@@ -150,7 +150,13 @@ export const useMessagesStore = defineStore("messages", () => {
     };
   }
 
+  // Monotonically increases on each server-search dispatch (and on each
+  // clear). Late results from a stale request are dropped if their token
+  // no longer matches.
+  let serverSearchToken = 0;
+
   function clearServerSearch() {
+    serverSearchToken++;
     serverHits.value = [];
     serverSearchLoading.value = false;
     serverSearchError.value = null;
@@ -167,16 +173,23 @@ export const useMessagesStore = defineStore("messages", () => {
       has_attachment: quickFilter.value.has_attachment ? true : undefined,
     };
 
+    const myToken = ++serverSearchToken;
     serverSearchLoading.value = true;
     serverSearchError.value = null;
     try {
-      serverHits.value = await api.searchMessagesServer(accountId, query);
+      const hits = await api.searchMessagesServer(accountId, query);
+      // Drop the result if a newer search/clear has happened in the meantime.
+      if (myToken !== serverSearchToken) return;
+      serverHits.value = hits;
     } catch (e) {
+      if (myToken !== serverSearchToken) return;
       console.error("Server search failed:", e);
-      serverSearchError.value = String(e);
+      serverSearchError.value = e instanceof Error ? e.message : String(e);
       serverHits.value = [];
     } finally {
-      serverSearchLoading.value = false;
+      if (myToken === serverSearchToken) {
+        serverSearchLoading.value = false;
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Implements #119. Adds a "Search server" trigger to the existing `QuickFilterBar` that runs an account-wide search via the matching backend and renders the hits below the locally-cached message list.

- **IMAP**: per-folder `UID SEARCH CHARSET UTF-8 OR ... SUBJECT/FROM/TO/BODY` on a fresh connection, then `UID FETCH ENVELOPE` for matching UIDs.
- **JMAP**: `Email/query` with a `FilterCondition` (uses the single `text` field when all four toggles are on, OR-combines per-field filters otherwise) chained into `Email/get`.
- **Graph**: `GET /me/messages?$search="<kql>"` with `ConsistencyLevel: eventual`, single retry on HTTP 429 honoring `Retry-After`.

Dispatch follows the existing `mail_protocol` `if/else` pattern (no new trait), per the planning conversation.

## Out of scope (follow-ups)


- Streaming partial results to the UI.
- Cross-account fan-out, saved searches, local FTS index.

## Test plan

- [x] `cargo fmt && cargo clippy --all-targets -- -D warnings && cargo test` (182 tests, all green)
- [x] `cargo audit` (clean, post-Dependabot bumps from #116/#118)
- [x] `cargo build --release`
- [x] `pnpm test` (236 tests, all green; 7 new in `src/__tests__/server-search.test.ts`)
- [x] `pnpm build` (vue-tsc + vite)
- [x] Manual: typed a query in QuickFilterBar, clicked the trigger, hits rendered as expected
- [x] Reviewers: please verify against your own IMAP / JMAP / Graph (M365) accounts — the protocol-level search calls aren't covered by automated network tests

## How to find it

The search box is inside the existing Quick Filter bar (hidden by default). Press `/` or click **Quick Filter** at the bottom-right of the message list, type a query, then click **🔎 Search server for "..."**.