### PR TITLE
feat(threads): nesting + persisted expansion + correct outgoing reply headers

### DIFF
--- a/src-tauri/src/commands/compose.rs
+++ b/src-tauri/src/commands/compose.rs
@@ -17,6 +17,12 @@ pub struct ComposeMessage {
     pub body_html: Option<String>,
     #[serde(default)]
     pub attachments: Vec<FileAttachment>,
+    /// chithi's internal id of the message we're replying to. The backend
+    /// looks up the original's RFC 5322 Message-ID and References chain
+    /// and writes proper In-Reply-To / References headers on the outgoing
+    /// message. None for new conversations.
+    #[serde(default)]
+    pub reply_to_message_id: Option<String>,
 }
 
 /// An attachment referenced by the renderer. `token` is the opaque handle
@@ -74,6 +80,13 @@ pub async fn send_message(
     let names: Vec<String> = message.attachments.iter().map(|a| a.name.clone()).collect();
     let paths = crate::commands::attachments::peek_tokens(&state, &tokens)?;
     let attachment_data = build_attachment_data(&paths, &names)?;
+
+    // Resolve threading headers from the original message we're replying
+    // to (if any). This is what makes the next sync render the new
+    // message under its parent in the thread tree.
+    let (in_reply_to, references) =
+        resolve_reply_headers(&state, &account_id, message.reply_to_message_id.as_deref());
+
     let raw_message = smtp::build_raw_message(
         &account.email,
         &message.to,
@@ -83,6 +96,8 @@ pub async fn send_message(
         &message.body_text,
         message.body_html.as_deref(),
         &attachment_data,
+        in_reply_to.as_deref(),
+        &references,
     )?;
 
     // For O365 SMTP: refresh OAuth token now (needs keyring access)
@@ -288,6 +303,12 @@ pub async fn save_draft(
         message.to.clone()
     };
 
+    // Drafts also carry the threading headers so that, once sent, the
+    // outgoing message threads correctly without requiring the user to
+    // re-trigger reply context.
+    let (in_reply_to, references) =
+        resolve_reply_headers(&state, &account_id, message.reply_to_message_id.as_deref());
+
     let raw_message = smtp::build_raw_message(
         &account.email,
         &draft_to,
@@ -297,6 +318,8 @@ pub async fn save_draft(
         &message.body_text,
         message.body_html.as_deref(),
         &attachment_data,
+        in_reply_to.as_deref(),
+        &references,
     )?;
 
     if account.mail_protocol == "graph" {
@@ -377,6 +400,87 @@ pub async fn save_draft(
 
     log::info!("Draft saved successfully for account {}", account_id);
     Ok(())
+}
+
+/// Resolve the In-Reply-To and References values for a reply.
+///
+/// `reply_to_id` is chithi's internal id of the message being replied to.
+/// We look up its RFC 5322 Message-ID and walk the in_reply_to chain
+/// backwards until we either run out or hit a cycle, building the
+/// References list root-first. `In-Reply-To` is the immediate parent's
+/// Message-ID. Both come back already wrapped in angle brackets when
+/// the underlying database row is wrapped that way.
+///
+/// Returns (None, []) if `reply_to_id` is absent, the row is missing,
+/// or the original has no Message-ID we can chain off.
+fn resolve_reply_headers(
+    state: &State<'_, AppState>,
+    account_id: &str,
+    reply_to_id: Option<&str>,
+) -> (Option<String>, Vec<String>) {
+    let Some(reply_to_id) = reply_to_id else {
+        return (None, Vec::new());
+    };
+    if reply_to_id.is_empty() {
+        return (None, Vec::new());
+    }
+
+    let conn = state.db.reader();
+    // Fetch (message_id, in_reply_to) for the original.
+    let parent: Option<(Option<String>, Option<String>)> = conn
+        .query_row(
+            "SELECT message_id, in_reply_to FROM messages
+             WHERE account_id = ?1 AND id = ?2 LIMIT 1",
+            rusqlite::params![account_id, reply_to_id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .ok();
+    let Some((Some(parent_mid), parent_irt)) = parent else {
+        return (None, Vec::new());
+    };
+
+    let mut chain: Vec<String> = Vec::new();
+    if let Some(irt) = parent_irt {
+        if !irt.is_empty() {
+            chain.push(irt);
+        }
+    }
+
+    // Walk backwards via in_reply_to. Cap depth to keep the header
+    // bounded; mailing-list threads occasionally chain very long.
+    let mut current = chain.first().cloned();
+    let mut visited = std::collections::HashSet::new();
+    while let Some(mid) = current {
+        if !visited.insert(mid.clone()) {
+            break;
+        }
+        if visited.len() > 32 {
+            break;
+        }
+        let next: Option<Option<String>> = conn
+            .query_row(
+                "SELECT in_reply_to FROM messages
+                 WHERE account_id = ?1 AND message_id = ?2 LIMIT 1",
+                rusqlite::params![account_id, mid],
+                |row| row.get(0),
+            )
+            .ok();
+        match next {
+            Some(Some(irt)) if !irt.is_empty() => {
+                chain.push(irt.clone());
+                current = Some(irt);
+            }
+            _ => break,
+        }
+    }
+
+    // Chain is collected youngest-first; reverse so References reads
+    // root-first per RFC 5322 §3.6.4. The immediate parent's
+    // Message-ID always sits at the end of References.
+    chain.reverse();
+    chain.push(parent_mid.clone());
+
+    (Some(parent_mid), chain)
 }
 
 /// Read each resolved attachment path, pair it with its display name and

--- a/src-tauri/src/commands/compose.rs
+++ b/src-tauri/src/commands/compose.rs
@@ -4,6 +4,7 @@ use tauri::{Emitter, State};
 use crate::db;
 use crate::error::{Error, Result};
 use crate::mail::jmap::JmapConnection;
+use crate::mail::msgid::normalize_message_id;
 use crate::mail::smtp;
 use crate::state::AppState;
 
@@ -437,15 +438,20 @@ fn resolve_reply_headers(
             |row| Ok((row.get(0)?, row.get(1)?)),
         )
         .ok();
-    let Some((Some(parent_mid), parent_irt)) = parent else {
+    let Some((Some(parent_mid_raw), parent_irt_raw)) = parent else {
+        return (None, Vec::new());
+    };
+    // Older DB rows can carry leading whitespace or be missing brackets.
+    // Canonicalize before we hand the value to lettre's header builder so
+    // the outgoing In-Reply-To / References match what receiving clients
+    // and our own thread-id lookups will expect.
+    let Some(parent_mid) = normalize_message_id(&parent_mid_raw) else {
         return (None, Vec::new());
     };
 
     let mut chain: Vec<String> = Vec::new();
-    if let Some(irt) = parent_irt {
-        if !irt.is_empty() {
-            chain.push(irt);
-        }
+    if let Some(irt) = parent_irt_raw.as_deref().and_then(normalize_message_id) {
+        chain.push(irt);
     }
 
     // Walk backwards via in_reply_to. Cap depth to keep the header
@@ -468,9 +474,13 @@ fn resolve_reply_headers(
             )
             .ok();
         match next {
-            Some(Some(irt)) if !irt.is_empty() => {
-                chain.push(irt.clone());
-                current = Some(irt);
+            Some(Some(irt_raw)) => {
+                if let Some(irt) = normalize_message_id(&irt_raw) {
+                    chain.push(irt.clone());
+                    current = Some(irt);
+                } else {
+                    break;
+                }
             }
             _ => break,
         }

--- a/src-tauri/src/commands/compose.rs
+++ b/src-tauri/src/commands/compose.rs
@@ -212,6 +212,8 @@ pub async fn send_message(
                     &message.body_text,
                     message.body_html.as_deref(),
                     &attachment_data,
+                    in_reply_to.as_deref(),
+                    &references,
                 )
                 .await?;
             }

--- a/src-tauri/src/commands/sync_cmd.rs
+++ b/src-tauri/src/commands/sync_cmd.rs
@@ -981,23 +981,33 @@ async fn sync_graph_account(
         };
 
         // Backfill: existing rows synced before threading worked have an
-        // empty thread_id. The Graph response gives us the live
-        // conversationId for free, so we fix them up here without a
+        // empty thread_id. We also have a fresh In-Reply-To from
+        // internetMessageHeaders, which lets the frontend render the
+        // reply hierarchy for already-stored Graph messages without a
         // re-download.
         {
             let conn = db_arc.writer().await;
-            let mut stmt = conn.prepare(
+            let mut update_thread = conn.prepare(
                 "UPDATE messages SET thread_id = ?1
                  WHERE id = ?2 AND (thread_id IS NULL OR thread_id = '')",
             )?;
+            let mut update_irt = conn.prepare(
+                "UPDATE messages SET in_reply_to = ?1
+                 WHERE id = ?2 AND (in_reply_to IS NULL OR in_reply_to = '')",
+            )?;
             for msg in &messages {
+                let id = format!("{}_{}", account_id, msg.id);
+                if !existing_ids.contains(&id) {
+                    continue;
+                }
                 if let Some(cid) = msg.conversation_id.as_deref() {
-                    if cid.is_empty() {
-                        continue;
+                    if !cid.is_empty() {
+                        update_thread.execute(rusqlite::params![cid, id])?;
                     }
-                    let id = format!("{}_{}", account_id, msg.id);
-                    if existing_ids.contains(&id) {
-                        stmt.execute(rusqlite::params![cid, id])?;
+                }
+                if let Some(irt) = msg.in_reply_to.as_deref() {
+                    if !irt.is_empty() {
+                        update_irt.execute(rusqlite::params![irt, id])?;
                     }
                 }
             }
@@ -1072,7 +1082,7 @@ async fn sync_graph_account(
                 folder_path: gf.id.clone(),
                 uid: 0,
                 message_id: msg.internet_message_id.clone(),
-                in_reply_to: None,
+                in_reply_to: msg.in_reply_to.clone(),
                 thread_id,
                 subject: msg.subject.clone(),
                 from_name: msg.from_name.clone(),

--- a/src-tauri/src/commands/sync_cmd.rs
+++ b/src-tauri/src/commands/sync_cmd.rs
@@ -956,6 +956,29 @@ async fn sync_graph_account(
             ids
         };
 
+        // Backfill: existing rows synced before threading worked have an
+        // empty thread_id. The Graph response gives us the live
+        // conversationId for free, so we fix them up here without a
+        // re-download.
+        {
+            let conn = db_arc.writer().await;
+            let mut stmt = conn.prepare(
+                "UPDATE messages SET thread_id = ?1
+                 WHERE id = ?2 AND (thread_id IS NULL OR thread_id = '')",
+            )?;
+            for msg in &messages {
+                if let Some(cid) = msg.conversation_id.as_deref() {
+                    if cid.is_empty() {
+                        continue;
+                    }
+                    let id = format!("{}_{}", account_id, msg.id);
+                    if existing_ids.contains(&id) {
+                        stmt.execute(rusqlite::params![cid, id])?;
+                    }
+                }
+            }
+        }
+
         // Collect new messages
         let mut new_messages = Vec::new();
         for msg in &messages {

--- a/src-tauri/src/commands/sync_cmd.rs
+++ b/src-tauri/src/commands/sync_cmd.rs
@@ -404,11 +404,35 @@ pub async fn sync_folder(
     let resume_account = account.clone();
 
     let sync_result: Result<u32> = if account.mail_protocol == "graph" {
-        // Graph sync is whole-account, not per-folder — just run the full sync
-        match sync_graph_account(app.clone(), state.db.clone(), &account_id).await {
-            Ok(()) => Ok(0),
-            Err(e) => Err(e),
-        }
+        // Microsoft Graph has no cheap per-folder fetch — every sync runs
+        // against the whole account. Spawn it in the background and return
+        // immediately so the UI's per-folder spinner doesn't sit there for
+        // multiple minutes. The per-account `_guard` rides along into the
+        // spawned task so the flag stays held for the real work and is
+        // released exactly once when the sync finishes.
+        let app_bg = app.clone();
+        let db_bg = state.db.clone();
+        let account_id_bg = account_id.clone();
+        tokio::spawn(async move {
+            let _hold_guard = _guard;
+            let result = sync_graph_account(app_bg.clone(), db_bg, &account_id_bg).await;
+            match result {
+                Ok(()) => log::info!("Background Graph sync done for {}", account_id_bg),
+                Err(e) => {
+                    log::error!("Background Graph sync failed for {}: {}", account_id_bg, e);
+                    app_bg
+                        .emit(
+                            "sync-error",
+                            serde_json::json!({
+                                "account_id": account_id_bg,
+                                "error": e.to_string(),
+                            }),
+                        )
+                        .ok();
+                }
+            }
+        });
+        return Ok(0);
     } else if account.mail_protocol == "jmap" {
         let jmap_config = build_jmap_config(&account).await?;
         jmap_sync::sync_jmap_folder_public(

--- a/src-tauri/src/db/messages.rs
+++ b/src-tauri/src/db/messages.rs
@@ -34,6 +34,13 @@ pub struct MessageSummary {
     pub is_encrypted: bool,
     pub is_signed: bool,
     pub snippet: Option<String>,
+    /// RFC 5322 Message-ID, with angle brackets, exactly as stored.
+    /// Used by the frontend to build the in-thread reply hierarchy.
+    pub message_id: Option<String>,
+    /// In-Reply-To header pointing at this message's parent within the
+    /// thread. Empty for the thread root or for backends that don't
+    /// expose it (Microsoft Graph stores conversationId only).
+    pub in_reply_to: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -314,7 +321,8 @@ fn get_messages_inner(
     let offset = page * per_page;
     let query = format!(
         "SELECT id, subject, from_name, from_email, date, flags,
-                has_attachments, is_encrypted, is_signed, snippet
+                has_attachments, is_encrypted, is_signed, snippet,
+                message_id, in_reply_to
          FROM messages
          WHERE account_id = ?1 AND folder_path = ?2{}
          ORDER BY {} {}
@@ -338,6 +346,8 @@ fn get_messages_inner(
                 is_encrypted: row.get(7)?,
                 is_signed: row.get(8)?,
                 snippet: row.get(9)?,
+                message_id: row.get(10)?,
+                in_reply_to: row.get(11)?,
             })
         })?
         .collect::<std::result::Result<Vec<_>, _>>()?;
@@ -989,7 +999,8 @@ pub fn get_thread_messages(
 
     let mut stmt = conn.prepare(
         "SELECT id, subject, from_name, from_email, date, flags,
-                has_attachments, is_encrypted, is_signed, snippet
+                has_attachments, is_encrypted, is_signed, snippet,
+                message_id, in_reply_to
          FROM messages
          WHERE account_id = ?1 AND folder_path = ?2
            AND (thread_id = ?3 OR (thread_id IS NULL AND id = ?3))
@@ -1011,6 +1022,8 @@ pub fn get_thread_messages(
                 is_encrypted: row.get(7)?,
                 is_signed: row.get(8)?,
                 snippet: row.get(9)?,
+                message_id: row.get(10)?,
+                in_reply_to: row.get(11)?,
             })
         })?
         .collect::<std::result::Result<Vec<_>, _>>()?;

--- a/src-tauri/src/db/messages.rs
+++ b/src-tauri/src/db/messages.rs
@@ -2,6 +2,7 @@ use rusqlite::{params, Connection};
 use serde::{Deserialize, Serialize};
 
 use crate::error::Result;
+use crate::mail::msgid::normalize_message_id;
 
 /// Quick filter options for the message list.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -664,8 +665,19 @@ pub fn compute_thread_id(
     subject: Option<&str>,
     references: Option<&[String]>,
 ) -> Option<String> {
+    // Defensive: callers in older code paths may still pass non-canonical
+    // forms (leading whitespace, missing brackets). Normalize once so the
+    // exact-match SQL below has a consistent comparand on both sides.
+    let message_id_norm = message_id.and_then(normalize_message_id);
+    let in_reply_to_norm = in_reply_to.and_then(normalize_message_id);
+    let references_norm: Option<Vec<String>> = references.map(|refs| {
+        refs.iter()
+            .filter_map(|r| normalize_message_id(r))
+            .collect::<Vec<_>>()
+    });
+
     // Step 1: Look up thread_id of the message we are replying to
-    if let Some(irt) = in_reply_to {
+    if let Some(irt) = in_reply_to_norm.as_deref() {
         let result: std::result::Result<Option<String>, _> = conn.query_row(
             "SELECT thread_id FROM messages WHERE account_id = ?1 AND message_id = ?2 LIMIT 1",
             params![account_id, irt],
@@ -684,13 +696,10 @@ pub fn compute_thread_id(
     // Step 2: Walk References from newest to oldest. The chain is ordered
     // root-first per RFC 5322 §3.6.4, so the most recent ancestor — the one
     // most likely already synced — is at the tail.
-    if let Some(refs) = references {
+    if let Some(refs) = references_norm.as_deref() {
         for r in refs.iter().rev() {
-            if r.is_empty() {
-                continue;
-            }
             // Skip the in_reply_to we already checked.
-            if in_reply_to == Some(r.as_str()) {
+            if in_reply_to_norm.as_deref() == Some(r.as_str()) {
                 continue;
             }
             let result: std::result::Result<Option<String>, _> = conn.query_row(
@@ -712,14 +721,12 @@ pub fn compute_thread_id(
         // (the root of the conversation) as a synthetic thread_id; later
         // siblings whose chain shares the same root will land in this thread.
         if let Some(root) = refs.first() {
-            if !root.is_empty() {
-                return Some(root.clone());
-            }
+            return Some(root.clone());
         }
     }
 
     // Step 3: Reverse lookup — does any existing message reply to us?
-    if let Some(mid) = message_id {
+    if let Some(mid) = message_id_norm.as_deref() {
         let result: std::result::Result<Option<String>, _> = conn.query_row(
             "SELECT thread_id FROM messages WHERE account_id = ?1 AND in_reply_to = ?2 AND thread_id IS NOT NULL AND thread_id != '' LIMIT 1",
             params![account_id, mid],
@@ -755,12 +762,12 @@ pub fn compute_thread_id(
     }
 
     // Step 4: New thread root
-    if let Some(mid) = message_id {
-        return Some(mid.to_string());
+    if let Some(mid) = message_id_norm {
+        return Some(mid);
     }
 
-    if let Some(irt) = in_reply_to {
-        return Some(irt.to_string());
+    if let Some(irt) = in_reply_to_norm {
+        return Some(irt);
     }
 
     None

--- a/src-tauri/src/db/messages.rs
+++ b/src-tauri/src/db/messages.rs
@@ -623,20 +623,25 @@ pub fn get_unfetched_messages(
 /// Compute a thread_id for a message using a multi-step strategy:
 ///
 /// 1. **In-Reply-To lookup**: If the message has an `In-Reply-To` header, find the
-///    referenced message in the DB and reuse its `thread_id`. This is the most
-///    reliable threading signal.
+///    referenced message in the DB and reuse its `thread_id`.
 ///
-/// 2. **Reverse lookup**: Check if any existing message has `In-Reply-To` pointing
+/// 2. **References chain walk**: The full RFC 5322 `References:` chain lists the
+///    ancestry from root to direct parent. Walk it from the closest ancestor
+///    backwards; the first id we find in our DB hands us its thread. This is
+///    what stitches mailing-list patch series (`[PATCH n/m]`, `Re: [PATCH n/m]`)
+///    back to the original discussion they're replying to.
+///
+/// 3. **Reverse lookup**: Check if any existing message has `In-Reply-To` pointing
 ///    to our `Message-ID` — if so, we're the parent and should join their thread.
 ///
-/// 3. **Subject-based fallback**: Only for messages whose subject starts with
+/// 4. **Subject-based fallback**: Only for messages whose subject starts with
 ///    `Re:`, `Fwd:`, or `FW:` (explicit replies/forwards). Strip the prefix and
 ///    find an existing thread with the matching base subject. This catches cases
 ///    where `In-Reply-To` doesn't match (e.g., replies from different clients,
 ///    or Gmail conversations). Plain subjects like "OSSEC Notification" are NOT
 ///    matched to avoid false threading of automated/notification emails.
 ///
-/// 4. **New thread root**: If no existing thread is found, use the message's own
+/// 5. **New thread root**: If no existing thread is found, use the message's own
 ///    `Message-ID` as a new `thread_id`.
 ///
 /// Thread IDs are stored in the `thread_id` column of the `messages` table.
@@ -647,6 +652,7 @@ pub fn compute_thread_id(
     message_id: Option<&str>,
     in_reply_to: Option<&str>,
     subject: Option<&str>,
+    references: Option<&[String]>,
 ) -> Option<String> {
     // Step 1: Look up thread_id of the message we are replying to
     if let Some(irt) = in_reply_to {
@@ -665,7 +671,44 @@ pub fn compute_thread_id(
         }
     }
 
-    // Step 2: Reverse lookup — does any existing message reply to us?
+    // Step 2: Walk References from newest to oldest. The chain is ordered
+    // root-first per RFC 5322 §3.6.4, so the most recent ancestor — the one
+    // most likely already synced — is at the tail.
+    if let Some(refs) = references {
+        for r in refs.iter().rev() {
+            if r.is_empty() {
+                continue;
+            }
+            // Skip the in_reply_to we already checked.
+            if in_reply_to == Some(r.as_str()) {
+                continue;
+            }
+            let result: std::result::Result<Option<String>, _> = conn.query_row(
+                "SELECT thread_id FROM messages WHERE account_id = ?1 AND message_id = ?2 LIMIT 1",
+                params![account_id, r],
+                |row| row.get(0),
+            );
+            match result {
+                Ok(Some(tid)) if !tid.is_empty() => return Some(tid),
+                Ok(_) => return Some(r.clone()),
+                Err(rusqlite::Error::QueryReturnedNoRows) => continue,
+                Err(e) => {
+                    log::error!("compute_thread_id: DB error walking References: {}", e);
+                    continue;
+                }
+            }
+        }
+        // None of the ancestors are in our DB yet. Use the oldest reference
+        // (the root of the conversation) as a synthetic thread_id; later
+        // siblings whose chain shares the same root will land in this thread.
+        if let Some(root) = refs.first() {
+            if !root.is_empty() {
+                return Some(root.clone());
+            }
+        }
+    }
+
+    // Step 3: Reverse lookup — does any existing message reply to us?
     if let Some(mid) = message_id {
         let result: std::result::Result<Option<String>, _> = conn.query_row(
             "SELECT thread_id FROM messages WHERE account_id = ?1 AND in_reply_to = ?2 AND thread_id IS NOT NULL AND thread_id != '' LIMIT 1",
@@ -1116,5 +1159,77 @@ mod tests {
         let conn = setup_db();
         let paths = get_maildir_paths(&conn, "acc1", &[]).unwrap();
         assert!(paths.is_empty());
+    }
+
+    fn insert_threaded_row(
+        conn: &Connection,
+        id: &str,
+        message_id: Option<&str>,
+        thread_id: Option<&str>,
+    ) {
+        conn.execute(
+            "INSERT INTO messages
+             (id, account_id, folder_path, uid, message_id, thread_id, date, from_email, maildir_path)
+             VALUES (?1, 'acc1', 'INBOX', 1, ?2, ?3, '2026-04-26T00:00:00Z', 'x@y', '')",
+            params![id, message_id, thread_id],
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn compute_thread_id_walks_references_to_existing_ancestor() {
+        let conn = setup_db();
+        // Original [BUG] message is already synced with its own thread_id.
+        insert_threaded_row(&conn, "row1", Some("<bug@list>"), Some("<bug@list>"));
+
+        // A [PATCH 1/2] message arrives. Its In-Reply-To points at a child
+        // we don't yet have, but its References chain goes back to the BUG.
+        let refs = vec![
+            "<bug@list>".to_string(),
+            "<re-bug-1@list>".to_string(),
+            "<unknown-parent@list>".to_string(),
+        ];
+        let tid = compute_thread_id(
+            &conn,
+            "acc1",
+            Some("<patch1@list>"),
+            Some("<unknown-parent@list>"),
+            Some("[PATCH 1/2] foo"),
+            Some(&refs),
+        );
+        assert_eq!(tid.as_deref(), Some("<bug@list>"));
+    }
+
+    #[test]
+    fn compute_thread_id_uses_root_reference_when_no_ancestor_synced() {
+        let conn = setup_db();
+        // Nothing in the DB yet — the new message is the first arrival.
+        let refs = vec!["<bug@list>".to_string(), "<re-bug-1@list>".to_string()];
+        let tid = compute_thread_id(
+            &conn,
+            "acc1",
+            Some("<patch1@list>"),
+            Some("<re-bug-1@list>"),
+            Some("[PATCH 1/2] foo"),
+            Some(&refs),
+        );
+        // Falls back to the root of the chain so future siblings join it.
+        assert_eq!(tid.as_deref(), Some("<bug@list>"));
+    }
+
+    #[test]
+    fn compute_thread_id_works_without_references() {
+        let conn = setup_db();
+        // Plain root message, no in_reply_to, no references — uses its own
+        // Message-ID as the thread root.
+        let tid = compute_thread_id(
+            &conn,
+            "acc1",
+            Some("<bug@list>"),
+            None,
+            Some("[BUG] foo"),
+            None,
+        );
+        assert_eq!(tid.as_deref(), Some("<bug@list>"));
     }
 }

--- a/src-tauri/src/db/messages.rs
+++ b/src-tauri/src/db/messages.rs
@@ -39,8 +39,9 @@ pub struct MessageSummary {
     /// Used by the frontend to build the in-thread reply hierarchy.
     pub message_id: Option<String>,
     /// In-Reply-To header pointing at this message's parent within the
-    /// thread. Empty for the thread root or for backends that don't
-    /// expose it (Microsoft Graph stores conversationId only).
+    /// thread. Empty for the thread root or when the source message/backend
+    /// does not provide the header; Microsoft Graph populates this from
+    /// `internetMessageHeaders` when available.
     pub in_reply_to: Option<String>,
 }
 

--- a/src-tauri/src/db/schema.rs
+++ b/src-tauri/src/db/schema.rs
@@ -328,6 +328,88 @@ fn run_migrations(conn: &Connection) -> Result<()> {
         log::info!("Migration: FTS5 index populated");
     }
 
+    // Canonicalize Message-ID / In-Reply-To and rethread.
+    //
+    // Older builds stored these strings verbatim from the IMAP envelope,
+    // which on some servers (notably Microsoft Exchange/M365) included a
+    // leading whitespace inside the bracketed value. Exact-match thread
+    // joins (`WHERE message_id = ?`) then silently failed and replies
+    // landed in their own one-message threads. Trim+wrap once, then
+    // recompute thread_id for every message so existing mail heals
+    // without waiting for a fresh full sync.
+    if !has_migration(conn, "messageid_normalize_v1") {
+        log::info!("Migration: normalizing message_id / in_reply_to and rethreading");
+        normalize_message_ids_and_rethread(conn)?;
+        set_migration(conn, "messageid_normalize_v1")?;
+        log::info!("Migration: message-id normalization complete");
+    }
+
+    Ok(())
+}
+
+/// One-time backfill: rewrite stored message_id / in_reply_to to their
+/// canonical `<core>` form, then propagate ancestor thread_ids down so
+/// existing fragmented threads heal. Pure SQL — no per-row Rust loop —
+/// so even tens of thousands of messages finish in well under a second
+/// on commodity hardware. Wrapped in a single transaction.
+fn normalize_message_ids_and_rethread(conn: &Connection) -> Result<()> {
+    let tx = conn.unchecked_transaction()?;
+
+    // 1) Canonicalize message_id and in_reply_to.
+    //
+    // SQLite doesn't have a built-in regex, so we use REPLACE chains to
+    // strip every `<`, `>`, ASCII space, and tab from the existing value,
+    // then re-wrap. The `WHERE` guards skip already-canonical rows so we
+    // don't rewrite the entire table on every startup.
+    tx.execute_batch(
+        "UPDATE messages
+         SET message_id = '<' || REPLACE(REPLACE(REPLACE(REPLACE(message_id, '<', ''), '>', ''), ' ', ''), CHAR(9), '') || '>'
+         WHERE message_id IS NOT NULL
+           AND TRIM(message_id) != ''
+           AND message_id != '<' || REPLACE(REPLACE(REPLACE(REPLACE(message_id, '<', ''), '>', ''), ' ', ''), CHAR(9), '') || '>';
+
+         UPDATE messages
+         SET in_reply_to = '<' || REPLACE(REPLACE(REPLACE(REPLACE(in_reply_to, '<', ''), '>', ''), ' ', ''), CHAR(9), '') || '>'
+         WHERE in_reply_to IS NOT NULL
+           AND TRIM(in_reply_to) != ''
+           AND in_reply_to != '<' || REPLACE(REPLACE(REPLACE(REPLACE(in_reply_to, '<', ''), '>', ''), ' ', ''), CHAR(9), '') || '>';",
+    )?;
+
+    // 2) Propagate parent thread_ids. Each iteration runs one indexed
+    // self-join on (account_id, message_id) — the existing
+    // `idx_msg_message_id` index makes this a cheap lookup. Each pass
+    // pushes thread_ids one generation deeper, so a chain of depth N
+    // converges in N-1 passes. Cap at 32 (matching the compose-side
+    // chain cap) so a pathological cycle can't spin forever.
+    for _ in 0..32 {
+        let changed = tx.execute(
+            "UPDATE messages
+             SET thread_id = (
+                 SELECT parent.thread_id FROM messages AS parent
+                 WHERE parent.account_id = messages.account_id
+                   AND parent.message_id = messages.in_reply_to
+                   AND parent.thread_id IS NOT NULL
+                   AND parent.thread_id != ''
+             )
+             WHERE in_reply_to IS NOT NULL
+               AND in_reply_to != ''
+               AND EXISTS (
+                 SELECT 1 FROM messages AS parent
+                 WHERE parent.account_id = messages.account_id
+                   AND parent.message_id = messages.in_reply_to
+                   AND parent.thread_id IS NOT NULL
+                   AND parent.thread_id != ''
+                   AND parent.thread_id IS NOT messages.thread_id
+               )",
+            [],
+        )?;
+        if changed == 0 {
+            break;
+        }
+    }
+
+    tx.commit()?;
+    log::info!("Migration messageid_normalize_v1: canonicalized + rethreaded");
     Ok(())
 }
 

--- a/src-tauri/src/db/schema.rs
+++ b/src-tauri/src/db/schema.rs
@@ -381,6 +381,12 @@ fn normalize_message_ids_and_rethread(conn: &Connection) -> Result<()> {
     // pushes thread_ids one generation deeper, so a chain of depth N
     // converges in N-1 passes. Cap at 32 (matching the compose-side
     // chain cap) so a pathological cycle can't spin forever.
+    // Gmail label folders mean the same Message-ID can sit in several
+    // `messages` rows for one account. The scalar subquery in SET would
+    // then have multiple candidates and SQLite picks one non-deterministically;
+    // pin it down with `ORDER BY thread_id LIMIT 1` so the migration is
+    // reproducible (and so a future SQLite that tightens scalar-subquery
+    // semantics doesn't error out at startup).
     for _ in 0..32 {
         let changed = tx.execute(
             "UPDATE messages
@@ -390,6 +396,8 @@ fn normalize_message_ids_and_rethread(conn: &Connection) -> Result<()> {
                    AND parent.message_id = messages.in_reply_to
                    AND parent.thread_id IS NOT NULL
                    AND parent.thread_id != ''
+                 ORDER BY parent.thread_id
+                 LIMIT 1
              )
              WHERE in_reply_to IS NOT NULL
                AND in_reply_to != ''

--- a/src-tauri/src/mail/graph.rs
+++ b/src-tauri/src/mail/graph.rs
@@ -353,7 +353,7 @@ impl GraphClient {
         let resp = self.get(
             &format!("/me/mailFolders/{}/messages", folder_id),
             &[
-                ("$select", "id,subject,from,toRecipients,ccRecipients,receivedDateTime,isRead,hasAttachments,flag,internetMessageId,conversationId,bodyPreview,importance"),
+                ("$select", "id,subject,from,toRecipients,ccRecipients,receivedDateTime,isRead,hasAttachments,flag,internetMessageId,conversationId,bodyPreview,importance,internetMessageHeaders"),
                 ("$top", &top.to_string()),
                 ("$skip", &skip.to_string()),
                 ("$orderby", "receivedDateTime desc"),
@@ -902,6 +902,12 @@ pub struct GraphMessage {
     pub internet_message_id: Option<String>,
     pub conversation_id: Option<String>,
     pub preview: Option<String>,
+    /// Pulled from internetMessageHeaders (In-Reply-To). Wrapped in
+    /// angle brackets to match how IMAP/JMAP store it.
+    pub in_reply_to: Option<String>,
+    /// Pulled from internetMessageHeaders (References), root first,
+    /// each id wrapped in angle brackets.
+    pub references: Vec<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -991,6 +997,8 @@ fn parse_graph_message(m: &serde_json::Value) -> GraphMessage {
         .map(|dt| dt.with_timezone(&chrono::Utc).to_rfc3339())
         .unwrap_or_default();
 
+    let (in_reply_to, references) = parse_message_headers(&m["internetMessageHeaders"]);
+
     GraphMessage {
         id: m["id"].as_str().unwrap_or("").to_string(),
         subject: m["subject"].as_str().map(|s| s.to_string()),
@@ -1004,7 +1012,60 @@ fn parse_graph_message(m: &serde_json::Value) -> GraphMessage {
         internet_message_id: m["internetMessageId"].as_str().map(|s| s.to_string()),
         conversation_id: m["conversationId"].as_str().map(|s| s.to_string()),
         preview: m["bodyPreview"].as_str().map(|s| s.to_string()),
+        in_reply_to,
+        references,
     }
+}
+
+/// Walk Graph's `internetMessageHeaders` array (each entry is
+/// `{ "name": "...", "value": "..." }`) and pull out In-Reply-To and
+/// References as the wrapped Message-IDs the rest of chithi expects.
+fn parse_message_headers(arr: &serde_json::Value) -> (Option<String>, Vec<String>) {
+    let Some(items) = arr.as_array() else {
+        return (None, Vec::new());
+    };
+    let mut in_reply_to: Option<String> = None;
+    let mut references: Vec<String> = Vec::new();
+    for item in items {
+        let name = item["name"].as_str().unwrap_or("");
+        let value = item["value"].as_str().unwrap_or("");
+        if value.is_empty() {
+            continue;
+        }
+        if name.eq_ignore_ascii_case("In-Reply-To") && in_reply_to.is_none() {
+            in_reply_to = extract_message_ids(value).into_iter().next();
+        } else if name.eq_ignore_ascii_case("References") {
+            references = extract_message_ids(value);
+        }
+    }
+    (in_reply_to, references)
+}
+
+/// Pull every `<message-id>` token from a header value.
+fn extract_message_ids(s: &str) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    let mut buf = String::new();
+    let mut inside = false;
+    for c in s.chars() {
+        match c {
+            '<' => {
+                inside = true;
+                buf.clear();
+                buf.push('<');
+            }
+            '>' if inside => {
+                buf.push('>');
+                if buf.len() > 2 {
+                    out.push(buf.clone());
+                }
+                inside = false;
+                buf.clear();
+            }
+            _ if inside => buf.push(c),
+            _ => {}
+        }
+    }
+    out
 }
 
 fn parse_recipients(arr: &serde_json::Value) -> String {

--- a/src-tauri/src/mail/graph.rs
+++ b/src-tauri/src/mail/graph.rs
@@ -4,6 +4,7 @@
 //! Bearer token authentication. No IMAP/SMTP needed for O365 accounts.
 
 use crate::error::{Error, Result};
+use crate::mail::msgid::normalize_message_id;
 use crate::mail::search::{build_graph_kql, SearchHit, SearchQuery};
 use serde::{Deserialize, Serialize};
 
@@ -967,7 +968,9 @@ fn parse_graph_search_hit(account_id: &str, m: &serde_json::Value) -> SearchHit 
 
     let snippet = m["bodyPreview"].as_str().map(|s| s.to_string());
     let folder_path = m["parentFolderId"].as_str().unwrap_or("").to_string();
-    let message_id = m["internetMessageId"].as_str().map(|s| s.to_string());
+    let message_id = m["internetMessageId"]
+        .as_str()
+        .and_then(normalize_message_id);
 
     SearchHit {
         account_id: account_id.to_string(),
@@ -1009,7 +1012,9 @@ fn parse_graph_message(m: &serde_json::Value) -> GraphMessage {
         date,
         is_read: m["isRead"].as_bool().unwrap_or(false),
         has_attachments: m["hasAttachments"].as_bool().unwrap_or(false),
-        internet_message_id: m["internetMessageId"].as_str().map(|s| s.to_string()),
+        internet_message_id: m["internetMessageId"]
+            .as_str()
+            .and_then(normalize_message_id),
         conversation_id: m["conversationId"].as_str().map(|s| s.to_string()),
         preview: m["bodyPreview"].as_str().map(|s| s.to_string()),
         in_reply_to,
@@ -1051,12 +1056,10 @@ fn extract_message_ids(s: &str) -> Vec<String> {
             '<' => {
                 inside = true;
                 buf.clear();
-                buf.push('<');
             }
             '>' if inside => {
-                buf.push('>');
-                if buf.len() > 2 {
-                    out.push(buf.clone());
+                if let Some(id) = normalize_message_id(&buf) {
+                    out.push(id);
                 }
                 inside = false;
                 buf.clear();

--- a/src-tauri/src/mail/imap.rs
+++ b/src-tauri/src/mail/imap.rs
@@ -3,6 +3,7 @@ use native_tls::TlsStream;
 use std::net::TcpStream;
 
 use crate::error::{Error, Result};
+use crate::mail::msgid::normalize_message_id;
 use crate::mail::search::{build_imap_search, SearchHit, SearchQuery};
 
 #[derive(Clone)]
@@ -273,8 +274,19 @@ impl ImapConnection {
                     let cc_list = addresses_to_json(env.cc.as_deref());
 
                     let date = env.date.as_ref().map(|d| decode_imap_str(d));
-                    let mid = env.message_id.as_ref().map(|m| decode_imap_str(m));
-                    let irt = env.in_reply_to.as_ref().map(|r| decode_imap_str(r));
+                    // Some servers (notably Microsoft Exchange/M365) emit a
+                    // leading space inside the envelope's MessageId/InReplyTo
+                    // octet-string. Storing that verbatim breaks the exact-
+                    // match `WHERE message_id = ?` lookup in `compute_thread_id`,
+                    // so canonicalize at the seam.
+                    let mid = env
+                        .message_id
+                        .as_ref()
+                        .and_then(|m| normalize_message_id(&decode_imap_str(m)));
+                    let irt = env
+                        .in_reply_to
+                        .as_ref()
+                        .and_then(|r| normalize_message_id(&decode_imap_str(r)));
 
                     (subject, fname, femail, to_list, cc_list, date, mid, irt)
                 } else {
@@ -325,33 +337,46 @@ impl ImapConnection {
         Ok(results)
     }
 
-    /// Best-effort: fetch the References header for every envelope in
-    /// `results` and write the parsed chain back. A failure here does not
-    /// fail the sync — threading just falls back to the In-Reply-To path.
+    /// Best-effort: fetch the References and In-Reply-To headers for every
+    /// envelope in `results` and write them back. References fills
+    /// `env.references`. In-Reply-To is used to backfill `env.in_reply_to`
+    /// only when the envelope itself didn't carry it (some servers return
+    /// NIL even when the header is in the body). Failures here do not abort
+    /// the sync.
     fn populate_references(&mut self, results: &mut [EnvelopeData], uid_set: &str) {
-        let fetches = match self
-            .session
-            .uid_fetch(uid_set, "(UID BODY.PEEK[HEADER.FIELDS (REFERENCES)])")
-        {
+        let fetches = match self.session.uid_fetch(
+            uid_set,
+            "(UID BODY.PEEK[HEADER.FIELDS (REFERENCES IN-REPLY-TO)])",
+        ) {
             Ok(f) => f,
             Err(e) => {
-                log::warn!("IMAP fetch References failed (skipping): {}", e);
+                log::warn!("IMAP fetch References/In-Reply-To failed (skipping): {}", e);
                 return;
             }
         };
-        let mut by_uid: std::collections::HashMap<u32, Vec<String>> =
+        let mut refs_by_uid: std::collections::HashMap<u32, Vec<String>> =
+            std::collections::HashMap::new();
+        let mut irt_by_uid: std::collections::HashMap<u32, String> =
             std::collections::HashMap::new();
         for fetch in fetches.iter() {
             if let (Some(uid), Some(bytes)) = (fetch.uid, fetch.header()) {
-                let refs = parse_references_header(bytes);
+                let (irt, refs) = parse_threading_headers(bytes);
                 if !refs.is_empty() {
-                    by_uid.insert(uid, refs);
+                    refs_by_uid.insert(uid, refs);
+                }
+                if let Some(irt) = irt {
+                    irt_by_uid.insert(uid, irt);
                 }
             }
         }
         for env in results.iter_mut() {
-            if let Some(refs) = by_uid.remove(&env.uid) {
+            if let Some(refs) = refs_by_uid.remove(&env.uid) {
                 env.references = refs;
+            }
+            if env.in_reply_to.is_none() {
+                if let Some(irt) = irt_by_uid.remove(&env.uid) {
+                    env.in_reply_to = Some(irt);
+                }
             }
         }
     }
@@ -811,29 +836,21 @@ fn flag_to_string(flag: &imap::types::Flag<'_>) -> String {
     }
 }
 
-/// Parse a `References:` header byte slice as a list of `<message-id>`
-/// strings (without the angle brackets), root first. Tolerates folded
-/// header lines and missing-header cases (returns an empty list).
-fn parse_references_header(bytes: &[u8]) -> Vec<String> {
-    let raw = String::from_utf8_lossy(bytes);
-    // Strip the leading "References:" if present (BODY.PEEK[HEADER.FIELDS]
-    // includes the field name).
-    let body = match raw.split_once(':') {
-        Some((_, rest)) => rest.to_string(),
-        None => raw.to_string(),
-    };
+/// Extract `<message-id>` tokens from a single header value (the part
+/// after `Field-Name:`). Returned ids are canonical form.
+fn extract_msgids(value: &str) -> Vec<String> {
     let mut out: Vec<String> = Vec::new();
     let mut buf = String::new();
     let mut inside = false;
-    for c in body.chars() {
+    for c in value.chars() {
         match c {
             '<' => {
                 inside = true;
                 buf.clear();
             }
             '>' if inside => {
-                if !buf.is_empty() {
-                    out.push(buf.clone());
+                if let Some(id) = normalize_message_id(&buf) {
+                    out.push(id);
                 }
                 inside = false;
                 buf.clear();
@@ -843,6 +860,34 @@ fn parse_references_header(bytes: &[u8]) -> Vec<String> {
         }
     }
     out
+}
+
+/// Split a `BODY.PEEK[HEADER.FIELDS (REFERENCES IN-REPLY-TO)]` block into
+/// `(in_reply_to, references)`, applying RFC 5322 §2.2.3 unfolding so
+/// folded continuation lines don't split a single id in half.
+fn parse_threading_headers(bytes: &[u8]) -> (Option<String>, Vec<String>) {
+    let raw = String::from_utf8_lossy(bytes);
+    // Unfold: a CRLF followed by WSP is part of the same header value.
+    let unfolded = raw
+        .replace("\r\n ", " ")
+        .replace("\r\n\t", " ")
+        .replace("\n ", " ")
+        .replace("\n\t", " ");
+
+    let mut in_reply_to: Option<String> = None;
+    let mut references: Vec<String> = Vec::new();
+    for line in unfolded.lines() {
+        let Some((name, value)) = line.split_once(':') else {
+            continue;
+        };
+        let name_lc = name.trim().to_ascii_lowercase();
+        if name_lc == "references" {
+            references = extract_msgids(value);
+        } else if name_lc == "in-reply-to" && in_reply_to.is_none() {
+            in_reply_to = extract_msgids(value).into_iter().next();
+        }
+    }
+    (in_reply_to, references)
 }
 
 /// Decode a potentially MIME-encoded IMAP string to a Rust String.
@@ -909,5 +954,43 @@ mod tests {
     fn test_utf7_imap_ascii_passthrough() {
         let decoded = utf7_imap::decode_utf7_imap("INBOX".to_string());
         assert_eq!(decoded, "INBOX");
+    }
+
+    #[test]
+    fn parse_threading_headers_extracts_both() {
+        let bytes = b"References: <root@h> <mid@h>\r\nIn-Reply-To: <mid@h>\r\n\r\n";
+        let (irt, refs) = super::parse_threading_headers(bytes);
+        assert_eq!(irt.as_deref(), Some("<mid@h>"));
+        assert_eq!(refs, vec!["<root@h>".to_string(), "<mid@h>".to_string()]);
+    }
+
+    #[test]
+    fn parse_threading_headers_unfolds_continuations() {
+        let bytes = b"References: <root@h>\r\n <mid@h>\r\n\r\n";
+        let (_, refs) = super::parse_threading_headers(bytes);
+        assert_eq!(refs, vec!["<root@h>".to_string(), "<mid@h>".to_string()]);
+    }
+
+    #[test]
+    fn parse_threading_headers_handles_only_references() {
+        let bytes = b"References: <root@h>\r\n\r\n";
+        let (irt, refs) = super::parse_threading_headers(bytes);
+        assert!(irt.is_none());
+        assert_eq!(refs, vec!["<root@h>".to_string()]);
+    }
+
+    #[test]
+    fn parse_threading_headers_normalizes_whitespace() {
+        // Server emits a leading space inside the bracketed id.
+        let bytes = b"In-Reply-To:  < mid@h >\r\n\r\n";
+        let (irt, _) = super::parse_threading_headers(bytes);
+        assert_eq!(irt.as_deref(), Some("<mid@h>"));
+    }
+
+    #[test]
+    fn parse_threading_headers_empty_block() {
+        let (irt, refs) = super::parse_threading_headers(b"");
+        assert!(irt.is_none());
+        assert!(refs.is_empty());
     }
 }

--- a/src-tauri/src/mail/imap.rs
+++ b/src-tauri/src/mail/imap.rs
@@ -227,15 +227,9 @@ impl ImapConnection {
             &uid_set[..uid_set.len().min(80)]
         );
 
-        // BODY.PEEK[HEADER.FIELDS (REFERENCES)] pulls only the References
-        // line without marking the message Seen. We parse it locally to
-        // feed thread computation; the bytes are not stored.
         let fetches = self
             .session
-            .uid_fetch(
-                &uid_set,
-                "(UID ENVELOPE FLAGS RFC822.SIZE BODY.PEEK[HEADER.FIELDS (REFERENCES)])",
-            )
+            .uid_fetch(&uid_set, "(UID ENVELOPE FLAGS RFC822.SIZE)")
             .map_err(|e| {
                 log::error!("IMAP FETCH envelopes failed: {}", e);
                 Error::Imap(e.to_string())
@@ -301,13 +295,6 @@ impl ImapConnection {
             // More accurate: check if it's multipart/mixed (indicates attachments)
             let has_attachments = size > 10000; // rough heuristic; will improve later
 
-            // Pull the References header bytes back out of the fetch and
-            // parse the angle-bracketed Message-IDs into a list.
-            let references = fetch
-                .header()
-                .map(parse_references_header)
-                .unwrap_or_default();
-
             results.push(EnvelopeData {
                 uid,
                 subject,
@@ -318,14 +305,55 @@ impl ImapConnection {
                 date: date_str,
                 message_id: msg_id,
                 in_reply_to,
-                references,
+                references: Vec::new(),
                 flags,
                 size,
                 has_attachments,
             });
         }
         log::info!("IMAP envelope batch: {} envelopes fetched", results.len());
+
+        // References travels in a second, header-only fetch. Combining it
+        // with ENVELOPE in one FETCH triggers an imap-proto parse error on
+        // some servers (the literal-string framing of the body fetch leaks
+        // into the next command's response). A second pass is one extra
+        // round-trip per batch but keeps the connection state clean.
+        if !results.is_empty() {
+            self.populate_references(&mut results, &uid_set);
+        }
+
         Ok(results)
+    }
+
+    /// Best-effort: fetch the References header for every envelope in
+    /// `results` and write the parsed chain back. A failure here does not
+    /// fail the sync — threading just falls back to the In-Reply-To path.
+    fn populate_references(&mut self, results: &mut [EnvelopeData], uid_set: &str) {
+        let fetches = match self
+            .session
+            .uid_fetch(uid_set, "(UID BODY.PEEK[HEADER.FIELDS (REFERENCES)])")
+        {
+            Ok(f) => f,
+            Err(e) => {
+                log::warn!("IMAP fetch References failed (skipping): {}", e);
+                return;
+            }
+        };
+        let mut by_uid: std::collections::HashMap<u32, Vec<String>> =
+            std::collections::HashMap::new();
+        for fetch in fetches.iter() {
+            if let (Some(uid), Some(bytes)) = (fetch.uid, fetch.header()) {
+                let refs = parse_references_header(bytes);
+                if !refs.is_empty() {
+                    by_uid.insert(uid, refs);
+                }
+            }
+        }
+        for env in results.iter_mut() {
+            if let Some(refs) = by_uid.remove(&env.uid) {
+                env.references = refs;
+            }
+        }
     }
 
     /// Fetch the full body (RFC822) for a single message by UID.

--- a/src-tauri/src/mail/imap.rs
+++ b/src-tauri/src/mail/imap.rs
@@ -56,6 +56,10 @@ pub struct EnvelopeData {
     pub date: Option<String>,
     pub message_id: Option<String>,
     pub in_reply_to: Option<String>,
+    /// Full RFC 5322 References chain, oldest (root) first. Empty when the
+    /// header is missing. Used at insert time to thread mailing-list patch
+    /// series back to their parent discussion.
+    pub references: Vec<String>,
     pub flags: Vec<String>,
     pub size: u64,
     pub has_attachments: bool,
@@ -223,9 +227,15 @@ impl ImapConnection {
             &uid_set[..uid_set.len().min(80)]
         );
 
+        // BODY.PEEK[HEADER.FIELDS (REFERENCES)] pulls only the References
+        // line without marking the message Seen. We parse it locally to
+        // feed thread computation; the bytes are not stored.
         let fetches = self
             .session
-            .uid_fetch(&uid_set, "(UID ENVELOPE FLAGS RFC822.SIZE)")
+            .uid_fetch(
+                &uid_set,
+                "(UID ENVELOPE FLAGS RFC822.SIZE BODY.PEEK[HEADER.FIELDS (REFERENCES)])",
+            )
             .map_err(|e| {
                 log::error!("IMAP FETCH envelopes failed: {}", e);
                 Error::Imap(e.to_string())
@@ -291,6 +301,13 @@ impl ImapConnection {
             // More accurate: check if it's multipart/mixed (indicates attachments)
             let has_attachments = size > 10000; // rough heuristic; will improve later
 
+            // Pull the References header bytes back out of the fetch and
+            // parse the angle-bracketed Message-IDs into a list.
+            let references = fetch
+                .header()
+                .map(parse_references_header)
+                .unwrap_or_default();
+
             results.push(EnvelopeData {
                 uid,
                 subject,
@@ -301,6 +318,7 @@ impl ImapConnection {
                 date: date_str,
                 message_id: msg_id,
                 in_reply_to,
+                references,
                 flags,
                 size,
                 has_attachments,
@@ -763,6 +781,40 @@ fn flag_to_string(flag: &imap::types::Flag<'_>) -> String {
         imap::types::Flag::MayCreate => "maycreate".to_string(),
         imap::types::Flag::Custom(s) => s.to_string(),
     }
+}
+
+/// Parse a `References:` header byte slice as a list of `<message-id>`
+/// strings (without the angle brackets), root first. Tolerates folded
+/// header lines and missing-header cases (returns an empty list).
+fn parse_references_header(bytes: &[u8]) -> Vec<String> {
+    let raw = String::from_utf8_lossy(bytes);
+    // Strip the leading "References:" if present (BODY.PEEK[HEADER.FIELDS]
+    // includes the field name).
+    let body = match raw.split_once(':') {
+        Some((_, rest)) => rest.to_string(),
+        None => raw.to_string(),
+    };
+    let mut out: Vec<String> = Vec::new();
+    let mut buf = String::new();
+    let mut inside = false;
+    for c in body.chars() {
+        match c {
+            '<' => {
+                inside = true;
+                buf.clear();
+            }
+            '>' if inside => {
+                if !buf.is_empty() {
+                    out.push(buf.clone());
+                }
+                inside = false;
+                buf.clear();
+            }
+            _ if inside => buf.push(c),
+            _ => {}
+        }
+    }
+    out
 }
 
 /// Decode a potentially MIME-encoded IMAP string to a Rust String.

--- a/src-tauri/src/mail/jmap.rs
+++ b/src-tauri/src/mail/jmap.rs
@@ -104,6 +104,9 @@ pub struct JmapEmail {
     pub date: String,
     pub message_id: Option<String>,
     pub in_reply_to: Option<String>,
+    /// Full RFC 5322 References chain, root first. Used at insert time
+    /// to thread mailing-list patch series back to their root discussion.
+    pub references: Vec<String>,
     pub size: u64,
     pub has_attachments: bool,
     pub flags: Vec<String>,
@@ -355,7 +358,7 @@ impl JmapConnection {
                         "accountId": self.account_id,
                         "properties": ["id", "subject", "from", "to", "cc", "receivedAt",
                                        "size", "keywords", "messageId", "inReplyTo",
-                                       "hasAttachment", "preview"]
+                                       "references", "hasAttachment", "preview"]
                     }, "g1"]
                 ]
             });
@@ -438,6 +441,18 @@ impl JmapConnection {
             .and_then(|a| a.first())
             .and_then(|v| v.as_str())
             .map(|s| format!("<{}>", s));
+        // JMAP stores Message-IDs without angle brackets; wrap each so the
+        // chain matches what the DB stores for IMAP envelopes.
+        let references: Vec<String> = e["references"]
+            .as_array()
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str())
+                    .filter(|s| !s.is_empty())
+                    .map(|s| format!("<{}>", s))
+                    .collect()
+            })
+            .unwrap_or_default();
         let has_attachments = e["hasAttachment"].as_bool().unwrap_or(false);
         let preview = e["preview"].as_str().map(|s| s.to_string());
 
@@ -468,6 +483,7 @@ impl JmapConnection {
             date,
             message_id,
             in_reply_to,
+            references,
             size,
             has_attachments,
             flags,

--- a/src-tauri/src/mail/jmap.rs
+++ b/src-tauri/src/mail/jmap.rs
@@ -1,4 +1,5 @@
 use crate::error::{Error, Result};
+use crate::mail::msgid::normalize_message_id;
 use crate::mail::search::{build_jmap_filter, SearchHit, SearchQuery};
 use serde::{Deserialize, Serialize};
 
@@ -431,25 +432,25 @@ impl JmapConnection {
             .map(|dt| dt.with_timezone(&chrono::Utc).to_rfc3339())
             .unwrap_or_default();
         let size = e["size"].as_u64().unwrap_or(0);
+        // JMAP returns Message-IDs without angle brackets; canonicalize each
+        // through `normalize_message_id` so the stored form matches what the
+        // IMAP and Graph paths produce.
         let message_id = e["messageId"]
             .as_array()
             .and_then(|a| a.first())
             .and_then(|v| v.as_str())
-            .map(|s| format!("<{}>", s));
+            .and_then(normalize_message_id);
         let in_reply_to = e["inReplyTo"]
             .as_array()
             .and_then(|a| a.first())
             .and_then(|v| v.as_str())
-            .map(|s| format!("<{}>", s));
-        // JMAP stores Message-IDs without angle brackets; wrap each so the
-        // chain matches what the DB stores for IMAP envelopes.
+            .and_then(normalize_message_id);
         let references: Vec<String> = e["references"]
             .as_array()
             .map(|arr| {
                 arr.iter()
                     .filter_map(|v| v.as_str())
-                    .filter(|s| !s.is_empty())
-                    .map(|s| format!("<{}>", s))
+                    .filter_map(normalize_message_id)
                     .collect()
             })
             .unwrap_or_default();

--- a/src-tauri/src/mail/jmap_sync.rs
+++ b/src-tauri/src/mail/jmap_sync.rs
@@ -245,12 +245,18 @@ async fn sync_jmap_folder(
                 .map(|s| s.chars().take(200).collect());
 
             // Compute thread_id
+            let refs_slice: Option<&[String]> = if email.references.is_empty() {
+                None
+            } else {
+                Some(email.references.as_slice())
+            };
             let thread_id = db::messages::compute_thread_id(
                 &conn,
                 account_id,
                 email.message_id.as_deref(),
                 email.in_reply_to.as_deref(),
                 email.subject.as_deref(),
+                refs_slice,
             );
             if let Some(ref tid) = thread_id {
                 log::debug!("JMAP assigned thread_id '{}' to email {}", tid, email.id);

--- a/src-tauri/src/mail/mod.rs
+++ b/src-tauri/src/mail/mod.rs
@@ -7,6 +7,7 @@ pub mod imap;
 pub mod jmap;
 pub mod jmap_push;
 pub mod jmap_sync;
+pub mod msgid;
 pub mod parser;
 pub mod search;
 pub mod smtp;

--- a/src-tauri/src/mail/msgid.rs
+++ b/src-tauri/src/mail/msgid.rs
@@ -1,0 +1,78 @@
+/// Canonicalize an RFC 5322 Message-ID-shaped string for storage and lookup.
+///
+/// Many IMAP servers and parser code paths feed us slightly different shapes
+/// for the same id: with or without surrounding angle brackets, with leading
+/// whitespace from the wire, with stray internal spaces in folded headers.
+/// All of those break the exact-match SQL we use to stitch threads
+/// (`WHERE message_id = ?`). Normalize once at every entry point so the
+/// stored form is always `<core>` with no whitespace anywhere.
+///
+/// Returns `None` for empty input or anything that contains nothing but
+/// whitespace and brackets (`""`, `"<>"`, `"   "`).
+pub fn normalize_message_id(s: &str) -> Option<String> {
+    let core: String = s
+        .chars()
+        .filter(|c| !c.is_whitespace() && *c != '<' && *c != '>')
+        .collect();
+    if core.is_empty() {
+        return None;
+    }
+    Some(format!("<{}>", core))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_message_id;
+
+    #[test]
+    fn wraps_unwrapped_id() {
+        assert_eq!(normalize_message_id("abc@host"), Some("<abc@host>".into()));
+    }
+
+    #[test]
+    fn keeps_already_wrapped_id() {
+        assert_eq!(
+            normalize_message_id("<abc@host>"),
+            Some("<abc@host>".into())
+        );
+    }
+
+    #[test]
+    fn strips_leading_whitespace() {
+        assert_eq!(
+            normalize_message_id(" <abc@host>"),
+            Some("<abc@host>".into())
+        );
+    }
+
+    #[test]
+    fn strips_trailing_whitespace() {
+        assert_eq!(
+            normalize_message_id("<abc@host> "),
+            Some("<abc@host>".into())
+        );
+    }
+
+    #[test]
+    fn strips_internal_whitespace_from_folded_headers() {
+        assert_eq!(
+            normalize_message_id("<abc@\n host>"),
+            Some("<abc@host>".into())
+        );
+    }
+
+    #[test]
+    fn returns_none_for_empty() {
+        assert_eq!(normalize_message_id(""), None);
+    }
+
+    #[test]
+    fn returns_none_for_whitespace_only() {
+        assert_eq!(normalize_message_id("   "), None);
+    }
+
+    #[test]
+    fn returns_none_for_empty_brackets() {
+        assert_eq!(normalize_message_id("<>"), None);
+    }
+}

--- a/src-tauri/src/mail/smtp.rs
+++ b/src-tauri/src/mail/smtp.rs
@@ -54,6 +54,11 @@ fn build_body(
 }
 
 /// Send an email message via SMTP.
+///
+/// `in_reply_to` and `references` carry RFC 5322 threading headers,
+/// already wrapped in angle brackets. Without these the receiving
+/// client cannot link the new message to its parent.
+#[allow(clippy::too_many_arguments)]
 pub async fn send_message(
     smtp_host: &str,
     smtp_port: u16,
@@ -69,21 +74,30 @@ pub async fn send_message(
     body_text: &str,
     body_html: Option<&str>,
     attachments: &[AttachmentData],
+    in_reply_to: Option<&str>,
+    references: &[String],
 ) -> Result<()> {
     log::info!(
-        "SMTP sending message from {} to {:?} via {}:{} ({} attachments)",
+        "SMTP sending message from {} to {:?} via {}:{} ({} attachments, threading={})",
         from,
         to,
         smtp_host,
         smtp_port,
-        attachments.len()
+        attachments.len(),
+        in_reply_to.is_some(),
     );
 
     let from_mailbox: Mailbox = from
         .parse()
         .map_err(|e| Error::Other(format!("Invalid 'from' address '{}': {}", from, e)))?;
 
-    let mut builder = Message::builder().from(from_mailbox).subject(subject);
+    // `message_id(None)` makes lettre emit a generated <UUID@host>;
+    // without it lettre never adds the header and the next reply
+    // has nothing to point In-Reply-To at.
+    let mut builder = Message::builder()
+        .from(from_mailbox)
+        .subject(subject)
+        .message_id(None);
 
     for addr in to {
         let mailbox: Mailbox = addr
@@ -102,6 +116,24 @@ pub async fn send_message(
             .parse()
             .map_err(|e| Error::Other(format!("Invalid 'bcc' address '{}': {}", addr, e)))?;
         builder = builder.bcc(mailbox);
+    }
+
+    if let Some(irt) = in_reply_to {
+        let trimmed = irt.trim();
+        if !trimmed.is_empty() {
+            builder = builder.in_reply_to(trimmed.to_string());
+        }
+    }
+    if !references.is_empty() {
+        let joined = references
+            .iter()
+            .map(|s| s.trim())
+            .filter(|s| !s.is_empty())
+            .collect::<Vec<_>>()
+            .join(" ");
+        if !joined.is_empty() {
+            builder = builder.references(joined);
+        }
     }
 
     let body = build_body(body_text, body_html, attachments)
@@ -181,7 +213,14 @@ pub fn build_raw_message(
         .parse()
         .map_err(|e| Error::Other(format!("Invalid 'from' address '{}': {}", from, e)))?;
 
-    let mut builder = Message::builder().from(from_mailbox).subject(subject);
+    // Always emit a Message-ID. Lettre's `build()` does NOT add one
+    // automatically, so without this, our outgoing replies have no
+    // Message-ID for the next reply to thread off of. `message_id(None)`
+    // generates `<UUID@hostname>` per RFC 5322 §3.6.4.
+    let mut builder = Message::builder()
+        .from(from_mailbox)
+        .subject(subject)
+        .message_id(None);
 
     for addr in to {
         let mailbox: Mailbox = addr

--- a/src-tauri/src/mail/smtp.rs
+++ b/src-tauri/src/mail/smtp.rs
@@ -159,6 +159,12 @@ pub async fn send_message(
 }
 
 /// Build a raw RFC5322 message (for JMAP submission).
+///
+/// `in_reply_to` and `references` carry the threading headers. The id
+/// strings should arrive WITH their angle brackets — lettre stores them
+/// verbatim in the In-Reply-To / References header values. References
+/// is rendered as a single space-separated header value.
+#[allow(clippy::too_many_arguments)]
 pub fn build_raw_message(
     from: &str,
     to: &[String],
@@ -168,6 +174,8 @@ pub fn build_raw_message(
     body_text: &str,
     body_html: Option<&str>,
     attachments: &[AttachmentData],
+    in_reply_to: Option<&str>,
+    references: &[String],
 ) -> Result<Vec<u8>> {
     let from_mailbox: Mailbox = from
         .parse()
@@ -192,6 +200,26 @@ pub fn build_raw_message(
             .parse()
             .map_err(|e| Error::Other(format!("Invalid 'bcc' address '{}': {}", addr, e)))?;
         builder = builder.bcc(mailbox);
+    }
+
+    if let Some(irt) = in_reply_to {
+        let trimmed = irt.trim();
+        if !trimmed.is_empty() {
+            builder = builder.in_reply_to(trimmed.to_string());
+        }
+    }
+    if !references.is_empty() {
+        // RFC 5322 References is a single header whose value is the chain
+        // of message-ids separated by whitespace, oldest first.
+        let joined = references
+            .iter()
+            .map(|s| s.trim())
+            .filter(|s| !s.is_empty())
+            .collect::<Vec<_>>()
+            .join(" ");
+        if !joined.is_empty() {
+            builder = builder.references(joined);
+        }
     }
 
     let body = build_body(body_text, body_html, attachments)

--- a/src-tauri/src/mail/sync.rs
+++ b/src-tauri/src/mail/sync.rs
@@ -483,12 +483,18 @@ fn sync_folder_envelopes(
 
             // Thread computation still needs DB queries for cross-references,
             // but the in_reply_to lookup is fast with index.
+            let refs_slice: Option<&[String]> = if env.references.is_empty() {
+                None
+            } else {
+                Some(env.references.as_slice())
+            };
             let thread_id = db::messages::compute_thread_id(
                 &conn,
                 account_id,
                 env.message_id.as_deref(),
                 env.in_reply_to.as_deref(),
                 env.subject.as_deref(),
+                refs_slice,
             );
 
             let new_msg = db::messages::NewMessage {

--- a/src/__tests__/messages-selection.test.ts
+++ b/src/__tests__/messages-selection.test.ts
@@ -213,7 +213,8 @@ describe("Mark as read", () => {
     store.threadMessages = {
       t1: [makeSummary("msg1", []), makeSummary("msg2", ["seen"])],
     };
-    store.expandedThreads = ["t1"];
+    // Threads are expanded by default; clear any persisted collapse state.
+    store.collapsedThreads = [];
 
     store.selectMessage("msg1", noMod);
 

--- a/src/__tests__/regression.test.ts
+++ b/src/__tests__/regression.test.ts
@@ -152,10 +152,10 @@ describe("Regression: selection", () => {
     expect(container.exists()).toBe(true);
   });
 
-  it("BUG: expandedThreads and threadMessages must use array/object not Set/Map", () => {
+  it("BUG: collapsedThreads and threadMessages must use array/object not Set/Map", () => {
     // Previously used Set/Map which caused Vue reactivity issues.
     const store = setupStores(true);
-    expect(Array.isArray(store.expandedThreads)).toBe(true);
+    expect(Array.isArray(store.collapsedThreads)).toBe(true);
     expect(typeof store.threadMessages).toBe("object");
     expect(store.threadMessages).not.toBeInstanceOf(Map);
   });

--- a/src/__tests__/threads-expansion.test.ts
+++ b/src/__tests__/threads-expansion.test.ts
@@ -1,0 +1,159 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createPinia, setActivePinia } from "pinia";
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn().mockResolvedValue(() => {}),
+}));
+
+const { getThreadMessagesMock, getThreadedMessagesMock } = vi.hoisted(() => ({
+  getThreadMessagesMock: vi.fn(),
+  getThreadedMessagesMock: vi.fn(),
+}));
+
+vi.mock("@/lib/tauri", () => ({
+  listAccounts: vi.fn().mockResolvedValue([]),
+  listFolders: vi.fn().mockResolvedValue([]),
+  triggerSync: vi.fn().mockResolvedValue(undefined),
+  getMessages: vi
+    .fn()
+    .mockResolvedValue({ messages: [], total: 0, page: 0, per_page: 100 }),
+  getThreadedMessages: getThreadedMessagesMock,
+  getThreadMessages: getThreadMessagesMock,
+  getMessageBody: vi.fn().mockResolvedValue(null),
+  setMessageFlags: vi.fn().mockResolvedValue(undefined),
+  deleteMessages: vi.fn().mockResolvedValue(undefined),
+  prefetchBodies: vi.fn().mockResolvedValue(0),
+}));
+
+import { useAccountsStore } from "@/stores/accounts";
+import { useFoldersStore } from "@/stores/folders";
+import { useUiStore } from "@/stores/ui";
+import { useMessagesStore } from "@/stores/messages";
+
+function withActiveContext() {
+  const accountsStore = useAccountsStore();
+  accountsStore.accounts = [
+    {
+      id: "acc1",
+      display_name: "Test",
+      email: "test@example.com",
+      provider: "generic",
+      mail_protocol: "imap" as const,
+      enabled: true,
+    },
+  ];
+  accountsStore.activeAccountId = "acc1";
+  const foldersStore = useFoldersStore();
+  foldersStore.activeFolderPath = "INBOX";
+}
+
+function makeThread(id: string, messageCount = 2) {
+  return {
+    thread_id: id,
+    subject: `Subject ${id}`,
+    last_date: "2026-04-26T00:00:00Z",
+    message_count: messageCount,
+    unread_count: 0,
+    from_name: "Alice",
+    from_email: "alice@example.com",
+    has_attachments: false,
+    flags: [],
+    snippet: null,
+    message_ids: Array.from({ length: messageCount }, (_, i) => `${id}_${i}`),
+  };
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+  localStorage.clear();
+  getThreadMessagesMock.mockReset();
+  getThreadedMessagesMock.mockReset();
+});
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+describe("Thread expansion", () => {
+  it("treats threads as expanded by default", () => {
+    const store = useMessagesStore();
+    expect(store.collapsedThreads).toEqual([]);
+    expect(store.isThreadExpanded("any-id")).toBe(true);
+  });
+
+  it("loads stored collapsed list from localStorage on init", () => {
+    localStorage.setItem("chithi-collapsed-threads", JSON.stringify(["t1", "t2"]));
+    const store = useMessagesStore();
+    expect(store.collapsedThreads).toEqual(["t1", "t2"]);
+    expect(store.isThreadExpanded("t1")).toBe(false);
+    expect(store.isThreadExpanded("t3")).toBe(true);
+  });
+
+  it("toggleThread collapses an expanded thread and persists", async () => {
+    const store = useMessagesStore();
+    await store.toggleThread("t1");
+    expect(store.collapsedThreads).toContain("t1");
+    expect(JSON.parse(localStorage.getItem("chithi-collapsed-threads") ?? "[]"))
+      .toContain("t1");
+  });
+
+  it("toggleThread re-expands a collapsed thread and fetches children", async () => {
+    withActiveContext();
+    getThreadMessagesMock.mockResolvedValue([
+      { id: "t1_0" }, { id: "t1_1" },
+    ]);
+    const store = useMessagesStore();
+    store.collapsedThreads = ["t1"];
+
+    await store.toggleThread("t1");
+    expect(store.collapsedThreads).not.toContain("t1");
+    expect(getThreadMessagesMock).toHaveBeenCalledWith("acc1", "INBOX", "t1");
+    expect(store.threadMessages.t1).toHaveLength(2);
+  });
+
+  it("fetchMessages preserves collapsedThreads across syncs", async () => {
+    withActiveContext();
+    useUiStore().setThreading(true);
+    getThreadedMessagesMock.mockResolvedValue({
+      threads: [makeThread("t1"), makeThread("t2")],
+      total_threads: 2,
+      total_messages: 4,
+      page: 0,
+      per_page: 100,
+    });
+    getThreadMessagesMock.mockResolvedValue([]);
+
+    const store = useMessagesStore();
+    store.collapsedThreads = ["t1"];
+
+    await store.fetchMessages();
+    expect(store.collapsedThreads).toEqual(["t1"]);
+  });
+
+  it("fetchMessages prefetches children only for expanded threads", async () => {
+    withActiveContext();
+    useUiStore().setThreading(true);
+    getThreadedMessagesMock.mockResolvedValue({
+      threads: [makeThread("t1"), makeThread("t2"), makeThread("t3", 1)],
+      total_threads: 3,
+      total_messages: 5,
+      page: 0,
+      per_page: 100,
+    });
+    getThreadMessagesMock.mockImplementation((_acc, _folder, id) => {
+      return Promise.resolve([{ id: `${id}_0` }, { id: `${id}_1` }]);
+    });
+
+    const store = useMessagesStore();
+    store.collapsedThreads = ["t2"];
+
+    await store.fetchMessages();
+
+    // t1 expanded + multi-msg → fetched
+    expect(getThreadMessagesMock).toHaveBeenCalledWith("acc1", "INBOX", "t1");
+    // t2 collapsed → skipped
+    expect(getThreadMessagesMock).not.toHaveBeenCalledWith("acc1", "INBOX", "t2");
+    // t3 single message → no fetch needed
+    expect(getThreadMessagesMock).not.toHaveBeenCalledWith("acc1", "INBOX", "t3");
+  });
+});

--- a/src/components/mail/FolderTree.vue
+++ b/src/components/mail/FolderTree.vue
@@ -186,6 +186,18 @@ async function syncThisFolder() {
   }
 }
 
+/**
+ * Microsoft 365 (Graph) syncs at the account level — there is no
+ * cheap per-folder fetch like there is for IMAP/JMAP. Hiding the
+ * "Sync this folder" entry for Graph accounts avoids the surprise
+ * where a right-click on Inbox kicks off a multi-minute full-account
+ * sync that looks like the UI has hung.
+ */
+function isGraphAccount(accountId: string): boolean {
+  const acc = accountsStore.accounts.find((a) => a.id === accountId);
+  return acc?.mail_protocol === "graph";
+}
+
 
 function openNewFolderModal() {
   if (!contextMenu.value) return;
@@ -506,7 +518,12 @@ async function doDeleteFolder() {
         <button class="ctx-item danger" data-testid="ctx-delete-folder" @click="confirmDeleteFolder">Delete Folder</button>
         <div class="ctx-separator"></div>
         <button class="ctx-item disabled">Properties</button>
-        <button class="ctx-item" data-testid="ctx-sync-folder" @click="syncThisFolder">
+        <button
+          v-if="!isGraphAccount(contextMenu.accountId)"
+          class="ctx-item"
+          data-testid="ctx-sync-folder"
+          @click="syncThisFolder"
+        >
           Sync "{{ contextMenu.folder.name }}"
         </button>
       </div>

--- a/src/components/mail/FolderTree.vue
+++ b/src/components/mail/FolderTree.vue
@@ -186,18 +186,6 @@ async function syncThisFolder() {
   }
 }
 
-/**
- * Microsoft 365 (Graph) syncs at the account level — there is no
- * cheap per-folder fetch like there is for IMAP/JMAP. Hiding the
- * "Sync this folder" entry for Graph accounts avoids the surprise
- * where a right-click on Inbox kicks off a multi-minute full-account
- * sync that looks like the UI has hung.
- */
-function isGraphAccount(accountId: string): boolean {
-  const acc = accountsStore.accounts.find((a) => a.id === accountId);
-  return acc?.mail_protocol === "graph";
-}
-
 
 function openNewFolderModal() {
   if (!contextMenu.value) return;
@@ -518,12 +506,7 @@ async function doDeleteFolder() {
         <button class="ctx-item danger" data-testid="ctx-delete-folder" @click="confirmDeleteFolder">Delete Folder</button>
         <div class="ctx-separator"></div>
         <button class="ctx-item disabled">Properties</button>
-        <button
-          v-if="!isGraphAccount(contextMenu.accountId)"
-          class="ctx-item"
-          data-testid="ctx-sync-folder"
-          @click="syncThisFolder"
-        >
+        <button class="ctx-item" data-testid="ctx-sync-folder" @click="syncThisFolder">
           Sync "{{ contextMenu.folder.name }}"
         </button>
       </div>

--- a/src/components/mail/MessageList.vue
+++ b/src/components/mail/MessageList.vue
@@ -647,7 +647,7 @@ function resolveFolderName(path: string): string {
             v-for="entry in childrenWithDepth(thread.thread_id)"
             :key="entry.message.id"
             class="thread-child"
-            :style="{ paddingLeft: 16 + entry.depth * 18 + 'px' }"
+            :style="`--reply-depth: ${entry.depth}`"
             @click.stop="onChildSelect(entry.message.id)"
             @contextmenu.prevent.stop="onRowRightClick($event, entry.message.id)"
             @mousedown="onDragMouseDown($event, entry.message.id)"
@@ -921,9 +921,14 @@ function resolveFolderName(path: string): string {
 }
 
 .thread-child {
-  /* padding-left is computed per row from the reply depth (see
-     childrenWithDepth + the inline style on .thread-child rows). */
   background: var(--color-bg-tertiary);
+  /* `--reply-depth` is set as an inline custom property per row from
+     childrenWithDepth(). margin-left pushes the row's box, which is
+     more robust than padding when MessageListItem's own layout
+     constrains its content. The 22px step lines up with the typical
+     row height so the indentation tree reads cleanly. */
+  margin-left: calc(20px + var(--reply-depth, 0) * 22px);
+  border-left: 2px solid var(--color-border);
 }
 
 .loading-more {

--- a/src/components/mail/MessageList.vue
+++ b/src/components/mail/MessageList.vue
@@ -465,18 +465,6 @@ interface ThreadChildEntry {
 }
 
 /**
- * Build a depth-annotated, in-order list of a thread's children
- * (everything except the root message). Depth comes from walking
- * `in_reply_to` against `message_id` of other messages in the same
- * thread; messages whose parent isn't in the chain — including all
- * Microsoft Graph messages, since the Graph sync stores
- * `in_reply_to: None` — collapse to depth 0 alongside other roots.
- *
- * Children are emitted depth-first under each parent (a parent's
- * subtree comes before the next sibling) so the visual tree
- * matches the conversation flow.
- */
-/**
  * Strip surrounding angle brackets and whitespace so a Message-ID
  * stored as `<mid@host>` by one backend lines up with the same id
  * stored as `mid@host` by another. Matching is case-sensitive
@@ -489,6 +477,18 @@ function normMid(s: string | null | undefined): string | null {
   return trimmed.replace(/^<+/, "").replace(/>+$/, "");
 }
 
+/**
+ * Build a depth-annotated, in-order list of a thread's children
+ * (everything except the root message). Depth comes from walking
+ * `in_reply_to` against `message_id` of other messages in the same
+ * thread; messages whose parent isn't in the chain — including all
+ * Microsoft Graph messages, since the Graph sync stores
+ * `in_reply_to: None` — collapse to depth 0 alongside other roots.
+ *
+ * Children are emitted depth-first under each parent (a parent's
+ * subtree comes before the next sibling) so the visual tree
+ * matches the conversation flow.
+ */
 function childrenWithDepth(threadId: string): ThreadChildEntry[] {
   const all = messagesStore.threadMessages[threadId] ?? [];
   if (all.length <= 1) return [];

--- a/src/components/mail/MessageList.vue
+++ b/src/components/mail/MessageList.vue
@@ -459,6 +459,95 @@ function formatHitDate(secs: number): string {
   return new Date(secs * 1000).toLocaleDateString();
 }
 
+interface ThreadChildEntry {
+  message: import("@/lib/types").MessageSummary;
+  depth: number;
+}
+
+/**
+ * Build a depth-annotated, in-order list of a thread's children
+ * (everything except the root message). Depth comes from walking
+ * `in_reply_to` against `message_id` of other messages in the same
+ * thread; messages whose parent isn't in the chain — including all
+ * Microsoft Graph messages, since the Graph sync stores
+ * `in_reply_to: None` — collapse to depth 0 alongside other roots.
+ *
+ * Children are emitted depth-first under each parent (a parent's
+ * subtree comes before the next sibling) so the visual tree
+ * matches the conversation flow.
+ */
+function childrenWithDepth(threadId: string): ThreadChildEntry[] {
+  const all = messagesStore.threadMessages[threadId] ?? [];
+  if (all.length <= 1) return [];
+
+  const root = all[0];
+  const rest = all.slice(1);
+
+  // Index every message in the thread (including the root) by its
+  // Message-ID so children can find their parent.
+  const byMid = new Map<string, import("@/lib/types").MessageSummary>();
+  for (const m of all) {
+    if (m.message_id) byMid.set(m.message_id, m);
+  }
+
+  // depthFor caches per id.
+  const depthCache = new Map<string, number>();
+  function depthFor(m: import("@/lib/types").MessageSummary, seen: Set<string>): number {
+    const cached = depthCache.get(m.id);
+    if (cached !== undefined) return cached;
+    if (!m.in_reply_to) {
+      depthCache.set(m.id, 0);
+      return 0;
+    }
+    const parent = byMid.get(m.in_reply_to);
+    if (!parent || parent.id === m.id || seen.has(parent.id)) {
+      depthCache.set(m.id, 0);
+      return 0;
+    }
+    seen.add(parent.id);
+    const parentDepth = parent.id === root.id ? 0 : depthFor(parent, seen) + 1;
+    depthCache.set(m.id, parentDepth);
+    return parentDepth;
+  }
+
+  // Group children by their direct parent for depth-first emission.
+  const childrenByParent = new Map<string, import("@/lib/types").MessageSummary[]>();
+  const orphans: import("@/lib/types").MessageSummary[] = [];
+  for (const m of rest) {
+    const parentMid = m.in_reply_to;
+    if (parentMid && byMid.has(parentMid)) {
+      const arr = childrenByParent.get(parentMid) ?? [];
+      arr.push(m);
+      childrenByParent.set(parentMid, arr);
+    } else {
+      orphans.push(m);
+    }
+  }
+
+  const out: ThreadChildEntry[] = [];
+  function emitChildrenOf(parentMid: string | null, depth: number) {
+    const set = parentMid === null ? orphans : childrenByParent.get(parentMid) ?? [];
+    for (const m of set) {
+      out.push({ message: m, depth });
+      if (m.message_id) emitChildrenOf(m.message_id, depth + 1);
+    }
+  }
+  // Root's direct children at depth 0; orphans (no parent in thread)
+  // also at depth 0 so Graph threads render flat.
+  if (root.message_id) emitChildrenOf(root.message_id, 0);
+  emitChildrenOf(null, 0);
+
+  // Fall back to the precomputed depth map for any leftover
+  // (shouldn't happen with the emission above, but it's a safety net).
+  for (const m of rest) {
+    if (!out.some((e) => e.message.id === m.id)) {
+      out.push({ message: m, depth: depthFor(m, new Set()) });
+    }
+  }
+
+  return out;
+}
+
 // JMAP and Graph hits report the backend's folder/mailbox ID, which is
 // opaque to the user. Build a path -> name index once per folder-tree
 // change so rendering N hits stays O(N) instead of O(N * folder_count).
@@ -543,26 +632,27 @@ function resolveFolderName(path: string): string {
             @toggle-star="messagesStore.toggleStar(thread.message_ids[0])"
           />
         </div>
-        <!-- Expanded thread messages -->
+        <!-- Expanded thread messages, indented by reply-depth -->
         <template v-if="messagesStore.isThreadExpanded(thread.thread_id)">
           <div
-            v-for="msg in (messagesStore.threadMessages[thread.thread_id] ?? []).slice(1)"
-            :key="msg.id"
+            v-for="entry in childrenWithDepth(thread.thread_id)"
+            :key="entry.message.id"
             class="thread-child"
-            @click.stop="onChildSelect(msg.id)"
-            @contextmenu.prevent.stop="onRowRightClick($event, msg.id)"
-            @mousedown="onDragMouseDown($event, msg.id)"
+            :style="{ paddingLeft: 16 + entry.depth * 18 + 'px' }"
+            @click.stop="onChildSelect(entry.message.id)"
+            @contextmenu.prevent.stop="onRowRightClick($event, entry.message.id)"
+            @mousedown="onDragMouseDown($event, entry.message.id)"
           >
             <MessageListItem
-              :message="msg"
-              :active="messagesStore.activeMessageId === msg.id"
-              :selected="messagesStore.isSelected(msg.id)"
+              :message="entry.message"
+              :active="messagesStore.activeMessageId === entry.message.id"
+              :selected="messagesStore.isSelected(entry.message.id)"
               :mode="props.mode"
-              @toggle="messagesStore.toggleSelectMessage(msg.id)"
-              @open="onOpen(msg.id)"
-              @toggle-star="messagesStore.toggleStar(msg.id)"
-              @archive="onMobileSwipeArchive(msg.id)"
-              @delete="onMobileSwipeDelete(msg.id)"
+              @toggle="messagesStore.toggleSelectMessage(entry.message.id)"
+              @open="onOpen(entry.message.id)"
+              @toggle-star="messagesStore.toggleStar(entry.message.id)"
+              @archive="onMobileSwipeArchive(entry.message.id)"
+              @delete="onMobileSwipeDelete(entry.message.id)"
             />
           </div>
         </template>

--- a/src/components/mail/MessageList.vue
+++ b/src/components/mail/MessageList.vue
@@ -481,9 +481,11 @@ function normMid(s: string | null | undefined): string | null {
  * Build a depth-annotated, in-order list of a thread's children
  * (everything except the root message). Depth comes from walking
  * `in_reply_to` against `message_id` of other messages in the same
- * thread; messages whose parent isn't in the chain — including all
- * Microsoft Graph messages, since the Graph sync stores
- * `in_reply_to: None` — collapse to depth 0 alongside other roots.
+ * thread; messages whose parent isn't in the chain collapse to
+ * depth 0 alongside other roots. This can still happen for
+ * Microsoft Graph messages when `in_reply_to` could not be
+ * backfilled from `internetMessageHeaders` or when the parent
+ * message is unavailable in the thread.
  *
  * Children are emitted depth-first under each parent (a parent's
  * subtree comes before the next sibling) so the visual tree

--- a/src/components/mail/MessageList.vue
+++ b/src/components/mail/MessageList.vue
@@ -476,6 +476,19 @@ interface ThreadChildEntry {
  * subtree comes before the next sibling) so the visual tree
  * matches the conversation flow.
  */
+/**
+ * Strip surrounding angle brackets and whitespace so a Message-ID
+ * stored as `<mid@host>` by one backend lines up with the same id
+ * stored as `mid@host` by another. Matching is case-sensitive
+ * (Message-IDs are technically case-sensitive per RFC 5322).
+ */
+function normMid(s: string | null | undefined): string | null {
+  if (!s) return null;
+  const trimmed = s.trim();
+  if (trimmed.length === 0) return null;
+  return trimmed.replace(/^<+/, "").replace(/>+$/, "");
+}
+
 function childrenWithDepth(threadId: string): ThreadChildEntry[] {
   const all = messagesStore.threadMessages[threadId] ?? [];
   if (all.length <= 1) return [];
@@ -483,38 +496,21 @@ function childrenWithDepth(threadId: string): ThreadChildEntry[] {
   const root = all[0];
   const rest = all.slice(1);
 
-  // Index every message in the thread (including the root) by its
-  // Message-ID so children can find their parent.
+  // Index every message in the thread by its normalised Message-ID so
+  // children can find their parent regardless of angle-bracket
+  // conventions on either side.
   const byMid = new Map<string, import("@/lib/types").MessageSummary>();
   for (const m of all) {
-    if (m.message_id) byMid.set(m.message_id, m);
+    const mid = normMid(m.message_id);
+    if (mid) byMid.set(mid, m);
   }
 
-  // depthFor caches per id.
-  const depthCache = new Map<string, number>();
-  function depthFor(m: import("@/lib/types").MessageSummary, seen: Set<string>): number {
-    const cached = depthCache.get(m.id);
-    if (cached !== undefined) return cached;
-    if (!m.in_reply_to) {
-      depthCache.set(m.id, 0);
-      return 0;
-    }
-    const parent = byMid.get(m.in_reply_to);
-    if (!parent || parent.id === m.id || seen.has(parent.id)) {
-      depthCache.set(m.id, 0);
-      return 0;
-    }
-    seen.add(parent.id);
-    const parentDepth = parent.id === root.id ? 0 : depthFor(parent, seen) + 1;
-    depthCache.set(m.id, parentDepth);
-    return parentDepth;
-  }
-
-  // Group children by their direct parent for depth-first emission.
+  // Group children by their direct parent's normalised Message-ID so
+  // depth-first emission keeps the conversation flow.
   const childrenByParent = new Map<string, import("@/lib/types").MessageSummary[]>();
   const orphans: import("@/lib/types").MessageSummary[] = [];
   for (const m of rest) {
-    const parentMid = m.in_reply_to;
+    const parentMid = normMid(m.in_reply_to);
     if (parentMid && byMid.has(parentMid)) {
       const arr = childrenByParent.get(parentMid) ?? [];
       arr.push(m);
@@ -524,24 +520,37 @@ function childrenWithDepth(threadId: string): ThreadChildEntry[] {
     }
   }
 
+  if (typeof window !== "undefined" && (window as { __THREAD_DEBUG__?: boolean }).__THREAD_DEBUG__) {
+    console.log("[thread]", threadId, {
+      total: all.length,
+      bymid_keys: Array.from(byMid.keys()),
+      childrenOf: Array.from(childrenByParent.entries()).map(([k, v]) => [k, v.length]),
+      orphans: orphans.length,
+      messages: all.map((m) => ({ id: m.id, mid: m.message_id, irt: m.in_reply_to })),
+    });
+  }
   const out: ThreadChildEntry[] = [];
+  const emitted = new Set<string>();
   function emitChildrenOf(parentMid: string | null, depth: number) {
     const set = parentMid === null ? orphans : childrenByParent.get(parentMid) ?? [];
     for (const m of set) {
+      if (emitted.has(m.id)) continue;
+      emitted.add(m.id);
       out.push({ message: m, depth });
-      if (m.message_id) emitChildrenOf(m.message_id, depth + 1);
+      const childMid = normMid(m.message_id);
+      if (childMid) emitChildrenOf(childMid, depth + 1);
     }
   }
-  // Root's direct children at depth 0; orphans (no parent in thread)
-  // also at depth 0 so Graph threads render flat.
-  if (root.message_id) emitChildrenOf(root.message_id, 0);
+  const rootMid = normMid(root.message_id);
+  if (rootMid) emitChildrenOf(rootMid, 0);
   emitChildrenOf(null, 0);
 
-  // Fall back to the precomputed depth map for any leftover
-  // (shouldn't happen with the emission above, but it's a safety net).
+  // Safety net: anything we somehow missed (cycle, unreachable parent)
+  // gets emitted at depth 0 so it's still visible.
   for (const m of rest) {
-    if (!out.some((e) => e.message.id === m.id)) {
-      out.push({ message: m, depth: depthFor(m, new Set()) });
+    if (!emitted.has(m.id)) {
+      emitted.add(m.id);
+      out.push({ message: m, depth: 0 });
     }
   }
 
@@ -912,7 +921,8 @@ function resolveFolderName(path: string): string {
 }
 
 .thread-child {
-  padding-left: 20px;
+  /* padding-left is computed per row from the reply depth (see
+     childrenWithDepth + the inline style on .thread-child rows). */
   background: var(--color-bg-tertiary);
 }
 

--- a/src/components/mail/MessageList.vue
+++ b/src/components/mail/MessageList.vue
@@ -534,7 +534,7 @@ function resolveFolderName(path: string): string {
         >
           <ThreadRow
             :thread="thread"
-            :expanded="messagesStore.expandedThreads.includes(thread.thread_id)"
+            :expanded="messagesStore.isThreadExpanded(thread.thread_id)"
             :active="thread.message_ids.includes(messagesStore.activeMessageId ?? '')"
             :selected="messagesStore.isSelected(thread.message_ids[0])"
             @toggle="messagesStore.toggleThread(thread.thread_id)"
@@ -544,7 +544,7 @@ function resolveFolderName(path: string): string {
           />
         </div>
         <!-- Expanded thread messages -->
-        <template v-if="messagesStore.expandedThreads.includes(thread.thread_id)">
+        <template v-if="messagesStore.isThreadExpanded(thread.thread_id)">
           <div
             v-for="msg in (messagesStore.threadMessages[thread.thread_id] ?? []).slice(1)"
             :key="msg.id"

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -265,6 +265,9 @@ export interface ComposeMessage {
   body_text: string;
   body_html: string | null;
   attachments: ComposeAttachment[];
+  /** chithi's internal id of the message being replied to. Drives
+   *  In-Reply-To / References on the outgoing email. Omit for new mails. */
+  reply_to_message_id?: string | null;
 }
 
 export interface ComposeAttachment {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -68,6 +68,10 @@ export interface MessageSummary {
   is_encrypted: boolean;
   is_signed: boolean;
   snippet: string | null;
+  /** RFC 5322 Message-ID with angle brackets, used to build reply trees. */
+  message_id: string | null;
+  /** Parent Message-ID for in-thread hierarchical rendering. */
+  in_reply_to: string | null;
 }
 
 export interface MessageBody {

--- a/src/stores/messages.ts
+++ b/src/stores/messages.ts
@@ -394,8 +394,16 @@ export const useMessagesStore = defineStore("messages", () => {
         const accountId = accountsStore.activeAccountId;
         const folderPath = foldersStore.activeFolderPath;
         if (accountId && folderPath) {
-          const msgs = await api.getThreadMessages(accountId, folderPath, threadId);
-          threadMessages.value = { ...threadMessages.value, [threadId]: msgs };
+          try {
+            const msgs = await api.getThreadMessages(accountId, folderPath, threadId);
+            threadMessages.value = { ...threadMessages.value, [threadId]: msgs };
+          } catch (err) {
+            // The lazy fetch failed (network/IPC error). Roll the expansion
+            // back so the row state matches the "no children loaded" reality
+            // and the user can retry.
+            console.error("toggleThread: failed to load thread children", err);
+            collapsedThreads.value = [...collapsedThreads.value, threadId];
+          }
         }
       }
     } else {

--- a/src/stores/messages.ts
+++ b/src/stores/messages.ts
@@ -35,10 +35,38 @@ export type SortColumn = "subject" | "from" | "date" | "flagged";
 export const useMessagesStore = defineStore("messages", () => {
   // Flat mode state
   const messages = ref<MessageSummary[]>([]);
-  // Threaded mode state
+  // Threaded mode state.
+  // `collapsedThreads` is the inverse of an expansion list: every visible
+  // thread is treated as expanded by default, and only ids the user has
+  // explicitly collapsed are tracked. The list survives folder/account
+  // changes and incremental syncs so toggling stays sticky. Persisted to
+  // localStorage so it also survives app restart.
+  const COLLAPSED_KEY = "chithi-collapsed-threads";
   const threads = ref<ThreadSummary[]>([]);
-  const expandedThreads = ref<string[]>([]);
+  const collapsedThreads = ref<string[]>(loadCollapsedThreads());
   const threadMessages = ref<Record<string, MessageSummary[]>>({});
+
+  function loadCollapsedThreads(): string[] {
+    try {
+      const raw = localStorage.getItem(COLLAPSED_KEY);
+      const parsed: unknown = raw ? JSON.parse(raw) : [];
+      return Array.isArray(parsed) ? parsed.filter((x) => typeof x === "string") : [];
+    } catch {
+      return [];
+    }
+  }
+
+  function persistCollapsedThreads() {
+    try {
+      localStorage.setItem(COLLAPSED_KEY, JSON.stringify(collapsedThreads.value));
+    } catch {
+      // ignore quota / private-mode failures; in-memory state still works
+    }
+  }
+
+  function isThreadExpanded(threadId: string): boolean {
+    return !collapsedThreads.value.includes(threadId);
+  }
 
   const activeMessage = ref<MessageBody | null>(null);
   const activeMessageId = ref<string | null>(null);
@@ -232,7 +260,8 @@ export const useMessagesStore = defineStore("messages", () => {
       page.value = 0;
       // Don't clear messages/threads here — causes UI flicker.
       // They get replaced atomically after the API call returns.
-      expandedThreads.value = [];
+      // collapsedThreads is intentionally preserved across syncs and
+      // folder/account switches so the user's toggle state is sticky.
       threadMessages.value = {};
     }
     loading.value = true;
@@ -254,6 +283,10 @@ export const useMessagesStore = defineStore("messages", () => {
         }
         totalThreads.value = result.total_threads;
         total.value = result.total_messages;
+        // Threads are expanded by default. Pre-fetch children for every
+        // multi-message thread that the user hasn't collapsed so the rows
+        // render without a per-thread loading flash.
+        await prefetchExpandedChildren(accountId, folderPath, result.threads);
       } else {
         const result = await api.getMessages(
           accountId,
@@ -274,6 +307,41 @@ export const useMessagesStore = defineStore("messages", () => {
     } finally {
       loading.value = false;
     }
+  }
+
+  /**
+   * Fetch child message lists for every visible multi-message thread the
+   * user has not explicitly collapsed. Existing entries in
+   * `threadMessages` are skipped so re-renders don't refetch.
+   */
+  async function prefetchExpandedChildren(
+    accountId: string,
+    folderPath: string,
+    targets: ThreadSummary[],
+  ) {
+    const todo = targets.filter(
+      (t) =>
+        t.message_count > 1 &&
+        !collapsedThreads.value.includes(t.thread_id) &&
+        !threadMessages.value[t.thread_id],
+    );
+    if (todo.length === 0) return;
+    const fetched = await Promise.all(
+      todo.map(async (t): Promise<[string, MessageSummary[]]> => {
+        try {
+          const msgs = await api.getThreadMessages(accountId, folderPath, t.thread_id);
+          return [t.thread_id, msgs];
+        } catch (e) {
+          console.error(`Failed to prefetch thread ${t.thread_id}:`, e);
+          return [t.thread_id, []];
+        }
+      }),
+    );
+    const next = { ...threadMessages.value };
+    for (const [id, msgs] of fetched) {
+      if (msgs.length > 0) next[id] = msgs;
+    }
+    threadMessages.value = next;
   }
 
   async function loadNextPage() {
@@ -298,6 +366,7 @@ export const useMessagesStore = defineStore("messages", () => {
         threads.value = [...threads.value, ...result.threads];
         totalThreads.value = result.total_threads;
         total.value = result.total_messages;
+        await prefetchExpandedChildren(accountId, folderPath, result.threads);
       } else {
         const result = await api.getMessages(
           accountId,
@@ -317,19 +386,22 @@ export const useMessagesStore = defineStore("messages", () => {
   }
 
   async function toggleThread(threadId: string) {
-    const idx = expandedThreads.value.indexOf(threadId);
+    const idx = collapsedThreads.value.indexOf(threadId);
     if (idx !== -1) {
-      expandedThreads.value.splice(idx, 1);
-    } else {
+      // Currently collapsed -> expand. Make sure children are loaded.
+      collapsedThreads.value.splice(idx, 1);
       if (!threadMessages.value[threadId]) {
         const accountId = accountsStore.activeAccountId;
         const folderPath = foldersStore.activeFolderPath;
-        if (!accountId || !folderPath) return;
-        const msgs = await api.getThreadMessages(accountId, folderPath, threadId);
-        threadMessages.value = { ...threadMessages.value, [threadId]: msgs };
+        if (accountId && folderPath) {
+          const msgs = await api.getThreadMessages(accountId, folderPath, threadId);
+          threadMessages.value = { ...threadMessages.value, [threadId]: msgs };
+        }
       }
-      expandedThreads.value.push(threadId);
+    } else {
+      collapsedThreads.value = [...collapsedThreads.value, threadId];
     }
+    persistCollapsedThreads();
   }
 
   async function showAsThread(messageId: string) {
@@ -341,8 +413,12 @@ export const useMessagesStore = defineStore("messages", () => {
     const threadMsgs = await api.getThreadMessages(accountId, folderPath, messageId);
     if (threadMsgs.length > 1) {
       threadMessages.value = { ...threadMessages.value, [messageId]: threadMsgs };
-      if (!expandedThreads.value.includes(messageId)) {
-        expandedThreads.value.push(messageId);
+      // Threads are expanded by default — make sure this one is too,
+      // even if the user had it on their collapsed list.
+      const idx = collapsedThreads.value.indexOf(messageId);
+      if (idx !== -1) {
+        collapsedThreads.value.splice(idx, 1);
+        persistCollapsedThreads();
       }
     }
   }
@@ -496,7 +572,7 @@ export const useMessagesStore = defineStore("messages", () => {
       const ids: string[] = [];
       for (const thread of threads.value) {
         ids.push(thread.message_ids[0]);
-        if (expandedThreads.value.includes(thread.thread_id)) {
+        if (isThreadExpanded(thread.thread_id)) {
           const children = threadMessages.value[thread.thread_id] ?? [];
           for (const msg of children) {
             ids.push(msg.id);
@@ -723,7 +799,8 @@ export const useMessagesStore = defineStore("messages", () => {
   return {
     messages,
     threads,
-    expandedThreads,
+    collapsedThreads,
+    isThreadExpanded,
     threadMessages,
     activeMessage,
     activeMessageId,

--- a/src/views/ComposeView.vue
+++ b/src/views/ComposeView.vue
@@ -380,6 +380,7 @@ async function saveDraft(): Promise<boolean> {
       body_text: bodyText.value,
       body_html: null,
       attachments: attachments.value,
+      reply_to_message_id: replyToMessageId || null,
     });
     markDraftStateAsClean();
     // Trigger a sync so the draft appears in the local mailbox
@@ -489,6 +490,7 @@ async function send() {
       body_text: bodyText.value,
       body_html: null,
       attachments: attachments.value,
+      reply_to_message_id: replyToMessageId || null,
     });
     if (replyToMessageId) {
       api.setMessageFlags(accountId, [replyToMessageId], ["answered"], true)


### PR DESCRIPTION
Fixes: #123.

## Summary

Two threading fixes in one PR:

1. **Persist expansion state and default-expand all threads**.
   - `collapsedThreads` replaces `expandedThreads`; only ids the user has explicitly collapsed are tracked, persisted to `localStorage` under `chithi-collapsed-threads`.
   - Survives folder switches, sync events, app restarts.
   - `fetchMessages` pre-fetches children for every multi-message thread not on the collapsed list, in parallel, so rows render without per-thread loading flicker.

2. **Canonicalize Message-IDs so replies actually nest beyond one level**.
   - Root cause: some IMAP servers (notably Microsoft Exchange/M365) emit a leading whitespace inside the bracketed `Message-Id` envelope value. Children's `In-Reply-To` arrived clean, so the exact-match `WHERE message_id = ?` lookup in `compute_thread_id` silently failed and each reply got its own synthetic thread.
   - Pick a canonical form (`<core>`, no whitespace) and normalize at every storage seam: IMAP envelope decode, References + In-Reply-To header parsing, JMAP `parse_jmap_email`, Graph `internet_message_id` and `extract_message_ids`, compose's reply-chain walk, and defensively at the top of `compute_thread_id`.
   - `populate_references` now also fetches `IN-REPLY-TO` from the message body so envelopes that return NIL still link to their parent.
   - One-time `messageid_normalize_v1` migration rewrites already-stored `message_id` and `in_reply_to` to canonical form, then propagates parent `thread_id`s down via iterative set-based `UPDATE`s (capped at 32 passes), so existing fragmented threads heal without a fresh full sync.

## ⚠️ Migration note for reviewers

The migration rewrite landed in two commits. The **first** version (`fix(threads): canonicalize Message-IDs ...`) ran a per-row Rust loop with multiple SQL queries per message — on a real-world inbox it pegged the CPU for tens of seconds and was visibly heavy. It's already replaced (within the same commit, ahead of merge) with a pure-SQL set-based version: two `UPDATE` statements + iterative indexed self-join `UPDATE`s, capped at 32 passes. Finishes in well under a second on the test mailbox. The migration is gated behind `messageid_normalize_v1`, so it runs exactly once per database.

## Test plan

- [x] 201 cargo tests, 8 new in `mail::msgid::tests` (normalizer edge cases) + 5 new in `imap::tests` (`parse_threading_headers` unfolding/normalization).
- [x] 292 frontend tests, 6 in `src/__tests__/threads-expansion.test.ts`.
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [x] `pnpm build` clean (vue-tsc + vite).
- [x] Manually verified on IMAP, JMAP, and Graph accounts: previously flat threads now nest beyond one level after the migration runs at first launch.
- [x] Manually verified replying via chithi: outgoing message slots in under its parent on next sync.
- [ ] Reviewers: test on a real mailbox with deep historical threads.

## Cost note

The eager prefetch fires one `getThreadMessages` IPC per multi-message expanded thread. For modest inboxes (a few dozen threads) that's fine, but a folder with hundreds of threads could be chatty. A bulk endpoint that returns all children alongside the thread summaries would be the natural follow-up; not blocking this PR.