### PR TITLE
feat(menu): ADR 0044 menu system and shortcuts

### DIFF
--- a/src-tauri/src/commands/app.rs
+++ b/src-tauri/src/commands/app.rs
@@ -1,0 +1,10 @@
+use tauri::AppHandle;
+
+/// Cleanly exit the application from any window. The frontend uses this for
+/// the `File > Quit` menu item and the `Ctrl+Q` shortcut. Closing a single
+/// window is handled directly in the renderer via `getCurrentWindow().close()`.
+#[tauri::command]
+pub fn quit_app(app: AppHandle) {
+    log::info!("Quit requested via menu/shortcut");
+    app.exit(0);
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,5 +1,6 @@
 pub mod accounts;
 pub mod actions;
+pub mod app;
 pub mod attachments;
 pub mod calendar;
 pub mod compose;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -39,6 +39,7 @@ pub fn run() {
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
+            commands::app::quit_app,
             commands::accounts::list_accounts,
             commands::accounts::add_account,
             commands::accounts::get_account_config,

--- a/src/__tests__/compose-menu-bar.test.ts
+++ b/src/__tests__/compose-menu-bar.test.ts
@@ -1,0 +1,211 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+import { __setPlatformForTests } from "@/lib/shortcuts";
+
+const { openUrlMock } = vi.hoisted(() => ({ openUrlMock: vi.fn() }));
+vi.mock("@tauri-apps/plugin-opener", () => ({ openUrl: openUrlMock }));
+
+(globalThis as { __APP_VERSION__?: string }).__APP_VERSION__ = "0.0.0-test";
+
+import ComposeMenuBar from "@/components/compose/ComposeMenuBar.vue";
+
+beforeEach(() => {
+  __setPlatformForTests(false);
+  openUrlMock.mockReset();
+  // Clean up any teleported nodes from previous tests so dialog assertions
+  // don't pick up stale DOM.
+  document.body.innerHTML = "";
+});
+
+afterEach(() => {
+  __setPlatformForTests(null);
+});
+
+function makeWrapper(props: { showCc?: boolean; showBcc?: boolean } = {}) {
+  return mount(ComposeMenuBar, {
+    props: { showCc: false, showBcc: false, ...props },
+  });
+}
+
+describe("ComposeMenuBar", () => {
+  it("renders all five top-level menu labels", () => {
+    const wrapper = makeWrapper();
+    const text = wrapper.text();
+    expect(text).toContain("File");
+    expect(text).toContain("Edit");
+    expect(text).toContain("View");
+    expect(text).toContain("Options");
+    expect(text).toContain("Help");
+    // Tools is intentionally absent (ADR 0044)
+    expect(text).not.toContain("Tools");
+  });
+
+  it("File menu shows Save Draft / Send / Close Window with shortcuts", async () => {
+    const wrapper = makeWrapper();
+    await wrapper.findAll(".menu-item")[0].trigger("click");
+    const dropdown = wrapper.find('[data-testid="compose-menu-file-dropdown"]');
+    expect(dropdown.text()).toContain("Save Draft");
+    expect(dropdown.text()).toContain("Ctrl+S");
+    expect(dropdown.text()).toContain("Send");
+    expect(dropdown.text()).toContain("Ctrl+Enter");
+    expect(dropdown.text()).toContain("Close Window");
+    expect(dropdown.text()).toContain("Esc");
+    expect(dropdown.text()).not.toContain("Ctrl+W");
+  });
+
+  it("emits saveDraft when Save Draft is clicked", async () => {
+    const wrapper = makeWrapper();
+    await wrapper.findAll(".menu-item")[0].trigger("click");
+    await wrapper.find('[data-testid="compose-menu-save-draft"]').trigger("click");
+    expect(wrapper.emitted("saveDraft")).toBeTruthy();
+  });
+
+  it("emits send when Send is clicked", async () => {
+    const wrapper = makeWrapper();
+    await wrapper.findAll(".menu-item")[0].trigger("click");
+    await wrapper.find('[data-testid="compose-menu-send"]').trigger("click");
+    expect(wrapper.emitted("send")).toBeTruthy();
+  });
+
+  it("emits closeWindow when Close Window is clicked", async () => {
+    const wrapper = makeWrapper();
+    await wrapper.findAll(".menu-item")[0].trigger("click");
+    await wrapper.find('[data-testid="compose-menu-close-window"]').trigger("click");
+    expect(wrapper.emitted("closeWindow")).toBeTruthy();
+  });
+
+  it("Edit menu items dispatch document.execCommand", async () => {
+    // happy-dom doesn't implement execCommand; install a spy in its place.
+    const exec = vi.fn().mockReturnValue(true);
+    Object.defineProperty(document, "execCommand", {
+      value: exec,
+      configurable: true,
+      writable: true,
+    });
+    const wrapper = makeWrapper();
+    await wrapper.findAll(".menu-item")[1].trigger("click");
+    await wrapper.find('[data-testid="compose-menu-undo"]').trigger("click");
+    expect(exec).toHaveBeenLastCalledWith("undo");
+    // The dropdown closes after a click, so re-open it before the next.
+    await wrapper.findAll(".menu-item")[1].trigger("click");
+    await wrapper.find('[data-testid="compose-menu-redo"]').trigger("click");
+    expect(exec).toHaveBeenLastCalledWith("redo");
+  });
+
+  it("View menu shows checkmark for the active Cc/Bcc state", async () => {
+    const wrapper = makeWrapper({ showCc: true, showBcc: false });
+    await wrapper.findAll(".menu-item")[2].trigger("click");
+    const cc = wrapper.find('[data-testid="compose-menu-show-cc"]');
+    const bcc = wrapper.find('[data-testid="compose-menu-show-bcc"]');
+    expect(cc.text()).toContain("\u2713");
+    expect(bcc.text()).not.toContain("\u2713");
+  });
+
+  it("Options > Attach File emits attach", async () => {
+    const wrapper = makeWrapper();
+    await wrapper.findAll(".menu-item")[3].trigger("click");
+    await wrapper.find('[data-testid="compose-menu-attach"]').trigger("click");
+    expect(wrapper.emitted("attach")).toBeTruthy();
+  });
+
+  it("Help > About Chithi opens the About dialog with version + links", async () => {
+    const wrapper = makeWrapper();
+    await wrapper.findAll(".menu-item")[4].trigger("click");
+    await wrapper.find('[data-testid="compose-menu-about"]').trigger("click");
+    await wrapper.vm.$nextTick();
+
+    const overlay = document.querySelector('[data-testid="about-overlay"]');
+    expect(overlay).not.toBeNull();
+    expect(document.body.textContent).toContain("0.0.0-test");
+
+    const sourceLink = document.querySelector(
+      '[data-testid="about-source-link"]',
+    ) as HTMLElement | null;
+    expect(sourceLink).not.toBeNull();
+    sourceLink?.click();
+    expect(openUrlMock).toHaveBeenCalledWith(
+      "https://github.com/SUNET/chithi",
+    );
+
+    const licenseLink = document.querySelector(
+      '[data-testid="about-license-link"]',
+    ) as HTMLElement | null;
+    licenseLink?.click();
+    expect(openUrlMock).toHaveBeenLastCalledWith(
+      "https://github.com/SUNET/chithi/blob/main/LICENSE",
+    );
+
+    // Closing via the X button removes the overlay.
+    const closeBtn = document.querySelector('[data-testid="about-close"]') as HTMLElement | null;
+    closeBtn?.click();
+    await wrapper.vm.$nextTick();
+    expect(document.querySelector('[data-testid="about-overlay"]')).toBeNull();
+  });
+
+  it("Ctrl+S keydown emits saveDraft (and works while focus is in a textarea)", () => {
+    const wrapper = makeWrapper();
+    const textarea = document.createElement("textarea");
+    document.body.appendChild(textarea);
+    textarea.focus();
+    const event = new KeyboardEvent("keydown", {
+      key: "s",
+      ctrlKey: true,
+      cancelable: true,
+      bubbles: true,
+    });
+    textarea.dispatchEvent(event);
+    expect(wrapper.emitted("saveDraft")).toBeTruthy();
+    textarea.remove();
+  });
+
+  it("Ctrl+Enter keydown emits send", () => {
+    const wrapper = makeWrapper();
+    window.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Enter", ctrlKey: true, cancelable: true }),
+    );
+    expect(wrapper.emitted("send")).toBeTruthy();
+  });
+
+  it("Escape keydown emits closeWindow", () => {
+    const wrapper = makeWrapper();
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", cancelable: true }));
+    expect(wrapper.emitted("closeWindow")).toBeTruthy();
+  });
+
+  it("Escape closes the About dialog when it is open", async () => {
+    const wrapper = makeWrapper();
+    await wrapper.findAll(".menu-item")[4].trigger("click");
+    await wrapper.find('[data-testid="compose-menu-about"]').trigger("click");
+    await wrapper.vm.$nextTick();
+    expect(document.querySelector('[data-testid="about-overlay"]')).not.toBeNull();
+
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", cancelable: true }));
+    await wrapper.vm.$nextTick();
+    expect(document.querySelector('[data-testid="about-overlay"]')).toBeNull();
+  });
+
+  it("Ctrl+Shift+A keydown emits attach", () => {
+    const wrapper = makeWrapper();
+    window.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        key: "A",
+        ctrlKey: true,
+        shiftKey: true,
+        cancelable: true,
+      }),
+    );
+    expect(wrapper.emitted("attach")).toBeTruthy();
+  });
+
+  it("Ctrl+Z is NOT intercepted (left to browser/WebKitGTK workaround)", () => {
+    const wrapper = makeWrapper();
+    window.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "z", ctrlKey: true, cancelable: true }),
+    );
+    // No emit should fire — the menu does not bind Edit shortcuts.
+    expect(wrapper.emitted("saveDraft")).toBeFalsy();
+    expect(wrapper.emitted("send")).toBeFalsy();
+    expect(wrapper.emitted("closeWindow")).toBeFalsy();
+    expect(wrapper.emitted("attach")).toBeFalsy();
+  });
+});

--- a/src/__tests__/compose-menu-bar.test.ts
+++ b/src/__tests__/compose-menu-bar.test.ts
@@ -5,9 +5,12 @@ import { __setPlatformForTests } from "@/lib/shortcuts";
 const { openUrlMock } = vi.hoisted(() => ({ openUrlMock: vi.fn() }));
 vi.mock("@tauri-apps/plugin-opener", () => ({ openUrl: openUrlMock }));
 
-(globalThis as { __APP_VERSION__?: string }).__APP_VERSION__ = "0.0.0-test";
-
 import ComposeMenuBar from "@/components/compose/ComposeMenuBar.vue";
+import pkg from "../../package.json";
+
+// `__APP_VERSION__` is injected by Vite's `define` from package.json
+// (see vite.config.ts); the test asserts against the same source.
+const APP_VERSION = pkg.version as string;
 
 beforeEach(() => {
   __setPlatformForTests(false);
@@ -116,7 +119,7 @@ describe("ComposeMenuBar", () => {
 
     const overlay = document.querySelector('[data-testid="about-overlay"]');
     expect(overlay).not.toBeNull();
-    expect(document.body.textContent).toContain("0.0.0-test");
+    expect(document.body.textContent).toContain(APP_VERSION);
 
     const sourceLink = document.querySelector(
       '[data-testid="about-source-link"]',

--- a/src/__tests__/menu-bar.test.ts
+++ b/src/__tests__/menu-bar.test.ts
@@ -5,15 +5,19 @@ import { createMemoryHistory, createRouter } from "vue-router";
 import { __setPlatformForTests } from "@/lib/shortcuts";
 import MenuBar from "@/components/common/MenuBar.vue";
 
-const { invokeMock, setDecorationsMock } = vi.hoisted(() => ({
+const { invokeMock, setDecorationsMock, openUrlMock } = vi.hoisted(() => ({
   invokeMock: vi.fn(),
   setDecorationsMock: vi.fn(),
+  openUrlMock: vi.fn(),
 }));
 
 vi.mock("@tauri-apps/api/core", () => ({ invoke: invokeMock }));
 vi.mock("@tauri-apps/api/window", () => ({
   getCurrentWindow: () => ({ setDecorations: setDecorationsMock }),
 }));
+vi.mock("@tauri-apps/plugin-opener", () => ({ openUrl: openUrlMock }));
+
+(globalThis as { __APP_VERSION__?: string }).__APP_VERSION__ = "0.0.0-test";
 vi.mock("@/lib/tauri", () => ({
   listTimezones: vi.fn().mockResolvedValue([]),
   getDefaultTimezone: vi.fn().mockResolvedValue("UTC"),
@@ -33,6 +37,8 @@ beforeEach(() => {
   setActivePinia(createPinia());
   invokeMock.mockReset();
   setDecorationsMock.mockReset();
+  openUrlMock.mockReset();
+  document.body.innerHTML = "";
   __setPlatformForTests(false);
 });
 
@@ -41,10 +47,20 @@ afterEach(() => {
 });
 
 describe("MenuBar", () => {
-  it("renders File and View menu labels", () => {
+  it("renders File / View / Help menu labels", () => {
     const wrapper = mount(MenuBar, { global: { plugins: [makeRouter()] } });
     expect(wrapper.text()).toContain("File");
     expect(wrapper.text()).toContain("View");
+    expect(wrapper.text()).toContain("Help");
+  });
+
+  it("Help > About opens the About dialog", async () => {
+    const wrapper = mount(MenuBar, { global: { plugins: [makeRouter()] } });
+    await wrapper.find('.menu-item:nth-of-type(3)').trigger("click");
+    await wrapper.find('[data-testid="menu-help-about"]').trigger("click");
+    await wrapper.vm.$nextTick();
+    expect(document.querySelector('[data-testid="about-overlay"]')).not.toBeNull();
+    expect(document.body.textContent).toContain("0.0.0-test");
   });
 
   it("File menu shows Preferences / Quit with shortcut labels", async () => {

--- a/src/__tests__/menu-bar.test.ts
+++ b/src/__tests__/menu-bar.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+import { createMemoryHistory, createRouter } from "vue-router";
+import { __setPlatformForTests } from "@/lib/shortcuts";
+import MenuBar from "@/components/common/MenuBar.vue";
+
+const { invokeMock, closeMock, setDecorationsMock } = vi.hoisted(() => ({
+  invokeMock: vi.fn(),
+  closeMock: vi.fn(),
+  setDecorationsMock: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({ invoke: invokeMock }));
+vi.mock("@tauri-apps/api/window", () => ({
+  getCurrentWindow: () => ({ close: closeMock, setDecorations: setDecorationsMock }),
+}));
+vi.mock("@/lib/tauri", () => ({
+  listTimezones: vi.fn().mockResolvedValue([]),
+  getDefaultTimezone: vi.fn().mockResolvedValue("UTC"),
+}));
+
+function makeRouter() {
+  return createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      { path: "/", component: { template: "<div/>" } },
+      { path: "/settings", component: { template: "<div/>" } },
+      { path: "/filters", component: { template: "<div/>" } },
+    ],
+  });
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+  invokeMock.mockReset();
+  closeMock.mockReset();
+  setDecorationsMock.mockReset();
+  __setPlatformForTests(false);
+});
+
+afterEach(() => {
+  __setPlatformForTests(null);
+});
+
+describe("MenuBar", () => {
+  it("renders File and View menu labels", () => {
+    const wrapper = mount(MenuBar, { global: { plugins: [makeRouter()] } });
+    expect(wrapper.text()).toContain("File");
+    expect(wrapper.text()).toContain("View");
+  });
+
+  it("File menu shows Preferences / Close Window / Quit with shortcut labels", async () => {
+    const wrapper = mount(MenuBar, { global: { plugins: [makeRouter()] } });
+    await wrapper.find('.menu-item:nth-of-type(1)').trigger("click");
+    const dropdown = wrapper.find('[data-testid="menu-file-dropdown"]');
+    expect(dropdown.exists()).toBe(true);
+    expect(dropdown.text()).toContain("Preferences");
+    expect(dropdown.text()).toContain("Ctrl+,");
+    expect(dropdown.text()).toContain("Close Window");
+    expect(dropdown.text()).toContain("Ctrl+W");
+    expect(dropdown.text()).toContain("Quit");
+    expect(dropdown.text()).toContain("Ctrl+Q");
+  });
+
+  it("File > Quit invokes the quit_app command", async () => {
+    const wrapper = mount(MenuBar, { global: { plugins: [makeRouter()] } });
+    await wrapper.find('.menu-item:nth-of-type(1)').trigger("click");
+    await wrapper.find('[data-testid="menu-file-quit"]').trigger("click");
+    expect(invokeMock).toHaveBeenCalledWith("quit_app");
+  });
+
+  it("File > Close Window calls getCurrentWindow().close()", async () => {
+    const wrapper = mount(MenuBar, { global: { plugins: [makeRouter()] } });
+    await wrapper.find('.menu-item:nth-of-type(1)').trigger("click");
+    await wrapper.find('[data-testid="menu-file-close-window"]').trigger("click");
+    expect(closeMock).toHaveBeenCalled();
+  });
+
+  it("File > Preferences routes to /settings", async () => {
+    const router = makeRouter();
+    const push = vi.spyOn(router, "push");
+    const wrapper = mount(MenuBar, { global: { plugins: [router] } });
+    await wrapper.find('.menu-item:nth-of-type(1)').trigger("click");
+    await wrapper.find('[data-testid="menu-file-preferences"]').trigger("click");
+    expect(push).toHaveBeenCalledWith("/settings");
+  });
+
+  it("View menu shows the radio group with the active position prefixed", async () => {
+    const wrapper = mount(MenuBar, { global: { plugins: [makeRouter()] } });
+    await wrapper.find('.menu-item:nth-of-type(2)').trigger("click");
+    const dropdown = wrapper.find('[data-testid="menu-view-dropdown"]');
+    expect(dropdown.text()).toContain("Message Pane Position");
+    expect(dropdown.text()).toContain("Right");
+    expect(dropdown.text()).toContain("Bottom");
+    expect(dropdown.text()).toContain("Tabs");
+    // Default messageViewMode is "right"; that row should carry the bullet.
+    const right = wrapper.find('[data-testid="menu-view-position-right"]');
+    expect(right.text()).toContain("\u25CF");
+    const bottom = wrapper.find('[data-testid="menu-view-position-bottom"]');
+    expect(bottom.text()).not.toContain("\u25CF");
+  });
+
+  it("Ctrl+T toggles threading via the keydown listener", async () => {
+    const wrapper = mount(MenuBar, { global: { plugins: [makeRouter()] } });
+    // We don't have direct access to uiStore here without importing; check
+    // via the menu rendering after dispatch.
+    const event = new KeyboardEvent("keydown", { key: "t", ctrlKey: true, cancelable: true });
+    window.dispatchEvent(event);
+    await wrapper.vm.$nextTick();
+    // Open View again to inspect the new state of "Threaded View" prefix.
+    await wrapper.find('.menu-item:nth-of-type(2)').trigger("click");
+    const threaded = wrapper.find('[data-testid="menu-view-threaded"]');
+    // Default threading is enabled; after Ctrl+T it should be off (no checkmark).
+    expect(threaded.text()).not.toContain("\u2713");
+  });
+
+  it("Ctrl+Q invokes quit_app via the keydown listener", () => {
+    mount(MenuBar, { global: { plugins: [makeRouter()] } });
+    window.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "q", ctrlKey: true, cancelable: true }),
+    );
+    expect(invokeMock).toHaveBeenCalledWith("quit_app");
+  });
+
+  it("ignores shortcuts dispatched while focus is in an input", () => {
+    mount(MenuBar, { global: { plugins: [makeRouter()] } });
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    input.focus();
+    input.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "q", ctrlKey: true, cancelable: true, bubbles: true }),
+    );
+    expect(invokeMock).not.toHaveBeenCalled();
+    input.remove();
+  });
+});

--- a/src/__tests__/menu-bar.test.ts
+++ b/src/__tests__/menu-bar.test.ts
@@ -4,6 +4,12 @@ import { createPinia, setActivePinia } from "pinia";
 import { createMemoryHistory, createRouter } from "vue-router";
 import { __setPlatformForTests } from "@/lib/shortcuts";
 import MenuBar from "@/components/common/MenuBar.vue";
+import pkg from "../../package.json";
+
+// `__APP_VERSION__` is injected by Vite's `define` from package.json (see
+// vite.config.ts). Asserting against package.json keeps the test in sync
+// with whatever the build pipeline actually inlines.
+const APP_VERSION = pkg.version as string;
 
 const { invokeMock, setDecorationsMock, openUrlMock } = vi.hoisted(() => ({
   invokeMock: vi.fn(),
@@ -17,7 +23,6 @@ vi.mock("@tauri-apps/api/window", () => ({
 }));
 vi.mock("@tauri-apps/plugin-opener", () => ({ openUrl: openUrlMock }));
 
-(globalThis as { __APP_VERSION__?: string }).__APP_VERSION__ = "0.0.0-test";
 vi.mock("@/lib/tauri", () => ({
   listTimezones: vi.fn().mockResolvedValue([]),
   getDefaultTimezone: vi.fn().mockResolvedValue("UTC"),
@@ -60,7 +65,7 @@ describe("MenuBar", () => {
     await wrapper.find('[data-testid="menu-help-about"]').trigger("click");
     await wrapper.vm.$nextTick();
     expect(document.querySelector('[data-testid="about-overlay"]')).not.toBeNull();
-    expect(document.body.textContent).toContain("0.0.0-test");
+    expect(document.body.textContent).toContain(APP_VERSION);
   });
 
   it("File menu shows Preferences / Quit with shortcut labels", async () => {

--- a/src/__tests__/menu-bar.test.ts
+++ b/src/__tests__/menu-bar.test.ts
@@ -80,7 +80,7 @@ describe("MenuBar", () => {
     const wrapper = mount(MenuBar, { global: { plugins: [makeRouter()] } });
     await wrapper.find('.menu-item:nth-of-type(2)').trigger("click");
     const dropdown = wrapper.find('[data-testid="menu-view-dropdown"]');
-    expect(dropdown.text()).toContain("Message Pane Position");
+    expect(dropdown.text()).toContain("Message Pane");
     expect(dropdown.text()).toContain("None");
     expect(dropdown.text()).toContain("Right");
     expect(dropdown.text()).toContain("Bottom");

--- a/src/__tests__/menu-bar.test.ts
+++ b/src/__tests__/menu-bar.test.ts
@@ -24,8 +24,7 @@ function makeRouter() {
     history: createMemoryHistory(),
     routes: [
       { path: "/", component: { template: "<div/>" } },
-      { path: "/settings", component: { template: "<div/>" } },
-      { path: "/filters", component: { template: "<div/>" } },
+      { path: "/preferences", component: { template: "<div/>" } },
     ],
   });
 }
@@ -67,13 +66,13 @@ describe("MenuBar", () => {
     expect(invokeMock).toHaveBeenCalledWith("quit_app");
   });
 
-  it("File > Preferences routes to /settings", async () => {
+  it("File > Preferences routes to /preferences", async () => {
     const router = makeRouter();
     const push = vi.spyOn(router, "push");
     const wrapper = mount(MenuBar, { global: { plugins: [router] } });
     await wrapper.find('.menu-item:nth-of-type(1)').trigger("click");
     await wrapper.find('[data-testid="menu-file-preferences"]').trigger("click");
-    expect(push).toHaveBeenCalledWith("/settings");
+    expect(push).toHaveBeenCalledWith("/preferences");
   });
 
   it("View menu shows the four-way radio with None / Right / Bottom / Tabs", async () => {

--- a/src/__tests__/menu-bar.test.ts
+++ b/src/__tests__/menu-bar.test.ts
@@ -5,15 +5,14 @@ import { createMemoryHistory, createRouter } from "vue-router";
 import { __setPlatformForTests } from "@/lib/shortcuts";
 import MenuBar from "@/components/common/MenuBar.vue";
 
-const { invokeMock, closeMock, setDecorationsMock } = vi.hoisted(() => ({
+const { invokeMock, setDecorationsMock } = vi.hoisted(() => ({
   invokeMock: vi.fn(),
-  closeMock: vi.fn(),
   setDecorationsMock: vi.fn(),
 }));
 
 vi.mock("@tauri-apps/api/core", () => ({ invoke: invokeMock }));
 vi.mock("@tauri-apps/api/window", () => ({
-  getCurrentWindow: () => ({ close: closeMock, setDecorations: setDecorationsMock }),
+  getCurrentWindow: () => ({ setDecorations: setDecorationsMock }),
 }));
 vi.mock("@/lib/tauri", () => ({
   listTimezones: vi.fn().mockResolvedValue([]),
@@ -34,7 +33,6 @@ function makeRouter() {
 beforeEach(() => {
   setActivePinia(createPinia());
   invokeMock.mockReset();
-  closeMock.mockReset();
   setDecorationsMock.mockReset();
   __setPlatformForTests(false);
 });
@@ -50,17 +48,16 @@ describe("MenuBar", () => {
     expect(wrapper.text()).toContain("View");
   });
 
-  it("File menu shows Preferences / Close Window / Quit with shortcut labels", async () => {
+  it("File menu shows Preferences / Quit with shortcut labels", async () => {
     const wrapper = mount(MenuBar, { global: { plugins: [makeRouter()] } });
     await wrapper.find('.menu-item:nth-of-type(1)').trigger("click");
     const dropdown = wrapper.find('[data-testid="menu-file-dropdown"]');
     expect(dropdown.exists()).toBe(true);
     expect(dropdown.text()).toContain("Preferences");
     expect(dropdown.text()).toContain("Ctrl+,");
-    expect(dropdown.text()).toContain("Close Window");
-    expect(dropdown.text()).toContain("Ctrl+W");
     expect(dropdown.text()).toContain("Quit");
     expect(dropdown.text()).toContain("Ctrl+Q");
+    expect(dropdown.text()).not.toContain("Close Window");
   });
 
   it("File > Quit invokes the quit_app command", async () => {
@@ -68,13 +65,6 @@ describe("MenuBar", () => {
     await wrapper.find('.menu-item:nth-of-type(1)').trigger("click");
     await wrapper.find('[data-testid="menu-file-quit"]').trigger("click");
     expect(invokeMock).toHaveBeenCalledWith("quit_app");
-  });
-
-  it("File > Close Window calls getCurrentWindow().close()", async () => {
-    const wrapper = mount(MenuBar, { global: { plugins: [makeRouter()] } });
-    await wrapper.find('.menu-item:nth-of-type(1)').trigger("click");
-    await wrapper.find('[data-testid="menu-file-close-window"]').trigger("click");
-    expect(closeMock).toHaveBeenCalled();
   });
 
   it("File > Preferences routes to /settings", async () => {
@@ -86,19 +76,40 @@ describe("MenuBar", () => {
     expect(push).toHaveBeenCalledWith("/settings");
   });
 
-  it("View menu shows the radio group with the active position prefixed", async () => {
+  it("View menu shows the four-way radio with None / Right / Bottom / Tabs", async () => {
     const wrapper = mount(MenuBar, { global: { plugins: [makeRouter()] } });
     await wrapper.find('.menu-item:nth-of-type(2)').trigger("click");
     const dropdown = wrapper.find('[data-testid="menu-view-dropdown"]');
     expect(dropdown.text()).toContain("Message Pane Position");
+    expect(dropdown.text()).toContain("None");
     expect(dropdown.text()).toContain("Right");
     expect(dropdown.text()).toContain("Bottom");
     expect(dropdown.text()).toContain("Tabs");
+    // The standalone "Show Message Pane" toggle is gone.
+    expect(dropdown.text()).not.toContain("Show Message Pane");
     // Default messageViewMode is "right"; that row should carry the bullet.
     const right = wrapper.find('[data-testid="menu-view-position-right"]');
     expect(right.text()).toContain("\u25CF");
-    const bottom = wrapper.find('[data-testid="menu-view-position-bottom"]');
-    expect(bottom.text()).not.toContain("\u25CF");
+    const none = wrapper.find('[data-testid="menu-view-position-none"]');
+    expect(none.text()).not.toContain("\u25CF");
+  });
+
+  it("Selecting None hides the pane via setMessageViewMode", async () => {
+    const { useUiStore } = await import("@/stores/ui");
+    const wrapper = mount(MenuBar, { global: { plugins: [makeRouter()] } });
+    await wrapper.find('.menu-item:nth-of-type(2)').trigger("click");
+    await wrapper.find('[data-testid="menu-view-position-none"]').trigger("click");
+    const ui = useUiStore();
+    expect(ui.messageViewMode).toBe("none");
+  });
+
+  it("Selecting Right after None re-enables the reader pane", async () => {
+    const { useUiStore } = await import("@/stores/ui");
+    const ui = useUiStore();
+    ui.setMessageViewMode("none");
+    ui.hideReader();
+    ui.setMessageViewMode("right");
+    expect(ui.readerVisible).toBe(true);
   });
 
   it("Ctrl+T toggles threading via the keydown listener", async () => {

--- a/src/__tests__/preferences-view.test.ts
+++ b/src/__tests__/preferences-view.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+import { createMemoryHistory, createRouter } from "vue-router";
+
+const { setDecorationsMock } = vi.hoisted(() => ({
+  setDecorationsMock: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/window", () => ({
+  getCurrentWindow: () => ({ setDecorations: setDecorationsMock }),
+}));
+
+vi.mock("@/lib/tauri", () => ({
+  listTimezones: vi.fn().mockResolvedValue(["UTC", "Europe/Stockholm", "America/New_York"]),
+  getDefaultTimezone: vi.fn().mockResolvedValue("UTC"),
+}));
+
+import PreferencesView from "@/views/PreferencesView.vue";
+import { useUiStore } from "@/stores/ui";
+
+function makeRouter() {
+  return createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      { path: "/", component: { template: "<div/>" } },
+      { path: "/preferences", component: PreferencesView },
+    ],
+  });
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+  setDecorationsMock.mockReset();
+  localStorage.clear();
+});
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+describe("PreferencesView", () => {
+  it("defaults to the General section", () => {
+    const wrapper = mount(PreferencesView, { global: { plugins: [makeRouter()] } });
+    expect(wrapper.find('[data-testid="prefs-section-general"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="prefs-section-date-time"]').exists()).toBe(false);
+  });
+
+  it("nav swaps the visible section", async () => {
+    const wrapper = mount(PreferencesView, { global: { plugins: [makeRouter()] } });
+    await wrapper.find('[data-testid="prefs-nav-date-time"]').trigger("click");
+    expect(wrapper.find('[data-testid="prefs-section-date-time"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="prefs-section-general"]').exists()).toBe(false);
+  });
+
+  it("does not expose Mail-only settings (threading, message pane)", () => {
+    const wrapper = mount(PreferencesView, { global: { plugins: [makeRouter()] } });
+    expect(wrapper.find('[data-testid="prefs-nav-mail"]').exists()).toBe(false);
+    expect(wrapper.find('[data-testid="prefs-threaded"]').exists()).toBe(false);
+    expect(wrapper.find('[data-testid="prefs-pane-tab"]').exists()).toBe(false);
+  });
+
+  it("Theme buttons drive uiStore.setTheme", async () => {
+    const wrapper = mount(PreferencesView, { global: { plugins: [makeRouter()] } });
+    const ui = useUiStore();
+    await wrapper.find('[data-testid="prefs-theme-dark"]').trigger("click");
+    expect(ui.theme).toBe("dark");
+    expect(localStorage.getItem("chithi-theme")).toBe("dark");
+
+    await wrapper.find('[data-testid="prefs-theme-system"]').trigger("click");
+    expect(ui.theme).toBe("system");
+  });
+
+  it("Hide Title Bar toggle drives uiStore.setDecorations (inverted sense)", async () => {
+    const wrapper = mount(PreferencesView, { global: { plugins: [makeRouter()] } });
+    const ui = useUiStore();
+    expect(ui.decorationsEnabled).toBe(true);
+    await wrapper.find('[data-testid="prefs-hide-title-bar"]').setValue(true);
+    expect(ui.decorationsEnabled).toBe(false);
+    await wrapper.find('[data-testid="prefs-hide-title-bar"]').setValue(false);
+    expect(ui.decorationsEnabled).toBe(true);
+  });
+
+  it("Date and Time section drives week start, time format, and timezone", async () => {
+    const wrapper = mount(PreferencesView, { global: { plugins: [makeRouter()] } });
+    const ui = useUiStore();
+    ui.timezoneList = ["UTC", "Europe/Stockholm"];
+    await wrapper.find('[data-testid="prefs-nav-date-time"]').trigger("click");
+
+    await wrapper.find('[data-testid="prefs-week-start-1"]').trigger("click");
+    expect(ui.weekStartDay).toBe(1);
+
+    await wrapper.find('[data-testid="prefs-time-format-24"]').trigger("click");
+    expect(ui.timeFormat).toBe("24");
+
+    const input = wrapper.find('[data-testid="prefs-timezone-search"]');
+    await input.trigger("focus");
+    await wrapper.vm.$nextTick();
+    const opt = wrapper.find('[data-testid="prefs-timezone-option-Europe/Stockholm"]');
+    await opt.trigger("mousedown");
+    expect(ui.displayTimezone).toBe("Europe/Stockholm");
+  });
+
+  it("close button calls router.back", async () => {
+    const router = makeRouter();
+    const back = vi.spyOn(router, "back");
+    const wrapper = mount(PreferencesView, { global: { plugins: [router] } });
+    await wrapper.find('[data-testid="prefs-close"]').trigger("click");
+    expect(back).toHaveBeenCalled();
+  });
+});
+
+describe("UI store theme system", () => {
+  it("resolvedTheme follows the OS preference when theme === 'system'", () => {
+    setActivePinia(createPinia());
+    const matchMedia = vi.fn().mockReturnValue({
+      matches: true,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    });
+    vi.stubGlobal("matchMedia", matchMedia);
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: matchMedia,
+    });
+    const ui = useUiStore();
+    ui.setTheme("system");
+    expect(ui.resolvedTheme).toBe("dark");
+    vi.unstubAllGlobals();
+  });
+
+  it("validates a stale stored theme and falls back to 'system'", () => {
+    localStorage.setItem("chithi-theme", "neon");
+    setActivePinia(createPinia());
+    const ui = useUiStore();
+    expect(ui.theme).toBe("system");
+  });
+});

--- a/src/__tests__/preferences-view.test.ts
+++ b/src/__tests__/preferences-view.test.ts
@@ -135,4 +135,31 @@ describe("UI store theme system", () => {
     const ui = useUiStore();
     expect(ui.theme).toBe("system");
   });
+
+  it("resolvedTheme reacts when the OS preference flips while theme === 'system'", () => {
+    setActivePinia(createPinia());
+    let changeHandler: ((e: { matches: boolean }) => void) | null = null;
+    const mql = {
+      matches: false, // OS starts in light mode
+      addEventListener: (_evt: string, h: (e: { matches: boolean }) => void) => {
+        changeHandler = h;
+      },
+      removeEventListener: vi.fn(),
+    };
+    vi.stubGlobal("matchMedia", () => mql);
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: () => mql,
+    });
+    const ui = useUiStore();
+    ui.setTheme("system");
+    ui.initTheme();
+    expect(ui.resolvedTheme).toBe("light");
+
+    // Simulate the OS flipping to dark.
+    expect(changeHandler).not.toBeNull();
+    changeHandler!({ matches: true });
+    expect(ui.resolvedTheme).toBe("dark");
+    vi.unstubAllGlobals();
+  });
 });

--- a/src/__tests__/shortcuts.test.ts
+++ b/src/__tests__/shortcuts.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  __setPlatformForTests,
+  dispatch,
+  formatShortcut,
+  matchesShortcut,
+} from "@/lib/shortcuts";
+
+afterEach(() => __setPlatformForTests(null));
+
+function ev(
+  key: string,
+  mods: { ctrl?: boolean; meta?: boolean; shift?: boolean; alt?: boolean } = {},
+): KeyboardEvent {
+  return new KeyboardEvent("keydown", {
+    key,
+    ctrlKey: !!mods.ctrl,
+    metaKey: !!mods.meta,
+    shiftKey: !!mods.shift,
+    altKey: !!mods.alt,
+    cancelable: true,
+  });
+}
+
+describe("formatShortcut", () => {
+  it("renders Ctrl+X on non-mac", () => {
+    __setPlatformForTests(false);
+    expect(formatShortcut({ key: "s", ctrl: true })).toBe("Ctrl+S");
+  });
+
+  it("renders ⌘S on mac", () => {
+    __setPlatformForTests(true);
+    expect(formatShortcut({ key: "s", ctrl: true })).toBe("⌘S");
+  });
+
+  it("includes Shift segment", () => {
+    __setPlatformForTests(false);
+    expect(formatShortcut({ key: "z", ctrl: true, shift: true })).toBe(
+      "Ctrl+Shift+Z",
+    );
+  });
+
+  it("normalises Enter on macOS to ↩", () => {
+    __setPlatformForTests(true);
+    expect(formatShortcut({ key: "Enter", ctrl: true })).toBe("⌘↩");
+  });
+});
+
+describe("matchesShortcut", () => {
+  it("matches case-insensitively on letter keys", () => {
+    __setPlatformForTests(false);
+    expect(matchesShortcut(ev("S", { ctrl: true }), { key: "s", ctrl: true }))
+      .toBe(true);
+    expect(matchesShortcut(ev("s", { ctrl: true }), { key: "s", ctrl: true }))
+      .toBe(true);
+  });
+
+  it("requires the platform-correct primary modifier", () => {
+    __setPlatformForTests(true);
+    // Ctrl alone on macOS does not satisfy the abstract `ctrl: true`.
+    expect(matchesShortcut(ev("s", { ctrl: true }), { key: "s", ctrl: true }))
+      .toBe(false);
+    // ⌘ does.
+    expect(matchesShortcut(ev("s", { meta: true }), { key: "s", ctrl: true }))
+      .toBe(true);
+  });
+
+  it("ignores extra modifier presses that aren't requested", () => {
+    __setPlatformForTests(false);
+    expect(
+      matchesShortcut(ev("s", { ctrl: true, shift: true }), {
+        key: "s",
+        ctrl: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("matches non-letter keys exactly", () => {
+    __setPlatformForTests(false);
+    expect(matchesShortcut(ev(",", { ctrl: true }), { key: ",", ctrl: true }))
+      .toBe(true);
+    expect(matchesShortcut(ev("Enter", { ctrl: true }), {
+      key: "Enter",
+      ctrl: true,
+    })).toBe(true);
+  });
+});
+
+describe("dispatch", () => {
+  it("calls the matching handler and prevents default", () => {
+    __setPlatformForTests(false);
+    const handler = vi.fn();
+    const event = ev("w", { ctrl: true });
+    const preventDefault = vi.spyOn(event, "preventDefault");
+    const matched = dispatch(event, [{ key: "w", ctrl: true, handler }]);
+    expect(matched).toBe(true);
+    expect(handler).toHaveBeenCalledOnce();
+    expect(preventDefault).toHaveBeenCalled();
+  });
+
+  it("returns false and does not preventDefault for unmatched events", () => {
+    __setPlatformForTests(false);
+    const handler = vi.fn();
+    const event = ev("a");
+    const preventDefault = vi.spyOn(event, "preventDefault");
+    const matched = dispatch(event, [{ key: "w", ctrl: true, handler }]);
+    expect(matched).toBe(false);
+    expect(handler).not.toHaveBeenCalled();
+    expect(preventDefault).not.toHaveBeenCalled();
+  });
+
+  it("first matching binding wins", () => {
+    __setPlatformForTests(false);
+    const first = vi.fn();
+    const second = vi.fn();
+    dispatch(ev("s", { ctrl: true }), [
+      { key: "s", ctrl: true, handler: first },
+      { key: "s", ctrl: true, handler: second },
+    ]);
+    expect(first).toHaveBeenCalledOnce();
+    expect(second).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/shortcuts.test.ts
+++ b/src/__tests__/shortcuts.test.ts
@@ -65,7 +65,7 @@ describe("matchesShortcut", () => {
       .toBe(true);
   });
 
-  it("ignores extra modifier presses that aren't requested", () => {
+  it("requires modifier flags to match exactly (no extras allowed)", () => {
     __setPlatformForTests(false);
     expect(
       matchesShortcut(ev("s", { ctrl: true, shift: true }), {

--- a/src/components/calendar/CalendarSidebar.vue
+++ b/src/components/calendar/CalendarSidebar.vue
@@ -1,8 +1,7 @@
 <script setup lang="ts">
-import { ref, computed, nextTick, onBeforeUnmount, watch } from "vue";
+import { ref, onBeforeUnmount, watch } from "vue";
 import { useCalendarStore } from "@/stores/calendar";
 import { useAccountsStore } from "@/stores/accounts";
-import { useUiStore } from "@/stores/ui";
 import type { Calendar } from "@/lib/types";
 import { dragCalendarEvent, isCalendarDragging } from "@/lib/calendar-drag-state";
 import { showToast } from "@/lib/toast";
@@ -20,7 +19,6 @@ const emit = defineEmits<{
 
 const calendarStore = useCalendarStore();
 const accountsStore = useAccountsStore();
-const uiStore = useUiStore();
 
 function getAccountLabel(accountId: string): string {
   const acc = accountsStore.accounts.find((a) => a.id === accountId);
@@ -113,73 +111,6 @@ async function syncThisCalendar() {
   } finally {
     syncing.value = null;
   }
-}
-
-const tzSearch = ref("");
-const tzDropdownOpen = ref(false);
-const tzHighlightIndex = ref(-1);
-const tzDropdownRef = ref<HTMLElement | null>(null);
-
-const filteredTimezones = computed(() => {
-  const query = tzSearch.value.toLowerCase();
-  if (!query) return uiStore.timezoneList;
-  return uiStore.timezoneList.filter((tz: string) => tz.toLowerCase().includes(query));
-});
-
-function selectTimezone(tz: string) {
-  uiStore.setDisplayTimezone(tz);
-  tzSearch.value = "";
-  tzDropdownOpen.value = false;
-  tzHighlightIndex.value = -1;
-}
-
-function onTzInput(e: Event) {
-  tzSearch.value = (e.target as HTMLInputElement).value;
-  tzHighlightIndex.value = 0;
-}
-
-function onTzInputFocus() {
-  tzDropdownOpen.value = true;
-  tzSearch.value = "";
-  tzHighlightIndex.value = -1;
-}
-
-function onTzInputBlur() {
-  setTimeout(() => {
-    tzDropdownOpen.value = false;
-    tzSearch.value = "";
-    tzHighlightIndex.value = -1;
-  }, 200);
-}
-
-function onTzKeydown(e: KeyboardEvent) {
-  if (!tzDropdownOpen.value) return;
-  const list = filteredTimezones.value;
-  if (e.key === "ArrowDown") {
-    e.preventDefault();
-    tzHighlightIndex.value = Math.min(tzHighlightIndex.value + 1, list.length - 1);
-    scrollHighlightedIntoView();
-  } else if (e.key === "ArrowUp") {
-    e.preventDefault();
-    tzHighlightIndex.value = Math.max(tzHighlightIndex.value - 1, 0);
-    scrollHighlightedIntoView();
-  } else if (e.key === "Enter") {
-    e.preventDefault();
-    if (tzHighlightIndex.value >= 0 && tzHighlightIndex.value < list.length) {
-      selectTimezone(list[tzHighlightIndex.value]);
-      (e.target as HTMLInputElement)?.blur();
-    }
-  } else if (e.key === "Escape") {
-    tzDropdownOpen.value = false;
-    (e.target as HTMLInputElement)?.blur();
-  }
-}
-
-function scrollHighlightedIntoView() {
-  nextTick(() => {
-    const el = tzDropdownRef.value?.querySelector(".tz-option.highlighted");
-    if (el) el.scrollIntoView({ block: "nearest" });
-  });
 }
 
 const renaming = ref<{ calendar: Calendar; value: string } | null>(null);
@@ -282,84 +213,6 @@ async function unsubscribeThisCalendar() {
       </div>
       <div v-if="calendarStore.calendars.length === 0" class="empty">
         No calendars
-      </div>
-    </div>
-
-    <div class="week-start-section">
-      <div class="section-header">Week starts on</div>
-      <div class="week-start-options">
-        <button
-          v-for="opt in [{ day: 0, label: 'Sunday' }, { day: 1, label: 'Monday' }, { day: 6, label: 'Saturday' }]"
-          :key="opt.day"
-          class="week-start-btn"
-          :class="{ active: uiStore.weekStartDay === opt.day }"
-          :data-testid="`week-start-${opt.day}`"
-          @click="uiStore.setWeekStartDay(opt.day)"
-        >{{ opt.label }}</button>
-      </div>
-    </div>
-
-    <div class="time-format-section">
-      <div class="section-header">Time format</div>
-      <div class="time-format-options">
-        <button
-          v-for="opt in [{ value: 'auto' as const, label: 'Auto' }, { value: '12' as const, label: '12h' }, { value: '24' as const, label: '24h' }]"
-          :key="opt.value"
-          class="time-format-btn"
-          :class="{ active: uiStore.timeFormat === opt.value }"
-          :data-testid="`time-format-${opt.value}`"
-          @click="uiStore.setTimeFormat(opt.value)"
-        >{{ opt.label }}</button>
-      </div>
-    </div>
-
-    <div class="timezone-section">
-      <div class="section-header">Use timezone</div>
-      <div class="timezone-picker">
-        <input
-          type="text"
-          class="tz-search-input"
-          :placeholder="uiStore.displayTimezone"
-          :value="tzDropdownOpen ? tzSearch : ''"
-          @input="onTzInput($event)"
-          @focus="onTzInputFocus"
-          @blur="onTzInputBlur"
-          @keydown="onTzKeydown"
-          aria-label="Display timezone"
-          role="combobox"
-          :aria-expanded="tzDropdownOpen"
-          aria-controls="tz-listbox"
-          aria-autocomplete="list"
-          :aria-activedescendant="tzHighlightIndex >= 0 ? `tz-opt-${tzHighlightIndex}` : undefined"
-          data-testid="timezone-search"
-        />
-        <div
-          v-if="tzDropdownOpen"
-          ref="tzDropdownRef"
-          id="tz-listbox"
-          role="listbox"
-          aria-label="Timezones"
-          class="tz-dropdown"
-          data-testid="timezone-dropdown"
-        >
-          <button
-            v-for="(tz, idx) in filteredTimezones"
-            :key="tz"
-            :id="`tz-opt-${idx}`"
-            role="option"
-            :aria-selected="tz === uiStore.displayTimezone"
-            class="tz-option"
-            :class="{ active: tz === uiStore.displayTimezone, highlighted: idx === tzHighlightIndex }"
-            @mousedown.prevent="selectTimezone(tz)"
-            @mouseenter="tzHighlightIndex = idx"
-            :data-testid="`timezone-option-${tz}`"
-          >
-            {{ tz }}
-          </button>
-          <div v-if="filteredTimezones.length === 0" class="tz-empty">
-            No matching timezones
-          </div>
-        </div>
       </div>
     </div>
 
@@ -524,153 +377,6 @@ async function unsubscribeThisCalendar() {
   padding: 8px 4px;
 }
 
-.week-start-section {
-  margin-top: 16px;
-  padding-top: 12px;
-  border-top: 1px solid var(--color-border);
-}
-
-.section-header {
-  font-size: 10px;
-  font-weight: 700;
-  color: var(--color-text-muted);
-  text-transform: uppercase;
-  letter-spacing: 1px;
-  padding: 0 4px 8px;
-}
-
-.week-start-options {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-}
-
-.week-start-btn {
-  padding: 4px 8px;
-  font-size: 12px;
-  color: var(--color-text-secondary);
-  text-align: left;
-  border-radius: 4px;
-  transition: background 0.1s;
-}
-
-.week-start-btn:hover {
-  background: var(--color-bg-hover);
-}
-
-.week-start-btn.active {
-  color: var(--color-accent);
-  font-weight: 600;
-}
-
-.time-format-section {
-  margin-top: 16px;
-  padding-top: 12px;
-  border-top: 1px solid var(--color-border);
-}
-
-.time-format-options {
-  display: flex;
-  gap: 4px;
-  padding: 0 4px;
-}
-
-.time-format-btn {
-  flex: 1;
-  padding: 4px 0;
-  font-size: 12px;
-  color: var(--color-text-secondary);
-  text-align: center;
-  border-radius: 4px;
-  border: 1px solid var(--color-border);
-  background: transparent;
-  transition: background 0.1s, border-color 0.1s;
-}
-
-.time-format-btn:hover {
-  background: var(--color-bg-hover);
-}
-
-.time-format-btn.active {
-  color: var(--color-accent);
-  border-color: var(--color-accent);
-  font-weight: 600;
-}
-
-.timezone-section {
-  margin-top: 16px;
-  padding-top: 12px;
-  border-top: 1px solid var(--color-border);
-}
-
-.timezone-picker {
-  position: relative;
-  padding: 0 4px;
-}
-
-.tz-search-input {
-  width: 100%;
-  padding: 4px 8px;
-  font-size: 12px;
-  border: 1px solid var(--color-border);
-  border-radius: 4px;
-  background: var(--color-bg);
-  color: var(--color-text);
-  outline: none;
-  box-sizing: border-box;
-}
-
-.tz-search-input:focus {
-  border-color: var(--color-accent);
-}
-
-.tz-search-input::placeholder {
-  color: var(--color-text-secondary);
-}
-
-.tz-dropdown {
-  position: absolute;
-  bottom: 100%;
-  left: 4px;
-  right: 4px;
-  max-height: 200px;
-  overflow-y: auto;
-  background: var(--color-bg-secondary);
-  border: 1px solid var(--color-border);
-  border-radius: 4px;
-  margin-bottom: 2px;
-  z-index: 50;
-  box-shadow: 0 -4px 12px rgba(0, 0, 0, 0.15);
-}
-
-.tz-option {
-  display: block;
-  width: 100%;
-  padding: 4px 8px;
-  text-align: left;
-  font-size: 12px;
-  color: var(--color-text-secondary);
-  background: none;
-  border: none;
-  cursor: pointer;
-}
-
-.tz-option:hover,
-.tz-option.highlighted {
-  background: var(--color-bg-hover);
-}
-
-.tz-option.active {
-  color: var(--color-accent);
-  font-weight: 600;
-}
-
-.tz-empty {
-  padding: 8px;
-  font-size: 12px;
-  color: var(--color-text-muted);
-  text-align: center;
-}
 </style>
 
 <style>

--- a/src/components/common/AboutDialog.vue
+++ b/src/components/common/AboutDialog.vue
@@ -1,0 +1,169 @@
+<script setup lang="ts">
+import { onMounted, onUnmounted } from "vue";
+import { openUrl } from "@tauri-apps/plugin-opener";
+
+const props = defineProps<{ open: boolean }>();
+const emit = defineEmits<{ close: [] }>();
+
+const SOURCE_URL = "https://github.com/SUNET/chithi";
+const LICENSE_URL = "https://github.com/SUNET/chithi/blob/main/LICENSE";
+
+const version = __APP_VERSION__;
+
+async function openExternal(url: string) {
+  try {
+    await openUrl(url);
+  } catch (e) {
+    console.error("Failed to open URL:", url, e);
+  }
+}
+
+function onKeyDown(e: KeyboardEvent) {
+  if (!props.open || e.key !== "Escape") return;
+  // Vue mounts children before parents, so this listener registers BEFORE
+  // any ancestor menubar's keydown listener. Use stopImmediatePropagation
+  // so the parent's Esc-bound action (e.g. close-window in compose) does
+  // not fire when the user is just dismissing this modal.
+  e.stopImmediatePropagation();
+  e.preventDefault();
+  emit("close");
+}
+
+onMounted(() => window.addEventListener("keydown", onKeyDown));
+onUnmounted(() => window.removeEventListener("keydown", onKeyDown));
+</script>
+
+<template>
+  <Teleport to="body">
+    <div
+      v-if="open"
+      class="about-overlay"
+      data-testid="about-overlay"
+      @click.self="emit('close')"
+    >
+      <div class="about-modal" role="dialog" aria-modal="true" aria-labelledby="about-title">
+        <header class="about-header">
+          <h2 id="about-title">Chithi</h2>
+          <button
+            class="about-close"
+            data-testid="about-close"
+            aria-label="Close"
+            @click="emit('close')"
+          >&times;</button>
+        </header>
+
+        <div class="about-body">
+          <p class="about-tagline">A personal mail and calendar client.</p>
+          <dl class="about-meta">
+            <dt>Version</dt>
+            <dd data-testid="about-version">{{ version }}</dd>
+            <dt>Source</dt>
+            <dd>
+              <a
+                href="#"
+                data-testid="about-source-link"
+                @click.prevent="openExternal(SOURCE_URL)"
+              >github.com/SUNET/chithi</a>
+            </dd>
+            <dt>License</dt>
+            <dd>
+              <a
+                href="#"
+                data-testid="about-license-link"
+                @click.prevent="openExternal(LICENSE_URL)"
+              >GPL-3.0</a>
+            </dd>
+          </dl>
+        </div>
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<style scoped>
+.about-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10000;
+}
+
+.about-modal {
+  width: 380px;
+  max-width: calc(100vw - 32px);
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+  color: var(--color-text);
+}
+
+.about-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.about-header h2 {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.about-close {
+  background: none;
+  border: none;
+  color: var(--color-text-muted);
+  font-size: 22px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 6px;
+}
+
+.about-close:hover {
+  color: var(--color-text);
+}
+
+.about-body {
+  padding: 18px;
+}
+
+.about-tagline {
+  margin: 0 0 14px;
+  font-size: 13px;
+  color: var(--color-text-secondary);
+}
+
+.about-meta {
+  display: grid;
+  grid-template-columns: 84px 1fr;
+  row-gap: 6px;
+  column-gap: 12px;
+  margin: 0;
+  font-size: 13px;
+}
+
+.about-meta dt {
+  color: var(--color-text-muted);
+  font-weight: 500;
+}
+
+.about-meta dd {
+  margin: 0;
+}
+
+.about-meta a {
+  color: var(--color-accent);
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.about-meta a:hover {
+  text-decoration: underline;
+}
+</style>

--- a/src/components/common/MenuBar.vue
+++ b/src/components/common/MenuBar.vue
@@ -1,7 +1,15 @@
 <script setup lang="ts">
-import { ref } from "vue";
+import { onMounted, onUnmounted, ref } from "vue";
 import { useRouter } from "vue-router";
+import { invoke } from "@tauri-apps/api/core";
+import { getCurrentWindow } from "@tauri-apps/api/window";
 import { useUiStore, type MessageViewMode } from "@/stores/ui";
+import {
+  dispatch,
+  formatShortcut,
+  type ShortcutBinding,
+  type ShortcutDef,
+} from "@/lib/shortcuts";
 
 const router = useRouter();
 const uiStore = useUiStore();
@@ -15,23 +23,27 @@ function closeMenus() {
   openMenu.value = null;
 }
 
-function goSettings() {
+// --- Actions ----------------------------------------------------------------
+
+function openPreferences() {
   closeMenus();
+  // ADR 0044 Phase 2 will introduce a dedicated Preferences window. Until
+  // then, route to the existing /settings page so the menu item works.
   router.push("/settings");
 }
 
-function goFilters() {
+async function closeWindow() {
   closeMenus();
-  router.push("/filters");
+  await getCurrentWindow().close();
+}
+
+async function quitApp() {
+  closeMenus();
+  await invoke("quit_app");
 }
 
 function setViewMode(mode: MessageViewMode) {
   uiStore.setMessageViewMode(mode);
-  closeMenus();
-}
-
-function setTheme(theme: "dark" | "light") {
-  uiStore.setTheme(theme);
   closeMenus();
 }
 
@@ -40,85 +52,129 @@ function toggleReader() {
   closeMenus();
 }
 
-function toggleDecorations() {
+function toggleThreading() {
+  uiStore.setThreading(!uiStore.threadingEnabled);
+  closeMenus();
+}
+
+function openFilters() {
+  closeMenus();
+  router.push("/filters");
+}
+
+function toggleTitleBar() {
+  // `decorationsEnabled = false` means the title bar is hidden. The menu
+  // label "Hide Title Bar" reads as a toggle — checked when hidden.
   uiStore.setDecorations(!uiStore.decorationsEnabled);
   closeMenus();
 }
+
+// --- Shortcut definitions ---------------------------------------------------
+
+const sc = {
+  preferences: { key: ",", ctrl: true } satisfies ShortcutDef,
+  closeWindow: { key: "w", ctrl: true } satisfies ShortcutDef,
+  quit: { key: "q", ctrl: true } satisfies ShortcutDef,
+  toggleReader: { key: "\\", ctrl: true } satisfies ShortcutDef,
+  toggleThreading: { key: "t", ctrl: true } satisfies ShortcutDef,
+} as const;
+
+const bindings: readonly ShortcutBinding[] = [
+  { ...sc.preferences, handler: openPreferences },
+  { ...sc.closeWindow, handler: closeWindow },
+  { ...sc.quit, handler: quitApp },
+  { ...sc.toggleReader, handler: toggleReader },
+  { ...sc.toggleThreading, handler: toggleThreading },
+];
+
+function onKeyDown(event: KeyboardEvent) {
+  const target = event.target;
+  // Don't fight text-editing shortcuts in inputs / textareas / contenteditables.
+  if (target instanceof HTMLElement && target.isContentEditable) return;
+  if (target instanceof HTMLInputElement) return;
+  if (target instanceof HTMLTextAreaElement) return;
+  dispatch(event, bindings);
+}
+
+onMounted(() => window.addEventListener("keydown", onKeyDown));
+onUnmounted(() => window.removeEventListener("keydown", onKeyDown));
 </script>
 
 <template>
-  <div class="menu-bar" @mouseleave="closeMenus">
+  <div class="menu-bar" @mouseleave="closeMenus" data-testid="menu-bar">
     <!-- File menu -->
     <div class="menu-item" @click.stop="toggleMenu('file')">
       <span class="menu-label">File</span>
-      <div v-if="openMenu === 'file'" class="menu-dropdown">
-        <button class="menu-action" @click="goSettings">Settings</button>
+      <div v-if="openMenu === 'file'" class="menu-dropdown" data-testid="menu-file-dropdown">
+        <button class="menu-action" data-testid="menu-file-preferences" @click="openPreferences">
+          <span class="action-label">Preferences&hellip;</span>
+          <span class="action-shortcut">{{ formatShortcut(sc.preferences) }}</span>
+        </button>
         <div class="menu-separator"></div>
-        <button class="menu-action" @click="closeMenus">Close</button>
+        <button class="menu-action" data-testid="menu-file-close-window" @click="closeWindow">
+          <span class="action-label">Close Window</span>
+          <span class="action-shortcut">{{ formatShortcut(sc.closeWindow) }}</span>
+        </button>
+        <button class="menu-action" data-testid="menu-file-quit" @click="quitApp">
+          <span class="action-label">Quit</span>
+          <span class="action-shortcut">{{ formatShortcut(sc.quit) }}</span>
+        </button>
       </div>
     </div>
 
     <!-- View menu -->
     <div class="menu-item" @click.stop="toggleMenu('view')">
       <span class="menu-label">View</span>
-      <div v-if="openMenu === 'view'" class="menu-dropdown">
-        <button class="menu-action" @click="toggleReader">
-          {{ uiStore.readerVisible ? 'Hide' : 'Show' }} Message Pane
+      <div v-if="openMenu === 'view'" class="menu-dropdown" data-testid="menu-view-dropdown">
+        <button class="menu-action" data-testid="menu-view-show-pane" @click="toggleReader">
+          <span class="action-prefix">{{ uiStore.readerVisible ? '\u2713' : '\u00A0' }}</span>
+          <span class="action-label">Show Message Pane</span>
+          <span class="action-shortcut">{{ formatShortcut(sc.toggleReader) }}</span>
         </button>
+
+        <div class="menu-group-heading">Message Pane Position</div>
         <button
-          class="menu-action"
-          @click="uiStore.setThreading(!uiStore.threadingEnabled); closeMenus()"
-        >
-          {{ uiStore.threadingEnabled ? '\u2713 ' : '\u00A0\u00A0\u00A0' }}Threading
-        </button>
-        <button class="menu-action" @click="goFilters">Message Filters</button>
-        <div class="menu-separator"></div>
-        <div class="menu-group-label">Message View Position</div>
-        <button
-          class="menu-action"
-          :class="{ checked: uiStore.messageViewMode === 'right' }"
+          class="menu-action menu-action-radio"
+          data-testid="menu-view-position-right"
           @click="setViewMode('right')"
         >
-          {{ uiStore.messageViewMode === 'right' ? '\u2713 ' : '\u00A0\u00A0\u00A0' }}Right Side
+          <span class="action-prefix">{{ uiStore.messageViewMode === 'right' ? '\u25CF' : '\u00A0' }}</span>
+          <span class="action-label">Right</span>
         </button>
         <button
-          class="menu-action"
-          :class="{ checked: uiStore.messageViewMode === 'bottom' }"
+          class="menu-action menu-action-radio"
+          data-testid="menu-view-position-bottom"
           @click="setViewMode('bottom')"
-          data-testid="menu-view-bottom"
         >
-          {{ uiStore.messageViewMode === 'bottom' ? '\u2713 ' : '\u00A0\u00A0\u00A0' }}Bottom
+          <span class="action-prefix">{{ uiStore.messageViewMode === 'bottom' ? '\u25CF' : '\u00A0' }}</span>
+          <span class="action-label">Bottom</span>
         </button>
         <button
-          class="menu-action"
-          :class="{ checked: uiStore.messageViewMode === 'tab' }"
+          class="menu-action menu-action-radio"
+          data-testid="menu-view-position-tabs"
           @click="setViewMode('tab')"
         >
-          {{ uiStore.messageViewMode === 'tab' ? '\u2713 ' : '\u00A0\u00A0\u00A0' }}Tabs
+          <span class="action-prefix">{{ uiStore.messageViewMode === 'tab' ? '\u25CF' : '\u00A0' }}</span>
+          <span class="action-label">Tabs</span>
         </button>
+
         <div class="menu-separator"></div>
-        <div class="menu-group-label">Theme</div>
-        <button
-          class="menu-action"
-          :class="{ checked: uiStore.theme === 'dark' }"
-          @click="setTheme('dark')"
-        >
-          {{ uiStore.theme === 'dark' ? '\u2713 ' : '\u00A0\u00A0\u00A0' }}Dark
+
+        <button class="menu-action" data-testid="menu-view-threaded" @click="toggleThreading">
+          <span class="action-prefix">{{ uiStore.threadingEnabled ? '\u2713' : '\u00A0' }}</span>
+          <span class="action-label">Threaded View</span>
+          <span class="action-shortcut">{{ formatShortcut(sc.toggleThreading) }}</span>
         </button>
-        <button
-          class="menu-action"
-          :class="{ checked: uiStore.theme === 'light' }"
-          @click="setTheme('light')"
-        >
-          {{ uiStore.theme === 'light' ? '\u2713 ' : '\u00A0\u00A0\u00A0' }}Light
+        <button class="menu-action" data-testid="menu-view-filters" @click="openFilters">
+          <span class="action-prefix">&#160;</span>
+          <span class="action-label">Message Filters&hellip;</span>
         </button>
+
         <div class="menu-separator"></div>
-        <button
-          class="menu-action"
-          :class="{ checked: !uiStore.decorationsEnabled }"
-          @click="toggleDecorations"
-        >
-          {{ !uiStore.decorationsEnabled ? '\u2713 ' : '\u00A0\u00A0\u00A0' }}Hide Window Decorations
+
+        <button class="menu-action" data-testid="menu-view-hide-title-bar" @click="toggleTitleBar">
+          <span class="action-prefix">{{ !uiStore.decorationsEnabled ? '\u2713' : '\u00A0' }}</span>
+          <span class="action-label">Hide Title Bar</span>
         </button>
       </div>
     </div>
@@ -157,7 +213,7 @@ function toggleDecorations() {
   position: absolute;
   top: 100%;
   left: 0;
-  min-width: 200px;
+  min-width: 240px;
   background: var(--color-bg-secondary);
   border: 1px solid var(--color-border);
   border-radius: 6px;
@@ -167,21 +223,48 @@ function toggleDecorations() {
 }
 
 .menu-action {
-  display: block;
+  display: grid;
+  grid-template-columns: 18px 1fr auto;
+  align-items: center;
   width: 100%;
   padding: 6px 16px;
   text-align: left;
   font-size: 12px;
   color: var(--color-text);
   white-space: nowrap;
+  background: transparent;
+  border: none;
+  cursor: pointer;
 }
 
 .menu-action:hover {
   background: var(--color-bg-hover);
 }
 
-.menu-action.checked {
+.action-prefix {
+  font-family: var(--font-mono, monospace);
+  font-size: 11px;
   color: var(--color-accent);
+  text-align: center;
+}
+
+.action-label {
+  /* takes the middle column */
+}
+
+.action-shortcut {
+  font-size: 11px;
+  color: var(--color-text-muted);
+  margin-left: 24px;
+}
+
+.menu-action-radio {
+  padding-left: 28px;
+}
+
+.menu-action-radio .action-prefix {
+  /* nudge so the dot aligns visually inside the indented radio cluster */
+  margin-left: -12px;
 }
 
 .menu-separator {
@@ -190,11 +273,10 @@ function toggleDecorations() {
   margin: 4px 0;
 }
 
-.menu-group-label {
-  padding: 4px 16px 2px;
-  font-size: 10px;
-  color: var(--color-text-muted);
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
+.menu-group-heading {
+  padding: 6px 16px 2px;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--color-text);
 }
 </style>

--- a/src/components/common/MenuBar.vue
+++ b/src/components/common/MenuBar.vue
@@ -2,7 +2,6 @@
 import { onMounted, onUnmounted, ref } from "vue";
 import { useRouter } from "vue-router";
 import { invoke } from "@tauri-apps/api/core";
-import { getCurrentWindow } from "@tauri-apps/api/window";
 import { useUiStore, type MessageViewMode } from "@/stores/ui";
 import {
   dispatch,
@@ -32,11 +31,6 @@ function openPreferences() {
   router.push("/settings");
 }
 
-async function closeWindow() {
-  closeMenus();
-  await getCurrentWindow().close();
-}
-
 async function quitApp() {
   closeMenus();
   await invoke("quit_app");
@@ -44,11 +38,6 @@ async function quitApp() {
 
 function setViewMode(mode: MessageViewMode) {
   uiStore.setMessageViewMode(mode);
-  closeMenus();
-}
-
-function toggleReader() {
-  uiStore.toggleReader();
   closeMenus();
 }
 
@@ -73,17 +62,13 @@ function toggleTitleBar() {
 
 const sc = {
   preferences: { key: ",", ctrl: true } satisfies ShortcutDef,
-  closeWindow: { key: "w", ctrl: true } satisfies ShortcutDef,
   quit: { key: "q", ctrl: true } satisfies ShortcutDef,
-  toggleReader: { key: "\\", ctrl: true } satisfies ShortcutDef,
   toggleThreading: { key: "t", ctrl: true } satisfies ShortcutDef,
 } as const;
 
 const bindings: readonly ShortcutBinding[] = [
   { ...sc.preferences, handler: openPreferences },
-  { ...sc.closeWindow, handler: closeWindow },
   { ...sc.quit, handler: quitApp },
-  { ...sc.toggleReader, handler: toggleReader },
   { ...sc.toggleThreading, handler: toggleThreading },
 ];
 
@@ -111,10 +96,6 @@ onUnmounted(() => window.removeEventListener("keydown", onKeyDown));
           <span class="action-shortcut">{{ formatShortcut(sc.preferences) }}</span>
         </button>
         <div class="menu-separator"></div>
-        <button class="menu-action" data-testid="menu-file-close-window" @click="closeWindow">
-          <span class="action-label">Close Window</span>
-          <span class="action-shortcut">{{ formatShortcut(sc.closeWindow) }}</span>
-        </button>
         <button class="menu-action" data-testid="menu-file-quit" @click="quitApp">
           <span class="action-label">Quit</span>
           <span class="action-shortcut">{{ formatShortcut(sc.quit) }}</span>
@@ -126,13 +107,15 @@ onUnmounted(() => window.removeEventListener("keydown", onKeyDown));
     <div class="menu-item" @click.stop="toggleMenu('view')">
       <span class="menu-label">View</span>
       <div v-if="openMenu === 'view'" class="menu-dropdown" data-testid="menu-view-dropdown">
-        <button class="menu-action" data-testid="menu-view-show-pane" @click="toggleReader">
-          <span class="action-prefix">{{ uiStore.readerVisible ? '\u2713' : '\u00A0' }}</span>
-          <span class="action-label">Show Message Pane</span>
-          <span class="action-shortcut">{{ formatShortcut(sc.toggleReader) }}</span>
-        </button>
-
         <div class="menu-group-heading">Message Pane Position</div>
+        <button
+          class="menu-action menu-action-radio"
+          data-testid="menu-view-position-none"
+          @click="setViewMode('none')"
+        >
+          <span class="action-prefix">{{ uiStore.messageViewMode === 'none' ? '\u25CF' : '\u00A0' }}</span>
+          <span class="action-label">None</span>
+        </button>
         <button
           class="menu-action menu-action-radio"
           data-testid="menu-view-position-right"

--- a/src/components/common/MenuBar.vue
+++ b/src/components/common/MenuBar.vue
@@ -86,11 +86,13 @@ onUnmounted(() => window.removeEventListener("keydown", onKeyDown));
       <span class="menu-label">File</span>
       <div v-if="openMenu === 'file'" class="menu-dropdown" @click.stop data-testid="menu-file-dropdown">
         <button class="menu-action" data-testid="menu-file-preferences" @click="openPreferences">
+          <span class="action-prefix">&#160;</span>
           <span class="action-label">Preferences&hellip;</span>
           <span class="action-shortcut">{{ formatShortcut(sc.preferences) }}</span>
         </button>
         <div class="menu-separator"></div>
         <button class="menu-action" data-testid="menu-file-quit" @click="quitApp">
+          <span class="action-prefix">&#160;</span>
           <span class="action-label">Quit</span>
           <span class="action-shortcut">{{ formatShortcut(sc.quit) }}</span>
         </button>

--- a/src/components/common/MenuBar.vue
+++ b/src/components/common/MenuBar.vue
@@ -9,6 +9,7 @@ import {
   type ShortcutBinding,
   type ShortcutDef,
 } from "@/lib/shortcuts";
+import AboutDialog from "@/components/common/AboutDialog.vue";
 
 const router = useRouter();
 const uiStore = useUiStore();
@@ -44,6 +45,13 @@ function toggleThreading() {
   closeMenus();
 }
 
+const aboutOpen = ref(false);
+
+function openAbout() {
+  closeMenus();
+  aboutOpen.value = true;
+}
+
 // --- Shortcut definitions ---------------------------------------------------
 
 const sc = {
@@ -76,7 +84,7 @@ onUnmounted(() => window.removeEventListener("keydown", onKeyDown));
     <!-- File menu -->
     <div class="menu-item" @click.stop="toggleMenu('file')">
       <span class="menu-label">File</span>
-      <div v-if="openMenu === 'file'" class="menu-dropdown" data-testid="menu-file-dropdown">
+      <div v-if="openMenu === 'file'" class="menu-dropdown" @click.stop data-testid="menu-file-dropdown">
         <button class="menu-action" data-testid="menu-file-preferences" @click="openPreferences">
           <span class="action-label">Preferences&hellip;</span>
           <span class="action-shortcut">{{ formatShortcut(sc.preferences) }}</span>
@@ -92,7 +100,7 @@ onUnmounted(() => window.removeEventListener("keydown", onKeyDown));
     <!-- View menu -->
     <div class="menu-item" @click.stop="toggleMenu('view')">
       <span class="menu-label">View</span>
-      <div v-if="openMenu === 'view'" class="menu-dropdown" data-testid="menu-view-dropdown">
+      <div v-if="openMenu === 'view'" class="menu-dropdown" @click.stop data-testid="menu-view-dropdown">
         <div class="menu-group-heading">Message Pane</div>
         <button
           class="menu-action menu-action-radio"
@@ -136,6 +144,19 @@ onUnmounted(() => window.removeEventListener("keydown", onKeyDown));
         </button>
       </div>
     </div>
+
+    <!-- Help menu -->
+    <div class="menu-item" @click.stop="toggleMenu('help')">
+      <span class="menu-label">Help</span>
+      <div v-if="openMenu === 'help'" class="menu-dropdown" @click.stop data-testid="menu-help-dropdown">
+        <button class="menu-action" data-testid="menu-help-about" @click="openAbout">
+          <span class="action-prefix">&#160;</span>
+          <span class="action-label">About Chithi&hellip;</span>
+        </button>
+      </div>
+    </div>
+
+    <AboutDialog :open="aboutOpen" @close="aboutOpen = false" />
   </div>
 </template>
 

--- a/src/components/common/MenuBar.vue
+++ b/src/components/common/MenuBar.vue
@@ -107,7 +107,7 @@ onUnmounted(() => window.removeEventListener("keydown", onKeyDown));
     <div class="menu-item" @click.stop="toggleMenu('view')">
       <span class="menu-label">View</span>
       <div v-if="openMenu === 'view'" class="menu-dropdown" data-testid="menu-view-dropdown">
-        <div class="menu-group-heading">Message Pane Position</div>
+        <div class="menu-group-heading">Message Pane</div>
         <button
           class="menu-action menu-action-radio"
           data-testid="menu-view-position-none"

--- a/src/components/common/MenuBar.vue
+++ b/src/components/common/MenuBar.vue
@@ -26,9 +26,7 @@ function closeMenus() {
 
 function openPreferences() {
   closeMenus();
-  // ADR 0044 Phase 2 will introduce a dedicated Preferences window. Until
-  // then, route to the existing /settings page so the menu item works.
-  router.push("/settings");
+  router.push("/preferences");
 }
 
 async function quitApp() {
@@ -43,18 +41,6 @@ function setViewMode(mode: MessageViewMode) {
 
 function toggleThreading() {
   uiStore.setThreading(!uiStore.threadingEnabled);
-  closeMenus();
-}
-
-function openFilters() {
-  closeMenus();
-  router.push("/filters");
-}
-
-function toggleTitleBar() {
-  // `decorationsEnabled = false` means the title bar is hidden. The menu
-  // label "Hide Title Bar" reads as a toggle — checked when hidden.
-  uiStore.setDecorations(!uiStore.decorationsEnabled);
   closeMenus();
 }
 
@@ -147,17 +133,6 @@ onUnmounted(() => window.removeEventListener("keydown", onKeyDown));
           <span class="action-prefix">{{ uiStore.threadingEnabled ? '\u2713' : '\u00A0' }}</span>
           <span class="action-label">Threaded View</span>
           <span class="action-shortcut">{{ formatShortcut(sc.toggleThreading) }}</span>
-        </button>
-        <button class="menu-action" data-testid="menu-view-filters" @click="openFilters">
-          <span class="action-prefix">&#160;</span>
-          <span class="action-label">Message Filters&hellip;</span>
-        </button>
-
-        <div class="menu-separator"></div>
-
-        <button class="menu-action" data-testid="menu-view-hide-title-bar" @click="toggleTitleBar">
-          <span class="action-prefix">{{ !uiStore.decorationsEnabled ? '\u2713' : '\u00A0' }}</span>
-          <span class="action-label">Hide Title Bar</span>
         </button>
       </div>
     </div>

--- a/src/components/common/Sidebar.vue
+++ b/src/components/common/Sidebar.vue
@@ -1,27 +1,15 @@
 <script setup lang="ts">
 import { useRouter, useRoute } from "vue-router";
-import { useAccountsStore } from "@/stores/accounts";
-import { openComposeWindow } from "@/lib/compose-window";
 
 const router = useRouter();
 const route = useRoute();
-const accountsStore = useAccountsStore();
 
 const topItems = [
   { path: "/", label: "Mail", name: "mail" },
   { path: "/calendar", label: "Calendar", name: "calendar" },
-  { path: "", label: "Compose", name: "compose" },
   { path: "/contacts", label: "Contacts", name: "contacts" },
   { path: "/filters", label: "Filters", name: "filters" },
 ];
-
-function handleNavClick(item: typeof topItems[0]) {
-  if (item.name === "compose") {
-    openComposeWindow({ accountId: accountsStore.activeAccountId ?? undefined });
-  } else {
-    router.push(item.path);
-  }
-}
 </script>
 
 <template>
@@ -31,10 +19,10 @@ function handleNavClick(item: typeof topItems[0]) {
         v-for="item in topItems"
         :key="item.name"
         class="sidebar-item"
-        :class="{ active: item.name !== 'compose' && route.name === item.name }"
+        :class="{ active: route.name === item.name }"
         :title="item.label"
         :data-testid="`nav-${item.name}`"
-        @click="handleNavClick(item)"
+        @click="router.push(item.path)"
       >
         <!-- Mail icon -->
         <svg v-if="item.name === 'mail'" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
@@ -45,10 +33,6 @@ function handleNavClick(item: typeof topItems[0]) {
         <svg v-else-if="item.name === 'calendar'" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
           <rect x="3" y="4" width="18" height="18" rx="2" />
           <path d="M16 2v4M8 2v4M3 10h18" />
-        </svg>
-        <!-- Compose icon -->
-        <svg v-else-if="item.name === 'compose'" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-          <path d="M12 20h9M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z" />
         </svg>
         <!-- Contacts icon -->
         <svg v-else-if="item.name === 'contacts'" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">

--- a/src/components/compose/ComposeMenuBar.vue
+++ b/src/components/compose/ComposeMenuBar.vue
@@ -1,0 +1,311 @@
+<script setup lang="ts">
+import { onMounted, onUnmounted, ref } from "vue";
+import {
+  dispatch,
+  formatShortcut,
+  type ShortcutBinding,
+  type ShortcutDef,
+} from "@/lib/shortcuts";
+import AboutDialog from "@/components/common/AboutDialog.vue";
+
+const props = defineProps<{
+  showCc: boolean;
+  showBcc: boolean;
+}>();
+
+const emit = defineEmits<{
+  saveDraft: [];
+  send: [];
+  closeWindow: [];
+  attach: [];
+  toggleCc: [];
+  toggleBcc: [];
+}>();
+
+const openMenu = ref<string | null>(null);
+
+function toggleMenu(name: string) {
+  openMenu.value = openMenu.value === name ? null : name;
+}
+
+function closeMenus() {
+  openMenu.value = null;
+}
+
+// --- Action wrappers --------------------------------------------------------
+
+function onSaveDraft() {
+  closeMenus();
+  emit("saveDraft");
+}
+
+function onSend() {
+  closeMenus();
+  emit("send");
+}
+
+function onCloseWindow() {
+  closeMenus();
+  emit("closeWindow");
+}
+
+function onAttach() {
+  closeMenus();
+  emit("attach");
+}
+
+function onToggleCc() {
+  closeMenus();
+  emit("toggleCc");
+}
+
+function onToggleBcc() {
+  closeMenus();
+  emit("toggleBcc");
+}
+
+/**
+ * Edit menu items invoke document.execCommand directly because the menu is
+ * effectively a clickable surface for the same operations the OS exposes via
+ * the standard editing shortcuts. The keyboard shortcuts are intentionally
+ * NOT registered with our dispatch table — the browser (or the WebKitGTK
+ * workaround in ComposeView) handles them so platform behaviour stays
+ * intact when focus is inside a text input.
+ */
+function execEdit(cmd: "undo" | "redo" | "cut" | "copy" | "paste" | "selectAll") {
+  closeMenus();
+  document.execCommand(cmd);
+}
+
+const aboutOpen = ref(false);
+
+function onAbout() {
+  closeMenus();
+  aboutOpen.value = true;
+}
+
+// --- Shortcut definitions ---------------------------------------------------
+
+const sc = {
+  saveDraft: { key: "s", ctrl: true } satisfies ShortcutDef,
+  send: { key: "Enter", ctrl: true } satisfies ShortcutDef,
+  closeWindow: { key: "Escape" } satisfies ShortcutDef,
+  attach: { key: "a", ctrl: true, shift: true } satisfies ShortcutDef,
+  // Edit shortcuts are display-only — see execEdit() comment.
+  undo: { key: "z", ctrl: true } satisfies ShortcutDef,
+  redo: { key: "z", ctrl: true, shift: true } satisfies ShortcutDef,
+  cut: { key: "x", ctrl: true } satisfies ShortcutDef,
+  copy: { key: "c", ctrl: true } satisfies ShortcutDef,
+  paste: { key: "v", ctrl: true } satisfies ShortcutDef,
+  selectAll: { key: "a", ctrl: true } satisfies ShortcutDef,
+} as const;
+
+const bindings: readonly ShortcutBinding[] = [
+  { ...sc.saveDraft, handler: onSaveDraft },
+  { ...sc.send, handler: onSend },
+  { ...sc.closeWindow, handler: onCloseWindow },
+  { ...sc.attach, handler: onAttach },
+];
+
+function onKeyDown(event: KeyboardEvent) {
+  // Compose-window shortcuts intentionally fire even with focus in the
+  // compose textarea so Ctrl+S / Ctrl+Return / Esc work while writing.
+  // The Edit shortcuts (Z/X/C/V/A) are NOT in this dispatch table; they
+  // fall through to the browser / WebKitGTK workaround.
+  // The AboutDialog's own Esc handler stops propagation when the modal
+  // is open, so we don't need a guard here.
+  dispatch(event, bindings);
+}
+
+onMounted(() => window.addEventListener("keydown", onKeyDown));
+onUnmounted(() => window.removeEventListener("keydown", onKeyDown));
+</script>
+
+<template>
+  <div class="menu-bar" @mouseleave="closeMenus" data-testid="compose-menu-bar">
+    <!-- File -->
+    <div class="menu-item" @click.stop="toggleMenu('file')">
+      <span class="menu-label">File</span>
+      <div v-if="openMenu === 'file'" class="menu-dropdown" @click.stop data-testid="compose-menu-file-dropdown">
+        <button class="menu-action" data-testid="compose-menu-save-draft" @click="onSaveDraft">
+          <span class="action-prefix">&#160;</span>
+          <span class="action-label">Save Draft</span>
+          <span class="action-shortcut">{{ formatShortcut(sc.saveDraft) }}</span>
+        </button>
+        <button class="menu-action" data-testid="compose-menu-send" @click="onSend">
+          <span class="action-prefix">&#160;</span>
+          <span class="action-label">Send</span>
+          <span class="action-shortcut">{{ formatShortcut(sc.send) }}</span>
+        </button>
+        <div class="menu-separator"></div>
+        <button class="menu-action" data-testid="compose-menu-close-window" @click="onCloseWindow">
+          <span class="action-prefix">&#160;</span>
+          <span class="action-label">Close Window</span>
+          <span class="action-shortcut">{{ formatShortcut(sc.closeWindow) }}</span>
+        </button>
+      </div>
+    </div>
+
+    <!-- Edit -->
+    <div class="menu-item" @click.stop="toggleMenu('edit')">
+      <span class="menu-label">Edit</span>
+      <div v-if="openMenu === 'edit'" class="menu-dropdown" @click.stop data-testid="compose-menu-edit-dropdown">
+        <button class="menu-action" data-testid="compose-menu-undo" @click="execEdit('undo')">
+          <span class="action-prefix">&#160;</span>
+          <span class="action-label">Undo</span>
+          <span class="action-shortcut">{{ formatShortcut(sc.undo) }}</span>
+        </button>
+        <button class="menu-action" data-testid="compose-menu-redo" @click="execEdit('redo')">
+          <span class="action-prefix">&#160;</span>
+          <span class="action-label">Redo</span>
+          <span class="action-shortcut">{{ formatShortcut(sc.redo) }}</span>
+        </button>
+        <div class="menu-separator"></div>
+        <button class="menu-action" data-testid="compose-menu-cut" @click="execEdit('cut')">
+          <span class="action-prefix">&#160;</span>
+          <span class="action-label">Cut</span>
+          <span class="action-shortcut">{{ formatShortcut(sc.cut) }}</span>
+        </button>
+        <button class="menu-action" data-testid="compose-menu-copy" @click="execEdit('copy')">
+          <span class="action-prefix">&#160;</span>
+          <span class="action-label">Copy</span>
+          <span class="action-shortcut">{{ formatShortcut(sc.copy) }}</span>
+        </button>
+        <button class="menu-action" data-testid="compose-menu-paste" @click="execEdit('paste')">
+          <span class="action-prefix">&#160;</span>
+          <span class="action-label">Paste</span>
+          <span class="action-shortcut">{{ formatShortcut(sc.paste) }}</span>
+        </button>
+        <div class="menu-separator"></div>
+        <button class="menu-action" data-testid="compose-menu-select-all" @click="execEdit('selectAll')">
+          <span class="action-prefix">&#160;</span>
+          <span class="action-label">Select All</span>
+          <span class="action-shortcut">{{ formatShortcut(sc.selectAll) }}</span>
+        </button>
+      </div>
+    </div>
+
+    <!-- View -->
+    <div class="menu-item" @click.stop="toggleMenu('view')">
+      <span class="menu-label">View</span>
+      <div v-if="openMenu === 'view'" class="menu-dropdown" @click.stop data-testid="compose-menu-view-dropdown">
+        <button class="menu-action" data-testid="compose-menu-show-cc" @click="onToggleCc">
+          <span class="action-prefix">{{ props.showCc ? '\u2713' : '\u00A0' }}</span>
+          <span class="action-label">Show Cc</span>
+          <span class="action-shortcut"></span>
+        </button>
+        <button class="menu-action" data-testid="compose-menu-show-bcc" @click="onToggleBcc">
+          <span class="action-prefix">{{ props.showBcc ? '\u2713' : '\u00A0' }}</span>
+          <span class="action-label">Show Bcc</span>
+          <span class="action-shortcut"></span>
+        </button>
+      </div>
+    </div>
+
+    <!-- Options -->
+    <div class="menu-item" @click.stop="toggleMenu('options')">
+      <span class="menu-label">Options</span>
+      <div v-if="openMenu === 'options'" class="menu-dropdown" @click.stop data-testid="compose-menu-options-dropdown">
+        <button class="menu-action" data-testid="compose-menu-attach" @click="onAttach">
+          <span class="action-prefix">&#160;</span>
+          <span class="action-label">Attach File&hellip;</span>
+          <span class="action-shortcut">{{ formatShortcut(sc.attach) }}</span>
+        </button>
+      </div>
+    </div>
+
+    <!-- Help -->
+    <div class="menu-item" @click.stop="toggleMenu('help')">
+      <span class="menu-label">Help</span>
+      <div v-if="openMenu === 'help'" class="menu-dropdown" @click.stop data-testid="compose-menu-help-dropdown">
+        <button class="menu-action" data-testid="compose-menu-about" @click="onAbout">
+          <span class="action-prefix">&#160;</span>
+          <span class="action-label">About Chithi&hellip;</span>
+          <span class="action-shortcut"></span>
+        </button>
+      </div>
+    </div>
+
+    <AboutDialog :open="aboutOpen" @close="aboutOpen = false" />
+  </div>
+</template>
+
+<style scoped>
+.menu-bar {
+  display: flex;
+  align-items: center;
+  height: 32px;
+  background: var(--color-bg);
+  border-bottom: 1px solid var(--color-border);
+  padding: 0 8px;
+  font-size: 12px;
+  flex-shrink: 0;
+  user-select: none;
+}
+
+.menu-item {
+  position: relative;
+  padding: 4px 12px;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.menu-item:hover {
+  background: var(--color-bg-hover);
+}
+
+.menu-label {
+  color: var(--color-text-secondary);
+}
+
+.menu-dropdown {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  min-width: 240px;
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  padding: 4px 0;
+  z-index: 1000;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+.menu-action {
+  display: grid;
+  grid-template-columns: 18px 1fr auto;
+  align-items: center;
+  width: 100%;
+  padding: 6px 16px;
+  text-align: left;
+  font-size: 12px;
+  color: var(--color-text);
+  white-space: nowrap;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+}
+
+.menu-action:hover {
+  background: var(--color-bg-hover);
+}
+
+.action-prefix {
+  font-family: var(--font-mono, monospace);
+  font-size: 11px;
+  color: var(--color-accent);
+  text-align: center;
+}
+
+.action-shortcut {
+  font-size: 11px;
+  color: var(--color-text-muted);
+  margin-left: 24px;
+}
+
+.menu-separator {
+  height: 1px;
+  background: var(--color-border);
+  margin: 4px 0;
+}
+</style>

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -5,3 +5,6 @@ declare module "*.vue" {
   const component: DefineComponent<object, object, unknown>;
   export default component;
 }
+
+/** Injected by Vite's `define`; sourced from package.json at build time. */
+declare const __APP_VERSION__: string;

--- a/src/lib/shortcuts.ts
+++ b/src/lib/shortcuts.ts
@@ -88,10 +88,11 @@ export type ShortcutBinding = ShortcutDef & {
 };
 
 /**
- * Build a keydown handler from a list of bindings. Returns `undefined` for
- * unmatched events so the browser default keeps working (text editing,
- * focus navigation, etc.). The first matching binding wins; later ones are
- * ignored.
+ * Run the first matching binding for a keydown event and return whether
+ * one fired. When no binding matches the function returns `false` and
+ * does NOT preventDefault, so the browser's default behaviour (text
+ * editing, focus navigation, etc.) keeps working. Later matching
+ * bindings after the first are ignored.
  */
 export function dispatch(
   event: KeyboardEvent,

--- a/src/lib/shortcuts.ts
+++ b/src/lib/shortcuts.ts
@@ -1,0 +1,108 @@
+/**
+ * Keyboard shortcut helpers.
+ *
+ * One platform-modifier abstraction is used everywhere so menu labels and
+ * keydown handlers cannot drift. Platform detection runs once per module
+ * load; tests can override via `__setPlatformForTests`.
+ *
+ * Shortcut "key" matching is case-insensitive on letters, exact on
+ * everything else (e.g. `Enter`, `,`, `\`). Modifier flags default to false
+ * so a definition only lists what it cares about.
+ */
+
+export type ShortcutDef = {
+  /** Single-character or named key. Letter case is ignored on match. */
+  key: string;
+  /** Platform-resolved primary modifier (Ctrl on Linux/Win, Cmd on macOS). */
+  ctrl?: boolean;
+  /** Always Shift. */
+  shift?: boolean;
+  /** Always Alt/Option. */
+  alt?: boolean;
+};
+
+let cachedIsMac: boolean | null = null;
+
+function detectIsMac(): boolean {
+  if (typeof navigator === "undefined") return false;
+  const platform = (navigator as { platform?: string; userAgentData?: { platform?: string } });
+  const value =
+    platform.userAgentData?.platform ?? platform.platform ?? "";
+  return /mac|darwin|iphone|ipad|ipod/i.test(value);
+}
+
+export function isMac(): boolean {
+  if (cachedIsMac === null) cachedIsMac = detectIsMac();
+  return cachedIsMac;
+}
+
+/** Test seam for forcing platform in unit tests. */
+export function __setPlatformForTests(mac: boolean | null): void {
+  cachedIsMac = mac;
+}
+
+/** Render a shortcut as the user-visible label, e.g. `Ctrl+S` or `⌘S`. */
+export function formatShortcut(def: ShortcutDef): string {
+  const parts: string[] = [];
+  if (isMac()) {
+    if (def.ctrl) parts.push("⌘");
+    if (def.shift) parts.push("⇧");
+    if (def.alt) parts.push("⌥");
+    parts.push(formatKey(def.key));
+    return parts.join("");
+  }
+  if (def.ctrl) parts.push("Ctrl");
+  if (def.alt) parts.push("Alt");
+  if (def.shift) parts.push("Shift");
+  parts.push(formatKey(def.key));
+  return parts.join("+");
+}
+
+function formatKey(key: string): string {
+  if (key.length === 1) return key.toUpperCase();
+  // Normalise a few common names so the label matches what users expect.
+  if (key === "Enter" || key === "Return") return isMac() ? "↩" : "Enter";
+  if (key === "Escape") return "Esc";
+  return key;
+}
+
+/** Does this keyboard event match the shortcut definition? */
+export function matchesShortcut(
+  event: KeyboardEvent,
+  def: ShortcutDef,
+): boolean {
+  const primaryDown = isMac() ? event.metaKey : event.ctrlKey;
+  if (!!def.ctrl !== primaryDown) return false;
+  if (!!def.shift !== event.shiftKey) return false;
+  if (!!def.alt !== event.altKey) return false;
+
+  const eventKey = event.key;
+  if (def.key.length === 1) {
+    return eventKey.toLowerCase() === def.key.toLowerCase();
+  }
+  return eventKey === def.key;
+}
+
+export type ShortcutBinding = ShortcutDef & {
+  handler: (event: KeyboardEvent) => void;
+};
+
+/**
+ * Build a keydown handler from a list of bindings. Returns `undefined` for
+ * unmatched events so the browser default keeps working (text editing,
+ * focus navigation, etc.). The first matching binding wins; later ones are
+ * ignored.
+ */
+export function dispatch(
+  event: KeyboardEvent,
+  bindings: readonly ShortcutBinding[],
+): boolean {
+  for (const binding of bindings) {
+    if (matchesShortcut(event, binding)) {
+      event.preventDefault();
+      binding.handler(event);
+      return true;
+    }
+  }
+  return false;
+}

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -45,6 +45,11 @@ const router = createRouter({
       component: () => import("@/views/SettingsView.vue"),
     },
     {
+      path: "/preferences",
+      name: "preferences",
+      component: () => import("@/views/PreferencesView.vue"),
+    },
+    {
       // Mobile-only thread detail (pushed from MailView on tap).
       path: "/mail/thread/:id",
       name: "mobile-reader",

--- a/src/stores/ui.ts
+++ b/src/stores/ui.ts
@@ -3,7 +3,9 @@ import { computed, ref } from "vue";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import * as api from "@/lib/tauri";
 
-export type MessageViewMode = "right" | "bottom" | "tab";
+export type MessageViewMode = "right" | "bottom" | "tab" | "none";
+
+const VALID_VIEW_MODES: MessageViewMode[] = ["right", "bottom", "tab", "none"];
 export type Theme = "dark" | "light";
 export type TimeFormat = "auto" | "12" | "24";
 export type ComposeKind = "new" | "reply" | "reply-all" | "forward";
@@ -16,7 +18,10 @@ export const useUiStore = defineStore("ui", () => {
   const messageListWidth = ref(400);
   const readerVisible = ref(true);
   const messageViewMode = ref<MessageViewMode>(
-    (localStorage.getItem("chithi-message-view-mode") as MessageViewMode) || "right",
+    (() => {
+      const stored = localStorage.getItem("chithi-message-view-mode") as MessageViewMode | null;
+      return stored && VALID_VIEW_MODES.includes(stored) ? stored : "right";
+    })(),
   );
   const theme = ref<Theme>(
     (localStorage.getItem("chithi-theme") as Theme) || "light",
@@ -73,6 +78,12 @@ export const useUiStore = defineStore("ui", () => {
   function setMessageViewMode(mode: MessageViewMode) {
     messageViewMode.value = mode;
     localStorage.setItem("chithi-message-view-mode", mode);
+    // Picking a non-"none" mode re-enables the reader pane so the user
+    // sees their selection take effect immediately. The reader's close
+    // button still toggles `readerVisible` for per-session dismissal.
+    if (mode !== "none") {
+      readerVisible.value = true;
+    }
   }
 
   function setTheme(t: Theme) {

--- a/src/stores/ui.ts
+++ b/src/stores/ui.ts
@@ -6,7 +6,14 @@ import * as api from "@/lib/tauri";
 export type MessageViewMode = "right" | "bottom" | "tab" | "none";
 
 const VALID_VIEW_MODES: MessageViewMode[] = ["right", "bottom", "tab", "none"];
-export type Theme = "dark" | "light";
+
+const VALID_THEMES: Theme[] = ["system", "light", "dark"];
+
+function resolveSystemTheme(): "light" | "dark" {
+  if (typeof window === "undefined" || !window.matchMedia) return "light";
+  return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+}
+export type Theme = "system" | "light" | "dark";
 export type TimeFormat = "auto" | "12" | "24";
 export type ComposeKind = "new" | "reply" | "reply-all" | "forward";
 
@@ -24,8 +31,17 @@ export const useUiStore = defineStore("ui", () => {
     })(),
   );
   const theme = ref<Theme>(
-    (localStorage.getItem("chithi-theme") as Theme) || "light",
+    (() => {
+      const stored = localStorage.getItem("chithi-theme") as Theme | null;
+      return stored && VALID_THEMES.includes(stored) ? stored : "system";
+    })(),
   );
+
+  /** The actually-applied theme. Tracks the OS preference when theme === "system". */
+  const resolvedTheme = computed<"light" | "dark">(() => {
+    if (theme.value === "system") return resolveSystemTheme();
+    return theme.value;
+  });
   const decorationsEnabled = ref(
     localStorage.getItem("chithi-decorations") !== "false",
   );
@@ -89,7 +105,7 @@ export const useUiStore = defineStore("ui", () => {
   function setTheme(t: Theme) {
     theme.value = t;
     localStorage.setItem("chithi-theme", t);
-    document.documentElement.setAttribute("data-theme", t);
+    document.documentElement.setAttribute("data-theme", resolvedTheme.value);
   }
 
   function setThreading(enabled: boolean) {
@@ -142,8 +158,21 @@ export const useUiStore = defineStore("ui", () => {
     }
   }
 
+  let mediaQueryUnsub: (() => void) | null = null;
+
   function initTheme() {
-    document.documentElement.setAttribute("data-theme", theme.value);
+    document.documentElement.setAttribute("data-theme", resolvedTheme.value);
+    // Re-apply when the OS preference changes while theme === "system".
+    if (typeof window !== "undefined" && window.matchMedia && !mediaQueryUnsub) {
+      const mql = window.matchMedia("(prefers-color-scheme: dark)");
+      const onChange = () => {
+        if (theme.value === "system") {
+          document.documentElement.setAttribute("data-theme", resolvedTheme.value);
+        }
+      };
+      mql.addEventListener("change", onChange);
+      mediaQueryUnsub = () => mql.removeEventListener("change", onChange);
+    }
   }
 
   function initDecorations() {
@@ -193,6 +222,7 @@ export const useUiStore = defineStore("ui", () => {
     readerVisible,
     messageViewMode,
     theme,
+    resolvedTheme,
     toggleReader,
     showReader,
     hideReader,

--- a/src/stores/ui.ts
+++ b/src/stores/ui.ts
@@ -1,5 +1,5 @@
 import { defineStore } from "pinia";
-import { computed, ref } from "vue";
+import { computed, ref, watch } from "vue";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import * as api from "@/lib/tauri";
 
@@ -8,11 +8,6 @@ export type MessageViewMode = "right" | "bottom" | "tab" | "none";
 const VALID_VIEW_MODES: MessageViewMode[] = ["right", "bottom", "tab", "none"];
 
 const VALID_THEMES: Theme[] = ["system", "light", "dark"];
-
-function resolveSystemTheme(): "light" | "dark" {
-  if (typeof window === "undefined" || !window.matchMedia) return "light";
-  return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
-}
 export type Theme = "system" | "light" | "dark";
 export type TimeFormat = "auto" | "12" | "24";
 export type ComposeKind = "new" | "reply" | "reply-all" | "forward";
@@ -37,9 +32,18 @@ export const useUiStore = defineStore("ui", () => {
     })(),
   );
 
+  // Reactive mirror of the OS dark-mode preference. The matchMedia handler
+  // writes to this ref so `resolvedTheme` recomputes when the OS toggles
+  // light/dark — without this, the computed would cache the first read.
+  const systemDark = ref(
+    typeof window !== "undefined" && window.matchMedia
+      ? window.matchMedia("(prefers-color-scheme: dark)").matches
+      : false,
+  );
+
   /** The actually-applied theme. Tracks the OS preference when theme === "system". */
   const resolvedTheme = computed<"light" | "dark">(() => {
-    if (theme.value === "system") return resolveSystemTheme();
+    if (theme.value === "system") return systemDark.value ? "dark" : "light";
     return theme.value;
   });
   const decorationsEnabled = ref(
@@ -105,7 +109,8 @@ export const useUiStore = defineStore("ui", () => {
   function setTheme(t: Theme) {
     theme.value = t;
     localStorage.setItem("chithi-theme", t);
-    document.documentElement.setAttribute("data-theme", resolvedTheme.value);
+    // The data-theme attribute is updated reactively by the watch on
+    // resolvedTheme; no manual DOM write needed here.
   }
 
   function setThreading(enabled: boolean) {
@@ -162,18 +167,26 @@ export const useUiStore = defineStore("ui", () => {
 
   function initTheme() {
     document.documentElement.setAttribute("data-theme", resolvedTheme.value);
-    // Re-apply when the OS preference changes while theme === "system".
+    // Subscribe to OS dark-mode changes so `systemDark` (and therefore
+    // `resolvedTheme`) updates live; the watch below applies the new
+    // value to the DOM whenever the resolved theme actually changes.
     if (typeof window !== "undefined" && window.matchMedia && !mediaQueryUnsub) {
       const mql = window.matchMedia("(prefers-color-scheme: dark)");
-      const onChange = () => {
-        if (theme.value === "system") {
-          document.documentElement.setAttribute("data-theme", resolvedTheme.value);
-        }
+      const onChange = (e: MediaQueryListEvent) => {
+        systemDark.value = e.matches;
       };
       mql.addEventListener("change", onChange);
       mediaQueryUnsub = () => mql.removeEventListener("change", onChange);
     }
   }
+
+  // Keep the document attribute in sync with whatever resolvedTheme yields.
+  // Fires for both user-driven (setTheme) and OS-driven (systemDark) changes.
+  watch(resolvedTheme, (next) => {
+    if (typeof document !== "undefined") {
+      document.documentElement.setAttribute("data-theme", next);
+    }
+  });
 
   function initDecorations() {
     if (!decorationsEnabled.value) {

--- a/src/views/ComposeView.vue
+++ b/src/views/ComposeView.vue
@@ -8,6 +8,7 @@ import type { Account, ComposeAttachment } from "@/lib/types";
 import * as api from "@/lib/tauri";
 import { acctColor } from "@/lib/account-colors";
 import Select from "@/components/common/Select.vue";
+import ComposeMenuBar from "@/components/compose/ComposeMenuBar.vue";
 
 const route = useRoute();
 const accountsStore = useAccountsStore();
@@ -56,19 +57,21 @@ onMounted(async () => {
 
 // WebKitGTK on Linux doesn't forward standard editing shortcuts (Ctrl+Z,
 // Ctrl+Shift+Z, Ctrl+A, Ctrl+X/C/V) to secondary WebviewWindows.
-// Intercept them and delegate to document.execCommand.
+// Intercept them and delegate to document.execCommand. Note `e.key` is
+// uppercase whenever Shift is held, so we normalise before matching.
 function onEditShortcut(e: KeyboardEvent) {
   if (!(e.ctrlKey || e.metaKey)) return;
   const tag = (e.target as HTMLElement)?.tagName;
   if (tag !== "INPUT" && tag !== "TEXTAREA") return;
 
+  const key = e.key.toLowerCase();
   let cmd: string | null = null;
-  if (e.key === "z" && e.shiftKey) cmd = "redo";
-  else if (e.key === "z") cmd = "undo";
-  else if (e.key === "a") cmd = "selectAll";
-  else if (e.key === "x") cmd = "cut";
-  else if (e.key === "c") cmd = "copy";
-  else if (e.key === "v") cmd = "paste";
+  if (key === "z" && e.shiftKey) cmd = "redo";
+  else if (key === "z") cmd = "undo";
+  else if (key === "a") cmd = "selectAll";
+  else if (key === "x") cmd = "cut";
+  else if (key === "c") cmd = "copy";
+  else if (key === "v") cmd = "paste";
   if (cmd) {
     document.execCommand(cmd);
   }
@@ -505,14 +508,16 @@ async function send() {
 <template>
   <div class="compose-view">
     <!-- Menu Bar -->
-    <div class="compose-menubar">
-      <span class="menu-item">File</span>
-      <span class="menu-item">Edit</span>
-      <span class="menu-item">View</span>
-      <span class="menu-item">Options</span>
-      <span class="menu-item">Tools</span>
-      <span class="menu-item">Help</span>
-    </div>
+    <ComposeMenuBar
+      :show-cc="showCc"
+      :show-bcc="showBcc"
+      @save-draft="saveDraft"
+      @send="send"
+      @close-window="currentWindow.close()"
+      @attach="addAttachment"
+      @toggle-cc="showCc = !showCc"
+      @toggle-bcc="showBcc = !showBcc"
+    />
 
     <!-- Toolbar -->
     <div class="compose-toolbar">
@@ -711,31 +716,6 @@ async function send() {
   flex-direction: column;
   height: 100vh;
   background: var(--color-bg);
-}
-
-/* Menu Bar */
-.compose-menubar {
-  display: flex;
-  align-items: center;
-  height: 32px;
-  padding: 0 8px;
-  background: var(--color-bg-secondary);
-  border-bottom: 0.8px solid var(--color-border);
-  flex-shrink: 0;
-  gap: 0;
-}
-
-.menu-item {
-  padding: 4px 12px;
-  font-size: 16px;
-  font-weight: 500;
-  color: var(--color-text);
-  cursor: pointer;
-  border-radius: 4px;
-}
-
-.menu-item:hover {
-  background: var(--color-bg-hover);
 }
 
 /* Toolbar */

--- a/src/views/MailView.vue
+++ b/src/views/MailView.vue
@@ -132,15 +132,18 @@ function stopResize() {
 }
 
 // Double-click behavior depends on view mode:
-//  - right:  ensure the inline reader pane is visible
-//  - bottom: open the message in a new standalone window
-//  - tab:    open the message in a new tab (or focus existing)
+//  - right, bottom: ensure the inline reader pane is visible
+//  - none:          open the message in a new standalone window
+//  - tab:           open the message in a new tab (or focus existing)
 function onOpenMessage(messageId: string) {
-  if (uiStore.messageViewMode === "right") {
+  if (
+    uiStore.messageViewMode === "right" ||
+    uiStore.messageViewMode === "bottom"
+  ) {
     uiStore.showReader();
     return;
   }
-  if (uiStore.messageViewMode === "bottom") {
+  if (uiStore.messageViewMode === "none") {
     const accountId = accountsStore.activeAccountId;
     if (!accountId) return;
     const subject = messagesStore.subjectForMessage(messageId) ?? undefined;
@@ -383,6 +386,11 @@ onUnmounted(() => {
             <MessageReader @close="uiStore.hideReader()" />
           </div>
         </div>
+      </template>
+
+      <!-- None mode: list only, no reader. Double-click opens a window. -->
+      <template v-else-if="uiStore.messageViewMode === 'none'">
+        <MessageList data-testid="none-mode-list" @open-message="onOpenMessage" />
       </template>
 
       <!-- Tab mode: tab bar on top, list or reader content below -->

--- a/src/views/PreferencesView.vue
+++ b/src/views/PreferencesView.vue
@@ -61,7 +61,9 @@ function selectTimezone(tz: string) {
 
 function onTzInput(e: Event) {
   tzSearch.value = (e.target as HTMLInputElement).value;
-  tzHighlightIndex.value = 0;
+  // Reset to the first match, or clear the highlight when nothing matches
+  // so aria-activedescendant doesn't point at a non-existent option.
+  tzHighlightIndex.value = filteredTimezones.value.length > 0 ? 0 : -1;
 }
 
 function onTzInputFocus() {
@@ -113,7 +115,12 @@ function scrollHighlightedIntoView() {
   <div class="preferences-view" data-testid="preferences-view">
     <header class="prefs-header">
       <h1>Preferences</h1>
-      <button class="prefs-close" data-testid="prefs-close" @click="close">&times;</button>
+      <button
+        class="prefs-close"
+        data-testid="prefs-close"
+        aria-label="Close Preferences"
+        @click="close"
+      >&times;</button>
     </header>
 
     <div class="prefs-body">
@@ -148,9 +155,10 @@ function scrollHighlightedIntoView() {
             </div>
           </div>
           <div class="prefs-row">
-            <label class="prefs-label">Hide title bar</label>
+            <label class="prefs-label" for="prefs-hide-title-bar">Hide title bar</label>
             <div class="prefs-toggle">
               <input
+                id="prefs-hide-title-bar"
                 type="checkbox"
                 :checked="!uiStore.decorationsEnabled"
                 data-testid="prefs-hide-title-bar"
@@ -207,7 +215,11 @@ function scrollHighlightedIntoView() {
                 :aria-expanded="tzDropdownOpen"
                 aria-controls="prefs-tz-listbox"
                 aria-autocomplete="list"
-                :aria-activedescendant="tzHighlightIndex >= 0 ? `prefs-tz-opt-${tzHighlightIndex}` : undefined"
+                :aria-activedescendant="
+                  tzHighlightIndex >= 0 && tzHighlightIndex < filteredTimezones.length
+                    ? `prefs-tz-opt-${tzHighlightIndex}`
+                    : undefined
+                "
                 data-testid="prefs-timezone-search"
               />
               <div

--- a/src/views/PreferencesView.vue
+++ b/src/views/PreferencesView.vue
@@ -1,0 +1,447 @@
+<script setup lang="ts">
+import { computed, nextTick, ref } from "vue";
+import { useRouter } from "vue-router";
+import { useUiStore, type Theme, type TimeFormat } from "@/stores/ui";
+
+type Section = "general" | "date-time";
+
+const router = useRouter();
+const uiStore = useUiStore();
+const activeSection = ref<Section>("general");
+
+const sections: ReadonlyArray<{ id: Section; label: string }> = [
+  { id: "general", label: "General" },
+  { id: "date-time", label: "Date and Time" },
+];
+
+function close() {
+  router.back();
+}
+
+// --- General ----------------------------------------------------------------
+
+const themeOptions: ReadonlyArray<{ value: Theme; label: string }> = [
+  { value: "system", label: "System" },
+  { value: "light", label: "Light" },
+  { value: "dark", label: "Dark" },
+];
+
+// --- Date and Time ----------------------------------------------------------
+
+const weekStartOptions: ReadonlyArray<{ day: number; label: string }> = [
+  { day: 0, label: "Sunday" },
+  { day: 1, label: "Monday" },
+  { day: 6, label: "Saturday" },
+];
+
+const timeFormatOptions: ReadonlyArray<{ value: TimeFormat; label: string }> = [
+  { value: "auto", label: "Auto" },
+  { value: "12", label: "12h" },
+  { value: "24", label: "24h" },
+];
+
+// Timezone picker (combobox)
+const tzSearch = ref("");
+const tzDropdownOpen = ref(false);
+const tzHighlightIndex = ref(-1);
+const tzDropdownRef = ref<HTMLElement | null>(null);
+
+const filteredTimezones = computed(() => {
+  const query = tzSearch.value.toLowerCase();
+  if (!query) return uiStore.timezoneList;
+  return uiStore.timezoneList.filter((tz: string) => tz.toLowerCase().includes(query));
+});
+
+function selectTimezone(tz: string) {
+  uiStore.setDisplayTimezone(tz);
+  tzSearch.value = "";
+  tzDropdownOpen.value = false;
+  tzHighlightIndex.value = -1;
+}
+
+function onTzInput(e: Event) {
+  tzSearch.value = (e.target as HTMLInputElement).value;
+  tzHighlightIndex.value = 0;
+}
+
+function onTzInputFocus() {
+  tzDropdownOpen.value = true;
+  tzSearch.value = "";
+  tzHighlightIndex.value = -1;
+}
+
+function onTzInputBlur() {
+  setTimeout(() => {
+    tzDropdownOpen.value = false;
+    tzSearch.value = "";
+    tzHighlightIndex.value = -1;
+  }, 200);
+}
+
+function onTzKeydown(e: KeyboardEvent) {
+  if (!tzDropdownOpen.value) return;
+  const list = filteredTimezones.value;
+  if (e.key === "ArrowDown") {
+    e.preventDefault();
+    tzHighlightIndex.value = Math.min(tzHighlightIndex.value + 1, list.length - 1);
+    scrollHighlightedIntoView();
+  } else if (e.key === "ArrowUp") {
+    e.preventDefault();
+    tzHighlightIndex.value = Math.max(tzHighlightIndex.value - 1, 0);
+    scrollHighlightedIntoView();
+  } else if (e.key === "Enter") {
+    e.preventDefault();
+    if (tzHighlightIndex.value >= 0 && tzHighlightIndex.value < list.length) {
+      selectTimezone(list[tzHighlightIndex.value]);
+      (e.target as HTMLInputElement)?.blur();
+    }
+  } else if (e.key === "Escape") {
+    tzDropdownOpen.value = false;
+    (e.target as HTMLInputElement)?.blur();
+  }
+}
+
+function scrollHighlightedIntoView() {
+  nextTick(() => {
+    const el = tzDropdownRef.value?.querySelector(".tz-option.highlighted");
+    if (el) el.scrollIntoView({ block: "nearest" });
+  });
+}
+</script>
+
+<template>
+  <div class="preferences-view" data-testid="preferences-view">
+    <header class="prefs-header">
+      <h1>Preferences</h1>
+      <button class="prefs-close" data-testid="prefs-close" @click="close">&times;</button>
+    </header>
+
+    <div class="prefs-body">
+      <nav class="prefs-nav" aria-label="Preferences sections">
+        <button
+          v-for="s in sections"
+          :key="s.id"
+          class="prefs-nav-item"
+          :class="{ active: activeSection === s.id }"
+          :data-testid="`prefs-nav-${s.id}`"
+          @click="activeSection = s.id"
+        >
+          {{ s.label }}
+        </button>
+      </nav>
+
+      <main class="prefs-detail">
+        <!-- General -->
+        <section v-if="activeSection === 'general'" data-testid="prefs-section-general">
+          <h2>General</h2>
+          <div class="prefs-row">
+            <label class="prefs-label">Theme</label>
+            <div class="prefs-radio-group">
+              <button
+                v-for="opt in themeOptions"
+                :key="opt.value"
+                class="prefs-radio"
+                :class="{ active: uiStore.theme === opt.value }"
+                :data-testid="`prefs-theme-${opt.value}`"
+                @click="uiStore.setTheme(opt.value)"
+              >{{ opt.label }}</button>
+            </div>
+          </div>
+          <div class="prefs-row">
+            <label class="prefs-label">Hide title bar</label>
+            <div class="prefs-toggle">
+              <input
+                type="checkbox"
+                :checked="!uiStore.decorationsEnabled"
+                data-testid="prefs-hide-title-bar"
+                @change="(e) => uiStore.setDecorations(!(e.target as HTMLInputElement).checked)"
+              />
+            </div>
+          </div>
+        </section>
+
+        <!-- Date and Time -->
+        <section v-if="activeSection === 'date-time'" data-testid="prefs-section-date-time">
+          <h2>Date and Time</h2>
+          <div class="prefs-row">
+            <label class="prefs-label">Week starts on</label>
+            <div class="prefs-radio-group">
+              <button
+                v-for="opt in weekStartOptions"
+                :key="opt.day"
+                class="prefs-radio"
+                :class="{ active: uiStore.weekStartDay === opt.day }"
+                :data-testid="`prefs-week-start-${opt.day}`"
+                @click="uiStore.setWeekStartDay(opt.day)"
+              >{{ opt.label }}</button>
+            </div>
+          </div>
+          <div class="prefs-row">
+            <label class="prefs-label">Time format</label>
+            <div class="prefs-radio-group">
+              <button
+                v-for="opt in timeFormatOptions"
+                :key="opt.value"
+                class="prefs-radio"
+                :class="{ active: uiStore.timeFormat === opt.value }"
+                :data-testid="`prefs-time-format-${opt.value}`"
+                @click="uiStore.setTimeFormat(opt.value)"
+              >{{ opt.label }}</button>
+            </div>
+          </div>
+          <div class="prefs-row">
+            <label class="prefs-label" for="prefs-tz">Display timezone</label>
+            <div class="tz-picker">
+              <input
+                id="prefs-tz"
+                type="text"
+                class="tz-search-input"
+                :placeholder="uiStore.displayTimezone"
+                :value="tzDropdownOpen ? tzSearch : ''"
+                @input="onTzInput($event)"
+                @focus="onTzInputFocus"
+                @blur="onTzInputBlur"
+                @keydown="onTzKeydown"
+                aria-label="Display timezone"
+                role="combobox"
+                :aria-expanded="tzDropdownOpen"
+                aria-controls="prefs-tz-listbox"
+                aria-autocomplete="list"
+                :aria-activedescendant="tzHighlightIndex >= 0 ? `prefs-tz-opt-${tzHighlightIndex}` : undefined"
+                data-testid="prefs-timezone-search"
+              />
+              <div
+                v-if="tzDropdownOpen"
+                ref="tzDropdownRef"
+                id="prefs-tz-listbox"
+                role="listbox"
+                aria-label="Timezones"
+                class="tz-dropdown"
+                data-testid="prefs-timezone-dropdown"
+              >
+                <button
+                  v-for="(tz, idx) in filteredTimezones"
+                  :key="tz"
+                  :id="`prefs-tz-opt-${idx}`"
+                  role="option"
+                  :aria-selected="tz === uiStore.displayTimezone"
+                  class="tz-option"
+                  :class="{ active: tz === uiStore.displayTimezone, highlighted: idx === tzHighlightIndex }"
+                  @mousedown.prevent="selectTimezone(tz)"
+                  @mouseenter="tzHighlightIndex = idx"
+                  :data-testid="`prefs-timezone-option-${tz}`"
+                >
+                  {{ tz }}
+                </button>
+                <div v-if="filteredTimezones.length === 0" class="tz-empty">
+                  No matching timezones
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+      </main>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.preferences-view {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background: var(--color-bg);
+  color: var(--color-text);
+}
+
+.prefs-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 20px;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.prefs-header h1 {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.prefs-close {
+  background: none;
+  border: none;
+  color: var(--color-text-muted);
+  font-size: 22px;
+  cursor: pointer;
+  padding: 0 6px;
+}
+
+.prefs-close:hover {
+  color: var(--color-text);
+}
+
+.prefs-body {
+  flex: 1;
+  display: grid;
+  grid-template-columns: 200px 1fr;
+  min-height: 0;
+}
+
+.prefs-nav {
+  display: flex;
+  flex-direction: column;
+  border-right: 1px solid var(--color-border);
+  padding: 12px 0;
+  background: var(--color-bg-secondary);
+}
+
+.prefs-nav-item {
+  background: none;
+  border: none;
+  text-align: left;
+  padding: 8px 20px;
+  font-size: 13px;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  border-left: 3px solid transparent;
+}
+
+.prefs-nav-item:hover {
+  background: var(--color-bg-hover);
+  color: var(--color-text);
+}
+
+.prefs-nav-item.active {
+  color: var(--color-text);
+  border-left-color: var(--color-accent);
+  background: var(--color-bg-hover);
+}
+
+.prefs-detail {
+  padding: 20px 28px;
+  overflow-y: auto;
+}
+
+.prefs-detail h2 {
+  margin: 0 0 16px;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.prefs-row {
+  display: grid;
+  grid-template-columns: 180px 1fr;
+  align-items: center;
+  gap: 16px;
+  padding: 10px 0;
+}
+
+.prefs-label {
+  font-size: 13px;
+  color: var(--color-text-secondary);
+}
+
+.prefs-radio-group {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.prefs-radio {
+  padding: 5px 14px;
+  font-size: 12px;
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  background: var(--color-bg);
+  color: var(--color-text-secondary);
+  cursor: pointer;
+}
+
+.prefs-radio:hover {
+  background: var(--color-bg-hover);
+}
+
+.prefs-radio.active {
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+  font-weight: 600;
+}
+
+.prefs-toggle input {
+  width: 16px;
+  height: 16px;
+  cursor: pointer;
+}
+
+/* Timezone picker (mirrors the calendar-sidebar styling, kept local) */
+.tz-picker {
+  position: relative;
+  max-width: 320px;
+  width: 100%;
+}
+
+.tz-search-input {
+  width: 100%;
+  padding: 5px 10px;
+  font-size: 12px;
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  background: var(--color-bg);
+  color: var(--color-text);
+  outline: none;
+  box-sizing: border-box;
+}
+
+.tz-search-input:focus {
+  border-color: var(--color-accent);
+}
+
+.tz-search-input::placeholder {
+  color: var(--color-text-secondary);
+}
+
+.tz-dropdown {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  max-height: 220px;
+  overflow-y: auto;
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  margin-top: 2px;
+  z-index: 50;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+.tz-option {
+  display: block;
+  width: 100%;
+  padding: 5px 10px;
+  text-align: left;
+  font-size: 12px;
+  color: var(--color-text-secondary);
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+
+.tz-option:hover,
+.tz-option.highlighted {
+  background: var(--color-bg-hover);
+}
+
+.tz-option.active {
+  color: var(--color-accent);
+  font-weight: 600;
+}
+
+.tz-empty {
+  padding: 8px;
+  font-size: 12px;
+  color: var(--color-text-muted);
+  text-align: center;
+}
+</style>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "skipLibCheck": true,
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
     "isolatedModules": true,
     "moduleDetection": "force",
     "noEmit": true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,11 +1,18 @@
 import { defineConfig } from "vite";
 import vue from "@vitejs/plugin-vue";
 import { resolve } from "path";
+import { readFileSync } from "fs";
 
 const host = process.env.TAURI_DEV_HOST;
+const pkg = JSON.parse(
+  readFileSync(resolve(__dirname, "package.json"), "utf-8"),
+) as { version: string };
 
 export default defineConfig(async () => ({
   plugins: [vue()],
+  define: {
+    __APP_VERSION__: JSON.stringify(pkg.version),
+  },
   resolve: {
     alias: {
       "@": resolve(__dirname, "./src"),


### PR DESCRIPTION
Implements [ADR 0044](https://github.com/SUNET/chithi/blob/main/docs/adr/0044-menu-system-and-shortcuts.md) as a single PR with one commit per phase. Tracks #121.

## Phases (one commit each)

- **Phase 1 — Main window menus + shortcut wiring**. `File` (Preferences… / Quit), `View` with the four-way `Message Pane` radio + Threaded View. New `src/lib/shortcuts.ts` registry shared by menu labels and the window-level keydown listener. New `quit_app` Tauri command.
- **Phase 2 — Preferences window**. New `/preferences` route with two sections: General (Theme / Hide title bar) and Date and Time (Week starts on / Time format / Display timezone). Strips the three settings blocks from the calendar sidebar.
- **Phase 3 — Compose window menus + shortcuts + About dialog**. Replaces the placeholder `<span>` row with a real menu bar (File / Edit / View / Options / Help). New shared `AboutDialog` component (linked source + license) wired into both compose's Help and the main window's new Help menu. Drops the unused Tools entry.

## Deviations from the ADR

Picked up while implementing each phase:

1. `Close Window` removed from the main-window `File` menu. Closing the only visible window of a desktop app is unusual; the verb belongs in the compose window.
2. The `Show Message Pane` toggle is folded into the `Message Pane` radio as a `None` option. One control instead of two; the heading reads `Message Pane`, not `Message Pane Position`. Selecting `None` keeps the message list visible and double-click on a message opens it in a standalone window.
3. Theme gains a `System` option that follows `prefers-color-scheme`.
4. Preferences sections trimmed: no `Mail` tab (threading and message pane are kept in the View menu — view-state, not persistent prefs); `Calendar` renamed to `Date and Time` since the settings are platform-wide, not calendar-specific.
5. Compose `Close Window` is bound to `Esc`, not `Ctrl+W`. The About dialog stops Esc propagation when open so dismissing the dialog doesn't also close the compose window.

## Test plan

- [x] **Phase 1**: vue-tsc clean, all frontend tests pass, 170 Rust tests, cargo clippy `-D warnings` clean. Manually verified menu interactions and shortcuts.
- [x] **Phase 2**: Preferences UI loads, each setting round-trips through localStorage, calendar sidebar no longer shows the migrated controls.
- [x] **Phase 3**: All compose menu items dispatch correctly, shortcuts (`Ctrl+S`, `Ctrl+Return`, `Esc`, `Ctrl+Shift+A`) work in compose, About dialog opens from both windows with working source/license links.
- [x] 275 frontend tests, 170 Rust tests, vue-tsc + cargo clippy clean.
- [ ] Reviewers: please verify the macOS modifier rendering if you're on a Mac (the platform helper is unit-tested but the dev branch is Linux-only).

Fixes: #121 