### PR TITLE
fix(sync): emit sync-started for Microsoft Graph syncs

### DIFF
--- a/src-tauri/src/commands/sync_cmd.rs
+++ b/src-tauri/src/commands/sync_cmd.rs
@@ -925,6 +925,24 @@ async fn sync_graph_account(
 
     let data_dir = app.state::<AppState>().data_dir.clone();
 
+    // Mirror sync_account / sync_jmap_account: emit sync-started so the
+    // activity store can mark the operation running and spin the StatusBar
+    // icon. Without this, Graph syncs are silent on the frontend.
+    let account_name = {
+        let conn = db_arc.reader();
+        db::accounts::get_account_full(&conn, account_id)
+            .map(|a| a.display_name)
+            .unwrap_or_else(|_| account_id.to_string())
+    };
+    app.emit(
+        "sync-started",
+        serde_json::json!({
+            "account_id": account_id,
+            "account_name": account_name,
+        }),
+    )
+    .ok();
+
     let token = graph::get_graph_token(account_id).await?;
     let client = GraphClient::new(&token);
 

--- a/src-tauri/src/commands/sync_cmd.rs
+++ b/src-tauri/src/commands/sync_cmd.rs
@@ -380,15 +380,9 @@ pub async fn sync_folder(
         db::accounts::get_account_full(&conn, &account_id)?
     };
 
-    // Emit sync-started for ALL protocols so the activity UI tracks every sync
-    app.emit(
-        "sync-started",
-        serde_json::json!({
-            "account_id": account_id,
-            "account_name": account.display_name,
-        }),
-    )
-    .ok();
+    // sync-started is emitted by each protocol-specific path below, so the
+    // activity store sees exactly one start per sync (sync_graph_account,
+    // sync_jmap_folder_public, and the IMAP branch each emit their own).
 
     let suspended_idle = if account.mail_protocol == "imap"
         && should_suspend_idle_for_imap_operation(&account.provider)
@@ -445,7 +439,18 @@ pub async fn sync_folder(
         )
         .await
     } else {
-        // IMAP path — for O365, refresh IMAP-scoped token
+        // IMAP path — sync_folder_envelopes_public is a low-level helper and
+        // doesn't emit sync-started itself, so do it here.
+        app.emit(
+            "sync-started",
+            serde_json::json!({
+                "account_id": account_id,
+                "account_name": account.display_name,
+            }),
+        )
+        .ok();
+
+        // For O365, refresh IMAP-scoped token
         let (password, use_xoauth2) = if account.provider == "o365" {
             let tokens = crate::oauth::load_tokens(&account_id)?
                 .ok_or_else(|| Error::Other("No O365 tokens".into()))?;


### PR DESCRIPTION
## Summary
- Fixes #115 — sync icon no longer spun during a sync.
- `sync_graph_account` was missing the `sync-started` emit that the IMAP and JMAP sync paths both have, so the activity store never marked a Graph sync as running and the StatusBar's `.spinning` class was never applied. Regressed in `cb08a43e` when O365 mail switched from IMAP to Graph.

## Test plan
- [x] `cargo check` / `cargo clippy` clean.
- [x] `pnpm vitest run` — 292 passing.
- [x] Manual: clicked Sync on an O365 account, icon spins for the duration of the sync and stops on completion.