### PR TITLE
feat(accounts+calendar): identity + service-bindings refactor, multi-calendar Graph (#43, #47)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -584,6 +584,7 @@ dependencies = [
  "dirs",
  "fern",
  "futures",
+ "hickory-resolver",
  "iana-time-zone",
  "icalendar",
  "imap",
@@ -1176,6 +1177,18 @@ name = "endi"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enum-as-inner"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "enumflags2"
@@ -1927,6 +1940,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hickory-proto"
+version = "0.24.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92652067c9ce6f66ce53cc38d1169daa36e6e7eb7dd3b63b5103bd9d97117248"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "enum-as-inner",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "idna",
+ "ipnet",
+ "once_cell",
+ "rand 0.8.5",
+ "thiserror 1.0.69",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.24.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbb117a1ca520e111743ab2f6688eddee69db4e0ea242545a604dce8a66fd22e"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-proto",
+ "ipconfig",
+ "lru-cache",
+ "once_cell",
+ "parking_lot",
+ "rand 0.8.5",
+ "resolv-conf",
+ "smallvec",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "hostname"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2332,6 +2390,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipconfig"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
+dependencies = [
+ "socket2",
+ "widestring",
+ "windows-registry",
+ "windows-result 0.4.1",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2695,6 +2766,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2734,6 +2811,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
  "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "lru-cache"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
+dependencies = [
+ "linked-hash-map",
 ]
 
 [[package]]
@@ -4316,6 +4402,12 @@ dependencies = [
  "wasm-streams 0.5.0",
  "web-sys",
 ]
+
+[[package]]
+name = "resolv-conf"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "rfd"
@@ -6609,6 +6701,12 @@ dependencies = [
  "windows",
  "windows-core 0.61.2",
 ]
+
+[[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
 name = "winapi"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -563,6 +563,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "charset"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -590,7 +601,7 @@ dependencies = [
  "imap",
  "imap-proto",
  "jmap-client",
- "jni",
+ "jni 0.21.1",
  "keyring",
  "lettre",
  "libc",
@@ -761,6 +772,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -768,6 +788,12 @@ checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-channel"
@@ -1177,18 +1203,6 @@ name = "endi"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
-
-[[package]]
-name = "enum-as-inner"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
-dependencies = [
- "heck 0.5.0",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
 
 [[package]]
 name = "enumflags2"
@@ -1703,6 +1717,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -1940,23 +1955,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "hickory-proto"
-version = "0.24.4"
+name = "hickory-net"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92652067c9ce6f66ce53cc38d1169daa36e6e7eb7dd3b63b5103bd9d97117248"
+checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
 dependencies = [
  "async-trait",
  "cfg-if",
  "data-encoding",
- "enum-as-inner",
  "futures-channel",
  "futures-io",
  "futures-util",
+ "hickory-proto",
  "idna",
  "ipnet",
- "once_cell",
- "rand 0.8.5",
- "thiserror 1.0.69",
+ "jni 0.22.4",
+ "rand 0.10.1",
+ "thiserror 2.0.18",
  "tinyvec",
  "tokio",
  "tracing",
@@ -1964,22 +1979,47 @@ dependencies = [
 ]
 
 [[package]]
-name = "hickory-resolver"
-version = "0.24.4"
+name = "hickory-proto"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbb117a1ca520e111743ab2f6688eddee69db4e0ea242545a604dce8a66fd22e"
+checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
+dependencies = [
+ "data-encoding",
+ "idna",
+ "ipnet",
+ "jni 0.22.4",
+ "once_cell",
+ "prefix-trie",
+ "rand 0.10.1",
+ "ring",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
 dependencies = [
  "cfg-if",
  "futures-util",
+ "hickory-net",
  "hickory-proto",
  "ipconfig",
- "lru-cache",
+ "ipnet",
+ "jni 0.22.4",
+ "moka",
+ "ndk-context",
  "once_cell",
  "parking_lot",
- "rand 0.8.5",
+ "rand 0.10.1",
  "resolv-conf",
  "smallvec",
- "thiserror 1.0.69",
+ "system-configuration",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -2407,6 +2447,9 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "iri-string"
@@ -2520,6 +2563,36 @@ dependencies = [
  "thiserror 1.0.69",
  "walkdir",
  "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2766,12 +2839,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2811,15 +2878,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
  "hashbrown 0.15.5",
-]
-
-[[package]]
-name = "lru-cache"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
-dependencies = [
- "linked-hash-map",
 ]
 
 [[package]]
@@ -3049,6 +3107,23 @@ dependencies = [
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "moka"
+version = "0.12.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid",
 ]
 
 [[package]]
@@ -3451,6 +3526,10 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
 
 [[package]]
 name = "oneshot"
@@ -3900,6 +3979,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3928,6 +4013,17 @@ name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
+name = "prefix-trie"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23370be78b7e5bcbb0cab4a02047eb040279a693c78daad04c2c5f1c24a83503"
+dependencies = [
+ "either",
+ "ipnet",
+ "num-traits",
+]
 
 [[package]]
 name = "prettyplease"
@@ -4143,6 +4239,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4198,6 +4305,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_distr"
@@ -4909,7 +5022,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -4920,7 +5033,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -4945,6 +5058,22 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "siphasher"
@@ -5207,6 +5336,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
+
+[[package]]
 name = "tantivy"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5364,7 +5499,7 @@ dependencies = [
  "gdkwayland-sys",
  "gdkx11-sys",
  "gtk",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "ndk",
@@ -5419,7 +5554,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "mime",
@@ -5644,7 +5779,7 @@ dependencies = [
  "dpi",
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "objc2",
  "objc2-ui-kit",
  "objc2-web-kit",
@@ -5667,7 +5802,7 @@ checksum = "e11ea2e6f801d275fdd890d6c9603736012742a1c33b96d0db788c9cdebf7f9e"
 dependencies = [
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "log",
  "objc2",
  "objc2-app-kit",
@@ -7302,7 +7437,7 @@ dependencies = [
  "gtk",
  "http",
  "javascriptcore-rs",
- "jni",
+ "jni 0.21.1",
  "libc",
  "ndk",
  "objc2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -50,7 +50,7 @@ sha2 = "0.10"
 base64 = "0.22"
 rand = "0.9"
 # Pure-Rust DNS resolver for MX-record lookup during email autoconfig (#43).
-hickory-resolver = "0.24"
+hickory-resolver = "0.26"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -49,6 +49,8 @@ utf7-imap = "0.3"
 sha2 = "0.10"
 base64 = "0.22"
 rand = "0.9"
+# Pure-Rust DNS resolver for MX-record lookup during email autoconfig (#43).
+hickory-resolver = "0.24"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/src-tauri/gen/schemas/linux-schema.json
+++ b/src-tauri/gen/schemas/linux-schema.json
@@ -140,70 +140,52 @@
                   "identifier": {
                     "anyOf": [
                       {
-                        "description": "This permission set configures which\nshell functionality is exposed by default.\n\n#### Granted Permissions\n\nIt allows to use the `open` functionality with a reasonable\nscope pre-configured. It will allow opening `http(s)://`,\n`tel:` and `mailto:` links.\n\n#### This default permission set includes:\n\n- `allow-open`",
+                        "description": "This permission set allows opening `mailto:`, `tel:`, `https://` and `http://` urls using their default application\nas well as reveal file in directories using default file explorer\n#### This default permission set includes:\n\n- `allow-open-url`\n- `allow-reveal-item-in-dir`\n- `allow-default-urls`",
                         "type": "string",
-                        "const": "shell:default",
-                        "markdownDescription": "This permission set configures which\nshell functionality is exposed by default.\n\n#### Granted Permissions\n\nIt allows to use the `open` functionality with a reasonable\nscope pre-configured. It will allow opening `http(s)://`,\n`tel:` and `mailto:` links.\n\n#### This default permission set includes:\n\n- `allow-open`"
+                        "const": "opener:default",
+                        "markdownDescription": "This permission set allows opening `mailto:`, `tel:`, `https://` and `http://` urls using their default application\nas well as reveal file in directories using default file explorer\n#### This default permission set includes:\n\n- `allow-open-url`\n- `allow-reveal-item-in-dir`\n- `allow-default-urls`"
                       },
                       {
-                        "description": "Enables the execute command without any pre-configured scope.",
+                        "description": "This enables opening `mailto:`, `tel:`, `https://` and `http://` urls using their default application.",
                         "type": "string",
-                        "const": "shell:allow-execute",
-                        "markdownDescription": "Enables the execute command without any pre-configured scope."
+                        "const": "opener:allow-default-urls",
+                        "markdownDescription": "This enables opening `mailto:`, `tel:`, `https://` and `http://` urls using their default application."
                       },
                       {
-                        "description": "Enables the kill command without any pre-configured scope.",
+                        "description": "Enables the open_path command without any pre-configured scope.",
                         "type": "string",
-                        "const": "shell:allow-kill",
-                        "markdownDescription": "Enables the kill command without any pre-configured scope."
+                        "const": "opener:allow-open-path",
+                        "markdownDescription": "Enables the open_path command without any pre-configured scope."
                       },
                       {
-                        "description": "Enables the open command without any pre-configured scope.",
+                        "description": "Enables the open_url command without any pre-configured scope.",
                         "type": "string",
-                        "const": "shell:allow-open",
-                        "markdownDescription": "Enables the open command without any pre-configured scope."
+                        "const": "opener:allow-open-url",
+                        "markdownDescription": "Enables the open_url command without any pre-configured scope."
                       },
                       {
-                        "description": "Enables the spawn command without any pre-configured scope.",
+                        "description": "Enables the reveal_item_in_dir command without any pre-configured scope.",
                         "type": "string",
-                        "const": "shell:allow-spawn",
-                        "markdownDescription": "Enables the spawn command without any pre-configured scope."
+                        "const": "opener:allow-reveal-item-in-dir",
+                        "markdownDescription": "Enables the reveal_item_in_dir command without any pre-configured scope."
                       },
                       {
-                        "description": "Enables the stdin_write command without any pre-configured scope.",
+                        "description": "Denies the open_path command without any pre-configured scope.",
                         "type": "string",
-                        "const": "shell:allow-stdin-write",
-                        "markdownDescription": "Enables the stdin_write command without any pre-configured scope."
+                        "const": "opener:deny-open-path",
+                        "markdownDescription": "Denies the open_path command without any pre-configured scope."
                       },
                       {
-                        "description": "Denies the execute command without any pre-configured scope.",
+                        "description": "Denies the open_url command without any pre-configured scope.",
                         "type": "string",
-                        "const": "shell:deny-execute",
-                        "markdownDescription": "Denies the execute command without any pre-configured scope."
+                        "const": "opener:deny-open-url",
+                        "markdownDescription": "Denies the open_url command without any pre-configured scope."
                       },
                       {
-                        "description": "Denies the kill command without any pre-configured scope.",
+                        "description": "Denies the reveal_item_in_dir command without any pre-configured scope.",
                         "type": "string",
-                        "const": "shell:deny-kill",
-                        "markdownDescription": "Denies the kill command without any pre-configured scope."
-                      },
-                      {
-                        "description": "Denies the open command without any pre-configured scope.",
-                        "type": "string",
-                        "const": "shell:deny-open",
-                        "markdownDescription": "Denies the open command without any pre-configured scope."
-                      },
-                      {
-                        "description": "Denies the spawn command without any pre-configured scope.",
-                        "type": "string",
-                        "const": "shell:deny-spawn",
-                        "markdownDescription": "Denies the spawn command without any pre-configured scope."
-                      },
-                      {
-                        "description": "Denies the stdin_write command without any pre-configured scope.",
-                        "type": "string",
-                        "const": "shell:deny-stdin-write",
-                        "markdownDescription": "Denies the stdin_write command without any pre-configured scope."
+                        "const": "opener:deny-reveal-item-in-dir",
+                        "markdownDescription": "Denies the reveal_item_in_dir command without any pre-configured scope."
                       }
                     ]
                   }
@@ -213,120 +195,96 @@
                 "properties": {
                   "allow": {
                     "items": {
-                      "title": "ShellScopeEntry",
-                      "description": "Shell scope entry.",
+                      "title": "OpenerScopeEntry",
+                      "description": "Opener scope entry.",
                       "anyOf": [
                         {
                           "type": "object",
                           "required": [
-                            "cmd",
-                            "name"
+                            "url"
                           ],
                           "properties": {
-                            "args": {
-                              "description": "The allowed arguments for the command execution.",
+                            "app": {
+                              "description": "An application to open this url with, for example: firefox.",
                               "allOf": [
                                 {
-                                  "$ref": "#/definitions/ShellScopeEntryAllowedArgs"
+                                  "$ref": "#/definitions/Application"
                                 }
                               ]
                             },
-                            "cmd": {
-                              "description": "The command name. It can start with a variable that resolves to a system base directory. The variables are: `$AUDIO`, `$CACHE`, `$CONFIG`, `$DATA`, `$LOCALDATA`, `$DESKTOP`, `$DOCUMENT`, `$DOWNLOAD`, `$EXE`, `$FONT`, `$HOME`, `$PICTURE`, `$PUBLIC`, `$RUNTIME`, `$TEMPLATE`, `$VIDEO`, `$RESOURCE`, `$LOG`, `$TEMP`, `$APPCONFIG`, `$APPDATA`, `$APPLOCALDATA`, `$APPCACHE`, `$APPLOG`.",
-                              "type": "string"
-                            },
-                            "name": {
-                              "description": "The name for this allowed shell command configuration.\n\nThis name will be used inside of the webview API to call this command along with any specified arguments.",
+                            "url": {
+                              "description": "A URL that can be opened by the webview when using the Opener APIs.\n\nWildcards can be used following the UNIX glob pattern.\n\nExamples:\n\n- \"https://*\" : allows all HTTPS origin\n\n- \"https://*.github.com/tauri-apps/tauri\": allows any subdomain of \"github.com\" with the \"tauri-apps/api\" path\n\n- \"https://myapi.service.com/users/*\": allows access to any URLs that begins with \"https://myapi.service.com/users/\"",
                               "type": "string"
                             }
-                          },
-                          "additionalProperties": false
+                          }
                         },
                         {
                           "type": "object",
                           "required": [
-                            "name",
-                            "sidecar"
+                            "path"
                           ],
                           "properties": {
-                            "args": {
-                              "description": "The allowed arguments for the command execution.",
+                            "app": {
+                              "description": "An application to open this path with, for example: xdg-open.",
                               "allOf": [
                                 {
-                                  "$ref": "#/definitions/ShellScopeEntryAllowedArgs"
+                                  "$ref": "#/definitions/Application"
                                 }
                               ]
                             },
-                            "name": {
-                              "description": "The name for this allowed shell command configuration.\n\nThis name will be used inside of the webview API to call this command along with any specified arguments.",
+                            "path": {
+                              "description": "A path that can be opened by the webview when using the Opener APIs.\n\nThe pattern can start with a variable that resolves to a system base directory. The variables are: `$AUDIO`, `$CACHE`, `$CONFIG`, `$DATA`, `$LOCALDATA`, `$DESKTOP`, `$DOCUMENT`, `$DOWNLOAD`, `$EXE`, `$FONT`, `$HOME`, `$PICTURE`, `$PUBLIC`, `$RUNTIME`, `$TEMPLATE`, `$VIDEO`, `$RESOURCE`, `$APP`, `$LOG`, `$TEMP`, `$APPCONFIG`, `$APPDATA`, `$APPLOCALDATA`, `$APPCACHE`, `$APPLOG`.",
                               "type": "string"
-                            },
-                            "sidecar": {
-                              "description": "If this command is a sidecar command.",
-                              "type": "boolean"
                             }
-                          },
-                          "additionalProperties": false
+                          }
                         }
                       ]
                     }
                   },
                   "deny": {
                     "items": {
-                      "title": "ShellScopeEntry",
-                      "description": "Shell scope entry.",
+                      "title": "OpenerScopeEntry",
+                      "description": "Opener scope entry.",
                       "anyOf": [
                         {
                           "type": "object",
                           "required": [
-                            "cmd",
-                            "name"
+                            "url"
                           ],
                           "properties": {
-                            "args": {
-                              "description": "The allowed arguments for the command execution.",
+                            "app": {
+                              "description": "An application to open this url with, for example: firefox.",
                               "allOf": [
                                 {
-                                  "$ref": "#/definitions/ShellScopeEntryAllowedArgs"
+                                  "$ref": "#/definitions/Application"
                                 }
                               ]
                             },
-                            "cmd": {
-                              "description": "The command name. It can start with a variable that resolves to a system base directory. The variables are: `$AUDIO`, `$CACHE`, `$CONFIG`, `$DATA`, `$LOCALDATA`, `$DESKTOP`, `$DOCUMENT`, `$DOWNLOAD`, `$EXE`, `$FONT`, `$HOME`, `$PICTURE`, `$PUBLIC`, `$RUNTIME`, `$TEMPLATE`, `$VIDEO`, `$RESOURCE`, `$LOG`, `$TEMP`, `$APPCONFIG`, `$APPDATA`, `$APPLOCALDATA`, `$APPCACHE`, `$APPLOG`.",
-                              "type": "string"
-                            },
-                            "name": {
-                              "description": "The name for this allowed shell command configuration.\n\nThis name will be used inside of the webview API to call this command along with any specified arguments.",
+                            "url": {
+                              "description": "A URL that can be opened by the webview when using the Opener APIs.\n\nWildcards can be used following the UNIX glob pattern.\n\nExamples:\n\n- \"https://*\" : allows all HTTPS origin\n\n- \"https://*.github.com/tauri-apps/tauri\": allows any subdomain of \"github.com\" with the \"tauri-apps/api\" path\n\n- \"https://myapi.service.com/users/*\": allows access to any URLs that begins with \"https://myapi.service.com/users/\"",
                               "type": "string"
                             }
-                          },
-                          "additionalProperties": false
+                          }
                         },
                         {
                           "type": "object",
                           "required": [
-                            "name",
-                            "sidecar"
+                            "path"
                           ],
                           "properties": {
-                            "args": {
-                              "description": "The allowed arguments for the command execution.",
+                            "app": {
+                              "description": "An application to open this path with, for example: xdg-open.",
                               "allOf": [
                                 {
-                                  "$ref": "#/definitions/ShellScopeEntryAllowedArgs"
+                                  "$ref": "#/definitions/Application"
                                 }
                               ]
                             },
-                            "name": {
-                              "description": "The name for this allowed shell command configuration.\n\nThis name will be used inside of the webview API to call this command along with any specified arguments.",
+                            "path": {
+                              "description": "A path that can be opened by the webview when using the Opener APIs.\n\nThe pattern can start with a variable that resolves to a system base directory. The variables are: `$AUDIO`, `$CACHE`, `$CONFIG`, `$DATA`, `$LOCALDATA`, `$DESKTOP`, `$DOCUMENT`, `$DOWNLOAD`, `$EXE`, `$FONT`, `$HOME`, `$PICTURE`, `$PUBLIC`, `$RUNTIME`, `$TEMPLATE`, `$VIDEO`, `$RESOURCE`, `$APP`, `$LOG`, `$TEMP`, `$APPCONFIG`, `$APPDATA`, `$APPLOCALDATA`, `$APPCACHE`, `$APPLOG`.",
                               "type": "string"
-                            },
-                            "sidecar": {
-                              "description": "If this command is a sidecar command.",
-                              "type": "boolean"
                             }
-                          },
-                          "additionalProperties": false
+                          }
                         }
                       ]
                     }
@@ -2619,6 +2577,54 @@
           "markdownDescription": "Denies the show command without any pre-configured scope."
         },
         {
+          "description": "This permission set allows opening `mailto:`, `tel:`, `https://` and `http://` urls using their default application\nas well as reveal file in directories using default file explorer\n#### This default permission set includes:\n\n- `allow-open-url`\n- `allow-reveal-item-in-dir`\n- `allow-default-urls`",
+          "type": "string",
+          "const": "opener:default",
+          "markdownDescription": "This permission set allows opening `mailto:`, `tel:`, `https://` and `http://` urls using their default application\nas well as reveal file in directories using default file explorer\n#### This default permission set includes:\n\n- `allow-open-url`\n- `allow-reveal-item-in-dir`\n- `allow-default-urls`"
+        },
+        {
+          "description": "This enables opening `mailto:`, `tel:`, `https://` and `http://` urls using their default application.",
+          "type": "string",
+          "const": "opener:allow-default-urls",
+          "markdownDescription": "This enables opening `mailto:`, `tel:`, `https://` and `http://` urls using their default application."
+        },
+        {
+          "description": "Enables the open_path command without any pre-configured scope.",
+          "type": "string",
+          "const": "opener:allow-open-path",
+          "markdownDescription": "Enables the open_path command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the open_url command without any pre-configured scope.",
+          "type": "string",
+          "const": "opener:allow-open-url",
+          "markdownDescription": "Enables the open_url command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the reveal_item_in_dir command without any pre-configured scope.",
+          "type": "string",
+          "const": "opener:allow-reveal-item-in-dir",
+          "markdownDescription": "Enables the reveal_item_in_dir command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the open_path command without any pre-configured scope.",
+          "type": "string",
+          "const": "opener:deny-open-path",
+          "markdownDescription": "Denies the open_path command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the open_url command without any pre-configured scope.",
+          "type": "string",
+          "const": "opener:deny-open-url",
+          "markdownDescription": "Denies the open_url command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the reveal_item_in_dir command without any pre-configured scope.",
+          "type": "string",
+          "const": "opener:deny-reveal-item-in-dir",
+          "markdownDescription": "Denies the reveal_item_in_dir command without any pre-configured scope."
+        },
+        {
           "description": "This permission set configures which\noperating system information are available\nto gather from the frontend.\n\n#### Granted Permissions\n\nAll information except the host name are available.\n\n\n#### This default permission set includes:\n\n- `allow-arch`\n- `allow-exe-extension`\n- `allow-family`\n- `allow-locale`\n- `allow-os-type`\n- `allow-platform`\n- `allow-version`",
           "type": "string",
           "const": "os:default",
@@ -2719,72 +2725,6 @@
           "type": "string",
           "const": "os:deny-version",
           "markdownDescription": "Denies the version command without any pre-configured scope."
-        },
-        {
-          "description": "This permission set configures which\nshell functionality is exposed by default.\n\n#### Granted Permissions\n\nIt allows to use the `open` functionality with a reasonable\nscope pre-configured. It will allow opening `http(s)://`,\n`tel:` and `mailto:` links.\n\n#### This default permission set includes:\n\n- `allow-open`",
-          "type": "string",
-          "const": "shell:default",
-          "markdownDescription": "This permission set configures which\nshell functionality is exposed by default.\n\n#### Granted Permissions\n\nIt allows to use the `open` functionality with a reasonable\nscope pre-configured. It will allow opening `http(s)://`,\n`tel:` and `mailto:` links.\n\n#### This default permission set includes:\n\n- `allow-open`"
-        },
-        {
-          "description": "Enables the execute command without any pre-configured scope.",
-          "type": "string",
-          "const": "shell:allow-execute",
-          "markdownDescription": "Enables the execute command without any pre-configured scope."
-        },
-        {
-          "description": "Enables the kill command without any pre-configured scope.",
-          "type": "string",
-          "const": "shell:allow-kill",
-          "markdownDescription": "Enables the kill command without any pre-configured scope."
-        },
-        {
-          "description": "Enables the open command without any pre-configured scope.",
-          "type": "string",
-          "const": "shell:allow-open",
-          "markdownDescription": "Enables the open command without any pre-configured scope."
-        },
-        {
-          "description": "Enables the spawn command without any pre-configured scope.",
-          "type": "string",
-          "const": "shell:allow-spawn",
-          "markdownDescription": "Enables the spawn command without any pre-configured scope."
-        },
-        {
-          "description": "Enables the stdin_write command without any pre-configured scope.",
-          "type": "string",
-          "const": "shell:allow-stdin-write",
-          "markdownDescription": "Enables the stdin_write command without any pre-configured scope."
-        },
-        {
-          "description": "Denies the execute command without any pre-configured scope.",
-          "type": "string",
-          "const": "shell:deny-execute",
-          "markdownDescription": "Denies the execute command without any pre-configured scope."
-        },
-        {
-          "description": "Denies the kill command without any pre-configured scope.",
-          "type": "string",
-          "const": "shell:deny-kill",
-          "markdownDescription": "Denies the kill command without any pre-configured scope."
-        },
-        {
-          "description": "Denies the open command without any pre-configured scope.",
-          "type": "string",
-          "const": "shell:deny-open",
-          "markdownDescription": "Denies the open command without any pre-configured scope."
-        },
-        {
-          "description": "Denies the spawn command without any pre-configured scope.",
-          "type": "string",
-          "const": "shell:deny-spawn",
-          "markdownDescription": "Denies the spawn command without any pre-configured scope."
-        },
-        {
-          "description": "Denies the stdin_write command without any pre-configured scope.",
-          "type": "string",
-          "const": "shell:deny-stdin-write",
-          "markdownDescription": "Denies the stdin_write command without any pre-configured scope."
         }
       ]
     },
@@ -2882,47 +2822,20 @@
         }
       ]
     },
-    "ShellScopeEntryAllowedArg": {
-      "description": "A command argument allowed to be executed by the webview API.",
+    "Application": {
+      "description": "Opener scope application.",
       "anyOf": [
         {
-          "description": "A non-configurable argument that is passed to the command in the order it was specified.",
-          "type": "string"
+          "description": "Open in default application.",
+          "type": "null"
         },
         {
-          "description": "A variable that is set while calling the command from the webview API.",
-          "type": "object",
-          "required": [
-            "validator"
-          ],
-          "properties": {
-            "raw": {
-              "description": "Marks the validator as a raw regex, meaning the plugin should not make any modification at runtime.\n\nThis means the regex will not match on the entire string by default, which might be exploited if your regex allow unexpected input to be considered valid. When using this option, make sure your regex is correct.",
-              "default": false,
-              "type": "boolean"
-            },
-            "validator": {
-              "description": "[regex] validator to require passed values to conform to an expected input.\n\nThis will require the argument value passed to this variable to match the `validator` regex before it will be executed.\n\nThe regex string is by default surrounded by `^...$` to match the full string. For example the `https?://\\w+` regex would be registered as `^https?://\\w+$`.\n\n[regex]: <https://docs.rs/regex/latest/regex/#syntax>",
-              "type": "string"
-            }
-          },
-          "additionalProperties": false
-        }
-      ]
-    },
-    "ShellScopeEntryAllowedArgs": {
-      "description": "A set of command arguments allowed to be executed by the webview API.\n\nA value of `true` will allow any arguments to be passed to the command. `false` will disable all arguments. A list of [`ShellScopeEntryAllowedArg`] will set those arguments as the only valid arguments to be passed to the attached command configuration.",
-      "anyOf": [
-        {
-          "description": "Use a simple boolean to allow all or disable all arguments to this command configuration.",
+          "description": "If true, allow open with any application.",
           "type": "boolean"
         },
         {
-          "description": "A specific set of [`ShellScopeEntryAllowedArg`] that are valid to call for the command configuration.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/ShellScopeEntryAllowedArg"
-          }
+          "description": "Allow specific application to open with.",
+          "type": "string"
         }
       ]
     }

--- a/src-tauri/src/commands/accounts.rs
+++ b/src-tauri/src/commands/accounts.rs
@@ -101,17 +101,16 @@ pub async fn probe_dav_endpoints(
                 String::new()
             }
         };
-    let carddav_url =
-        match crate::mail::carddav::auto_discover_hosts(&http, &auth, &hosts).await {
-            Ok(url) => {
-                log::info!("probe_dav_endpoints: carddav={}", url);
-                url
-            }
-            Err(e) => {
-                log::debug!("probe_dav_endpoints: carddav probe failed: {}", e);
-                String::new()
-            }
-        };
+    let carddav_url = match crate::mail::carddav::auto_discover_hosts(&http, &auth, &hosts).await {
+        Ok(url) => {
+            log::info!("probe_dav_endpoints: carddav={}", url);
+            url
+        }
+        Err(e) => {
+            log::debug!("probe_dav_endpoints: carddav probe failed: {}", e);
+            String::new()
+        }
+    };
 
     let s = servers.unwrap_or_default();
     Ok(AutoconfigResult {

--- a/src-tauri/src/commands/accounts.rs
+++ b/src-tauri/src/commands/accounts.rs
@@ -205,6 +205,10 @@ pub async fn get_account_config(
     log::debug!("Getting config for account {}", account_id);
     let conn = state.db.reader();
     let full = db::accounts::get_account_full(&conn, &account_id)?;
+    // Compute binding-presence flags before we partial-move `full`'s
+    // String fields into the AccountConfig literal below.
+    let has_calendar_binding = full.calendar_binding().is_some();
+    let has_contacts_binding = full.contacts_binding().is_some();
     // Never return the actual password to the frontend.
     // The edit form shows a placeholder; empty on save means "keep existing".
     Ok(db::accounts::AccountConfig {
@@ -231,6 +235,8 @@ pub async fn get_account_config(
         mail_sync_interval_seconds: full.mail_sync_interval_seconds,
         calendar_sync_interval_seconds: full.calendar_sync_interval_seconds,
         contacts_sync_interval_seconds: full.contacts_sync_interval_seconds,
+        has_calendar_binding,
+        has_contacts_binding,
     })
 }
 

--- a/src-tauri/src/commands/accounts.rs
+++ b/src-tauri/src/commands/accounts.rs
@@ -1,3 +1,4 @@
+use serde::{Deserialize, Serialize};
 use tauri::State;
 
 use crate::commands::calendar::random_calendar_color;
@@ -5,6 +6,126 @@ use crate::db;
 use crate::db::calendar::NewCalendar;
 use crate::error::Result;
 use crate::state::AppState;
+
+/// Combined autoconfig result returned to the Settings UI when the user
+/// clicks "Auto-discover". Carries both the IMAP/SMTP server settings
+/// (Thunderbird-style autoconfig + MX fallback) and the CalDAV/CardDAV
+/// URLs from `.well-known` probing. Empty strings on any field mean
+/// "not found" — the UI keeps whatever was already in the form. The
+/// `source` string is purely informational ("isp-db", "domain-autoconfig",
+/// "well-known", "mx", or "" if no autoconfig source matched).
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct AutoconfigResult {
+    pub imap_host: String,
+    pub imap_port: u16,
+    pub imap_use_tls: bool,
+    pub smtp_host: String,
+    pub smtp_port: u16,
+    pub smtp_use_tls: bool,
+    pub caldav_url: String,
+    pub carddav_url: String,
+    pub source: String,
+}
+
+/// Run Thunderbird-style email autoconfig (Mozilla ISP DB / provider
+/// autoconfig / `.well-known` / MX fallback) followed by CalDAV /
+/// CardDAV `.well-known` probing across every candidate hostname we
+/// know about (#43). Returns an `AutoconfigResult` with whichever
+/// fields could be discovered; failures degrade to empty strings so
+/// the UI can still save the account without auto-fill.
+#[tauri::command]
+pub async fn probe_dav_endpoints(
+    email: String,
+    username: String,
+    password: String,
+    imap_host: Option<String>,
+    smtp_host: Option<String>,
+) -> Result<AutoconfigResult> {
+    log::info!(
+        "probe_dav_endpoints: email={} imap_host={:?} smtp_host={:?}",
+        email,
+        imap_host,
+        smtp_host
+    );
+
+    // 1. Mail-server autoconfig. Soft-fails to None.
+    let (servers, source) = match crate::mail::autoconfig::discover(&email).await {
+        Ok(Some((s, src))) => (Some(s), src.to_string()),
+        Ok(None) => (None, String::new()),
+        Err(e) => {
+            log::debug!("autoconfig: discover errored: {}", e);
+            (None, String::new())
+        }
+    };
+
+    // 2. Build the DAV-probe hostname list. Order matters: we try the
+    // email domain first (cheapest, standards-compliant setups), then
+    // mail.<domain>, then any host autoconfig surfaced, then the user's
+    // entered IMAP / SMTP hosts. Dedup along the way.
+    let domain = email.rsplit('@').next().unwrap_or("").to_string();
+    let mut hosts: Vec<String> = Vec::new();
+    let mut push = |h: String| {
+        if !h.is_empty() && !hosts.contains(&h) {
+            hosts.push(h);
+        }
+    };
+    if !domain.is_empty() {
+        push(domain.clone());
+        push(format!("mail.{}", domain));
+    }
+    if let Some(s) = &servers {
+        push(s.imap_host.clone());
+        push(s.smtp_host.clone());
+    }
+    if let Some(h) = imap_host {
+        push(h);
+    }
+    if let Some(h) = smtp_host {
+        push(h);
+    }
+
+    let http = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(10))
+        .build()
+        .map_err(|e| crate::error::Error::Other(format!("http client: {}", e)))?;
+    let auth = crate::mail::caldav::DavAuth::Basic { username, password };
+
+    let caldav_url =
+        match crate::mail::caldav::CalDavClient::auto_discover_hosts(&http, &auth, &hosts).await {
+            Ok(url) => {
+                log::info!("probe_dav_endpoints: caldav={}", url);
+                url
+            }
+            Err(e) => {
+                log::debug!("probe_dav_endpoints: caldav probe failed: {}", e);
+                String::new()
+            }
+        };
+    let carddav_url =
+        match crate::mail::carddav::auto_discover_hosts(&http, &auth, &hosts).await {
+            Ok(url) => {
+                log::info!("probe_dav_endpoints: carddav={}", url);
+                url
+            }
+            Err(e) => {
+                log::debug!("probe_dav_endpoints: carddav probe failed: {}", e);
+                String::new()
+            }
+        };
+
+    let s = servers.unwrap_or_default();
+    Ok(AutoconfigResult {
+        imap_host: s.imap_host,
+        imap_port: s.imap_port,
+        imap_use_tls: s.imap_use_tls,
+        smtp_host: s.smtp_host,
+        smtp_port: s.smtp_port,
+        smtp_use_tls: s.smtp_use_tls,
+        caldav_url,
+        carddav_url,
+        source,
+    })
+}
 
 #[tauri::command]
 pub async fn list_accounts(state: State<'_, AppState>) -> Result<Vec<db::accounts::Account>> {
@@ -45,20 +166,34 @@ pub async fn add_account(
     db::accounts::insert_account(&conn, &id, &config)?;
     log::info!("Account created with id={}", id);
 
-    // Create a default calendar for the new account
-    let cal_id = uuid::Uuid::new_v4().to_string();
-    let default_calendar = NewCalendar {
-        account_id: id.clone(),
-        name: "Calendar".to_string(),
-        color: random_calendar_color(),
-        is_default: true,
-    };
-    db::calendar::insert_calendar(&conn, &cal_id, &default_calendar)?;
-    log::info!(
-        "Default calendar created with id={} for account={}",
-        cal_id,
-        id
-    );
+    // Create a default local calendar only if the account has an enabled
+    // calendar binding to attach it to. Plain IMAP accounts where DAV
+    // discovery turned up nothing get no calendar binding and therefore
+    // no calendar row — the calendar view simply won't list them.
+    let bindings = crate::db::service_bindings::list_for_account(&conn, &id)?;
+    let has_calendar_binding = bindings
+        .iter()
+        .any(|b| b.service == "calendar" && b.enabled);
+    if has_calendar_binding {
+        let cal_id = uuid::Uuid::new_v4().to_string();
+        let default_calendar = NewCalendar {
+            account_id: id.clone(),
+            name: "Calendar".to_string(),
+            color: random_calendar_color(),
+            is_default: true,
+        };
+        db::calendar::insert_calendar(&conn, &cal_id, &default_calendar)?;
+        log::info!(
+            "Default calendar created with id={} for account={}",
+            cal_id,
+            id
+        );
+    } else {
+        log::info!(
+            "No calendar binding for account {}; skipping default calendar",
+            id
+        );
+    }
 
     Ok(id)
 }
@@ -92,6 +227,11 @@ pub async fn get_account_config(
         oidc_token_endpoint: full.oidc_token_endpoint,
         oidc_client_id: full.oidc_client_id,
         calendar_sync_enabled: full.calendar_sync_enabled,
+        mail_sync_enabled: full.mail_sync_enabled,
+        contacts_sync_enabled: full.contacts_sync_enabled,
+        mail_sync_interval_seconds: full.mail_sync_interval_seconds,
+        calendar_sync_interval_seconds: full.calendar_sync_interval_seconds,
+        contacts_sync_interval_seconds: full.contacts_sync_interval_seconds,
     })
 }
 

--- a/src-tauri/src/commands/actions.rs
+++ b/src-tauri/src/commands/actions.rs
@@ -14,7 +14,7 @@ use crate::state::AppState;
 
 /// Build an ImapConfig for an account, handling O365 XOAUTH2 token refresh.
 async fn build_imap_config(account: &db::accounts::AccountFull) -> Result<ImapConfig> {
-    let (password, use_xoauth2) = if account.provider == "o365" {
+    let (password, use_xoauth2) = if account.auth_method == "oauth-microsoft" {
         let tokens = crate::oauth::load_tokens(&account.id)?
             .ok_or_else(|| Error::Other("No O365 tokens".into()))?;
         let refresh = tokens
@@ -69,7 +69,7 @@ pub async fn move_messages(
 
     // Gather data needed for the server operation before we modify the DB.
     // For IMAP we need UIDs grouped by folder; for JMAP/Graph we need the IDs.
-    let imap_by_folder = if account.mail_protocol != "graph" && account.mail_protocol != "jmap" {
+    let imap_by_folder = if account.mail_protocol_str() != "graph" && account.mail_protocol_str() != "jmap" {
         let conn = state.db.reader();
         let uid_rows = db::messages::get_message_uids(&conn, &message_ids)?;
         let grouped = group_by_folder(uid_rows);
@@ -92,7 +92,7 @@ pub async fn move_messages(
     emit_folders_changed(&app, &account_id);
 
     // --- Background: send to worker queue (IMAP) or spawn ad-hoc (JMAP/Graph) ---
-    if account.mail_protocol == "imap" {
+    if account.mail_protocol_str() == "imap" {
         if let Some(by_folder) = imap_by_folder {
             let sender = state.get_op_sender(&account_id, &app);
             if let Err(e) = sender
@@ -127,7 +127,7 @@ pub async fn move_messages(
 
         tokio::spawn(async move {
             let result: std::result::Result<(), Error> = async {
-                if account.mail_protocol == "graph" {
+                if account.mail_protocol_str() == "graph" {
                     let token = crate::mail::graph::get_graph_token(&account_id_bg).await?;
                     let client = crate::mail::graph::GraphClient::new(&token);
                     let mut errors: Vec<String> = Vec::new();
@@ -147,7 +147,7 @@ pub async fn move_messages(
                             errors.join("; ")
                         )));
                     }
-                } else if account.mail_protocol == "jmap" {
+                } else if account.mail_protocol_str() == "jmap" {
                     let jmap_config =
                         crate::commands::sync_cmd::build_jmap_config(&account).await?;
                     let mut by_folder: HashMap<String, Vec<String>> = HashMap::new();
@@ -239,7 +239,7 @@ pub async fn delete_messages(
     };
 
     // Gather IMAP UIDs before modifying the DB
-    let imap_by_folder = if account.mail_protocol != "graph" && account.mail_protocol != "jmap" {
+    let imap_by_folder = if account.mail_protocol_str() != "graph" && account.mail_protocol_str() != "jmap" {
         let conn = state.db.reader();
         let uid_rows = db::messages::get_message_uids(&conn, &message_ids)?;
         let grouped = group_by_folder(uid_rows);
@@ -262,7 +262,7 @@ pub async fn delete_messages(
     emit_folders_changed(&app, &account_id);
 
     // --- Background: send to worker queue (IMAP) or spawn ad-hoc (JMAP/Graph) ---
-    if account.mail_protocol == "imap" {
+    if account.mail_protocol_str() == "imap" {
         // Worker has its own connection — no IDLE suspend needed
         if let Some(by_folder) = imap_by_folder {
             let sender = state.get_op_sender(&account_id, &app);
@@ -298,7 +298,7 @@ pub async fn delete_messages(
 
         tokio::spawn(async move {
             let result: std::result::Result<(), Error> = async {
-                if account.mail_protocol == "graph" {
+                if account.mail_protocol_str() == "graph" {
                     let token = crate::mail::graph::get_graph_token(&account_id_bg).await?;
                     let client = crate::mail::graph::GraphClient::new(&token);
                     let mut errors: Vec<String> = Vec::new();
@@ -318,7 +318,7 @@ pub async fn delete_messages(
                             errors.join("; ")
                         )));
                     }
-                } else if account.mail_protocol == "jmap" {
+                } else if account.mail_protocol_str() == "jmap" {
                     let jmap_config =
                         crate::commands::sync_cmd::build_jmap_config(&account).await?;
                     let jmap_ids: Vec<String> = message_ids_bg
@@ -594,7 +594,7 @@ pub async fn set_message_flags(
     }
 
     // Now perform the remote operation (slow, network I/O)
-    if account.mail_protocol == "graph" {
+    if account.mail_protocol_str() == "graph" {
         // Graph path: use PATCH to update isRead
         let token = crate::mail::graph::get_graph_token(&account_id).await?;
         let client = crate::mail::graph::GraphClient::new(&token);
@@ -610,7 +610,7 @@ pub async fn set_message_flags(
                 .collect();
             client.set_read_status(&graph_ids, add).await?;
         }
-    } else if account.mail_protocol == "jmap" {
+    } else if account.mail_protocol_str() == "jmap" {
         // JMAP path: extract JMAP email IDs and set flags via JMAP API
         let jmap_config = crate::commands::sync_cmd::build_jmap_config(&account).await?;
 
@@ -709,7 +709,7 @@ pub async fn copy_messages(
         db::accounts::get_account_full(&conn, &account_id)?
     };
 
-    if account.mail_protocol != "imap" {
+    if account.mail_protocol_str() != "imap" {
         log::warn!(
             "Copy not implemented for protocol '{}' (account {}). Skipping.",
             account.mail_protocol,
@@ -781,7 +781,7 @@ pub async fn mark_account_read(
     };
 
     // Mark read on the server first
-    if account.mail_protocol == "graph" {
+    if account.mail_protocol_str() == "graph" {
         let unread_ids = {
             let conn = state.db.reader();
             let mut stmt = conn
@@ -811,7 +811,7 @@ pub async fn mark_account_read(
                 .collect();
             client.set_read_status(&graph_ids, true).await?;
         }
-    } else if account.mail_protocol == "imap" {
+    } else if account.mail_protocol_str() == "imap" {
         // IMAP: SELECT each folder and STORE +FLAGS \Seen on all messages
         let suspended_idle = if should_suspend_idle_for_imap_operation(&account.provider) {
             suspend_imap_idle_for_account(&state, &account_id).await?
@@ -845,7 +845,7 @@ pub async fn mark_account_read(
         // Always resume IDLE, even if the mark-read operation failed
         resume_imap_idle_for_account(&app, &state, &resume_account, suspended_idle).await?;
         imap_result?;
-    } else if account.mail_protocol == "jmap" {
+    } else if account.mail_protocol_str() == "jmap" {
         // JMAP: bulk update all unread emails to $seen via Email/set
         let jmap_config = crate::commands::sync_cmd::build_jmap_config(&account).await?;
         let conn_jmap = crate::mail::jmap::JmapConnection::connect(&jmap_config).await?;

--- a/src-tauri/src/commands/actions.rs
+++ b/src-tauri/src/commands/actions.rs
@@ -70,18 +70,19 @@ pub async fn move_messages(
 
     // Gather data needed for the server operation before we modify the DB.
     // For IMAP we need UIDs grouped by folder; for JMAP/Graph we need the IDs.
-    let imap_by_folder = if account.mail_protocol_str() != "graph" && account.mail_protocol_str() != "jmap" {
-        let conn = state.db.reader();
-        let uid_rows = db::messages::get_message_uids(&conn, &message_ids)?;
-        let grouped = group_by_folder(uid_rows);
-        if grouped.is_empty() {
-            log::warn!("No messages found for move operation");
-            return Ok(());
-        }
-        Some(grouped)
-    } else {
-        None
-    };
+    let imap_by_folder =
+        if account.mail_protocol_str() != "graph" && account.mail_protocol_str() != "jmap" {
+            let conn = state.db.reader();
+            let uid_rows = db::messages::get_message_uids(&conn, &message_ids)?;
+            let grouped = group_by_folder(uid_rows);
+            if grouped.is_empty() {
+                log::warn!("No messages found for move operation");
+                return Ok(());
+            }
+            Some(grouped)
+        } else {
+            None
+        };
 
     // --- Optimistic: update local DB and notify UI immediately ---
     {
@@ -240,18 +241,19 @@ pub async fn delete_messages(
     };
 
     // Gather IMAP UIDs before modifying the DB
-    let imap_by_folder = if account.mail_protocol_str() != "graph" && account.mail_protocol_str() != "jmap" {
-        let conn = state.db.reader();
-        let uid_rows = db::messages::get_message_uids(&conn, &message_ids)?;
-        let grouped = group_by_folder(uid_rows);
-        if grouped.is_empty() {
-            log::warn!("No messages found for delete operation");
-            return Ok(());
-        }
-        Some(grouped)
-    } else {
-        None
-    };
+    let imap_by_folder =
+        if account.mail_protocol_str() != "graph" && account.mail_protocol_str() != "jmap" {
+            let conn = state.db.reader();
+            let uid_rows = db::messages::get_message_uids(&conn, &message_ids)?;
+            let grouped = group_by_folder(uid_rows);
+            if grouped.is_empty() {
+                log::warn!("No messages found for delete operation");
+                return Ok(());
+            }
+            Some(grouped)
+        } else {
+            None
+        };
 
     // --- Optimistic: update local DB and notify UI immediately ---
     {

--- a/src-tauri/src/commands/actions.rs
+++ b/src-tauri/src/commands/actions.rs
@@ -31,12 +31,13 @@ async fn build_imap_config(account: &db::accounts::AccountFull) -> Result<ImapCo
     } else {
         (account.password.clone(), false)
     };
+    let imap = account.mail_imap_config().unwrap_or_default();
     Ok(ImapConfig {
-        host: account.imap_host.clone(),
-        port: account.imap_port,
+        host: imap.imap_host,
+        port: imap.imap_port,
         username: account.username.clone(),
         password,
-        use_tls: account.use_tls,
+        use_tls: imap.use_tls,
         use_xoauth2,
     })
 }
@@ -813,7 +814,7 @@ pub async fn mark_account_read(
         }
     } else if account.mail_protocol_str() == "imap" {
         // IMAP: SELECT each folder and STORE +FLAGS \Seen on all messages
-        let suspended_idle = if should_suspend_idle_for_imap_operation(&account.provider) {
+        let suspended_idle = if should_suspend_idle_for_imap_operation(&account.auth_method) {
             suspend_imap_idle_for_account(&state, &account_id).await?
         } else {
             false

--- a/src-tauri/src/commands/calendar.rs
+++ b/src-tauri/src/commands/calendar.rs
@@ -119,7 +119,8 @@ async fn push_calendar_rename(
     remote_id: &str,
     new_name: &str,
 ) -> Result<()> {
-    if account.mail_protocol == "jmap" {
+    let cal_proto = account.calendar_protocol_str();
+    if cal_proto == "jmap" {
         let jmap_config = crate::commands::sync_cmd::build_jmap_config(account).await?;
         let conn_jmap = crate::mail::jmap::JmapConnection::connect(&jmap_config).await?;
         conn_jmap
@@ -128,14 +129,14 @@ async fn push_calendar_rename(
         return Ok(());
     }
 
-    if account.provider == "o365" {
+    if cal_proto == "graph" {
         let token = crate::mail::graph::get_graph_token(&account.id).await?;
         let client = crate::mail::graph::GraphClient::new(&token);
         client.rename_calendar(remote_id, new_name).await?;
         return Ok(());
     }
 
-    if account.provider == "gmail" {
+    if cal_proto == "google" {
         // Prefer the Google Calendar REST endpoint; fall back to CalDAV
         // PROPPATCH if REST fails (OAuth not configured, or remote_id is
         // actually a CalDAV href).
@@ -180,8 +181,9 @@ async fn push_calendar_rename(
     }
 
     Err(crate::error::Error::Other(format!(
-        "No remote rename path configured for account {} (provider={}, protocol={})",
-        account.id, account.provider, account.mail_protocol
+        "No remote rename path configured for account {} (calendar_protocol={})",
+        account.id,
+        account.calendar_protocol_str()
     )))
 }
 
@@ -289,7 +291,7 @@ pub async fn create_event(state: State<'_, AppState>, event: NewEventInput) -> R
         db::calendar::insert_event(&conn, &cal_event)?;
         let account = db::accounts::get_account_full(&conn, &cal_event.account_id)?;
 
-        if account.provider == "gmail" {
+        if account.calendar_protocol_str() == "google" {
             // Create on Google Calendar via REST API
             drop(conn);
             if let Ok(token) = get_google_token(&cal_event.account_id).await {
@@ -375,7 +377,7 @@ pub async fn create_event(state: State<'_, AppState>, event: NewEventInput) -> R
                     Err(e) => log::error!("create_event: Google Calendar request failed: {}", e),
                 }
             }
-        } else if account.provider == "o365" {
+        } else if account.calendar_protocol_str() == "graph" {
             drop(conn);
             if let Ok(token) = crate::mail::graph::get_graph_token(&cal_event.account_id).await {
                 let client = crate::mail::graph::GraphClient::new(&token);
@@ -461,7 +463,7 @@ pub async fn create_event(state: State<'_, AppState>, event: NewEventInput) -> R
                     Err(e) => log::error!("create_event: Graph Calendar push failed: {}", e),
                 }
             }
-        } else if account.mail_protocol == "jmap" {
+        } else if account.calendar_protocol_str() == "jmap" {
             // Look up the remote calendar ID from local calendar
             let calendar = db::calendar::get_calendar(&conn, &cal_event.calendar_id)?;
             let remote_cal_id = calendar.remote_id.clone().unwrap_or_default();
@@ -568,7 +570,7 @@ pub async fn update_event(
     // Push update to server
     let account = db::accounts::get_account_full(&conn, &existing.account_id)?;
     if let Some(ref remote_id) = existing.remote_id.filter(|r| !r.is_empty()) {
-        if account.provider == "gmail" {
+        if account.calendar_protocol_str() == "google" {
             drop(conn);
             if let Ok(token) = get_google_token(&existing.account_id).await {
                 let http = reqwest::Client::new();
@@ -617,7 +619,7 @@ pub async fn update_event(
                     Err(e) => log::error!("update_event: Google Calendar request failed: {}", e),
                 }
             }
-        } else if account.provider == "o365" {
+        } else if account.calendar_protocol_str() == "graph" {
             drop(conn);
             if let Ok(token) = crate::mail::graph::get_graph_token(&existing.account_id).await {
                 let client = crate::mail::graph::GraphClient::new(&token);
@@ -664,7 +666,7 @@ pub async fn delete_event(state: State<'_, AppState>, event_id: String) -> Resul
     // Delete from server if event has a remote_id
     if let Some(ref remote_id) = event.remote_id {
         if !remote_id.is_empty() {
-            if account.provider == "gmail" {
+            if account.calendar_protocol_str() == "google" {
                 // Delete via Google Calendar API
                 match get_google_token(&event.account_id).await {
                     Ok(token) => {
@@ -699,7 +701,7 @@ pub async fn delete_event(state: State<'_, AppState>, event_id: String) -> Resul
                         e
                     ),
                 }
-            } else if account.provider == "o365" {
+            } else if account.calendar_protocol_str() == "graph" {
                 match crate::mail::graph::get_graph_token(&event.account_id).await {
                     Ok(token) => {
                         let client = crate::mail::graph::GraphClient::new(&token);
@@ -714,7 +716,7 @@ pub async fn delete_event(state: State<'_, AppState>, event_id: String) -> Resul
                         e
                     ),
                 }
-            } else if account.mail_protocol == "jmap" {
+            } else if account.calendar_protocol_str() == "jmap" {
                 let jmap_config = crate::commands::sync_cmd::build_jmap_config(&account).await?;
                 match crate::mail::jmap::JmapConnection::connect(&jmap_config).await {
                     Ok(conn_jmap) => {
@@ -799,9 +801,9 @@ pub async fn sync_calendars(
         );
     }
 
-    if account.mail_protocol == "jmap" {
+    if account.calendar_protocol_str() == "jmap" {
         sync_calendars_jmap(&state, &account_id, &account).await?;
-    } else if account.provider == "gmail" {
+    } else if account.calendar_protocol_str() == "google" {
         // Gmail: use Google CalDAV with OAuth2 bearer token
         match sync_calendars_google(&state, &account_id, &account).await {
             Ok(()) => {}
@@ -816,7 +818,7 @@ pub async fn sync_calendars(
                 }
             }
         }
-    } else if account.provider == "o365" {
+    } else if account.calendar_protocol_str() == "graph" {
         sync_calendars_graph(&state, &account_id).await?;
     } else if !account.caldav_url.is_empty() {
         sync_calendars_caldav(&state, &account_id, &account).await?;
@@ -1755,7 +1757,7 @@ pub async fn respond_to_invite(
             invite.summary.as_deref().unwrap_or("Calendar Invite")
         );
 
-        if account.mail_protocol == "jmap" {
+        if account.calendar_protocol_str() == "jmap" {
             log::info!("respond_to_invite: sending reply via JMAP");
             let jmap_config = crate::commands::sync_cmd::build_jmap_config(&account).await?;
 
@@ -1882,7 +1884,7 @@ pub async fn respond_to_invite(
     }
 
     // Step 5: Update Google Calendar if this is a Gmail account with OAuth
-    if account.provider == "gmail" {
+    if account.calendar_protocol_str() == "google" {
         drop(conn); // Release DB lock before async
         if let Ok(token) = get_google_token(&account_id).await {
             let google_status = match response.to_lowercase().as_str() {
@@ -2011,7 +2013,7 @@ pub async fn respond_to_invite(
     }
 
     // Step 6: Update O365 calendar via Graph API RSVP
-    if account.provider == "o365" {
+    if account.calendar_protocol_str() == "graph" {
         match crate::mail::graph::get_graph_token(&account_id).await {
             Ok(token) => {
                 let client = crate::mail::graph::GraphClient::new(&token);
@@ -2127,7 +2129,7 @@ fn build_calendar_reply_message(
 
 /// Get SMTP credentials for an account, refreshing OAuth tokens for O365.
 async fn get_smtp_credentials(account: &db::accounts::AccountFull) -> Result<(String, bool)> {
-    if account.provider == "o365" {
+    if account.calendar_protocol_str() == "graph" {
         let tokens = crate::oauth::load_tokens(&account.id)?
             .ok_or_else(|| crate::error::Error::Other("No O365 tokens for SMTP".into()))?;
         let refresh_token = tokens
@@ -2296,10 +2298,10 @@ pub async fn send_invites(
     // Gmail and O365 handle sending invite emails server-side when
     // events are pushed via Google Calendar API (sendUpdates=all) or
     // Graph API. Sending our own SMTP invite would create duplicates.
-    if account.provider == "gmail" || account.provider == "o365" {
+    if account.calendar_protocol_str() == "google" || account.calendar_protocol_str() == "graph" {
         log::info!(
             "send_invites: skipping manual send for {} account (server handles invites)",
-            account.provider
+            account.calendar_protocol_str()
         );
         // Still update attendees in the local DB
         let conn = state.db.writer().await;
@@ -2374,7 +2376,7 @@ pub async fn send_invites(
             continue;
         }
 
-        if account.mail_protocol == "jmap" {
+        if account.calendar_protocol_str() == "jmap" {
             let jmap_config = crate::commands::sync_cmd::build_jmap_config(&account).await?;
             let conn_jmap = crate::mail::jmap::JmapConnection::connect(&jmap_config).await?;
             conn_jmap.send_email(&jmap_config, &raw).await?;
@@ -2486,7 +2488,7 @@ pub async fn process_invite_reply(
             }
 
             // Update on JMAP server if applicable
-            if account.mail_protocol == "jmap" {
+            if account.calendar_protocol_str() == "jmap" {
                 if let Some(ref remote_id) = event.remote_id {
                     let jmap_config =
                         crate::commands::sync_cmd::build_jmap_config(&account).await?;

--- a/src-tauri/src/commands/calendar.rs
+++ b/src-tauri/src/commands/calendar.rs
@@ -2835,7 +2835,11 @@ async fn sync_calendars_graph(state: &State<'_, AppState>, account_id: &str) -> 
     };
     let client = crate::mail::graph::GraphClient::new(&token);
 
-    // 1. Sync calendar list
+    // 1. List Graph calendars and upsert each into the local table.
+    // Multi-calendar support (#47): we keep a remote_id -> (local_id,
+    // is_subscribed) map so the per-calendar event sync below can map
+    // events to the right local calendar AND skip calendars the user
+    // has unsubscribed from.
     let graph_calendars = match client.list_calendars().await {
         Ok(c) => c,
         Err(e) => {
@@ -2848,175 +2852,187 @@ async fn sync_calendars_graph(state: &State<'_, AppState>, account_id: &str) -> 
         graph_calendars.len()
     );
 
-    let conn = state.db.writer().await;
-    for gc in &graph_calendars {
-        // Check if calendar with this remote_id already exists
-        let existing: Option<String> = conn
-            .query_row(
-                "SELECT id FROM calendars WHERE account_id = ?1 AND remote_id = ?2",
-                rusqlite::params![account_id, gc.id],
-                |row| row.get(0),
-            )
-            .ok();
+    let mut remote_to_local: std::collections::HashMap<String, (String, bool)> =
+        std::collections::HashMap::new();
 
-        match existing {
-            Some(_) => {
-                // Calendar exists — update name/color
-                conn.execute(
-                    "UPDATE calendars SET name = ?1, color = ?2 WHERE account_id = ?3 AND remote_id = ?4",
-                    rusqlite::params![gc.name, gc.color, account_id, gc.id],
-                ).ok();
-            }
-            None => {
-                // New calendar — insert with remote_id
-                let cal_id = uuid::Uuid::new_v4().to_string();
-                let cal = NewCalendar {
-                    account_id: account_id.to_string(),
-                    name: gc.name.clone(),
-                    color: gc.color.clone(),
-                    is_default: gc.is_default,
-                };
-                db::calendar::insert_calendar(&conn, &cal_id, &cal)?;
-                // Set remote_id (insert_calendar doesn't handle it)
-                conn.execute(
-                    "UPDATE calendars SET remote_id = ?1 WHERE id = ?2",
-                    rusqlite::params![gc.id, cal_id],
+    {
+        let conn = state.db.writer().await;
+        for gc in &graph_calendars {
+            // Look up existing row to preserve the user's is_subscribed
+            // setting; if absent, we insert and default-subscribe.
+            let existing: Option<(String, bool)> = conn
+                .query_row(
+                    "SELECT id, is_subscribed FROM calendars WHERE account_id = ?1 AND remote_id = ?2",
+                    rusqlite::params![account_id, gc.id],
+                    |row| Ok((row.get(0)?, row.get(1)?)),
                 )
                 .ok();
-                log::info!(
-                    "sync_calendars_graph: created calendar '{}' ({})",
-                    gc.name,
-                    gc.id
-                );
-            }
+
+            let (local_id, subscribed) = match existing {
+                Some((local_id, subscribed)) => {
+                    conn.execute(
+                        "UPDATE calendars SET name = ?1, color = ?2 WHERE id = ?3",
+                        rusqlite::params![gc.name, gc.color, local_id],
+                    )
+                    .ok();
+                    (local_id, subscribed)
+                }
+                None => {
+                    let cal_id = uuid::Uuid::new_v4().to_string();
+                    let cal = NewCalendar {
+                        account_id: account_id.to_string(),
+                        name: gc.name.clone(),
+                        color: gc.color.clone(),
+                        is_default: gc.is_default,
+                    };
+                    db::calendar::insert_calendar(&conn, &cal_id, &cal)?;
+                    conn.execute(
+                        "UPDATE calendars SET remote_id = ?1 WHERE id = ?2",
+                        rusqlite::params![gc.id, cal_id],
+                    )
+                    .ok();
+                    log::info!(
+                        "sync_calendars_graph: created calendar '{}' ({})",
+                        gc.name,
+                        gc.id
+                    );
+                    (cal_id, true)
+                }
+            };
+            remote_to_local.insert(gc.id.clone(), (local_id, subscribed));
         }
     }
 
-    // 2. Fetch events for a 6-month window
+    // 2. Fetch events for each subscribed calendar individually
+    // (`/me/calendars/{id}/calendarView`) — the previous all-account
+    // `/me/calendarView` collapsed every calendar's events onto the
+    // default calendar.
     let now = chrono::Utc::now();
     let start =
         (now - chrono::Duration::days(90)).to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
     let end = (now + chrono::Duration::days(90)).to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
-    drop(conn); // Release lock before async call
 
-    let graph_events = match client.list_events(&start, &end).await {
-        Ok(e) => e,
-        Err(e) => {
-            log::error!("sync_calendars_graph: list_events failed: {}", e);
-            return Err(e);
-        }
-    };
-    log::info!(
-        "sync_calendars_graph: fetched {} events",
-        graph_events.len()
-    );
-
-    let conn = state.db.writer().await;
-
-    // Build a set of server event IDs for reconciliation
-    let server_ids: std::collections::HashSet<String> =
-        graph_events.iter().map(|e| e.id.clone()).collect();
-
-    // Find the default calendar's local ID
-    let default_cal = graph_calendars.iter().find(|c| c.is_default);
-    let default_cal_local_id: String = default_cal
-        .and_then(|dc| {
-            conn.query_row(
-                "SELECT id FROM calendars WHERE account_id = ?1 AND remote_id = ?2",
-                rusqlite::params![account_id, dc.id],
-                |row| row.get(0),
-            )
-            .ok()
-        })
-        .unwrap_or_default();
-
-    for ge in &graph_events {
-        // Find local calendar ID for this event
-        let cal_local_id = if default_cal_local_id.is_empty() {
-            String::new()
-        } else {
-            default_cal_local_id.clone()
+    for gc in &graph_calendars {
+        let Some((local_cal_id, subscribed)) = remote_to_local.get(&gc.id) else {
+            continue;
         };
-
-        let existing = conn.query_row(
-            "SELECT id FROM calendar_events WHERE account_id = ?1 AND remote_id = ?2",
-            rusqlite::params![account_id, ge.id],
-            |row| row.get::<_, String>(0),
-        );
-
-        match existing {
-            Ok(local_id) => {
-                // Update existing event
-                conn.execute(
-                    "UPDATE calendar_events SET title = ?1, start_time = ?2, end_time = ?3,
-                     all_day = ?4, location = ?5, organizer_email = ?6, attendees_json = ?7,
-                     description = ?8, timezone = ?9 WHERE id = ?10",
-                    rusqlite::params![
-                        ge.subject,
-                        ge.start,
-                        ge.end,
-                        ge.all_day,
-                        ge.location,
-                        ge.organizer_email,
-                        ge.attendees_json,
-                        ge.body_preview,
-                        ge.timezone,
-                        local_id,
-                    ],
-                )
-                .ok();
-            }
-            Err(_) => {
-                // Insert new event
-                let event = CalendarEvent {
-                    id: uuid::Uuid::new_v4().to_string(),
-                    account_id: account_id.to_string(),
-                    calendar_id: cal_local_id,
-                    uid: ge.ical_uid.clone(),
-                    title: ge.subject.clone(),
-                    description: ge.body_preview.clone(),
-                    location: ge.location.clone(),
-                    start_time: ge.start.clone(),
-                    end_time: ge.end.clone(),
-                    all_day: ge.all_day,
-                    timezone: ge.timezone.clone(),
-                    recurrence_rule: None,
-                    organizer_email: ge.organizer_email.clone(),
-                    attendees_json: ge.attendees_json.clone(),
-                    my_status: None,
-                    source_message_id: None,
-                    ical_data: None,
-                    remote_id: Some(ge.id.clone()),
-                    etag: None,
-                };
-                db::calendar::insert_event(&conn, &event)?;
-            }
+        if !subscribed {
+            log::debug!(
+                "sync_calendars_graph: skipping unsubscribed calendar '{}'",
+                gc.name
+            );
+            continue;
         }
-    }
 
-    // 3. Remove events deleted on server
-    let local_events: Vec<(String, String)> = conn
-        .prepare(
-            "SELECT id, remote_id FROM calendar_events WHERE account_id = ?1 AND remote_id IS NOT NULL AND remote_id != ''",
-        )?
-        .query_map(rusqlite::params![account_id], |row| {
-            Ok((row.get(0)?, row.get(1)?))
-        })?
-        .filter_map(|r| r.ok())
-        .collect();
-
-    let mut deleted = 0;
-    for (local_id, remote_id) in &local_events {
-        if !server_ids.contains(remote_id) {
-            db::calendar::delete_event(&conn, local_id)?;
-            deleted += 1;
-        }
-    }
-    if deleted > 0 {
+        let calendar_events = match client.list_events_for_calendar(&gc.id, &start, &end).await {
+            Ok(e) => e,
+            Err(e) => {
+                log::error!(
+                    "sync_calendars_graph: list_events_for_calendar('{}') failed: {}",
+                    gc.name,
+                    e
+                );
+                continue;
+            }
+        };
         log::info!(
-            "sync_calendars_graph: removed {} server-deleted events",
-            deleted
+            "sync_calendars_graph: fetched {} events for calendar '{}'",
+            calendar_events.len(),
+            gc.name
         );
+
+        let conn = state.db.writer().await;
+        let server_ids: std::collections::HashSet<String> =
+            calendar_events.iter().map(|e| e.id.clone()).collect();
+
+        for ge in &calendar_events {
+            let existing = conn.query_row(
+                "SELECT id FROM calendar_events WHERE account_id = ?1 AND remote_id = ?2",
+                rusqlite::params![account_id, ge.id],
+                |row| row.get::<_, String>(0),
+            );
+
+            match existing {
+                Ok(local_id) => {
+                    // Update in place. Also re-pin calendar_id in case
+                    // the event moved between calendars on the server.
+                    conn.execute(
+                        "UPDATE calendar_events SET title = ?1, start_time = ?2, end_time = ?3,
+                         all_day = ?4, location = ?5, organizer_email = ?6, attendees_json = ?7,
+                         description = ?8, timezone = ?9, calendar_id = ?10 WHERE id = ?11",
+                        rusqlite::params![
+                            ge.subject,
+                            ge.start,
+                            ge.end,
+                            ge.all_day,
+                            ge.location,
+                            ge.organizer_email,
+                            ge.attendees_json,
+                            ge.body_preview,
+                            ge.timezone,
+                            local_cal_id,
+                            local_id,
+                        ],
+                    )
+                    .ok();
+                }
+                Err(_) => {
+                    let event = CalendarEvent {
+                        id: uuid::Uuid::new_v4().to_string(),
+                        account_id: account_id.to_string(),
+                        calendar_id: local_cal_id.clone(),
+                        uid: ge.ical_uid.clone(),
+                        title: ge.subject.clone(),
+                        description: ge.body_preview.clone(),
+                        location: ge.location.clone(),
+                        start_time: ge.start.clone(),
+                        end_time: ge.end.clone(),
+                        all_day: ge.all_day,
+                        timezone: ge.timezone.clone(),
+                        recurrence_rule: None,
+                        organizer_email: ge.organizer_email.clone(),
+                        attendees_json: ge.attendees_json.clone(),
+                        my_status: None,
+                        source_message_id: None,
+                        ical_data: None,
+                        remote_id: Some(ge.id.clone()),
+                        etag: None,
+                    };
+                    db::calendar::insert_event(&conn, &event)?;
+                }
+            }
+        }
+
+        // Per-calendar reconciliation: drop events that this calendar
+        // used to carry but that the server no longer returns. Scoped
+        // to calendar_id so a deletion in one calendar doesn't wipe
+        // events still present in another.
+        let local_events: Vec<(String, String)> = conn
+            .prepare(
+                "SELECT id, remote_id FROM calendar_events
+                 WHERE account_id = ?1 AND calendar_id = ?2
+                   AND remote_id IS NOT NULL AND remote_id != ''",
+            )?
+            .query_map(rusqlite::params![account_id, local_cal_id], |row| {
+                Ok((row.get(0)?, row.get(1)?))
+            })?
+            .filter_map(|r| r.ok())
+            .collect();
+
+        let mut deleted = 0;
+        for (local_id, remote_id) in &local_events {
+            if !server_ids.contains(remote_id) {
+                db::calendar::delete_event(&conn, local_id)?;
+                deleted += 1;
+            }
+        }
+        if deleted > 0 {
+            log::info!(
+                "sync_calendars_graph: removed {} server-deleted events from '{}'",
+                deleted,
+                gc.name
+            );
+        }
     }
 
     log::info!("sync_calendars_graph: completed for account {}", account_id);

--- a/src-tauri/src/commands/compose.rs
+++ b/src-tauri/src/commands/compose.rs
@@ -102,30 +102,31 @@ pub async fn send_message(
     )?;
 
     // For O365 SMTP: refresh OAuth token now (needs keyring access)
-    let smtp_creds = if account.mail_protocol_str() != "jmap" && account.auth_method == "oauth-microsoft" {
-        let tokens = crate::oauth::load_tokens(&account_id)?
-            .ok_or_else(|| Error::Other("No O365 tokens for SMTP".into()))?;
-        let refresh_token = tokens
-            .refresh_token
-            .ok_or_else(|| Error::Other("No O365 refresh token for SMTP".into()))?;
-        let smtp_tokens = crate::oauth::refresh_with_scopes(
-            &crate::oauth::MICROSOFT,
-            &refresh_token,
-            crate::oauth::MICROSOFT_IMAP_SCOPES,
-        )
-        .await?;
-        crate::oauth::store_tokens(
-            &account_id,
-            &crate::oauth::OAuthTokens {
-                access_token: smtp_tokens.access_token.clone(),
-                refresh_token: smtp_tokens.refresh_token,
-                expires_at: smtp_tokens.expires_at,
-            },
-        )?;
-        Some((account.username.clone(), smtp_tokens.access_token, true))
-    } else {
-        None
-    };
+    let smtp_creds =
+        if account.mail_protocol_str() != "jmap" && account.auth_method == "oauth-microsoft" {
+            let tokens = crate::oauth::load_tokens(&account_id)?
+                .ok_or_else(|| Error::Other("No O365 tokens for SMTP".into()))?;
+            let refresh_token = tokens
+                .refresh_token
+                .ok_or_else(|| Error::Other("No O365 refresh token for SMTP".into()))?;
+            let smtp_tokens = crate::oauth::refresh_with_scopes(
+                &crate::oauth::MICROSOFT,
+                &refresh_token,
+                crate::oauth::MICROSOFT_IMAP_SCOPES,
+            )
+            .await?;
+            crate::oauth::store_tokens(
+                &account_id,
+                &crate::oauth::OAuthTokens {
+                    access_token: smtp_tokens.access_token.clone(),
+                    refresh_token: smtp_tokens.refresh_token,
+                    expires_at: smtp_tokens.expires_at,
+                },
+            )?;
+            Some((account.username.clone(), smtp_tokens.access_token, true))
+        } else {
+            None
+        };
 
     // Notify main window that send is starting
     let subject_display = if message.subject.is_empty() {

--- a/src-tauri/src/commands/compose.rs
+++ b/src-tauri/src/commands/compose.rs
@@ -102,7 +102,7 @@ pub async fn send_message(
     )?;
 
     // For O365 SMTP: refresh OAuth token now (needs keyring access)
-    let smtp_creds = if account.mail_protocol != "jmap" && account.provider == "o365" {
+    let smtp_creds = if account.mail_protocol_str() != "jmap" && account.auth_method == "oauth-microsoft" {
         let tokens = crate::oauth::load_tokens(&account_id)?
             .ok_or_else(|| Error::Other("No O365 tokens for SMTP".into()))?;
         let refresh_token = tokens
@@ -183,7 +183,7 @@ pub async fn send_message(
 
     tokio::spawn(async move {
         let result: std::result::Result<(), Error> = async {
-            if account.mail_protocol == "jmap" {
+            if account.mail_protocol_str() == "jmap" {
                 log::info!("Sending via JMAP for account {}", account.email);
                 let jmap_config = crate::commands::sync_cmd::build_jmap_config(&account).await?;
                 let conn_jmap = JmapConnection::connect(&jmap_config).await?;
@@ -325,7 +325,7 @@ pub async fn save_draft(
         &references,
     )?;
 
-    if account.mail_protocol == "graph" {
+    if account.mail_protocol_str() == "graph" {
         // Save draft via Graph API: POST /me/messages creates a draft without sending
         log::info!(
             "Saving draft via Microsoft Graph for account {}",
@@ -342,13 +342,13 @@ pub async fn save_draft(
                 body_text: message.body_text.clone(),
             })
             .await?;
-    } else if account.mail_protocol == "jmap" {
+    } else if account.mail_protocol_str() == "jmap" {
         let jmap_config = crate::commands::sync_cmd::build_jmap_config(&account).await?;
         let conn_jmap = JmapConnection::connect(&jmap_config).await?;
         conn_jmap.save_draft(&jmap_config, &raw_message).await?;
     } else {
         // IMAP: append to Drafts folder (O365 uses XOAUTH2)
-        let (imap_password, imap_xoauth2) = if account.provider == "o365" {
+        let (imap_password, imap_xoauth2) = if account.auth_method == "oauth-microsoft" {
             let tokens = crate::oauth::load_tokens(&account.id)?
                 .ok_or_else(|| Error::Other("No O365 tokens".into()))?;
             let refresh = tokens

--- a/src-tauri/src/commands/contacts.rs
+++ b/src-tauri/src/commands/contacts.rs
@@ -607,33 +607,34 @@ pub async fn sync_contacts(
         db::accounts::get_account_full(&conn, &account_id)?
     };
 
-    if account.mail_protocol == "jmap" {
-        sync_contacts_jmap(&state, &account_id, &account).await?;
-    } else if account.provider == "gmail" {
-        match sync_contacts_google(&state, &account_id, &account).await {
+    match account.contacts_protocol_str() {
+        "jmap" => {
+            sync_contacts_jmap(&state, &account_id, &account).await?;
+        }
+        "google" => match sync_contacts_google(&state, &account_id, &account).await {
             Ok(()) => {}
             Err(e) => {
                 log::warn!(
-                    "sync_contacts: Gmail CardDAV failed (OAuth may not be set up): {}",
+                    "sync_contacts: Gmail People API failed (OAuth may not be set up): {}",
                     e
                 );
             }
+        },
+        "graph" => {
+            sync_contacts_graph(&state, &account_id).await?;
         }
-    } else if account.provider == "o365" {
-        sync_contacts_graph(&state, &account_id).await?;
-    } else if account.mail_protocol == "imap" {
-        // Generic IMAP account — try CardDAV sync
-        match sync_contacts_carddav(&state, &account_id, &account).await {
+        "carddav" => match sync_contacts_carddav(&state, &account_id, &account).await {
             Ok(()) => {}
             Err(e) => {
                 log::warn!("sync_contacts: CardDAV failed for {}: {}", account_id, e);
             }
+        },
+        _ => {
+            log::debug!(
+                "sync_contacts: skipping account {} (no contacts binding)",
+                account_id
+            );
         }
-    } else {
-        log::debug!(
-            "sync_contacts: skipping account {} (no supported sync)",
-            account_id
-        );
     }
 
     // Notify frontend that contact data has changed

--- a/src-tauri/src/commands/filters.rs
+++ b/src-tauri/src/commands/filters.rs
@@ -90,7 +90,7 @@ pub async fn apply_filters_to_folder(
     };
 
     // Build IMAP config — O365 needs XOAUTH2 token refresh
-    let (imap_password, imap_xoauth2) = if account.provider == "o365" {
+    let (imap_password, imap_xoauth2) = if account.auth_method == "oauth-microsoft" {
         let tokens = crate::oauth::load_tokens(&account_id)?
             .ok_or_else(|| Error::Other("No O365 tokens".into()))?;
         let refresh = tokens

--- a/src-tauri/src/commands/mail.rs
+++ b/src-tauri/src/commands/mail.rs
@@ -342,7 +342,7 @@ pub async fn get_message_body(
         } else {
             log::info!("Body not on disk for {}, fetching from IMAP", message_id);
 
-            let suspended_idle = if should_suspend_idle_for_imap_operation(&account.provider) {
+            let suspended_idle = if should_suspend_idle_for_imap_operation(&account.auth_method) {
                 suspend_imap_idle_for_account(&state, &account_id).await?
             } else {
                 false

--- a/src-tauri/src/commands/mail.rs
+++ b/src-tauri/src/commands/mail.rs
@@ -117,18 +117,18 @@ pub async fn search_messages_server(
         db::accounts::get_account_full(&conn, &account_id)?
     };
 
-    let hits = if account.mail_protocol == "graph" {
+    let hits = if account.mail_protocol_str() == "graph" {
         let token = crate::mail::graph::get_graph_token(&account_id).await?;
         let client = crate::mail::graph::GraphClient::new(&token);
         client.search_messages(&account_id, &query).await?
-    } else if account.mail_protocol == "jmap" {
+    } else if account.mail_protocol_str() == "jmap" {
         let jmap_config = crate::commands::sync_cmd::build_jmap_config(&account).await?;
         let conn_jmap = crate::mail::jmap::JmapConnection::connect(&jmap_config).await?;
         conn_jmap
             .search_account(&jmap_config, &account_id, &query)
             .await?
     } else {
-        let (password, use_xoauth2) = if account.provider == "o365" {
+        let (password, use_xoauth2) = if account.auth_method == "oauth-microsoft" {
             let tokens = crate::oauth::load_tokens(&account_id)?
                 .ok_or_else(|| Error::Other("No O365 tokens".into()))?;
             let refresh = tokens
@@ -196,14 +196,14 @@ pub async fn import_search_hit(
         db::accounts::get_account_full(&conn, &account_id)?
     };
 
-    let (id, uid, maildir_path) = if account.mail_protocol == "graph" {
+    let (id, uid, maildir_path) = if account.mail_protocol_str() == "graph" {
         // Format matches sync_cmd::sync_graph_account: `{account_id}_{graph_id}`,
         // and `graph:{graph_id}` in maildir_path triggers the on-demand stream
         // path in get_message_body.
         let id = format!("{}_{}", account_id, hit.backend_id);
         let maildir = format!("graph:{}", hit.backend_id);
         (id, 0u32, maildir)
-    } else if account.mail_protocol == "jmap" {
+    } else if account.mail_protocol_str() == "jmap" {
         // Format matches jmap_sync: `{account_id}_{mailbox_id}_{email_id}`.
         let id = format!("{}_{}_{}", account_id, hit.folder_path, hit.backend_id);
         (id, 0u32, String::new())
@@ -286,7 +286,7 @@ pub async fn get_message_body(
         let flags: Vec<String> = serde_json::from_str(&flags_json).unwrap_or_default();
         let data_dir = state.data_dir.clone();
 
-        let relative_path = if account.mail_protocol == "graph" {
+        let relative_path = if account.mail_protocol_str() == "graph" {
             // Graph: stream raw MIME to disk via GET /me/messages/{id}/$value
             log::info!("Body not on disk for {}, streaming from Graph", message_id);
 
@@ -319,7 +319,7 @@ pub async fn get_message_body(
             let rp = format!("{}/{}/cur/{}", account_id, folder_dir, filename);
             log::info!("Graph body streamed: {} ({} bytes)", rp, bytes_written);
             rp
-        } else if account.mail_protocol == "jmap" {
+        } else if account.mail_protocol_str() == "jmap" {
             log::info!("Body not on disk for {}, fetching from JMAP", message_id);
 
             let jmap_config = crate::commands::sync_cmd::build_jmap_config(&account).await?;
@@ -350,7 +350,7 @@ pub async fn get_message_body(
             let resume_account = account.clone();
 
             // For O365, refresh IMAP-scoped token for XOAUTH2
-            let (password, use_xoauth2) = if account.provider == "o365" {
+            let (password, use_xoauth2) = if account.auth_method == "oauth-microsoft" {
                 let tokens = crate::oauth::load_tokens(&account_id)?
                     .ok_or_else(|| Error::Other("No O365 tokens".into()))?;
                 let refresh = tokens
@@ -658,7 +658,7 @@ pub async fn create_folder(
         db::accounts::get_account_full(&conn, &account_id)?
     };
 
-    if account.mail_protocol == "jmap" {
+    if account.mail_protocol_str() == "jmap" {
         // JMAP: Mailbox/set create
         let jmap_config = crate::commands::sync_cmd::build_jmap_config(&account).await?;
         let conn_jmap = crate::mail::jmap::JmapConnection::connect(&jmap_config).await?;
@@ -681,7 +681,7 @@ pub async fn create_folder(
             .await?;
     } else {
         // IMAP: CREATE (O365 uses XOAUTH2)
-        let (imap_password, imap_xoauth2) = if account.provider == "o365" {
+        let (imap_password, imap_xoauth2) = if account.auth_method == "oauth-microsoft" {
             let tokens = crate::oauth::load_tokens(&account_id)?
                 .ok_or_else(|| Error::Other("No O365 tokens".into()))?;
             let refresh = tokens
@@ -783,7 +783,7 @@ pub async fn delete_folder(
         db::accounts::get_account_full(&conn, &account_id)?
     };
 
-    if account.mail_protocol == "graph" {
+    if account.mail_protocol_str() == "graph" {
         let token = crate::mail::graph::get_graph_token(&account_id).await?;
         let client = crate::mail::graph::GraphClient::new(&token);
         client.delete_mail_folder(&folder_path).await.map_err(|e| {
@@ -795,7 +795,7 @@ pub async fn delete_folder(
             );
             e
         })?;
-    } else if account.mail_protocol == "jmap" {
+    } else if account.mail_protocol_str() == "jmap" {
         // JMAP: Mailbox/set destroy — folder_path is the mailbox ID
         let jmap_config = crate::commands::sync_cmd::build_jmap_config(&account).await?;
         let conn_jmap = crate::mail::jmap::JmapConnection::connect(&jmap_config).await?;
@@ -813,7 +813,7 @@ pub async fn delete_folder(
             })?;
     } else {
         // IMAP: DELETE
-        let (imap_password, imap_xoauth2) = if account.provider == "o365" {
+        let (imap_password, imap_xoauth2) = if account.auth_method == "oauth-microsoft" {
             let tokens = crate::oauth::load_tokens(&account_id)?
                 .ok_or_else(|| Error::Other("No O365 tokens".into()))?;
             let refresh = tokens

--- a/src-tauri/src/commands/sync_cmd.rs
+++ b/src-tauri/src/commands/sync_cmd.rs
@@ -116,12 +116,16 @@ pub async fn build_jmap_config(
     })
 }
 
-fn should_start_imap_idle(_provider: &str) -> bool {
+fn should_start_imap_idle(_auth_method: &str) -> bool {
     true
 }
 
-pub(crate) fn should_suspend_idle_for_imap_operation(provider: &str) -> bool {
-    provider == "o365"
+/// O365 IMAP needs IDLE suspended around any other operation because
+/// Microsoft's server only allows one connection per account at a time.
+/// Identifying O365 via auth_method is more accurate than the legacy
+/// `provider` string since Phase 3 dropped that column.
+pub(crate) fn should_suspend_idle_for_imap_operation(auth_method: &str) -> bool {
+    auth_method == "oauth-microsoft"
 }
 
 pub(crate) async fn suspend_imap_idle_for_account(
@@ -156,7 +160,7 @@ pub(crate) async fn resume_imap_idle_for_account(
     account: &db::accounts::AccountFull,
     suspended_idle: bool,
 ) -> Result<()> {
-    if !suspended_idle || !should_start_imap_idle(&account.provider) {
+    if !suspended_idle || !should_start_imap_idle(&account.auth_method) {
         return Ok(());
     }
 
@@ -232,7 +236,7 @@ pub async fn trigger_sync(
     };
 
     let suspended_idle = if account.mail_protocol_str() == "imap"
-        && should_suspend_idle_for_imap_operation(&account.provider)
+        && should_suspend_idle_for_imap_operation(&account.auth_method)
     {
         log::info!(
             "Suspending IMAP IDLE for account {} before sync",
@@ -385,7 +389,7 @@ pub async fn sync_folder(
     // sync_jmap_folder_public, and the IMAP branch each emit their own).
 
     let suspended_idle = if account.mail_protocol_str() == "imap"
-        && should_suspend_idle_for_imap_operation(&account.provider)
+        && should_suspend_idle_for_imap_operation(&account.auth_method)
     {
         log::info!(
             "Suspending IMAP IDLE for account {} before single-folder sync",
@@ -686,7 +690,7 @@ pub async fn prefetch_bodies(
         db::accounts::get_account_full(&conn, &account_id)?
     };
 
-    let suspended_idle = if should_suspend_idle_for_imap_operation(&account.provider) {
+    let suspended_idle = if should_suspend_idle_for_imap_operation(&account.auth_method) {
         log::info!(
             "Suspending IMAP IDLE for account {} before body prefetch",
             account_id
@@ -1367,8 +1371,14 @@ pub async fn stop_idle(state: State<'_, AppState>) -> Result<()> {
 mod tests {
     #[test]
     fn o365_sync_suspends_idle_but_still_allows_idle_startup() {
-        assert!(super::should_start_imap_idle("o365"));
-        assert!(super::should_suspend_idle_for_imap_operation("o365"));
-        assert!(!super::should_suspend_idle_for_imap_operation("gmail"));
+        // Phase 3: these helpers now key off auth_method, not provider.
+        assert!(super::should_start_imap_idle("oauth-microsoft"));
+        assert!(super::should_suspend_idle_for_imap_operation(
+            "oauth-microsoft"
+        ));
+        assert!(!super::should_suspend_idle_for_imap_operation(
+            "oauth-google"
+        ));
+        assert!(!super::should_suspend_idle_for_imap_operation("password"));
     }
 }

--- a/src-tauri/src/commands/sync_cmd.rs
+++ b/src-tauri/src/commands/sync_cmd.rs
@@ -231,7 +231,7 @@ pub async fn trigger_sync(
         }
     };
 
-    let suspended_idle = if account.mail_protocol == "imap"
+    let suspended_idle = if account.mail_protocol_str() == "imap"
         && should_suspend_idle_for_imap_operation(&account.provider)
     {
         log::info!(
@@ -244,7 +244,7 @@ pub async fn trigger_sync(
     };
     let resume_account = account.clone();
 
-    let sync_result = if account.mail_protocol == "graph" {
+    let sync_result = if account.mail_protocol_str() == "graph" {
         log::info!(
             "Syncing account {} ({}) via Microsoft Graph",
             account.display_name,
@@ -255,7 +255,7 @@ pub async fn trigger_sync(
         } else {
             Ok(())
         }
-    } else if account.mail_protocol == "jmap" {
+    } else if account.mail_protocol_str() == "jmap" {
         log::info!(
             "Syncing account {} ({}) via JMAP (url={})",
             account.display_name,
@@ -292,7 +292,7 @@ pub async fn trigger_sync(
         );
 
         // For O365 accounts, get an IMAP-scoped OAuth token
-        let (password, use_xoauth2) = if account.provider == "o365" {
+        let (password, use_xoauth2) = if account.auth_method == "oauth-microsoft" {
             let tokens = crate::oauth::load_tokens(&account_id)?.ok_or_else(|| {
                 Error::Other("No O365 OAuth tokens. Please sign in with Microsoft.".into())
             })?;
@@ -384,7 +384,7 @@ pub async fn sync_folder(
     // activity store sees exactly one start per sync (sync_graph_account,
     // sync_jmap_folder_public, and the IMAP branch each emit their own).
 
-    let suspended_idle = if account.mail_protocol == "imap"
+    let suspended_idle = if account.mail_protocol_str() == "imap"
         && should_suspend_idle_for_imap_operation(&account.provider)
     {
         log::info!(
@@ -397,7 +397,7 @@ pub async fn sync_folder(
     };
     let resume_account = account.clone();
 
-    let sync_result: Result<u32> = if account.mail_protocol == "graph" {
+    let sync_result: Result<u32> = if account.mail_protocol_str() == "graph" {
         // Microsoft Graph has no cheap per-folder fetch — every sync runs
         // against the whole account. Spawn it in the background and return
         // immediately so the UI's per-folder spinner doesn't sit there for
@@ -427,7 +427,7 @@ pub async fn sync_folder(
             }
         });
         return Ok(0);
-    } else if account.mail_protocol == "jmap" {
+    } else if account.mail_protocol_str() == "jmap" {
         let jmap_config = build_jmap_config(&account).await?;
         jmap_sync::sync_jmap_folder_public(
             app.clone(),
@@ -451,7 +451,7 @@ pub async fn sync_folder(
         .ok();
 
         // For O365, refresh IMAP-scoped token
-        let (password, use_xoauth2) = if account.provider == "o365" {
+        let (password, use_xoauth2) = if account.auth_method == "oauth-microsoft" {
             let tokens = crate::oauth::load_tokens(&account_id)?
                 .ok_or_else(|| Error::Other("No O365 tokens".into()))?;
             let refresh = tokens
@@ -675,7 +675,7 @@ pub async fn prefetch_bodies(
     {
         let conn = state.db.reader();
         let account = db::accounts::get_account_full(&conn, &account_id)?;
-        if account.mail_protocol == "jmap" {
+        if account.mail_protocol_str() == "jmap" {
             log::debug!("Prefetch: skipping JMAP account {}", account_id);
             return Ok(0);
         }
@@ -698,7 +698,7 @@ pub async fn prefetch_bodies(
     let resume_account = account.clone();
 
     // For O365: get IMAP-scoped OAuth token
-    let (password, use_xoauth2) = if account.provider == "o365" {
+    let (password, use_xoauth2) = if account.auth_method == "oauth-microsoft" {
         let tokens = crate::oauth::load_tokens(&account_id)?
             .ok_or_else(|| Error::Other("No O365 tokens for prefetch".into()))?;
         let refresh_token = tokens
@@ -1173,6 +1173,8 @@ pub async fn start_idle(app: AppHandle, state: State<'_, AppState>) -> Result<()
             continue;
         }
 
+        // Account summary still carries mail_protocol directly; dispatch
+        // here without going through AccountFull to avoid an extra DB hop.
         if account.mail_protocol == "imap" {
             start_imap_idle(&app, &state, account).await?;
         } else if account.mail_protocol == "jmap" {
@@ -1203,7 +1205,7 @@ async fn start_imap_idle(
     };
 
     // For O365: get IMAP-scoped OAuth token
-    let (password, use_xoauth2) = if full_account.provider == "o365" {
+    let (password, use_xoauth2) = if full_account.auth_method == "oauth-microsoft" {
         let tokens = crate::oauth::load_tokens(&account.id)?
             .ok_or_else(|| crate::error::Error::Other("No O365 tokens for IDLE".into()))?;
         let refresh_token = tokens

--- a/src-tauri/src/commands/sync_cmd.rs
+++ b/src-tauri/src/commands/sync_cmd.rs
@@ -171,6 +171,9 @@ pub(crate) async fn resume_imap_idle_for_account(
         provider: account.provider.clone(),
         mail_protocol: account.mail_protocol.clone(),
         enabled: account.enabled,
+        mail_sync_interval_seconds: account.mail_sync_interval_seconds,
+        calendar_sync_interval_seconds: account.calendar_sync_interval_seconds,
+        contacts_sync_interval_seconds: account.contacts_sync_interval_seconds,
     };
 
     start_imap_idle(app, state, &account_summary).await

--- a/src-tauri/src/db/accounts.rs
+++ b/src-tauri/src/db/accounts.rs
@@ -1,7 +1,9 @@
 use rusqlite::{params, Connection};
 use serde::{Deserialize, Serialize};
 
-use crate::db::service_bindings::ServiceBinding;
+use crate::db::service_bindings::{
+    DavBindingConfig, ImapBindingConfig, JmapBindingConfig, ServiceBinding,
+};
 use crate::error::Result;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -122,21 +124,145 @@ impl AccountFull {
             .map(|b| b.protocol.as_str())
             .unwrap_or("")
     }
+
+    /// Parsed IMAP/SMTP config from the mail binding, if it's an IMAP binding.
+    /// Returns `None` for non-IMAP mail accounts (graph/jmap) so callers can
+    /// pattern-match cleanly. Returns `Some(default)` if the binding exists
+    /// but the JSON parses with all defaults — that shouldn't happen in
+    /// practice but won't panic.
+    pub fn mail_imap_config(&self) -> Option<ImapBindingConfig> {
+        self.mail_binding()
+            .filter(|b| b.protocol == "imap")
+            .and_then(|b| b.imap_config().ok())
+    }
+
+    pub fn mail_jmap_config(&self) -> Option<JmapBindingConfig> {
+        self.mail_binding()
+            .filter(|b| b.protocol == "jmap")
+            .and_then(|b| b.jmap_config().ok())
+    }
+
+    pub fn calendar_caldav_config(&self) -> Option<DavBindingConfig> {
+        self.calendar_binding()
+            .filter(|b| b.protocol == "caldav")
+            .and_then(|b| b.dav_config().ok())
+    }
+
+    pub fn contacts_carddav_config(&self) -> Option<DavBindingConfig> {
+        self.contacts_binding()
+            .filter(|b| b.protocol == "carddav")
+            .and_then(|b| b.dav_config().ok())
+    }
+
+    /// Calendar URL for any DAV-style calendar (caldav today; future
+    /// caldav-over-google-fallback could land here too).
+    pub fn calendar_dav_url(&self) -> Option<String> {
+        self.calendar_caldav_config().map(|c| c.url)
+    }
+
+    pub fn contacts_dav_url(&self) -> Option<String> {
+        self.contacts_carddav_config().map(|c| c.url)
+    }
+
+    /// Whether the calendar binding is enabled (replaces `calendar_sync_enabled`
+    /// on the legacy schema). Returns `false` if the account has no calendar
+    /// binding at all.
+    pub fn calendar_enabled(&self) -> bool {
+        self.calendar_binding().is_some_and(|b| b.enabled)
+    }
+
+    /// Populate the legacy per-protocol fields (`provider`, `mail_protocol`,
+    /// `imap_host`, ...) from the loaded `bindings` and `auth_method`.
+    /// Phase 3 dropped these columns from the database, but the fields are
+    /// still part of `AccountFull` so the wire format and the dispatch sites
+    /// touched in earlier phases keep working unchanged.
+    pub fn populate_legacy_from_bindings(&mut self) {
+        self.provider = match self.auth_method.as_str() {
+            "oauth-google" => "gmail",
+            "oauth-microsoft" => "o365",
+            _ => "generic",
+        }
+        .to_string();
+
+        self.jmap_auth_method = if self.auth_method == "oauth-jmap-oidc" {
+            "oidc"
+        } else {
+            "basic"
+        }
+        .to_string();
+
+        self.mail_protocol = self
+            .mail_binding()
+            .map(|b| b.protocol.clone())
+            .unwrap_or_default();
+
+        if let Some(c) = self.mail_imap_config() {
+            self.imap_host = c.imap_host;
+            self.imap_port = c.imap_port;
+            self.smtp_host = c.smtp_host;
+            self.smtp_port = c.smtp_port;
+            self.use_tls = c.use_tls;
+        } else {
+            // Sensible defaults for non-IMAP accounts.
+            self.imap_host = String::new();
+            self.imap_port = 993;
+            self.smtp_host = String::new();
+            self.smtp_port = 587;
+            self.use_tls = true;
+        }
+
+        self.jmap_url = self
+            .mail_jmap_config()
+            .map(|c| c.url)
+            .unwrap_or_default();
+
+        // The legacy `caldav_url` column was a single string used for both
+        // CalDAV and CardDAV (same server in practice). Phase 3 splits it into
+        // independent bindings, so we surface the calendar URL here and fall
+        // back to the contacts URL for accounts that have only carddav.
+        self.caldav_url = self
+            .calendar_dav_url()
+            .or_else(|| self.contacts_dav_url())
+            .unwrap_or_default();
+
+        self.calendar_sync_enabled = self
+            .calendar_binding()
+            .map(|b| b.enabled)
+            .unwrap_or(true);
+    }
 }
 
 pub fn list_accounts(conn: &Connection) -> Result<Vec<Account>> {
+    // mail_protocol comes from the mail service binding (LEFT JOIN so
+    // calendar-only accounts show up with an empty mail_protocol).
+    // provider is derived from auth_method on the way out so the wire
+    // format stays compatible with the frontend.
     let mut stmt = conn.prepare(
-        "SELECT id, display_name, email, provider, mail_protocol, enabled FROM accounts ORDER BY display_name",
+        "SELECT a.id, a.display_name, a.email, a.auth_method, a.enabled,
+                COALESCE(
+                    (SELECT b.protocol FROM service_bindings b
+                     WHERE b.account_id = a.id AND b.service = 'mail' LIMIT 1),
+                    ''
+                ) AS mail_protocol
+         FROM accounts a
+         ORDER BY a.display_name",
     )?;
     let accounts = stmt
         .query_map([], |row| {
+            let auth_method: String = row.get(3)?;
+            let provider = match auth_method.as_str() {
+                "oauth-google" => "gmail",
+                "oauth-microsoft" => "o365",
+                _ => "generic",
+            }
+            .to_string();
             Ok(Account {
                 id: row.get(0)?,
                 display_name: row.get(1)?,
                 email: row.get(2)?,
-                provider: row.get(3)?,
-                mail_protocol: row.get(4)?,
-                enabled: row.get(5)?,
+                provider,
+                mail_protocol: row.get(5)?,
+                enabled: row.get(4)?,
             })
         })?
         .collect::<std::result::Result<Vec<_>, _>>()?;
@@ -145,31 +271,34 @@ pub fn list_accounts(conn: &Connection) -> Result<Vec<Account>> {
 
 pub fn get_account_full(conn: &Connection, id: &str) -> Result<AccountFull> {
     let mut account = conn.query_row(
-        "SELECT id, display_name, email, provider, mail_protocol, imap_host, imap_port, smtp_host, smtp_port, jmap_url, caldav_url, username, use_tls, enabled, signature, jmap_auth_method, oidc_token_endpoint, oidc_client_id, calendar_sync_enabled, auth_method FROM accounts WHERE id = ?1",
+        "SELECT id, display_name, email, username, enabled, signature,
+                oidc_token_endpoint, oidc_client_id, auth_method
+         FROM accounts WHERE id = ?1",
         params![id],
         |row| {
             Ok(AccountFull {
                 id: row.get(0)?,
                 display_name: row.get(1)?,
                 email: row.get(2)?,
-                provider: row.get(3)?,
-                mail_protocol: row.get(4)?,
-                imap_host: row.get(5)?,
-                imap_port: row.get::<_, u32>(6)? as u16,
-                smtp_host: row.get(7)?,
-                smtp_port: row.get::<_, u32>(8)? as u16,
-                jmap_url: row.get(9)?,
-                caldav_url: row.get(10)?,
-                username: row.get(11)?,
+                username: row.get(3)?,
+                enabled: row.get(4)?,
+                signature: row.get(5)?,
+                oidc_token_endpoint: row.get(6)?,
+                oidc_client_id: row.get(7)?,
+                auth_method: row.get(8)?,
+                // Legacy fields populated below from bindings + auth_method.
+                provider: String::new(),
+                mail_protocol: String::new(),
+                jmap_auth_method: String::new(),
+                imap_host: String::new(),
+                imap_port: 993,
+                smtp_host: String::new(),
+                smtp_port: 587,
+                jmap_url: String::new(),
+                caldav_url: String::new(),
                 password: String::new(),
-                use_tls: row.get(12)?,
-                enabled: row.get(13)?,
-                signature: row.get(14)?,
-                jmap_auth_method: row.get(15)?,
-                oidc_token_endpoint: row.get(16)?,
-                oidc_client_id: row.get(17)?,
-                calendar_sync_enabled: row.get(18)?,
-                auth_method: row.get(19)?,
+                use_tls: true,
+                calendar_sync_enabled: true,
                 bindings: Vec::new(),
             })
         },
@@ -178,10 +307,11 @@ pub fn get_account_full(conn: &Connection, id: &str) -> Result<AccountFull> {
         other => crate::error::Error::Database(other),
     })?;
 
-    // Phase-2: load service_bindings so dispatch helpers can read the
-    // protocol-of-record. A missing or incomplete binding row falls back
-    // to whatever the legacy column says via the *_str helpers.
+    // Phase-3: bindings are the source of truth. Load them, then populate
+    // the legacy AccountFull fields from the bindings + auth_method so the
+    // wire format stays unchanged.
     account.bindings = crate::db::service_bindings::list_for_account(conn, id)?;
+    account.populate_legacy_from_bindings();
 
     // Fetch password from the system keyring. OIDC/OAuth accounts don't
     // store a keyring password here — their tokens live under the
@@ -216,32 +346,53 @@ pub fn insert_account(conn: &Connection, id: &str, config: &AccountConfig) -> Re
         crate::db::service_bindings::auth_method_for(&config.provider, &config.jmap_auth_method);
 
     conn.execute(
-        "INSERT INTO accounts (id, display_name, email, provider, mail_protocol, imap_host, imap_port, smtp_host, smtp_port, jmap_url, caldav_url, username, use_tls, signature, jmap_auth_method, oidc_token_endpoint, oidc_client_id, calendar_sync_enabled, auth_method)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19)",
+        "INSERT INTO accounts (id, display_name, email, username, signature,
+                               oidc_token_endpoint, oidc_client_id, auth_method)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
         params![
             id,
             config.display_name,
             config.email,
-            config.provider,
-            config.mail_protocol,
-            config.imap_host,
-            config.imap_port,
-            config.smtp_host,
-            config.smtp_port,
-            config.jmap_url,
-            config.caldav_url,
             config.username,
-            config.use_tls,
             config.signature,
-            config.jmap_auth_method,
             config.oidc_token_endpoint,
             config.oidc_client_id,
-            config.calendar_sync_enabled,
             auth_method,
         ],
     )?;
-    crate::db::service_bindings::rebuild_for_account(conn, id)?;
+    crate::db::service_bindings::rebuild_for_account(
+        conn,
+        id,
+        config_to_legacy_fields(id, true, config),
+    )?;
     Ok(())
+}
+
+/// Build a `LegacyBindingFields` view over an `AccountConfig`. Used by
+/// `insert_account` / `update_account` so writes go through the same
+/// `derive_bindings` rules as the Phase-1 populate migration.
+fn config_to_legacy_fields<'a>(
+    account_id: &'a str,
+    enabled: bool,
+    config: &'a AccountConfig,
+) -> crate::db::service_bindings::LegacyBindingFields<'a> {
+    crate::db::service_bindings::LegacyBindingFields {
+        account_id,
+        enabled,
+        provider: &config.provider,
+        mail_protocol: &config.mail_protocol,
+        imap_host: &config.imap_host,
+        imap_port: config.imap_port,
+        smtp_host: &config.smtp_host,
+        smtp_port: config.smtp_port,
+        use_tls: config.use_tls,
+        jmap_url: &config.jmap_url,
+        jmap_auth_method: &config.jmap_auth_method,
+        oidc_token_endpoint: &config.oidc_token_endpoint,
+        oidc_client_id: &config.oidc_client_id,
+        caldav_url: &config.caldav_url,
+        calendar_sync_enabled: config.calendar_sync_enabled,
+    }
 }
 
 pub fn update_account(conn: &Connection, id: &str, config: &AccountConfig) -> Result<()> {
@@ -257,31 +408,18 @@ pub fn update_account(conn: &Connection, id: &str, config: &AccountConfig) -> Re
         crate::db::service_bindings::auth_method_for(&config.provider, &config.jmap_auth_method);
 
     let rows = conn.execute(
-        "UPDATE accounts SET display_name=?1, email=?2, provider=?3, mail_protocol=?4,
-         imap_host=?5, imap_port=?6, smtp_host=?7, smtp_port=?8, jmap_url=?9,
-         caldav_url=?10, username=?11, use_tls=?12, signature=?13,
-         jmap_auth_method=?14, oidc_token_endpoint=?15, oidc_client_id=?16,
-         calendar_sync_enabled=?17, auth_method=?18,
-         updated_at=CURRENT_TIMESTAMP
-         WHERE id=?19",
+        "UPDATE accounts
+         SET display_name=?1, email=?2, username=?3, signature=?4,
+             oidc_token_endpoint=?5, oidc_client_id=?6, auth_method=?7,
+             updated_at=CURRENT_TIMESTAMP
+         WHERE id=?8",
         params![
             config.display_name,
             config.email,
-            config.provider,
-            config.mail_protocol,
-            config.imap_host,
-            config.imap_port,
-            config.smtp_host,
-            config.smtp_port,
-            config.jmap_url,
-            config.caldav_url,
             config.username,
-            config.use_tls,
             config.signature,
-            config.jmap_auth_method,
             config.oidc_token_endpoint,
             config.oidc_client_id,
-            config.calendar_sync_enabled,
             auth_method,
             id,
         ],
@@ -289,7 +427,21 @@ pub fn update_account(conn: &Connection, id: &str, config: &AccountConfig) -> Re
     if rows == 0 {
         return Err(crate::error::Error::AccountNotFound(id.to_string()));
     }
-    crate::db::service_bindings::rebuild_for_account(conn, id)?;
+    // Preserve the existing enabled flag — AccountConfig doesn't carry
+    // enabled/disabled, so the previous binding's state would otherwise
+    // get clobbered to `true` on every update.
+    let enabled: bool = conn
+        .query_row(
+            "SELECT enabled FROM accounts WHERE id = ?1",
+            params![id],
+            |row| row.get(0),
+        )
+        .unwrap_or(true);
+    crate::db::service_bindings::rebuild_for_account(
+        conn,
+        id,
+        config_to_legacy_fields(id, enabled, config),
+    )?;
     log::info!("Updated account {}", id);
     Ok(())
 }
@@ -310,29 +462,19 @@ mod tests {
 
     fn setup_db() -> Connection {
         let conn = Connection::open_in_memory().unwrap();
+        // Phase-3 schema: identity-only columns plus service_bindings.
         conn.execute_batch(
             "
             CREATE TABLE accounts (
                 id TEXT PRIMARY KEY,
                 display_name TEXT NOT NULL,
                 email TEXT NOT NULL,
-                provider TEXT NOT NULL,
-                mail_protocol TEXT NOT NULL DEFAULT 'imap',
-                imap_host TEXT NOT NULL DEFAULT '',
-                imap_port INTEGER NOT NULL DEFAULT 993,
-                smtp_host TEXT NOT NULL DEFAULT '',
-                smtp_port INTEGER NOT NULL DEFAULT 587,
-                jmap_url TEXT NOT NULL DEFAULT '',
-                caldav_url TEXT NOT NULL DEFAULT '',
                 username TEXT NOT NULL,
-                use_tls INTEGER NOT NULL DEFAULT 1,
                 enabled INTEGER NOT NULL DEFAULT 1,
                 signature TEXT NOT NULL DEFAULT '',
-                jmap_auth_method TEXT NOT NULL DEFAULT 'basic',
+                auth_method TEXT NOT NULL DEFAULT '',
                 oidc_token_endpoint TEXT NOT NULL DEFAULT '',
                 oidc_client_id TEXT NOT NULL DEFAULT '',
-                calendar_sync_enabled INTEGER NOT NULL DEFAULT 1,
-                auth_method TEXT NOT NULL DEFAULT '',
                 created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
                 updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
             );
@@ -545,7 +687,12 @@ mod tests {
     fn test_calendar_sync_enabled_defaults_true_and_persists_toggle() {
         let conn = setup_db();
         let id = unique_id();
-        let config = make_config("alice@example.com", "Alice");
+        // calendar_sync_enabled now lives on the calendar binding's
+        // `enabled` flag. Use an IMAP+CalDAV account so a calendar
+        // binding actually gets created and the toggle has somewhere
+        // to round-trip through.
+        let mut config = make_config("alice@example.com", "Alice");
+        config.caldav_url = "https://dav.example.com/cal".into();
         assert!(config.calendar_sync_enabled);
         insert_account(&conn, &id, &config).unwrap();
 

--- a/src-tauri/src/db/accounts.rs
+++ b/src-tauri/src/db/accounts.rs
@@ -73,6 +73,16 @@ pub struct AccountConfig {
     pub calendar_sync_interval_seconds: Option<i64>,
     #[serde(default)]
     pub contacts_sync_interval_seconds: Option<i64>,
+    /// Whether a calendar / contacts binding actually exists for this
+    /// account, regardless of its enabled state. The Settings UI keys
+    /// off these to disambiguate standalone CalDAV-only vs CardDAV-only
+    /// accounts even after the user toggles the lone Sync-* flag off.
+    /// Read-only on save (the backend rebuilds bindings from the legacy
+    /// fields rather than these flags).
+    #[serde(default)]
+    pub has_calendar_binding: bool,
+    #[serde(default)]
+    pub has_contacts_binding: bool,
 }
 
 fn default_basic() -> String {
@@ -610,6 +620,8 @@ mod tests {
             mail_sync_interval_seconds: None,
             calendar_sync_interval_seconds: None,
             contacts_sync_interval_seconds: None,
+            has_calendar_binding: false,
+            has_contacts_binding: false,
         }
     }
 

--- a/src-tauri/src/db/accounts.rs
+++ b/src-tauri/src/db/accounts.rs
@@ -257,10 +257,7 @@ impl AccountFull {
             self.use_tls = true;
         }
 
-        self.jmap_url = self
-            .mail_jmap_config()
-            .map(|c| c.url)
-            .unwrap_or_default();
+        self.jmap_url = self.mail_jmap_config().map(|c| c.url).unwrap_or_default();
 
         // The legacy `caldav_url` column was a single string used for both
         // CalDAV and CardDAV (same server in practice). Phase 3 splits it into
@@ -271,27 +268,19 @@ impl AccountFull {
             .or_else(|| self.contacts_dav_url())
             .unwrap_or_default();
 
-        self.calendar_sync_enabled = self
-            .calendar_binding()
-            .map(|b| b.enabled)
-            .unwrap_or(true);
+        self.calendar_sync_enabled = self.calendar_binding().map(|b| b.enabled).unwrap_or(true);
 
         // Phase-4: surface per-binding state on the wire format so the
         // Settings edit form sees the toggles' current value.
-        self.mail_sync_enabled = self
-            .mail_binding()
-            .map(|b| b.enabled)
-            .unwrap_or(true);
-        self.contacts_sync_enabled = self
+        self.mail_sync_enabled = self.mail_binding().map(|b| b.enabled).unwrap_or(true);
+        self.contacts_sync_enabled = self.contacts_binding().map(|b| b.enabled).unwrap_or(true);
+        self.mail_sync_interval_seconds = self.mail_binding().and_then(|b| b.sync_interval_seconds);
+        self.calendar_sync_interval_seconds = self
+            .calendar_binding()
+            .and_then(|b| b.sync_interval_seconds);
+        self.contacts_sync_interval_seconds = self
             .contacts_binding()
-            .map(|b| b.enabled)
-            .unwrap_or(true);
-        self.mail_sync_interval_seconds =
-            self.mail_binding().and_then(|b| b.sync_interval_seconds);
-        self.calendar_sync_interval_seconds =
-            self.calendar_binding().and_then(|b| b.sync_interval_seconds);
-        self.contacts_sync_interval_seconds =
-            self.contacts_binding().and_then(|b| b.sync_interval_seconds);
+            .and_then(|b| b.sync_interval_seconds);
     }
 }
 
@@ -352,47 +341,51 @@ pub fn list_accounts(conn: &Connection) -> Result<Vec<Account>> {
 }
 
 pub fn get_account_full(conn: &Connection, id: &str) -> Result<AccountFull> {
-    let mut account = conn.query_row(
-        "SELECT id, display_name, email, username, enabled, signature,
+    let mut account = conn
+        .query_row(
+            "SELECT id, display_name, email, username, enabled, signature,
                 oidc_token_endpoint, oidc_client_id, auth_method
          FROM accounts WHERE id = ?1",
-        params![id],
-        |row| {
-            Ok(AccountFull {
-                id: row.get(0)?,
-                display_name: row.get(1)?,
-                email: row.get(2)?,
-                username: row.get(3)?,
-                enabled: row.get(4)?,
-                signature: row.get(5)?,
-                oidc_token_endpoint: row.get(6)?,
-                oidc_client_id: row.get(7)?,
-                auth_method: row.get(8)?,
-                // Legacy fields populated below from bindings + auth_method.
-                provider: String::new(),
-                mail_protocol: String::new(),
-                jmap_auth_method: String::new(),
-                imap_host: String::new(),
-                imap_port: 993,
-                smtp_host: String::new(),
-                smtp_port: 587,
-                jmap_url: String::new(),
-                caldav_url: String::new(),
-                password: String::new(),
-                use_tls: true,
-                calendar_sync_enabled: true,
-                bindings: Vec::new(),
-                mail_sync_enabled: true,
-                contacts_sync_enabled: true,
-                mail_sync_interval_seconds: None,
-                calendar_sync_interval_seconds: None,
-                contacts_sync_interval_seconds: None,
-            })
-        },
-    ).map_err(|e| match e {
-        rusqlite::Error::QueryReturnedNoRows => crate::error::Error::AccountNotFound(id.to_string()),
-        other => crate::error::Error::Database(other),
-    })?;
+            params![id],
+            |row| {
+                Ok(AccountFull {
+                    id: row.get(0)?,
+                    display_name: row.get(1)?,
+                    email: row.get(2)?,
+                    username: row.get(3)?,
+                    enabled: row.get(4)?,
+                    signature: row.get(5)?,
+                    oidc_token_endpoint: row.get(6)?,
+                    oidc_client_id: row.get(7)?,
+                    auth_method: row.get(8)?,
+                    // Legacy fields populated below from bindings + auth_method.
+                    provider: String::new(),
+                    mail_protocol: String::new(),
+                    jmap_auth_method: String::new(),
+                    imap_host: String::new(),
+                    imap_port: 993,
+                    smtp_host: String::new(),
+                    smtp_port: 587,
+                    jmap_url: String::new(),
+                    caldav_url: String::new(),
+                    password: String::new(),
+                    use_tls: true,
+                    calendar_sync_enabled: true,
+                    bindings: Vec::new(),
+                    mail_sync_enabled: true,
+                    contacts_sync_enabled: true,
+                    mail_sync_interval_seconds: None,
+                    calendar_sync_interval_seconds: None,
+                    contacts_sync_interval_seconds: None,
+                })
+            },
+        )
+        .map_err(|e| match e {
+            rusqlite::Error::QueryReturnedNoRows => {
+                crate::error::Error::AccountNotFound(id.to_string())
+            }
+            other => crate::error::Error::Database(other),
+        })?;
 
     // Phase-3: bindings are the source of truth. Load them, then populate
     // the legacy AccountFull fields from the bindings + auth_method so the

--- a/src-tauri/src/db/accounts.rs
+++ b/src-tauri/src/db/accounts.rs
@@ -1,6 +1,7 @@
 use rusqlite::{params, Connection};
 use serde::{Deserialize, Serialize};
 
+use crate::db::service_bindings::ServiceBinding;
 use crate::error::Result;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -70,6 +71,57 @@ pub struct AccountFull {
     pub oidc_token_endpoint: String,
     pub oidc_client_id: String,
     pub calendar_sync_enabled: bool,
+    /// Phase-2 field: how the user authenticates with this identity.
+    /// One of "password" | "oauth-google" | "oauth-microsoft" |
+    /// "oauth-jmap-oidc". Populated by the auth_method backfill migration.
+    pub auth_method: String,
+    /// Phase-2 field: bindings for this account, loaded via
+    /// `service_bindings::list_for_account` during `get_account_full`.
+    /// Dispatch code uses the helper methods below rather than reading
+    /// this field directly.
+    pub bindings: Vec<ServiceBinding>,
+}
+
+impl AccountFull {
+    /// Look up the binding for a given service ("mail" | "calendar" |
+    /// "contacts"). Returns `None` if the account has no binding for that
+    /// service (e.g. a CalDAV-only account has no mail binding).
+    pub fn binding_for(&self, service: &str) -> Option<&ServiceBinding> {
+        self.bindings.iter().find(|b| b.service == service)
+    }
+
+    pub fn mail_binding(&self) -> Option<&ServiceBinding> {
+        self.binding_for("mail")
+    }
+
+    pub fn calendar_binding(&self) -> Option<&ServiceBinding> {
+        self.binding_for("calendar")
+    }
+
+    pub fn contacts_binding(&self) -> Option<&ServiceBinding> {
+        self.binding_for("contacts")
+    }
+
+    /// Mail protocol as a string slice. Returns `""` for accounts with no
+    /// mail binding (calendar-only / contacts-only). Replaces direct reads
+    /// of `account.mail_protocol` at dispatch sites.
+    pub fn mail_protocol_str(&self) -> &str {
+        self.mail_binding()
+            .map(|b| b.protocol.as_str())
+            .unwrap_or("")
+    }
+
+    pub fn calendar_protocol_str(&self) -> &str {
+        self.calendar_binding()
+            .map(|b| b.protocol.as_str())
+            .unwrap_or("")
+    }
+
+    pub fn contacts_protocol_str(&self) -> &str {
+        self.contacts_binding()
+            .map(|b| b.protocol.as_str())
+            .unwrap_or("")
+    }
 }
 
 pub fn list_accounts(conn: &Connection) -> Result<Vec<Account>> {
@@ -93,7 +145,7 @@ pub fn list_accounts(conn: &Connection) -> Result<Vec<Account>> {
 
 pub fn get_account_full(conn: &Connection, id: &str) -> Result<AccountFull> {
     let mut account = conn.query_row(
-        "SELECT id, display_name, email, provider, mail_protocol, imap_host, imap_port, smtp_host, smtp_port, jmap_url, caldav_url, username, use_tls, enabled, signature, jmap_auth_method, oidc_token_endpoint, oidc_client_id, calendar_sync_enabled FROM accounts WHERE id = ?1",
+        "SELECT id, display_name, email, provider, mail_protocol, imap_host, imap_port, smtp_host, smtp_port, jmap_url, caldav_url, username, use_tls, enabled, signature, jmap_auth_method, oidc_token_endpoint, oidc_client_id, calendar_sync_enabled, auth_method FROM accounts WHERE id = ?1",
         params![id],
         |row| {
             Ok(AccountFull {
@@ -117,12 +169,19 @@ pub fn get_account_full(conn: &Connection, id: &str) -> Result<AccountFull> {
                 oidc_token_endpoint: row.get(16)?,
                 oidc_client_id: row.get(17)?,
                 calendar_sync_enabled: row.get(18)?,
+                auth_method: row.get(19)?,
+                bindings: Vec::new(),
             })
         },
     ).map_err(|e| match e {
         rusqlite::Error::QueryReturnedNoRows => crate::error::Error::AccountNotFound(id.to_string()),
         other => crate::error::Error::Database(other),
     })?;
+
+    // Phase-2: load service_bindings so dispatch helpers can read the
+    // protocol-of-record. A missing or incomplete binding row falls back
+    // to whatever the legacy column says via the *_str helpers.
+    account.bindings = crate::db::service_bindings::list_for_account(conn, id)?;
 
     // Fetch password from the system keyring. OIDC/OAuth accounts don't
     // store a keyring password here — their tokens live under the
@@ -153,9 +212,12 @@ pub fn insert_account(conn: &Connection, id: &str, config: &AccountConfig) -> Re
         crate::keyring::set_password(id, &config.password)?;
     }
 
+    let auth_method =
+        crate::db::service_bindings::auth_method_for(&config.provider, &config.jmap_auth_method);
+
     conn.execute(
-        "INSERT INTO accounts (id, display_name, email, provider, mail_protocol, imap_host, imap_port, smtp_host, smtp_port, jmap_url, caldav_url, username, use_tls, signature, jmap_auth_method, oidc_token_endpoint, oidc_client_id, calendar_sync_enabled)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18)",
+        "INSERT INTO accounts (id, display_name, email, provider, mail_protocol, imap_host, imap_port, smtp_host, smtp_port, jmap_url, caldav_url, username, use_tls, signature, jmap_auth_method, oidc_token_endpoint, oidc_client_id, calendar_sync_enabled, auth_method)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19)",
         params![
             id,
             config.display_name,
@@ -175,8 +237,10 @@ pub fn insert_account(conn: &Connection, id: &str, config: &AccountConfig) -> Re
             config.oidc_token_endpoint,
             config.oidc_client_id,
             config.calendar_sync_enabled,
+            auth_method,
         ],
     )?;
+    crate::db::service_bindings::rebuild_for_account(conn, id)?;
     Ok(())
 }
 
@@ -189,14 +253,17 @@ pub fn update_account(conn: &Connection, id: &str, config: &AccountConfig) -> Re
         crate::keyring::set_password(id, &config.password)?;
     }
 
+    let auth_method =
+        crate::db::service_bindings::auth_method_for(&config.provider, &config.jmap_auth_method);
+
     let rows = conn.execute(
         "UPDATE accounts SET display_name=?1, email=?2, provider=?3, mail_protocol=?4,
          imap_host=?5, imap_port=?6, smtp_host=?7, smtp_port=?8, jmap_url=?9,
          caldav_url=?10, username=?11, use_tls=?12, signature=?13,
          jmap_auth_method=?14, oidc_token_endpoint=?15, oidc_client_id=?16,
-         calendar_sync_enabled=?17,
+         calendar_sync_enabled=?17, auth_method=?18,
          updated_at=CURRENT_TIMESTAMP
-         WHERE id=?18",
+         WHERE id=?19",
         params![
             config.display_name,
             config.email,
@@ -215,12 +282,14 @@ pub fn update_account(conn: &Connection, id: &str, config: &AccountConfig) -> Re
             config.oidc_token_endpoint,
             config.oidc_client_id,
             config.calendar_sync_enabled,
+            auth_method,
             id,
         ],
     )?;
     if rows == 0 {
         return Err(crate::error::Error::AccountNotFound(id.to_string()));
     }
+    crate::db::service_bindings::rebuild_for_account(conn, id)?;
     log::info!("Updated account {}", id);
     Ok(())
 }
@@ -263,8 +332,21 @@ mod tests {
                 oidc_token_endpoint TEXT NOT NULL DEFAULT '',
                 oidc_client_id TEXT NOT NULL DEFAULT '',
                 calendar_sync_enabled INTEGER NOT NULL DEFAULT 1,
+                auth_method TEXT NOT NULL DEFAULT '',
                 created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
                 updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+            );
+            CREATE TABLE service_bindings (
+                id TEXT PRIMARY KEY,
+                account_id TEXT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+                service TEXT NOT NULL,
+                protocol TEXT NOT NULL,
+                enabled INTEGER NOT NULL DEFAULT 1,
+                sync_interval_seconds INTEGER,
+                config_json TEXT NOT NULL DEFAULT '{}',
+                created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE(account_id, service, protocol)
             );
             ",
         )

--- a/src-tauri/src/db/accounts.rs
+++ b/src-tauri/src/db/accounts.rs
@@ -14,6 +14,15 @@ pub struct Account {
     pub provider: String,
     pub mail_protocol: String,
     pub enabled: bool,
+    /// Phase-4 (#43): per-binding sync intervals so the frontend timers
+    /// can honor user preferences without an extra get_account_config
+    /// round-trip. `None` means "use the service's default cadence".
+    #[serde(default)]
+    pub mail_sync_interval_seconds: Option<i64>,
+    #[serde(default)]
+    pub calendar_sync_interval_seconds: Option<i64>,
+    #[serde(default)]
+    pub contacts_sync_interval_seconds: Option<i64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -21,6 +30,8 @@ pub struct AccountConfig {
     pub display_name: String,
     pub email: String,
     pub provider: String,
+    /// Mail protocol. Empty string means "no mail binding" — used for
+    /// standalone CalDAV / CardDAV / JMAP-cal-only accounts.
     pub mail_protocol: String,
     pub imap_host: String,
     pub imap_port: u16,
@@ -41,6 +52,27 @@ pub struct AccountConfig {
     pub oidc_client_id: String,
     #[serde(default = "default_true")]
     pub calendar_sync_enabled: bool,
+    /// Whether the mail binding is enabled. Default `true`. Set `false` to
+    /// keep a JMAP account's calendar/contacts sync running while turning
+    /// off mail (the "JMAP cal-only" use case in #43). For a non-mail
+    /// account (mail_protocol == "") this field is ignored.
+    #[serde(default = "default_true")]
+    pub mail_sync_enabled: bool,
+    /// Whether the contacts binding is enabled. Default `true`. Lets the
+    /// user disable CardDAV / Google People / Graph contacts for an
+    /// account that has them otherwise.
+    #[serde(default = "default_true")]
+    pub contacts_sync_enabled: bool,
+    /// Optional per-binding sync interval in seconds. `None` falls back to
+    /// the default cadence for that service (see calendar / contacts
+    /// stores on the frontend). Each service has its own field so the
+    /// wire format stays explicit.
+    #[serde(default)]
+    pub mail_sync_interval_seconds: Option<i64>,
+    #[serde(default)]
+    pub calendar_sync_interval_seconds: Option<i64>,
+    #[serde(default)]
+    pub contacts_sync_interval_seconds: Option<i64>,
 }
 
 fn default_basic() -> String {
@@ -82,6 +114,14 @@ pub struct AccountFull {
     /// Dispatch code uses the helper methods below rather than reading
     /// this field directly.
     pub bindings: Vec<ServiceBinding>,
+    /// Phase-4 wire-format mirrors of binding state. Populated from
+    /// `bindings` on fetch so the Settings edit form can round-trip the
+    /// per-binding `enabled` flags and sync intervals.
+    pub mail_sync_enabled: bool,
+    pub contacts_sync_enabled: bool,
+    pub mail_sync_interval_seconds: Option<i64>,
+    pub calendar_sync_interval_seconds: Option<i64>,
+    pub contacts_sync_interval_seconds: Option<i64>,
 }
 
 impl AccountFull {
@@ -105,22 +145,28 @@ impl AccountFull {
     }
 
     /// Mail protocol as a string slice. Returns `""` for accounts with no
-    /// mail binding (calendar-only / contacts-only). Replaces direct reads
-    /// of `account.mail_protocol` at dispatch sites.
+    /// mail binding (calendar-only / contacts-only) AND for accounts whose
+    /// mail binding is explicitly disabled (e.g. a JMAP server used for
+    /// calendar/contacts only). Replaces direct reads of
+    /// `account.mail_protocol` at dispatch sites — a disabled binding
+    /// short-circuits every protocol-specific branch.
     pub fn mail_protocol_str(&self) -> &str {
         self.mail_binding()
+            .filter(|b| b.enabled)
             .map(|b| b.protocol.as_str())
             .unwrap_or("")
     }
 
     pub fn calendar_protocol_str(&self) -> &str {
         self.calendar_binding()
+            .filter(|b| b.enabled)
             .map(|b| b.protocol.as_str())
             .unwrap_or("")
     }
 
     pub fn contacts_protocol_str(&self) -> &str {
         self.contacts_binding()
+            .filter(|b| b.enabled)
             .map(|b| b.protocol.as_str())
             .unwrap_or("")
     }
@@ -229,6 +275,23 @@ impl AccountFull {
             .calendar_binding()
             .map(|b| b.enabled)
             .unwrap_or(true);
+
+        // Phase-4: surface per-binding state on the wire format so the
+        // Settings edit form sees the toggles' current value.
+        self.mail_sync_enabled = self
+            .mail_binding()
+            .map(|b| b.enabled)
+            .unwrap_or(true);
+        self.contacts_sync_enabled = self
+            .contacts_binding()
+            .map(|b| b.enabled)
+            .unwrap_or(true);
+        self.mail_sync_interval_seconds =
+            self.mail_binding().and_then(|b| b.sync_interval_seconds);
+        self.calendar_sync_interval_seconds =
+            self.calendar_binding().and_then(|b| b.sync_interval_seconds);
+        self.contacts_sync_interval_seconds =
+            self.contacts_binding().and_then(|b| b.sync_interval_seconds);
     }
 }
 
@@ -237,13 +300,29 @@ pub fn list_accounts(conn: &Connection) -> Result<Vec<Account>> {
     // calendar-only accounts show up with an empty mail_protocol).
     // provider is derived from auth_method on the way out so the wire
     // format stays compatible with the frontend.
+    // Pull the mail protocol and per-binding sync intervals via correlated
+    // subqueries against service_bindings so the lightweight Account
+    // summary doesn't need a separate per-account query for the
+    // periodic-sync timers.
     let mut stmt = conn.prepare(
         "SELECT a.id, a.display_name, a.email, a.auth_method, a.enabled,
                 COALESCE(
                     (SELECT b.protocol FROM service_bindings b
-                     WHERE b.account_id = a.id AND b.service = 'mail' LIMIT 1),
+                     WHERE b.account_id = a.id
+                       AND b.service = 'mail'
+                       AND b.enabled = 1
+                     LIMIT 1),
                     ''
-                ) AS mail_protocol
+                ) AS mail_protocol,
+                (SELECT b.sync_interval_seconds FROM service_bindings b
+                 WHERE b.account_id = a.id AND b.service = 'mail' LIMIT 1)
+                    AS mail_sync_interval,
+                (SELECT b.sync_interval_seconds FROM service_bindings b
+                 WHERE b.account_id = a.id AND b.service = 'calendar' LIMIT 1)
+                    AS calendar_sync_interval,
+                (SELECT b.sync_interval_seconds FROM service_bindings b
+                 WHERE b.account_id = a.id AND b.service = 'contacts' LIMIT 1)
+                    AS contacts_sync_interval
          FROM accounts a
          ORDER BY a.display_name",
     )?;
@@ -263,6 +342,9 @@ pub fn list_accounts(conn: &Connection) -> Result<Vec<Account>> {
                 provider,
                 mail_protocol: row.get(5)?,
                 enabled: row.get(4)?,
+                mail_sync_interval_seconds: row.get(6)?,
+                calendar_sync_interval_seconds: row.get(7)?,
+                contacts_sync_interval_seconds: row.get(8)?,
             })
         })?
         .collect::<std::result::Result<Vec<_>, _>>()?;
@@ -300,6 +382,11 @@ pub fn get_account_full(conn: &Connection, id: &str) -> Result<AccountFull> {
                 use_tls: true,
                 calendar_sync_enabled: true,
                 bindings: Vec::new(),
+                mail_sync_enabled: true,
+                contacts_sync_enabled: true,
+                mail_sync_interval_seconds: None,
+                calendar_sync_interval_seconds: None,
+                contacts_sync_interval_seconds: None,
             })
         },
     ).map_err(|e| match e {
@@ -392,6 +479,11 @@ fn config_to_legacy_fields<'a>(
         oidc_client_id: &config.oidc_client_id,
         caldav_url: &config.caldav_url,
         calendar_sync_enabled: config.calendar_sync_enabled,
+        mail_sync_enabled: Some(config.mail_sync_enabled),
+        contacts_sync_enabled: Some(config.contacts_sync_enabled),
+        mail_sync_interval_seconds: config.mail_sync_interval_seconds,
+        calendar_sync_interval_seconds: config.calendar_sync_interval_seconds,
+        contacts_sync_interval_seconds: config.contacts_sync_interval_seconds,
     }
 }
 
@@ -520,6 +612,11 @@ mod tests {
             oidc_token_endpoint: String::new(),
             oidc_client_id: String::new(),
             calendar_sync_enabled: true,
+            mail_sync_enabled: true,
+            contacts_sync_enabled: true,
+            mail_sync_interval_seconds: None,
+            calendar_sync_interval_seconds: None,
+            contacts_sync_interval_seconds: None,
         }
     }
 

--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -6,3 +6,4 @@ pub mod folders;
 pub mod messages;
 pub mod pool;
 pub mod schema;
+pub mod service_bindings;

--- a/src-tauri/src/db/schema.rs
+++ b/src-tauri/src/db/schema.rs
@@ -8,20 +8,20 @@ pub fn initialize(conn: &Connection) -> Result<()> {
         PRAGMA journal_mode=WAL;
         PRAGMA foreign_keys=ON;
 
+        -- Phase 3: identity-only schema. Per-protocol settings (mail
+        -- host/port, JMAP url, CalDAV url, etc.) live in service_bindings.
+        -- Pre-Phase-3 databases keep their legacy columns until the
+        -- service_bindings_drop_legacy_columns migration drops them.
         CREATE TABLE IF NOT EXISTS accounts (
             id TEXT PRIMARY KEY,
             display_name TEXT NOT NULL,
             email TEXT NOT NULL,
-            provider TEXT NOT NULL,
-            mail_protocol TEXT NOT NULL DEFAULT 'imap',
-            imap_host TEXT NOT NULL DEFAULT '',
-            imap_port INTEGER NOT NULL DEFAULT 993,
-            smtp_host TEXT NOT NULL DEFAULT '',
-            smtp_port INTEGER NOT NULL DEFAULT 587,
-            jmap_url TEXT NOT NULL DEFAULT '',
             username TEXT NOT NULL,
-            use_tls INTEGER NOT NULL DEFAULT 1,
             enabled INTEGER NOT NULL DEFAULT 1,
+            signature TEXT NOT NULL DEFAULT '',
+            auth_method TEXT NOT NULL DEFAULT '',
+            oidc_token_endpoint TEXT NOT NULL DEFAULT '',
+            oidc_client_id TEXT NOT NULL DEFAULT '',
             created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
             updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
         );
@@ -235,25 +235,37 @@ pub fn initialize(conn: &Connection) -> Result<()> {
 }
 
 fn run_migrations(conn: &Connection) -> Result<()> {
-    // Add jmap_url column if it doesn't exist (added in JMAP support)
-    let has_jmap_url: bool = conn
-        .prepare("SELECT jmap_url FROM accounts LIMIT 0")
-        .is_ok();
-    if !has_jmap_url {
-        log::info!("Migration: adding jmap_url column to accounts table");
-        conn.execute_batch("ALTER TABLE accounts ADD COLUMN jmap_url TEXT NOT NULL DEFAULT '';")?;
+    // Skip the legacy column-add and populate migrations on databases that
+    // already finished Phase 3. Without this gate, fresh installs would
+    // re-create columns we just dropped (the ADD COLUMN sequence below
+    // sees the column missing and tries to add it back).
+    let phase3_done = has_migration(conn, "service_bindings_drop_legacy_columns");
+
+    if !phase3_done {
+        // Add jmap_url column if it doesn't exist (added in JMAP support)
+        let has_jmap_url: bool = conn
+            .prepare("SELECT jmap_url FROM accounts LIMIT 0")
+            .is_ok();
+        if !has_jmap_url {
+            log::info!("Migration: adding jmap_url column to accounts table");
+            conn.execute_batch(
+                "ALTER TABLE accounts ADD COLUMN jmap_url TEXT NOT NULL DEFAULT '';",
+            )?;
+        }
+
+        // Add caldav_url column if it doesn't exist (added in CalDAV support)
+        let has_caldav_url: bool = conn
+            .prepare("SELECT caldav_url FROM accounts LIMIT 0")
+            .is_ok();
+        if !has_caldav_url {
+            log::info!("Migration: adding caldav_url column to accounts table");
+            conn.execute_batch(
+                "ALTER TABLE accounts ADD COLUMN caldav_url TEXT NOT NULL DEFAULT '';",
+            )?;
+        }
     }
 
-    // Add caldav_url column if it doesn't exist (added in CalDAV support)
-    let has_caldav_url: bool = conn
-        .prepare("SELECT caldav_url FROM accounts LIMIT 0")
-        .is_ok();
-    if !has_caldav_url {
-        log::info!("Migration: adding caldav_url column to accounts table");
-        conn.execute_batch("ALTER TABLE accounts ADD COLUMN caldav_url TEXT NOT NULL DEFAULT '';")?;
-    }
-
-    // Add signature column if it doesn't exist
+    // Add signature column if it doesn't exist (still part of accounts post-Phase-3).
     let has_signature: bool = conn
         .prepare("SELECT signature FROM accounts LIMIT 0")
         .is_ok();
@@ -262,18 +274,20 @@ fn run_migrations(conn: &Connection) -> Result<()> {
         conn.execute_batch("ALTER TABLE accounts ADD COLUMN signature TEXT NOT NULL DEFAULT '';")?;
     }
 
-    // Add jmap_auth_method column if it doesn't exist
-    let has_jmap_auth_method: bool = conn
-        .prepare("SELECT jmap_auth_method FROM accounts LIMIT 0")
-        .is_ok();
-    if !has_jmap_auth_method {
-        log::info!("Migration: adding jmap_auth_method column to accounts table");
-        conn.execute_batch(
-            "ALTER TABLE accounts ADD COLUMN jmap_auth_method TEXT NOT NULL DEFAULT 'basic';",
-        )?;
+    if !phase3_done {
+        // Add jmap_auth_method column if it doesn't exist
+        let has_jmap_auth_method: bool = conn
+            .prepare("SELECT jmap_auth_method FROM accounts LIMIT 0")
+            .is_ok();
+        if !has_jmap_auth_method {
+            log::info!("Migration: adding jmap_auth_method column to accounts table");
+            conn.execute_batch(
+                "ALTER TABLE accounts ADD COLUMN jmap_auth_method TEXT NOT NULL DEFAULT 'basic';",
+            )?;
+        }
     }
 
-    // Add oidc_token_endpoint column if it doesn't exist
+    // Add oidc_token_endpoint column if it doesn't exist (kept post-Phase-3).
     let has_oidc_token_endpoint: bool = conn
         .prepare("SELECT oidc_token_endpoint FROM accounts LIMIT 0")
         .is_ok();
@@ -284,7 +298,7 @@ fn run_migrations(conn: &Connection) -> Result<()> {
         )?;
     }
 
-    // Add oidc_client_id column if it doesn't exist
+    // Add oidc_client_id column if it doesn't exist (kept post-Phase-3).
     let has_oidc_client_id: bool = conn
         .prepare("SELECT oidc_client_id FROM accounts LIMIT 0")
         .is_ok();
@@ -313,15 +327,17 @@ fn run_migrations(conn: &Connection) -> Result<()> {
         conn.execute_batch("ALTER TABLE folders ADD COLUMN uid_next INTEGER DEFAULT 0;")?;
     }
 
-    // Add calendar_sync_enabled column for per-account calendar-sync toggle
-    let has_calendar_sync_enabled: bool = conn
-        .prepare("SELECT calendar_sync_enabled FROM accounts LIMIT 0")
-        .is_ok();
-    if !has_calendar_sync_enabled {
-        log::info!("Migration: adding calendar_sync_enabled column to accounts table");
-        conn.execute_batch(
-            "ALTER TABLE accounts ADD COLUMN calendar_sync_enabled INTEGER NOT NULL DEFAULT 1;",
-        )?;
+    if !phase3_done {
+        // Add calendar_sync_enabled column for per-account calendar-sync toggle
+        let has_calendar_sync_enabled: bool = conn
+            .prepare("SELECT calendar_sync_enabled FROM accounts LIMIT 0")
+            .is_ok();
+        if !has_calendar_sync_enabled {
+            log::info!("Migration: adding calendar_sync_enabled column to accounts table");
+            conn.execute_batch(
+                "ALTER TABLE accounts ADD COLUMN calendar_sync_enabled INTEGER NOT NULL DEFAULT 1;",
+            )?;
+        }
     }
 
     // Add parent_id column to folders. Existing DBs that were populated by
@@ -364,10 +380,13 @@ fn run_migrations(conn: &Connection) -> Result<()> {
 
     // Backfill auth_method for any rows that haven't been populated yet
     // (covers both fresh-from-migration rows above and any older rows that
-    // were created before this migration ran). Idempotent.
+    // were created before this migration ran). Idempotent. Reads legacy
+    // columns, so skip if Phase 3 already dropped them.
     if !has_migration(conn, "auth_method_backfill_v1") {
-        log::info!("Migration: backfilling auth_method from provider/jmap_auth_method");
-        backfill_auth_method(conn)?;
+        if !phase3_done {
+            log::info!("Migration: backfilling auth_method from provider/jmap_auth_method");
+            backfill_auth_method(conn)?;
+        }
         set_migration(conn, "auth_method_backfill_v1")?;
     }
 
@@ -375,10 +394,25 @@ fn run_migrations(conn: &Connection) -> Result<()> {
     // Re-runnable (it deletes existing rows for an account before inserting),
     // but gated by a marker so the common-case startup is a single SELECT.
     if !has_migration(conn, "service_bindings_initial_populate") {
-        log::info!("Migration: deriving service_bindings from existing accounts");
-        populate_service_bindings(conn)?;
+        if !phase3_done {
+            log::info!("Migration: deriving service_bindings from existing accounts");
+            populate_service_bindings(conn)?;
+            log::info!("Migration: service_bindings populated");
+        }
         set_migration(conn, "service_bindings_initial_populate")?;
-        log::info!("Migration: service_bindings populated");
+    }
+
+    // Phase 3: drop the legacy per-protocol columns from accounts. Their
+    // data has already been mirrored into service_bindings by the populate
+    // migration above, so dropping them is safe. SQLite supports
+    // ALTER TABLE DROP COLUMN since 3.35 (March 2021). Run as a single
+    // batch in a transaction so a partial failure doesn't leave the
+    // schema half-dropped.
+    if !has_migration(conn, "service_bindings_drop_legacy_columns") {
+        log::info!("Migration: dropping legacy per-protocol columns from accounts");
+        drop_legacy_account_columns(conn)?;
+        set_migration(conn, "service_bindings_drop_legacy_columns")?;
+        log::info!("Migration: legacy columns dropped");
     }
 
     // Canonicalize Message-ID / In-Reply-To and rethread.
@@ -474,6 +508,39 @@ fn normalize_message_ids_and_rethread(conn: &Connection) -> Result<()> {
     Ok(())
 }
 
+/// Drop every legacy per-protocol column from `accounts`. Each column is
+/// dropped only if it actually exists, so the function is safe to run
+/// against partially-migrated databases or fresh installs (where the
+/// columns might be present from the legacy ADD COLUMN migrations
+/// running before this gate flipped).
+fn drop_legacy_account_columns(conn: &Connection) -> Result<()> {
+    const LEGACY_COLUMNS: &[&str] = &[
+        "provider",
+        "mail_protocol",
+        "imap_host",
+        "imap_port",
+        "smtp_host",
+        "smtp_port",
+        "use_tls",
+        "jmap_url",
+        "jmap_auth_method",
+        "caldav_url",
+        "calendar_sync_enabled",
+    ];
+
+    let tx = conn.unchecked_transaction()?;
+    for col in LEGACY_COLUMNS {
+        let exists = tx
+            .prepare(&format!("SELECT {col} FROM accounts LIMIT 0"))
+            .is_ok();
+        if exists {
+            tx.execute_batch(&format!("ALTER TABLE accounts DROP COLUMN {col};"))?;
+        }
+    }
+    tx.commit()?;
+    Ok(())
+}
+
 /// Backfill `accounts.auth_method` from the legacy (`provider`,
 /// `jmap_auth_method`) pair. Single UPDATE that only touches rows whose
 /// `auth_method` is still empty, so re-running is harmless.
@@ -492,62 +559,93 @@ fn backfill_auth_method(conn: &Connection) -> Result<()> {
 }
 
 /// Read every existing account, derive its bindings, and INSERT them.
-/// Wipes any pre-existing bindings for each account first so re-running
-/// after a code-side rule change converges to the latest mapping.
+/// Pulls legacy columns directly via SQL (intentionally bypassing
+/// get_account_full so the keyring is never touched at startup).
 fn populate_service_bindings(conn: &Connection) -> Result<()> {
-    use crate::db::accounts::list_accounts;
-    use crate::db::service_bindings::{
-        delete_for_account, derive_bindings_from_account, insert,
-    };
+    use crate::db::service_bindings::{rebuild_for_account, LegacyBindingFields};
 
-    // The summary list_accounts only carries the few columns shown in the
-    // sidebar; we need the full set to derive bindings, so re-query each
-    // row through get_account_full.
-    let summaries = list_accounts(conn)?;
-    for summary in summaries {
-        // Fetch full row directly via SQL — get_account_full pulls the
-        // password from the keyring as a side effect, which we don't want
-        // during a startup migration on headless hosts. Read just the
-        // columns we need.
-        let account = conn.query_row(
-            "SELECT id, display_name, email, provider, mail_protocol, imap_host, imap_port,
-                    smtp_host, smtp_port, jmap_url, caldav_url, username, use_tls,
-                    enabled, signature, jmap_auth_method, oidc_token_endpoint, oidc_client_id,
-                    calendar_sync_enabled
-             FROM accounts WHERE id = ?1",
-            rusqlite::params![summary.id],
-            |row| {
-                Ok(crate::db::accounts::AccountFull {
-                    id: row.get(0)?,
-                    display_name: row.get(1)?,
-                    email: row.get(2)?,
-                    provider: row.get(3)?,
-                    mail_protocol: row.get(4)?,
-                    imap_host: row.get(5)?,
-                    imap_port: row.get::<_, u32>(6)? as u16,
-                    smtp_host: row.get(7)?,
-                    smtp_port: row.get::<_, u32>(8)? as u16,
-                    jmap_url: row.get(9)?,
-                    caldav_url: row.get(10)?,
-                    username: row.get(11)?,
-                    password: String::new(),
-                    use_tls: row.get(12)?,
-                    enabled: row.get(13)?,
-                    signature: row.get(14)?,
-                    jmap_auth_method: row.get(15)?,
-                    oidc_token_endpoint: row.get(16)?,
-                    oidc_client_id: row.get(17)?,
-                    calendar_sync_enabled: row.get(18)?,
-                    auth_method: String::new(),
-                    bindings: Vec::new(),
-                })
+    // Fail-soft if the legacy columns have already been dropped (i.e.
+    // a fresh-install DB created with the Phase 3 schema). The migration
+    // marker logic below normally prevents this branch from running, but
+    // an out-of-order replay shouldn't error out the app.
+    if conn.prepare("SELECT mail_protocol FROM accounts LIMIT 0").is_err() {
+        log::info!(
+            "populate_service_bindings: legacy columns absent, skipping (Phase 3+ schema)"
+        );
+        return Ok(());
+    }
+
+    /// Tuple representation of the legacy column row. Named only to keep
+    /// clippy happy about the long type literal — it's not used elsewhere.
+    struct LegacyRow {
+        id: String,
+        provider: String,
+        mail_protocol: String,
+        imap_host: String,
+        imap_port: u16,
+        smtp_host: String,
+        smtp_port: u16,
+        jmap_url: String,
+        caldav_url: String,
+        use_tls: bool,
+        enabled: bool,
+        jmap_auth_method: String,
+        oidc_token_endpoint: String,
+        oidc_client_id: String,
+        calendar_sync_enabled: bool,
+    }
+
+    let mut stmt = conn.prepare(
+        "SELECT id, provider, mail_protocol, imap_host, imap_port,
+                smtp_host, smtp_port, jmap_url, caldav_url, use_tls,
+                enabled, jmap_auth_method, oidc_token_endpoint, oidc_client_id,
+                calendar_sync_enabled
+         FROM accounts",
+    )?;
+    let rows: Vec<LegacyRow> = stmt
+        .query_map([], |row| {
+            Ok(LegacyRow {
+                id: row.get(0)?,
+                provider: row.get(1)?,
+                mail_protocol: row.get(2)?,
+                imap_host: row.get(3)?,
+                imap_port: row.get::<_, u32>(4)? as u16,
+                smtp_host: row.get(5)?,
+                smtp_port: row.get::<_, u32>(6)? as u16,
+                jmap_url: row.get(7)?,
+                caldav_url: row.get(8)?,
+                use_tls: row.get(9)?,
+                enabled: row.get(10)?,
+                jmap_auth_method: row.get(11)?,
+                oidc_token_endpoint: row.get(12)?,
+                oidc_client_id: row.get(13)?,
+                calendar_sync_enabled: row.get(14)?,
+            })
+        })?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+
+    for r in &rows {
+        rebuild_for_account(
+            conn,
+            &r.id,
+            LegacyBindingFields {
+                account_id: &r.id,
+                enabled: r.enabled,
+                provider: &r.provider,
+                mail_protocol: &r.mail_protocol,
+                imap_host: &r.imap_host,
+                imap_port: r.imap_port,
+                smtp_host: &r.smtp_host,
+                smtp_port: r.smtp_port,
+                use_tls: r.use_tls,
+                jmap_url: &r.jmap_url,
+                jmap_auth_method: &r.jmap_auth_method,
+                oidc_token_endpoint: &r.oidc_token_endpoint,
+                oidc_client_id: &r.oidc_client_id,
+                caldav_url: &r.caldav_url,
+                calendar_sync_enabled: r.calendar_sync_enabled,
             },
         )?;
-
-        delete_for_account(conn, &account.id)?;
-        for binding in derive_bindings_from_account(&account) {
-            insert(conn, &binding)?;
-        }
     }
     Ok(())
 }

--- a/src-tauri/src/db/schema.rs
+++ b/src-tauri/src/db/schema.rs
@@ -644,6 +644,14 @@ fn populate_service_bindings(conn: &Connection) -> Result<()> {
                 oidc_client_id: &r.oidc_client_id,
                 caldav_url: &r.caldav_url,
                 calendar_sync_enabled: r.calendar_sync_enabled,
+                // Migration preserves legacy semantics: mail follows the
+                // row's enabled flag, contacts default to on, no per-binding
+                // intervals (use frontend defaults).
+                mail_sync_enabled: None,
+                contacts_sync_enabled: None,
+                mail_sync_interval_seconds: None,
+                calendar_sync_interval_seconds: None,
+                contacts_sync_interval_seconds: None,
             },
         )?;
     }

--- a/src-tauri/src/db/schema.rs
+++ b/src-tauri/src/db/schema.rs
@@ -176,6 +176,26 @@ pub fn initialize(conn: &Connection) -> Result<()> {
             value TEXT NOT NULL
         );
 
+        -- Per-service binding for an account. One identity (accounts row)
+        -- can have one mail binding, one calendar binding, and one contacts
+        -- binding, each with its own protocol and protocol-specific config.
+        -- Phase 1: populated alongside the legacy per-protocol columns on
+        -- accounts; nothing reads from here yet. Phases 2/3 migrate the
+        -- dispatch reads and drop the legacy columns.
+        CREATE TABLE IF NOT EXISTS service_bindings (
+            id TEXT PRIMARY KEY,
+            account_id TEXT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+            service TEXT NOT NULL,
+            protocol TEXT NOT NULL,
+            enabled INTEGER NOT NULL DEFAULT 1,
+            sync_interval_seconds INTEGER,
+            config_json TEXT NOT NULL DEFAULT '{}',
+            created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            UNIQUE(account_id, service, protocol)
+        );
+        CREATE INDEX IF NOT EXISTS idx_bindings_account ON service_bindings(account_id);
+
         -- FTS5 virtual table for fast message text search (quick filter)
         CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5(
             subject,
@@ -328,6 +348,39 @@ fn run_migrations(conn: &Connection) -> Result<()> {
         log::info!("Migration: FTS5 index populated");
     }
 
+    // Add auth_method column on accounts. Phase 1 of the service-bindings
+    // refactor: stored alongside the legacy `provider` column so dispatch
+    // code keeps working. Phase 2 starts reading auth_method instead;
+    // Phase 3 drops `provider`.
+    let has_auth_method: bool = conn
+        .prepare("SELECT auth_method FROM accounts LIMIT 0")
+        .is_ok();
+    if !has_auth_method {
+        log::info!("Migration: adding auth_method column to accounts table");
+        conn.execute_batch(
+            "ALTER TABLE accounts ADD COLUMN auth_method TEXT NOT NULL DEFAULT '';",
+        )?;
+    }
+
+    // Backfill auth_method for any rows that haven't been populated yet
+    // (covers both fresh-from-migration rows above and any older rows that
+    // were created before this migration ran). Idempotent.
+    if !has_migration(conn, "auth_method_backfill_v1") {
+        log::info!("Migration: backfilling auth_method from provider/jmap_auth_method");
+        backfill_auth_method(conn)?;
+        set_migration(conn, "auth_method_backfill_v1")?;
+    }
+
+    // One-time populate of service_bindings from legacy account columns.
+    // Re-runnable (it deletes existing rows for an account before inserting),
+    // but gated by a marker so the common-case startup is a single SELECT.
+    if !has_migration(conn, "service_bindings_initial_populate") {
+        log::info!("Migration: deriving service_bindings from existing accounts");
+        populate_service_bindings(conn)?;
+        set_migration(conn, "service_bindings_initial_populate")?;
+        log::info!("Migration: service_bindings populated");
+    }
+
     // Canonicalize Message-ID / In-Reply-To and rethread.
     //
     // Older builds stored these strings verbatim from the IMAP envelope,
@@ -418,6 +471,82 @@ fn normalize_message_ids_and_rethread(conn: &Connection) -> Result<()> {
 
     tx.commit()?;
     log::info!("Migration messageid_normalize_v1: canonicalized + rethreaded");
+    Ok(())
+}
+
+/// Backfill `accounts.auth_method` from the legacy (`provider`,
+/// `jmap_auth_method`) pair. Single UPDATE that only touches rows whose
+/// `auth_method` is still empty, so re-running is harmless.
+fn backfill_auth_method(conn: &Connection) -> Result<()> {
+    conn.execute_batch(
+        "UPDATE accounts
+         SET auth_method = CASE
+             WHEN provider = 'gmail' THEN 'oauth-google'
+             WHEN provider = 'o365'  THEN 'oauth-microsoft'
+             WHEN jmap_auth_method = 'oidc' THEN 'oauth-jmap-oidc'
+             ELSE 'password'
+         END
+         WHERE auth_method IS NULL OR auth_method = '';",
+    )?;
+    Ok(())
+}
+
+/// Read every existing account, derive its bindings, and INSERT them.
+/// Wipes any pre-existing bindings for each account first so re-running
+/// after a code-side rule change converges to the latest mapping.
+fn populate_service_bindings(conn: &Connection) -> Result<()> {
+    use crate::db::accounts::list_accounts;
+    use crate::db::service_bindings::{
+        delete_for_account, derive_bindings_from_account, insert,
+    };
+
+    // The summary list_accounts only carries the few columns shown in the
+    // sidebar; we need the full set to derive bindings, so re-query each
+    // row through get_account_full.
+    let summaries = list_accounts(conn)?;
+    for summary in summaries {
+        // Fetch full row directly via SQL — get_account_full pulls the
+        // password from the keyring as a side effect, which we don't want
+        // during a startup migration on headless hosts. Read just the
+        // columns we need.
+        let account = conn.query_row(
+            "SELECT id, display_name, email, provider, mail_protocol, imap_host, imap_port,
+                    smtp_host, smtp_port, jmap_url, caldav_url, username, use_tls,
+                    enabled, signature, jmap_auth_method, oidc_token_endpoint, oidc_client_id,
+                    calendar_sync_enabled
+             FROM accounts WHERE id = ?1",
+            rusqlite::params![summary.id],
+            |row| {
+                Ok(crate::db::accounts::AccountFull {
+                    id: row.get(0)?,
+                    display_name: row.get(1)?,
+                    email: row.get(2)?,
+                    provider: row.get(3)?,
+                    mail_protocol: row.get(4)?,
+                    imap_host: row.get(5)?,
+                    imap_port: row.get::<_, u32>(6)? as u16,
+                    smtp_host: row.get(7)?,
+                    smtp_port: row.get::<_, u32>(8)? as u16,
+                    jmap_url: row.get(9)?,
+                    caldav_url: row.get(10)?,
+                    username: row.get(11)?,
+                    password: String::new(),
+                    use_tls: row.get(12)?,
+                    enabled: row.get(13)?,
+                    signature: row.get(14)?,
+                    jmap_auth_method: row.get(15)?,
+                    oidc_token_endpoint: row.get(16)?,
+                    oidc_client_id: row.get(17)?,
+                    calendar_sync_enabled: row.get(18)?,
+                })
+            },
+        )?;
+
+        delete_for_account(conn, &account.id)?;
+        for binding in derive_bindings_from_account(&account) {
+            insert(conn, &binding)?;
+        }
+    }
     Ok(())
 }
 

--- a/src-tauri/src/db/schema.rs
+++ b/src-tauri/src/db/schema.rs
@@ -568,10 +568,11 @@ fn populate_service_bindings(conn: &Connection) -> Result<()> {
     // a fresh-install DB created with the Phase 3 schema). The migration
     // marker logic below normally prevents this branch from running, but
     // an out-of-order replay shouldn't error out the app.
-    if conn.prepare("SELECT mail_protocol FROM accounts LIMIT 0").is_err() {
-        log::info!(
-            "populate_service_bindings: legacy columns absent, skipping (Phase 3+ schema)"
-        );
+    if conn
+        .prepare("SELECT mail_protocol FROM accounts LIMIT 0")
+        .is_err()
+    {
+        log::info!("populate_service_bindings: legacy columns absent, skipping (Phase 3+ schema)");
         return Ok(());
     }
 

--- a/src-tauri/src/db/schema.rs
+++ b/src-tauri/src/db/schema.rs
@@ -538,6 +538,8 @@ fn populate_service_bindings(conn: &Connection) -> Result<()> {
                     oidc_token_endpoint: row.get(16)?,
                     oidc_client_id: row.get(17)?,
                     calendar_sync_enabled: row.get(18)?,
+                    auth_method: String::new(),
+                    bindings: Vec::new(),
                 })
             },
         )?;

--- a/src-tauri/src/db/schema.rs
+++ b/src-tauri/src/db/schema.rs
@@ -239,7 +239,27 @@ fn run_migrations(conn: &Connection) -> Result<()> {
     // already finished Phase 3. Without this gate, fresh installs would
     // re-create columns we just dropped (the ADD COLUMN sequence below
     // sees the column missing and tries to add it back).
-    let phase3_done = has_migration(conn, "service_bindings_drop_legacy_columns");
+    //
+    // Two ways to detect Phase 3:
+    // 1. The migration marker is set (existing DB that already migrated).
+    // 2. The CREATE TABLE in initialize() ran for a fresh install — i.e.
+    //    `provider` was never created, so the legacy column is absent.
+    //    Set the marker proactively so we skip the legacy add+drop dance
+    //    AND avoid relying on `ALTER TABLE ... DROP COLUMN` support on
+    //    fresh installs.
+    let mut phase3_done = has_migration(conn, "service_bindings_drop_legacy_columns");
+    if !phase3_done {
+        let legacy_provider_present = conn
+            .prepare("SELECT provider FROM accounts LIMIT 0")
+            .is_ok();
+        if !legacy_provider_present {
+            log::info!(
+                "Migration: detected Phase-3 schema (no `provider` column); marking drop-legacy migration done"
+            );
+            set_migration(conn, "service_bindings_drop_legacy_columns")?;
+            phase3_done = true;
+        }
+    }
 
     if !phase3_done {
         // Add jmap_url column if it doesn't exist (added in JMAP support)

--- a/src-tauri/src/db/service_bindings.rs
+++ b/src-tauri/src/db/service_bindings.rs
@@ -502,11 +502,19 @@ mod tests {
         let mail = bindings.iter().find(|b| b.service == "mail").unwrap();
         assert_eq!(mail.protocol, "imap");
         assert_eq!(
-            bindings.iter().find(|b| b.service == "calendar").unwrap().protocol,
+            bindings
+                .iter()
+                .find(|b| b.service == "calendar")
+                .unwrap()
+                .protocol,
             "google"
         );
         assert_eq!(
-            bindings.iter().find(|b| b.service == "contacts").unwrap().protocol,
+            bindings
+                .iter()
+                .find(|b| b.service == "contacts")
+                .unwrap()
+                .protocol,
             "google"
         );
     }
@@ -519,15 +527,27 @@ mod tests {
         let bindings = derive_bindings_from_account(&acc);
         assert_eq!(bindings.len(), 3);
         assert_eq!(
-            bindings.iter().find(|b| b.service == "mail").unwrap().protocol,
+            bindings
+                .iter()
+                .find(|b| b.service == "mail")
+                .unwrap()
+                .protocol,
             "imap"
         );
         assert_eq!(
-            bindings.iter().find(|b| b.service == "calendar").unwrap().protocol,
+            bindings
+                .iter()
+                .find(|b| b.service == "calendar")
+                .unwrap()
+                .protocol,
             "graph"
         );
         assert_eq!(
-            bindings.iter().find(|b| b.service == "contacts").unwrap().protocol,
+            bindings
+                .iter()
+                .find(|b| b.service == "contacts")
+                .unwrap()
+                .protocol,
             "graph"
         );
     }
@@ -555,7 +575,11 @@ mod tests {
             assert_eq!(b.protocol, "jmap", "service={}", b.service);
         }
         let mail_cfg: serde_json::Value = serde_json::from_str(
-            &bindings.iter().find(|b| b.service == "mail").unwrap().config_json,
+            &bindings
+                .iter()
+                .find(|b| b.service == "mail")
+                .unwrap()
+                .config_json,
         )
         .unwrap();
         assert_eq!(mail_cfg["url"], "https://jmap.example.com/jmap");
@@ -574,7 +598,10 @@ mod tests {
         let mail = bindings.iter().find(|b| b.service == "mail").unwrap();
         let mail_cfg: serde_json::Value = serde_json::from_str(&mail.config_json).unwrap();
         assert_eq!(mail_cfg["auth_method"], "oidc");
-        assert_eq!(mail_cfg["oidc_token_endpoint"], "https://idp.example.com/token");
+        assert_eq!(
+            mail_cfg["oidc_token_endpoint"],
+            "https://idp.example.com/token"
+        );
         assert_eq!(mail_cfg["oidc_client_id"], "client-123");
     }
 
@@ -593,11 +620,19 @@ mod tests {
         let bindings = derive_bindings_from_account(&acc);
         assert!(bindings.iter().all(|b| b.service != "mail"));
         assert_eq!(
-            bindings.iter().find(|b| b.service == "calendar").unwrap().protocol,
+            bindings
+                .iter()
+                .find(|b| b.service == "calendar")
+                .unwrap()
+                .protocol,
             "caldav"
         );
         assert_eq!(
-            bindings.iter().find(|b| b.service == "contacts").unwrap().protocol,
+            bindings
+                .iter()
+                .find(|b| b.service == "contacts")
+                .unwrap()
+                .protocol,
             "carddav"
         );
     }
@@ -683,7 +718,13 @@ mod tests {
         let cal = bindings.iter().find(|b| b.service == "calendar").unwrap();
         assert!(!cal.enabled);
         // Mail/contacts should still be enabled.
-        assert!(bindings.iter().find(|b| b.service == "mail").unwrap().enabled);
+        assert!(
+            bindings
+                .iter()
+                .find(|b| b.service == "mail")
+                .unwrap()
+                .enabled
+        );
     }
 
     #[test]
@@ -738,7 +779,8 @@ mod tests {
             config_json: "{}".into(),
         };
         insert(&conn, &b).unwrap();
-        conn.execute("DELETE FROM accounts WHERE id = 'a1'", []).unwrap();
+        conn.execute("DELETE FROM accounts WHERE id = 'a1'", [])
+            .unwrap();
         assert!(list_for_account(&conn, "a1").unwrap().is_empty());
     }
 }

--- a/src-tauri/src/db/service_bindings.rs
+++ b/src-tauri/src/db/service_bindings.rs
@@ -214,6 +214,57 @@ pub fn derive_bindings_from_account(account: &AccountFull) -> Vec<ServiceBinding
     out
 }
 
+/// Re-derive the bindings for a single account from the legacy account
+/// columns. Wipes existing rows for `account_id` and inserts the freshly
+/// derived set. Called from `insert_account` / `update_account` so the
+/// bindings table tracks settings edits during the parallel-population
+/// phase, and from the one-time initial-populate migration.
+pub fn rebuild_for_account(conn: &Connection, account_id: &str) -> Result<()> {
+    // Pull just the columns derive_bindings_from_account needs. Avoid
+    // get_account_full because it touches the OS keyring, which we don't
+    // want during write paths that are already inside a DB transaction.
+    let account = conn.query_row(
+        "SELECT id, display_name, email, provider, mail_protocol, imap_host, imap_port,
+                smtp_host, smtp_port, jmap_url, caldav_url, username, use_tls,
+                enabled, signature, jmap_auth_method, oidc_token_endpoint, oidc_client_id,
+                calendar_sync_enabled
+         FROM accounts WHERE id = ?1",
+        params![account_id],
+        |row| {
+            Ok(AccountFull {
+                id: row.get(0)?,
+                display_name: row.get(1)?,
+                email: row.get(2)?,
+                provider: row.get(3)?,
+                mail_protocol: row.get(4)?,
+                imap_host: row.get(5)?,
+                imap_port: row.get::<_, u32>(6)? as u16,
+                smtp_host: row.get(7)?,
+                smtp_port: row.get::<_, u32>(8)? as u16,
+                jmap_url: row.get(9)?,
+                caldav_url: row.get(10)?,
+                username: row.get(11)?,
+                password: String::new(),
+                use_tls: row.get(12)?,
+                enabled: row.get(13)?,
+                signature: row.get(14)?,
+                jmap_auth_method: row.get(15)?,
+                oidc_token_endpoint: row.get(16)?,
+                oidc_client_id: row.get(17)?,
+                calendar_sync_enabled: row.get(18)?,
+                auth_method: String::new(),
+                bindings: Vec::new(),
+            })
+        },
+    )?;
+
+    delete_for_account(conn, account_id)?;
+    for binding in derive_bindings_from_account(&account) {
+        insert(conn, &binding)?;
+    }
+    Ok(())
+}
+
 /// Map an old-schema `(provider, jmap_auth_method)` pair to the new
 /// `auth_method` value stored on `accounts`. Pure function so the migration
 /// and unit tests can both call it.
@@ -296,6 +347,8 @@ mod tests {
             oidc_token_endpoint: String::new(),
             oidc_client_id: String::new(),
             calendar_sync_enabled: true,
+            auth_method: String::new(),
+            bindings: Vec::new(),
         }
     }
 

--- a/src-tauri/src/db/service_bindings.rs
+++ b/src-tauri/src/db/service_bindings.rs
@@ -1,0 +1,491 @@
+use rusqlite::{params, Connection};
+use serde::{Deserialize, Serialize};
+
+use crate::db::accounts::AccountFull;
+use crate::error::Result;
+
+/// A per-service binding that says "this account talks to this protocol for
+/// this service". One identity in the `accounts` table can carry multiple
+/// bindings: a Gmail account has bindings for `mail/imap`, `calendar/google`,
+/// and `contacts/google`; a Nextcloud-hosted IMAP account adds `calendar/caldav`
+/// and `contacts/carddav` for the same identity.
+///
+/// Phase 1 of the bindings rollout: rows are populated alongside the existing
+/// per-protocol columns on `accounts`, but no dispatch code reads from here
+/// yet. Phase 2 switches reads, Phase 3 drops the old columns.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ServiceBinding {
+    pub id: String,
+    pub account_id: String,
+    pub service: String,
+    pub protocol: String,
+    pub enabled: bool,
+    pub sync_interval_seconds: Option<i64>,
+    pub config_json: String,
+}
+
+pub fn list_for_account(conn: &Connection, account_id: &str) -> Result<Vec<ServiceBinding>> {
+    let mut stmt = conn.prepare(
+        "SELECT id, account_id, service, protocol, enabled, sync_interval_seconds, config_json
+         FROM service_bindings
+         WHERE account_id = ?1
+         ORDER BY service, protocol",
+    )?;
+    let rows = stmt
+        .query_map(params![account_id], |row| {
+            Ok(ServiceBinding {
+                id: row.get(0)?,
+                account_id: row.get(1)?,
+                service: row.get(2)?,
+                protocol: row.get(3)?,
+                enabled: row.get(4)?,
+                sync_interval_seconds: row.get(5)?,
+                config_json: row.get(6)?,
+            })
+        })?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    Ok(rows)
+}
+
+pub fn list_all(conn: &Connection) -> Result<Vec<ServiceBinding>> {
+    let mut stmt = conn.prepare(
+        "SELECT id, account_id, service, protocol, enabled, sync_interval_seconds, config_json
+         FROM service_bindings
+         ORDER BY account_id, service, protocol",
+    )?;
+    let rows = stmt
+        .query_map([], |row| {
+            Ok(ServiceBinding {
+                id: row.get(0)?,
+                account_id: row.get(1)?,
+                service: row.get(2)?,
+                protocol: row.get(3)?,
+                enabled: row.get(4)?,
+                sync_interval_seconds: row.get(5)?,
+                config_json: row.get(6)?,
+            })
+        })?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    Ok(rows)
+}
+
+pub fn insert(conn: &Connection, b: &ServiceBinding) -> Result<()> {
+    conn.execute(
+        "INSERT INTO service_bindings
+         (id, account_id, service, protocol, enabled, sync_interval_seconds, config_json)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+        params![
+            b.id,
+            b.account_id,
+            b.service,
+            b.protocol,
+            b.enabled,
+            b.sync_interval_seconds,
+            b.config_json,
+        ],
+    )?;
+    Ok(())
+}
+
+pub fn update(conn: &Connection, b: &ServiceBinding) -> Result<()> {
+    let rows = conn.execute(
+        "UPDATE service_bindings
+         SET enabled = ?1, sync_interval_seconds = ?2, config_json = ?3,
+             updated_at = CURRENT_TIMESTAMP
+         WHERE id = ?4",
+        params![b.enabled, b.sync_interval_seconds, b.config_json, b.id],
+    )?;
+    if rows == 0 {
+        return Err(crate::error::Error::Other(format!(
+            "service_binding {} not found",
+            b.id
+        )));
+    }
+    Ok(())
+}
+
+pub fn delete(conn: &Connection, id: &str) -> Result<()> {
+    conn.execute("DELETE FROM service_bindings WHERE id = ?1", params![id])?;
+    Ok(())
+}
+
+pub fn delete_for_account(conn: &Connection, account_id: &str) -> Result<()> {
+    conn.execute(
+        "DELETE FROM service_bindings WHERE account_id = ?1",
+        params![account_id],
+    )?;
+    Ok(())
+}
+
+/// Derive the set of bindings implied by an existing `accounts` row.
+///
+/// Maps the provider + mail_protocol + caldav_url combinations that today's
+/// dispatch code reads from `AccountFull` directly into one binding per
+/// service. Used by the one-time `service_bindings_initial_populate`
+/// migration; fresh accounts created after Phase 3 will write bindings
+/// directly without going through this function.
+pub fn derive_bindings_from_account(account: &AccountFull) -> Vec<ServiceBinding> {
+    let mut out = Vec::new();
+    let aid = &account.id;
+
+    // --- Mail binding (one per account; matches mail_protocol exactly) ---
+    let mail_protocol = account.mail_protocol.as_str();
+    let mail_config = match mail_protocol {
+        "imap" => serde_json::json!({
+            "imap_host": account.imap_host,
+            "imap_port": account.imap_port,
+            "smtp_host": account.smtp_host,
+            "smtp_port": account.smtp_port,
+            "use_tls": account.use_tls,
+        }),
+        "jmap" => serde_json::json!({
+            "url": account.jmap_url,
+            "auth_method": account.jmap_auth_method,
+            "oidc_token_endpoint": account.oidc_token_endpoint,
+            "oidc_client_id": account.oidc_client_id,
+        }),
+        "graph" => serde_json::json!({}),
+        _ => serde_json::json!({}),
+    };
+    out.push(ServiceBinding {
+        id: format!("{aid}-mail"),
+        account_id: aid.clone(),
+        service: "mail".into(),
+        protocol: mail_protocol.into(),
+        enabled: account.enabled,
+        sync_interval_seconds: None,
+        config_json: mail_config.to_string(),
+    });
+
+    // --- Calendar binding ---
+    // Mirrors the dispatch in commands/calendar.rs:sync_calendars.
+    let cal: Option<(&str, serde_json::Value)> = if account.mail_protocol == "jmap" {
+        Some(("jmap", serde_json::json!({})))
+    } else if account.provider == "gmail" {
+        Some(("google", serde_json::json!({})))
+    } else if account.provider == "o365" {
+        Some(("graph", serde_json::json!({})))
+    } else if !account.caldav_url.is_empty() {
+        Some(("caldav", serde_json::json!({ "url": account.caldav_url })))
+    } else {
+        None
+    };
+    if let Some((proto, cfg)) = cal {
+        out.push(ServiceBinding {
+            id: format!("{aid}-calendar"),
+            account_id: aid.clone(),
+            service: "calendar".into(),
+            protocol: proto.into(),
+            enabled: account.calendar_sync_enabled,
+            sync_interval_seconds: None,
+            config_json: cfg.to_string(),
+        });
+    }
+
+    // --- Contacts binding ---
+    // Mirrors the dispatch in commands/contacts.rs:sync_contacts.
+    let contacts: Option<(&str, serde_json::Value)> = if account.mail_protocol == "jmap" {
+        Some(("jmap", serde_json::json!({})))
+    } else if account.provider == "gmail" {
+        Some(("google", serde_json::json!({})))
+    } else if account.provider == "o365" {
+        // Graph contacts via Microsoft, even for legacy IMAP-mail O365 rows.
+        Some(("graph", serde_json::json!({})))
+    } else if !account.caldav_url.is_empty() {
+        // Generic IMAP with a configured DAV URL: the same host serves CardDAV
+        // (ADR 0022). Store the URL on the binding so future edits don't
+        // reach back into the legacy column.
+        Some(("carddav", serde_json::json!({ "url": account.caldav_url })))
+    } else {
+        None
+    };
+    if let Some((proto, cfg)) = contacts {
+        out.push(ServiceBinding {
+            id: format!("{aid}-contacts"),
+            account_id: aid.clone(),
+            service: "contacts".into(),
+            protocol: proto.into(),
+            enabled: true,
+            sync_interval_seconds: None,
+            config_json: cfg.to_string(),
+        });
+    }
+
+    out
+}
+
+/// Map an old-schema `(provider, jmap_auth_method)` pair to the new
+/// `auth_method` value stored on `accounts`. Pure function so the migration
+/// and unit tests can both call it.
+pub fn auth_method_for(provider: &str, jmap_auth_method: &str) -> &'static str {
+    match provider {
+        "gmail" => "oauth-google",
+        "o365" => "oauth-microsoft",
+        _ if jmap_auth_method == "oidc" => "oauth-jmap-oidc",
+        _ => "password",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::accounts::AccountFull;
+
+    fn setup_db() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE accounts (
+                id TEXT PRIMARY KEY,
+                display_name TEXT NOT NULL DEFAULT '',
+                email TEXT NOT NULL DEFAULT '',
+                provider TEXT NOT NULL DEFAULT '',
+                mail_protocol TEXT NOT NULL DEFAULT 'imap',
+                imap_host TEXT NOT NULL DEFAULT '',
+                imap_port INTEGER NOT NULL DEFAULT 993,
+                smtp_host TEXT NOT NULL DEFAULT '',
+                smtp_port INTEGER NOT NULL DEFAULT 587,
+                jmap_url TEXT NOT NULL DEFAULT '',
+                caldav_url TEXT NOT NULL DEFAULT '',
+                username TEXT NOT NULL DEFAULT '',
+                use_tls INTEGER NOT NULL DEFAULT 1,
+                enabled INTEGER NOT NULL DEFAULT 1,
+                signature TEXT NOT NULL DEFAULT '',
+                jmap_auth_method TEXT NOT NULL DEFAULT 'basic',
+                oidc_token_endpoint TEXT NOT NULL DEFAULT '',
+                oidc_client_id TEXT NOT NULL DEFAULT '',
+                calendar_sync_enabled INTEGER NOT NULL DEFAULT 1,
+                created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+            );
+            CREATE TABLE service_bindings (
+                id TEXT PRIMARY KEY,
+                account_id TEXT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+                service TEXT NOT NULL,
+                protocol TEXT NOT NULL,
+                enabled INTEGER NOT NULL DEFAULT 1,
+                sync_interval_seconds INTEGER,
+                config_json TEXT NOT NULL DEFAULT '{}',
+                created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                UNIQUE(account_id, service, protocol)
+            );",
+        )
+        .unwrap();
+        conn
+    }
+
+    fn account_row(id: &str) -> AccountFull {
+        AccountFull {
+            id: id.into(),
+            display_name: "Test".into(),
+            email: "test@example.com".into(),
+            provider: "generic".into(),
+            mail_protocol: "imap".into(),
+            imap_host: "imap.example.com".into(),
+            imap_port: 993,
+            smtp_host: "smtp.example.com".into(),
+            smtp_port: 587,
+            jmap_url: String::new(),
+            caldav_url: String::new(),
+            username: "user".into(),
+            password: String::new(),
+            use_tls: true,
+            enabled: true,
+            signature: String::new(),
+            jmap_auth_method: "basic".into(),
+            oidc_token_endpoint: String::new(),
+            oidc_client_id: String::new(),
+            calendar_sync_enabled: true,
+        }
+    }
+
+    #[test]
+    fn auth_method_mapping() {
+        assert_eq!(auth_method_for("gmail", "basic"), "oauth-google");
+        assert_eq!(auth_method_for("o365", "basic"), "oauth-microsoft");
+        assert_eq!(auth_method_for("generic", "oidc"), "oauth-jmap-oidc");
+        assert_eq!(auth_method_for("generic", "basic"), "password");
+        assert_eq!(auth_method_for("", ""), "password");
+    }
+
+    #[test]
+    fn derive_generic_imap_no_dav() {
+        let acc = account_row("a1");
+        let bindings = derive_bindings_from_account(&acc);
+        assert_eq!(bindings.len(), 1);
+        assert_eq!(bindings[0].service, "mail");
+        assert_eq!(bindings[0].protocol, "imap");
+        let cfg: serde_json::Value = serde_json::from_str(&bindings[0].config_json).unwrap();
+        assert_eq!(cfg["imap_host"], "imap.example.com");
+        assert_eq!(cfg["smtp_port"], 587);
+    }
+
+    #[test]
+    fn derive_generic_imap_with_caldav_yields_three_bindings() {
+        let mut acc = account_row("a1");
+        acc.caldav_url = "https://nextcloud.example.com/dav".into();
+        let bindings = derive_bindings_from_account(&acc);
+        assert_eq!(bindings.len(), 3);
+        let cal = bindings.iter().find(|b| b.service == "calendar").unwrap();
+        assert_eq!(cal.protocol, "caldav");
+        let cal_cfg: serde_json::Value = serde_json::from_str(&cal.config_json).unwrap();
+        assert_eq!(cal_cfg["url"], "https://nextcloud.example.com/dav");
+        let con = bindings.iter().find(|b| b.service == "contacts").unwrap();
+        assert_eq!(con.protocol, "carddav");
+    }
+
+    #[test]
+    fn derive_gmail_yields_imap_plus_google() {
+        let mut acc = account_row("a1");
+        acc.provider = "gmail".into();
+        acc.imap_host = "imap.gmail.com".into();
+        acc.smtp_host = "smtp.gmail.com".into();
+        let bindings = derive_bindings_from_account(&acc);
+        assert_eq!(bindings.len(), 3);
+        let mail = bindings.iter().find(|b| b.service == "mail").unwrap();
+        assert_eq!(mail.protocol, "imap");
+        assert_eq!(
+            bindings.iter().find(|b| b.service == "calendar").unwrap().protocol,
+            "google"
+        );
+        assert_eq!(
+            bindings.iter().find(|b| b.service == "contacts").unwrap().protocol,
+            "google"
+        );
+    }
+
+    #[test]
+    fn derive_o365_imap_legacy_yields_imap_plus_graph() {
+        let mut acc = account_row("a1");
+        acc.provider = "o365".into();
+        acc.mail_protocol = "imap".into();
+        let bindings = derive_bindings_from_account(&acc);
+        assert_eq!(bindings.len(), 3);
+        assert_eq!(
+            bindings.iter().find(|b| b.service == "mail").unwrap().protocol,
+            "imap"
+        );
+        assert_eq!(
+            bindings.iter().find(|b| b.service == "calendar").unwrap().protocol,
+            "graph"
+        );
+        assert_eq!(
+            bindings.iter().find(|b| b.service == "contacts").unwrap().protocol,
+            "graph"
+        );
+    }
+
+    #[test]
+    fn derive_o365_graph_yields_all_graph() {
+        let mut acc = account_row("a1");
+        acc.provider = "o365".into();
+        acc.mail_protocol = "graph".into();
+        let bindings = derive_bindings_from_account(&acc);
+        assert_eq!(bindings.len(), 3);
+        for b in &bindings {
+            assert_eq!(b.protocol, "graph", "service={}", b.service);
+        }
+    }
+
+    #[test]
+    fn derive_jmap_basic_yields_three_jmap_bindings() {
+        let mut acc = account_row("a1");
+        acc.mail_protocol = "jmap".into();
+        acc.jmap_url = "https://jmap.example.com/jmap".into();
+        let bindings = derive_bindings_from_account(&acc);
+        assert_eq!(bindings.len(), 3);
+        for b in &bindings {
+            assert_eq!(b.protocol, "jmap", "service={}", b.service);
+        }
+        let mail_cfg: serde_json::Value = serde_json::from_str(
+            &bindings.iter().find(|b| b.service == "mail").unwrap().config_json,
+        )
+        .unwrap();
+        assert_eq!(mail_cfg["url"], "https://jmap.example.com/jmap");
+        assert_eq!(mail_cfg["auth_method"], "basic");
+    }
+
+    #[test]
+    fn derive_jmap_oidc_carries_oidc_metadata() {
+        let mut acc = account_row("a1");
+        acc.mail_protocol = "jmap".into();
+        acc.jmap_url = "https://jmap.example.com/jmap".into();
+        acc.jmap_auth_method = "oidc".into();
+        acc.oidc_token_endpoint = "https://idp.example.com/token".into();
+        acc.oidc_client_id = "client-123".into();
+        let bindings = derive_bindings_from_account(&acc);
+        let mail = bindings.iter().find(|b| b.service == "mail").unwrap();
+        let mail_cfg: serde_json::Value = serde_json::from_str(&mail.config_json).unwrap();
+        assert_eq!(mail_cfg["auth_method"], "oidc");
+        assert_eq!(mail_cfg["oidc_token_endpoint"], "https://idp.example.com/token");
+        assert_eq!(mail_cfg["oidc_client_id"], "client-123");
+    }
+
+    #[test]
+    fn calendar_disabled_propagates_to_binding() {
+        let mut acc = account_row("a1");
+        acc.caldav_url = "https://example.com/dav".into();
+        acc.calendar_sync_enabled = false;
+        let bindings = derive_bindings_from_account(&acc);
+        let cal = bindings.iter().find(|b| b.service == "calendar").unwrap();
+        assert!(!cal.enabled);
+        // Mail/contacts should still be enabled.
+        assert!(bindings.iter().find(|b| b.service == "mail").unwrap().enabled);
+    }
+
+    #[test]
+    fn crud_round_trip() {
+        let conn = setup_db();
+        conn.execute(
+            "INSERT INTO accounts (id, display_name, email, provider, username) VALUES ('a1', 'A', 'a@e', 'generic', 'u')",
+            [],
+        ).unwrap();
+        let b = ServiceBinding {
+            id: "a1-mail".into(),
+            account_id: "a1".into(),
+            service: "mail".into(),
+            protocol: "imap".into(),
+            enabled: true,
+            sync_interval_seconds: Some(120),
+            config_json: r#"{"imap_host":"x"}"#.into(),
+        };
+        insert(&conn, &b).unwrap();
+        let listed = list_for_account(&conn, "a1").unwrap();
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].sync_interval_seconds, Some(120));
+
+        let mut updated = listed[0].clone();
+        updated.enabled = false;
+        updated.sync_interval_seconds = None;
+        update(&conn, &updated).unwrap();
+        let after = list_for_account(&conn, "a1").unwrap();
+        assert!(!after[0].enabled);
+        assert_eq!(after[0].sync_interval_seconds, None);
+
+        delete(&conn, "a1-mail").unwrap();
+        assert!(list_for_account(&conn, "a1").unwrap().is_empty());
+    }
+
+    #[test]
+    fn deleting_account_cascades_to_bindings() {
+        let conn = setup_db();
+        // Need foreign keys ON for cascade in this in-memory connection.
+        conn.execute_batch("PRAGMA foreign_keys = ON;").unwrap();
+        conn.execute(
+            "INSERT INTO accounts (id, display_name, email, provider, username) VALUES ('a1', 'A', 'a@e', 'generic', 'u')",
+            [],
+        ).unwrap();
+        let b = ServiceBinding {
+            id: "a1-mail".into(),
+            account_id: "a1".into(),
+            service: "mail".into(),
+            protocol: "imap".into(),
+            enabled: true,
+            sync_interval_seconds: None,
+            config_json: "{}".into(),
+        };
+        insert(&conn, &b).unwrap();
+        conn.execute("DELETE FROM accounts WHERE id = 'a1'", []).unwrap();
+        assert!(list_for_account(&conn, "a1").unwrap().is_empty());
+    }
+}

--- a/src-tauri/src/db/service_bindings.rs
+++ b/src-tauri/src/db/service_bindings.rs
@@ -207,6 +207,9 @@ pub fn delete_for_account(conn: &Connection, account_id: &str) -> Result<()> {
 /// reads them straight out of SQL.
 pub struct LegacyBindingFields<'a> {
     pub account_id: &'a str,
+    /// Default for the mail binding's `enabled` flag when no explicit
+    /// `mail_sync_enabled` override is supplied. The migration sets this
+    /// to the row's `accounts.enabled` value to preserve old behavior.
     pub enabled: bool,
     pub provider: &'a str,
     pub mail_protocol: &'a str,
@@ -221,6 +224,13 @@ pub struct LegacyBindingFields<'a> {
     pub oidc_client_id: &'a str,
     pub caldav_url: &'a str,
     pub calendar_sync_enabled: bool,
+    /// Phase 4 additions. If `None`, falls back to `enabled` for the mail
+    /// binding (legacy behavior) or `true` for contacts.
+    pub mail_sync_enabled: Option<bool>,
+    pub contacts_sync_enabled: Option<bool>,
+    pub mail_sync_interval_seconds: Option<i64>,
+    pub calendar_sync_interval_seconds: Option<i64>,
+    pub contacts_sync_interval_seconds: Option<i64>,
 }
 
 /// Derive the set of bindings implied by a `(provider, mail_protocol, ...)`
@@ -253,8 +263,8 @@ pub fn derive_bindings(f: LegacyBindingFields<'_>) -> Vec<ServiceBinding> {
             account_id: aid.into(),
             service: "mail".into(),
             protocol: f.mail_protocol.into(),
-            enabled: f.enabled,
-            sync_interval_seconds: None,
+            enabled: f.mail_sync_enabled.unwrap_or(f.enabled),
+            sync_interval_seconds: f.mail_sync_interval_seconds,
             config_json: mail_config.to_string(),
         });
     }
@@ -278,7 +288,7 @@ pub fn derive_bindings(f: LegacyBindingFields<'_>) -> Vec<ServiceBinding> {
             service: "calendar".into(),
             protocol: proto.into(),
             enabled: f.calendar_sync_enabled,
-            sync_interval_seconds: None,
+            sync_interval_seconds: f.calendar_sync_interval_seconds,
             config_json: cfg.to_string(),
         });
     }
@@ -301,8 +311,8 @@ pub fn derive_bindings(f: LegacyBindingFields<'_>) -> Vec<ServiceBinding> {
             account_id: aid.into(),
             service: "contacts".into(),
             protocol: proto.into(),
-            enabled: true,
-            sync_interval_seconds: None,
+            enabled: f.contacts_sync_enabled.unwrap_or(true),
+            sync_interval_seconds: f.contacts_sync_interval_seconds,
             config_json: cfg.to_string(),
         });
     }
@@ -329,6 +339,11 @@ pub fn derive_bindings_from_account(account: &AccountFull) -> Vec<ServiceBinding
         oidc_client_id: &account.oidc_client_id,
         caldav_url: &account.caldav_url,
         calendar_sync_enabled: account.calendar_sync_enabled,
+        mail_sync_enabled: None,
+        contacts_sync_enabled: None,
+        mail_sync_interval_seconds: None,
+        calendar_sync_interval_seconds: None,
+        contacts_sync_interval_seconds: None,
     })
 }
 
@@ -433,6 +448,11 @@ mod tests {
             calendar_sync_enabled: true,
             auth_method: String::new(),
             bindings: Vec::new(),
+            mail_sync_enabled: true,
+            contacts_sync_enabled: true,
+            mail_sync_interval_seconds: None,
+            calendar_sync_interval_seconds: None,
+            contacts_sync_interval_seconds: None,
         }
     }
 
@@ -556,6 +576,102 @@ mod tests {
         assert_eq!(mail_cfg["auth_method"], "oidc");
         assert_eq!(mail_cfg["oidc_token_endpoint"], "https://idp.example.com/token");
         assert_eq!(mail_cfg["oidc_client_id"], "client-123");
+    }
+
+    #[test]
+    fn empty_mail_protocol_yields_no_mail_binding() {
+        // CalDAV-only Nextcloud-style account: no mail at all, just the
+        // shared dav URL. derive_bindings should still produce calendar +
+        // contacts but skip the mail binding entirely.
+        let mut acc = account_row("a1");
+        acc.mail_protocol = String::new();
+        acc.imap_host = String::new();
+        acc.imap_port = 0;
+        acc.smtp_host = String::new();
+        acc.smtp_port = 0;
+        acc.caldav_url = "https://nextcloud.example.com/dav".into();
+        let bindings = derive_bindings_from_account(&acc);
+        assert!(bindings.iter().all(|b| b.service != "mail"));
+        assert_eq!(
+            bindings.iter().find(|b| b.service == "calendar").unwrap().protocol,
+            "caldav"
+        );
+        assert_eq!(
+            bindings.iter().find(|b| b.service == "contacts").unwrap().protocol,
+            "carddav"
+        );
+    }
+
+    #[test]
+    fn mail_sync_enabled_override_disables_mail_binding() {
+        // JMAP cal-only: full JMAP account, but mail_sync_enabled=false
+        // marks the mail binding disabled while leaving cal/contacts on.
+        let mut acc = account_row("a1");
+        acc.mail_protocol = "jmap".into();
+        acc.jmap_url = "https://jmap.example.com".into();
+        let bindings = derive_bindings(LegacyBindingFields {
+            account_id: &acc.id,
+            enabled: true,
+            provider: &acc.provider,
+            mail_protocol: &acc.mail_protocol,
+            imap_host: &acc.imap_host,
+            imap_port: acc.imap_port,
+            smtp_host: &acc.smtp_host,
+            smtp_port: acc.smtp_port,
+            use_tls: acc.use_tls,
+            jmap_url: &acc.jmap_url,
+            jmap_auth_method: &acc.jmap_auth_method,
+            oidc_token_endpoint: &acc.oidc_token_endpoint,
+            oidc_client_id: &acc.oidc_client_id,
+            caldav_url: &acc.caldav_url,
+            calendar_sync_enabled: acc.calendar_sync_enabled,
+            mail_sync_enabled: Some(false),
+            contacts_sync_enabled: None,
+            mail_sync_interval_seconds: None,
+            calendar_sync_interval_seconds: None,
+            contacts_sync_interval_seconds: None,
+        });
+        let mail = bindings.iter().find(|b| b.service == "mail").unwrap();
+        assert_eq!(mail.protocol, "jmap");
+        assert!(
+            !mail.enabled,
+            "mail_sync_enabled=false should disable the mail binding"
+        );
+        let cal = bindings.iter().find(|b| b.service == "calendar").unwrap();
+        assert!(cal.enabled);
+    }
+
+    #[test]
+    fn per_binding_sync_intervals_propagate() {
+        let acc = account_row("a1");
+        let bindings = derive_bindings(LegacyBindingFields {
+            account_id: &acc.id,
+            enabled: true,
+            provider: &acc.provider,
+            mail_protocol: &acc.mail_protocol,
+            imap_host: &acc.imap_host,
+            imap_port: acc.imap_port,
+            smtp_host: &acc.smtp_host,
+            smtp_port: acc.smtp_port,
+            use_tls: acc.use_tls,
+            jmap_url: &acc.jmap_url,
+            jmap_auth_method: &acc.jmap_auth_method,
+            oidc_token_endpoint: &acc.oidc_token_endpoint,
+            oidc_client_id: &acc.oidc_client_id,
+            caldav_url: "https://example.com/dav",
+            calendar_sync_enabled: true,
+            mail_sync_enabled: None,
+            contacts_sync_enabled: None,
+            mail_sync_interval_seconds: Some(120),
+            calendar_sync_interval_seconds: Some(900),
+            contacts_sync_interval_seconds: Some(1800),
+        });
+        let mail = bindings.iter().find(|b| b.service == "mail").unwrap();
+        let cal = bindings.iter().find(|b| b.service == "calendar").unwrap();
+        let con = bindings.iter().find(|b| b.service == "contacts").unwrap();
+        assert_eq!(mail.sync_interval_seconds, Some(120));
+        assert_eq!(cal.sync_interval_seconds, Some(900));
+        assert_eq!(con.sync_interval_seconds, Some(1800));
     }
 
     #[test]

--- a/src-tauri/src/db/service_bindings.rs
+++ b/src-tauri/src/db/service_bindings.rs
@@ -1,8 +1,64 @@
 use rusqlite::{params, Connection};
 use serde::{Deserialize, Serialize};
 
+#[cfg(test)]
 use crate::db::accounts::AccountFull;
-use crate::error::Result;
+use crate::error::{Error, Result};
+
+// ---- Typed binding-config payloads ----------------------------------------
+//
+// Each binding stores its protocol-specific settings as JSON in `config_json`.
+// These structs let callers go through `serde_json::from_str` once and then
+// touch typed fields. A missing key falls through to its `Default`, so
+// partial / older config rows still parse.
+
+fn default_imap_port() -> u16 {
+    993
+}
+fn default_smtp_port() -> u16 {
+    587
+}
+fn default_use_tls() -> bool {
+    true
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ImapBindingConfig {
+    #[serde(default)]
+    pub imap_host: String,
+    #[serde(default = "default_imap_port")]
+    pub imap_port: u16,
+    #[serde(default)]
+    pub smtp_host: String,
+    #[serde(default = "default_smtp_port")]
+    pub smtp_port: u16,
+    #[serde(default = "default_use_tls")]
+    pub use_tls: bool,
+}
+
+impl Default for ImapBindingConfig {
+    fn default() -> Self {
+        Self {
+            imap_host: String::new(),
+            imap_port: default_imap_port(),
+            smtp_host: String::new(),
+            smtp_port: default_smtp_port(),
+            use_tls: default_use_tls(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct JmapBindingConfig {
+    #[serde(default)]
+    pub url: String,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct DavBindingConfig {
+    #[serde(default)]
+    pub url: String,
+}
 
 /// A per-service binding that says "this account talks to this protocol for
 /// this service". One identity in the `accounts` table can carry multiple
@@ -22,6 +78,35 @@ pub struct ServiceBinding {
     pub enabled: bool,
     pub sync_interval_seconds: Option<i64>,
     pub config_json: String,
+}
+
+impl ServiceBinding {
+    pub fn imap_config(&self) -> Result<ImapBindingConfig> {
+        serde_json::from_str(&self.config_json).map_err(|e| {
+            Error::Other(format!(
+                "binding {} has malformed imap config_json: {}",
+                self.id, e
+            ))
+        })
+    }
+
+    pub fn jmap_config(&self) -> Result<JmapBindingConfig> {
+        serde_json::from_str(&self.config_json).map_err(|e| {
+            Error::Other(format!(
+                "binding {} has malformed jmap config_json: {}",
+                self.id, e
+            ))
+        })
+    }
+
+    pub fn dav_config(&self) -> Result<DavBindingConfig> {
+        serde_json::from_str(&self.config_json).map_err(|e| {
+            Error::Other(format!(
+                "binding {} has malformed dav config_json: {}",
+                self.id, e
+            ))
+        })
+    }
 }
 
 pub fn list_for_account(conn: &Connection, account_id: &str) -> Result<Vec<ServiceBinding>> {
@@ -117,92 +202,103 @@ pub fn delete_for_account(conn: &Connection, account_id: &str) -> Result<()> {
     Ok(())
 }
 
-/// Derive the set of bindings implied by an existing `accounts` row.
-///
-/// Maps the provider + mail_protocol + caldav_url combinations that today's
-/// dispatch code reads from `AccountFull` directly into one binding per
-/// service. Used by the one-time `service_bindings_initial_populate`
-/// migration; fresh accounts created after Phase 3 will write bindings
-/// directly without going through this function.
-pub fn derive_bindings_from_account(account: &AccountFull) -> Vec<ServiceBinding> {
-    let mut out = Vec::new();
-    let aid = &account.id;
+/// Snapshot of the legacy per-protocol fields needed to derive bindings.
+/// `AccountFull` and `AccountConfig` both supply these; the migration
+/// reads them straight out of SQL.
+pub struct LegacyBindingFields<'a> {
+    pub account_id: &'a str,
+    pub enabled: bool,
+    pub provider: &'a str,
+    pub mail_protocol: &'a str,
+    pub imap_host: &'a str,
+    pub imap_port: u16,
+    pub smtp_host: &'a str,
+    pub smtp_port: u16,
+    pub use_tls: bool,
+    pub jmap_url: &'a str,
+    pub jmap_auth_method: &'a str,
+    pub oidc_token_endpoint: &'a str,
+    pub oidc_client_id: &'a str,
+    pub caldav_url: &'a str,
+    pub calendar_sync_enabled: bool,
+}
 
-    // --- Mail binding (one per account; matches mail_protocol exactly) ---
-    let mail_protocol = account.mail_protocol.as_str();
-    let mail_config = match mail_protocol {
+/// Derive the set of bindings implied by a `(provider, mail_protocol, ...)`
+/// tuple. Used both by the one-time Phase-1 populate migration (which
+/// reads the soon-to-be-dropped legacy columns) and by `insert_account` /
+/// `update_account` to build bindings from the wire-format `AccountConfig`.
+pub fn derive_bindings(f: LegacyBindingFields<'_>) -> Vec<ServiceBinding> {
+    let mut out = Vec::new();
+    let aid = f.account_id;
+
+    let mail_config = match f.mail_protocol {
         "imap" => serde_json::json!({
-            "imap_host": account.imap_host,
-            "imap_port": account.imap_port,
-            "smtp_host": account.smtp_host,
-            "smtp_port": account.smtp_port,
-            "use_tls": account.use_tls,
+            "imap_host": f.imap_host,
+            "imap_port": f.imap_port,
+            "smtp_host": f.smtp_host,
+            "smtp_port": f.smtp_port,
+            "use_tls": f.use_tls,
         }),
         "jmap" => serde_json::json!({
-            "url": account.jmap_url,
-            "auth_method": account.jmap_auth_method,
-            "oidc_token_endpoint": account.oidc_token_endpoint,
-            "oidc_client_id": account.oidc_client_id,
+            "url": f.jmap_url,
+            "auth_method": f.jmap_auth_method,
+            "oidc_token_endpoint": f.oidc_token_endpoint,
+            "oidc_client_id": f.oidc_client_id,
         }),
-        "graph" => serde_json::json!({}),
         _ => serde_json::json!({}),
     };
-    out.push(ServiceBinding {
-        id: format!("{aid}-mail"),
-        account_id: aid.clone(),
-        service: "mail".into(),
-        protocol: mail_protocol.into(),
-        enabled: account.enabled,
-        sync_interval_seconds: None,
-        config_json: mail_config.to_string(),
-    });
+    if !f.mail_protocol.is_empty() {
+        out.push(ServiceBinding {
+            id: format!("{aid}-mail"),
+            account_id: aid.into(),
+            service: "mail".into(),
+            protocol: f.mail_protocol.into(),
+            enabled: f.enabled,
+            sync_interval_seconds: None,
+            config_json: mail_config.to_string(),
+        });
+    }
 
-    // --- Calendar binding ---
-    // Mirrors the dispatch in commands/calendar.rs:sync_calendars.
-    let cal: Option<(&str, serde_json::Value)> = if account.mail_protocol == "jmap" {
+    // Calendar binding (mirrors the dispatch in commands/calendar.rs).
+    let cal: Option<(&str, serde_json::Value)> = if f.mail_protocol == "jmap" {
         Some(("jmap", serde_json::json!({})))
-    } else if account.provider == "gmail" {
+    } else if f.provider == "gmail" {
         Some(("google", serde_json::json!({})))
-    } else if account.provider == "o365" {
+    } else if f.provider == "o365" {
         Some(("graph", serde_json::json!({})))
-    } else if !account.caldav_url.is_empty() {
-        Some(("caldav", serde_json::json!({ "url": account.caldav_url })))
+    } else if !f.caldav_url.is_empty() {
+        Some(("caldav", serde_json::json!({ "url": f.caldav_url })))
     } else {
         None
     };
     if let Some((proto, cfg)) = cal {
         out.push(ServiceBinding {
             id: format!("{aid}-calendar"),
-            account_id: aid.clone(),
+            account_id: aid.into(),
             service: "calendar".into(),
             protocol: proto.into(),
-            enabled: account.calendar_sync_enabled,
+            enabled: f.calendar_sync_enabled,
             sync_interval_seconds: None,
             config_json: cfg.to_string(),
         });
     }
 
-    // --- Contacts binding ---
-    // Mirrors the dispatch in commands/contacts.rs:sync_contacts.
-    let contacts: Option<(&str, serde_json::Value)> = if account.mail_protocol == "jmap" {
+    // Contacts binding (mirrors the dispatch in commands/contacts.rs).
+    let contacts: Option<(&str, serde_json::Value)> = if f.mail_protocol == "jmap" {
         Some(("jmap", serde_json::json!({})))
-    } else if account.provider == "gmail" {
+    } else if f.provider == "gmail" {
         Some(("google", serde_json::json!({})))
-    } else if account.provider == "o365" {
-        // Graph contacts via Microsoft, even for legacy IMAP-mail O365 rows.
+    } else if f.provider == "o365" {
         Some(("graph", serde_json::json!({})))
-    } else if !account.caldav_url.is_empty() {
-        // Generic IMAP with a configured DAV URL: the same host serves CardDAV
-        // (ADR 0022). Store the URL on the binding so future edits don't
-        // reach back into the legacy column.
-        Some(("carddav", serde_json::json!({ "url": account.caldav_url })))
+    } else if !f.caldav_url.is_empty() {
+        Some(("carddav", serde_json::json!({ "url": f.caldav_url })))
     } else {
         None
     };
     if let Some((proto, cfg)) = contacts {
         out.push(ServiceBinding {
             id: format!("{aid}-contacts"),
-            account_id: aid.clone(),
+            account_id: aid.into(),
             service: "contacts".into(),
             protocol: proto.into(),
             enabled: true,
@@ -214,52 +310,40 @@ pub fn derive_bindings_from_account(account: &AccountFull) -> Vec<ServiceBinding
     out
 }
 
-/// Re-derive the bindings for a single account from the legacy account
-/// columns. Wipes existing rows for `account_id` and inserts the freshly
-/// derived set. Called from `insert_account` / `update_account` so the
-/// bindings table tracks settings edits during the parallel-population
-/// phase, and from the one-time initial-populate migration.
-pub fn rebuild_for_account(conn: &Connection, account_id: &str) -> Result<()> {
-    // Pull just the columns derive_bindings_from_account needs. Avoid
-    // get_account_full because it touches the OS keyring, which we don't
-    // want during write paths that are already inside a DB transaction.
-    let account = conn.query_row(
-        "SELECT id, display_name, email, provider, mail_protocol, imap_host, imap_port,
-                smtp_host, smtp_port, jmap_url, caldav_url, username, use_tls,
-                enabled, signature, jmap_auth_method, oidc_token_endpoint, oidc_client_id,
-                calendar_sync_enabled
-         FROM accounts WHERE id = ?1",
-        params![account_id],
-        |row| {
-            Ok(AccountFull {
-                id: row.get(0)?,
-                display_name: row.get(1)?,
-                email: row.get(2)?,
-                provider: row.get(3)?,
-                mail_protocol: row.get(4)?,
-                imap_host: row.get(5)?,
-                imap_port: row.get::<_, u32>(6)? as u16,
-                smtp_host: row.get(7)?,
-                smtp_port: row.get::<_, u32>(8)? as u16,
-                jmap_url: row.get(9)?,
-                caldav_url: row.get(10)?,
-                username: row.get(11)?,
-                password: String::new(),
-                use_tls: row.get(12)?,
-                enabled: row.get(13)?,
-                signature: row.get(14)?,
-                jmap_auth_method: row.get(15)?,
-                oidc_token_endpoint: row.get(16)?,
-                oidc_client_id: row.get(17)?,
-                calendar_sync_enabled: row.get(18)?,
-                auth_method: String::new(),
-                bindings: Vec::new(),
-            })
-        },
-    )?;
+/// Convenience wrapper used by the unit tests that fed the previous API.
+#[cfg(test)]
+pub fn derive_bindings_from_account(account: &AccountFull) -> Vec<ServiceBinding> {
+    derive_bindings(LegacyBindingFields {
+        account_id: &account.id,
+        enabled: account.enabled,
+        provider: &account.provider,
+        mail_protocol: &account.mail_protocol,
+        imap_host: &account.imap_host,
+        imap_port: account.imap_port,
+        smtp_host: &account.smtp_host,
+        smtp_port: account.smtp_port,
+        use_tls: account.use_tls,
+        jmap_url: &account.jmap_url,
+        jmap_auth_method: &account.jmap_auth_method,
+        oidc_token_endpoint: &account.oidc_token_endpoint,
+        oidc_client_id: &account.oidc_client_id,
+        caldav_url: &account.caldav_url,
+        calendar_sync_enabled: account.calendar_sync_enabled,
+    })
+}
 
+/// Re-derive the bindings for a single account from the supplied legacy
+/// fields and persist them. Wipes existing rows for `account_id` first so
+/// the table converges to the latest derivation rules. Called from
+/// `insert_account` / `update_account` (which build the fields from the
+/// wire-format `AccountConfig`).
+pub fn rebuild_for_account(
+    conn: &Connection,
+    account_id: &str,
+    fields: LegacyBindingFields<'_>,
+) -> Result<()> {
     delete_for_account(conn, account_id)?;
-    for binding in derive_bindings_from_account(&account) {
+    for binding in derive_bindings(fields) {
         insert(conn, &binding)?;
     }
     Ok(())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -45,6 +45,7 @@ pub fn run() {
             commands::accounts::get_account_config,
             commands::accounts::update_account,
             commands::accounts::delete_account,
+            commands::accounts::probe_dav_endpoints,
             commands::mail::list_folders,
             commands::mail::get_messages,
             commands::mail::search_messages_server,

--- a/src-tauri/src/mail/autoconfig.rs
+++ b/src-tauri/src/mail/autoconfig.rs
@@ -1,0 +1,419 @@
+//! Thunderbird-style email autoconfig (#43).
+//!
+//! Mirrors the discovery sequence used by Mozilla Thunderbird when a user
+//! types an email address into the new-account wizard. We run all the
+//! candidate sources in priority order, return the first successful
+//! parse, and surface the source so the UI can show "Found at <ISP DB>"
+//! style hints.
+//!
+//! Sources, in order:
+//! 1. Mozilla ISP database — `https://autoconfig.thunderbird.net/v1.1/<domain>`
+//! 2. Provider-hosted autoconfig — `https://autoconfig.<domain>/mail/config-v1.1.xml`
+//! 3. `.well-known` endpoint — `https://<domain>/.well-known/autoconfig/mail/config-v1.1.xml`
+//! 4. MX lookup — gives us the mailserver hostname even when the domain
+//!    has no autoconfig published. We never accept that hostname blindly,
+//!    we just use it as another candidate to probe IMAPS / DAV against.
+//!
+//! All HTTP fetches share a single 8s timeout. The XML response is
+//! capped at 64 KB so a hostile server can't make us load megabytes of
+//! garbage.
+
+use crate::error::{Error, Result};
+use serde::{Deserialize, Serialize};
+use uppsala::{Document, NodeId, NodeKind};
+
+/// Resolved IMAP / SMTP server settings from a Thunderbird-format
+/// `clientConfig` document. Subset of the schema — we only persist the
+/// fields the UI actually round-trips into AccountConfig.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct AutoconfigServers {
+    pub imap_host: String,
+    pub imap_port: u16,
+    pub imap_use_tls: bool,
+    pub smtp_host: String,
+    pub smtp_port: u16,
+    pub smtp_use_tls: bool,
+}
+
+const FETCH_TIMEOUT_SECS: u64 = 8;
+const MAX_BYTES: usize = 64 * 1024;
+
+fn http_client() -> Result<reqwest::Client> {
+    reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(FETCH_TIMEOUT_SECS))
+        .build()
+        .map_err(|e| Error::Other(format!("autoconfig http client: {}", e)))
+}
+
+/// Run the full autoconfig sequence for an email address. Returns the
+/// first successful result and the source it came from. If every probe
+/// fails, returns `Ok(None)` (a hard error here would block the user
+/// from saving an account that we just couldn't find a config for).
+pub async fn discover(email: &str) -> Result<Option<(AutoconfigServers, &'static str)>> {
+    let domain = email
+        .rsplit('@')
+        .next()
+        .filter(|d| !d.is_empty())
+        .ok_or_else(|| Error::Other("invalid email for autoconfig".into()))?;
+    if !is_valid_domain(domain) {
+        return Err(Error::Other(format!(
+            "rejecting suspicious autoconfig domain: {}",
+            domain
+        )));
+    }
+    let http = http_client()?;
+
+    // 1. Mozilla ISP DB. Fixed hostname so no domain-controlled URL.
+    let isp_url = format!("https://autoconfig.thunderbird.net/v1.1/{}", domain);
+    if let Some(parsed) = try_fetch_and_parse(&http, &isp_url).await {
+        return Ok(Some((parsed, "isp-db")));
+    }
+
+    // 2. Provider-hosted autoconfig. The path takes the full email so
+    // providers can return per-user settings.
+    let provider_url = format!(
+        "https://autoconfig.{}/mail/config-v1.1.xml?emailaddress={}",
+        domain,
+        urlencoding::encode(email)
+    );
+    if let Some(parsed) = try_fetch_and_parse(&http, &provider_url).await {
+        return Ok(Some((parsed, "domain-autoconfig")));
+    }
+
+    // 3. `.well-known` endpoint on the bare domain.
+    let well_known_url = format!(
+        "https://{}/.well-known/autoconfig/mail/config-v1.1.xml?emailaddress={}",
+        domain,
+        urlencoding::encode(email)
+    );
+    if let Some(parsed) = try_fetch_and_parse(&http, &well_known_url).await {
+        return Ok(Some((parsed, "well-known")));
+    }
+
+    // 4. MX-derived guess. We trust the MX hostname enough to probe its
+    // standard IMAPS / submission ports because it's the same source
+    // the user's mail is already going through. We don't fabricate ports
+    // beyond the IANA-assigned ones.
+    if let Some(mx_host) = lookup_mx(domain).await {
+        log::info!("autoconfig: MX for {} -> {}, guessing IMAPS/submission", domain, mx_host);
+        return Ok(Some((
+            AutoconfigServers {
+                imap_host: mx_host.clone(),
+                imap_port: 993,
+                imap_use_tls: true,
+                smtp_host: mx_host,
+                smtp_port: 587,
+                smtp_use_tls: true,
+            },
+            "mx",
+        )));
+    }
+
+    Ok(None)
+}
+
+async fn try_fetch_and_parse(
+    http: &reqwest::Client,
+    url: &str,
+) -> Option<AutoconfigServers> {
+    log::debug!("autoconfig: GET {}", url);
+    match http.get(url).send().await {
+        Ok(resp) if resp.status().is_success() => {
+            let body = match resp.bytes().await {
+                Ok(b) if b.len() <= MAX_BYTES => b,
+                Ok(_) => {
+                    log::warn!("autoconfig: response too large at {}", url);
+                    return None;
+                }
+                Err(e) => {
+                    log::debug!("autoconfig: body read failed at {}: {}", url, e);
+                    return None;
+                }
+            };
+            let xml = match std::str::from_utf8(&body) {
+                Ok(s) => s,
+                Err(_) => return None,
+            };
+            match parse_clientconfig_xml(xml) {
+                Some(s) => Some(s),
+                None => {
+                    log::debug!("autoconfig: response at {} did not parse", url);
+                    None
+                }
+            }
+        }
+        Ok(resp) => {
+            log::debug!("autoconfig: {} returned {}", url, resp.status());
+            None
+        }
+        Err(e) => {
+            log::debug!("autoconfig: GET failed for {}: {}", url, e);
+            None
+        }
+    }
+}
+
+/// Parse a Thunderbird `clientConfig` XML document into our small
+/// `AutoconfigServers` struct. Returns `None` if neither an
+/// `incomingServer type="imap"` nor an `outgoingServer type="smtp"`
+/// could be located — most providers ship both, and a result with no
+/// usable servers isn't worth surfacing.
+pub(crate) fn parse_clientconfig_xml(xml: &str) -> Option<AutoconfigServers> {
+    let doc = uppsala::parse(xml).ok()?;
+    let root = doc.root();
+
+    let mut imap_host = String::new();
+    let mut imap_port: u16 = 0;
+    let mut imap_use_tls = true;
+    let mut smtp_host = String::new();
+    let mut smtp_port: u16 = 0;
+    let mut smtp_use_tls = true;
+
+    visit_servers(&doc, root, &mut |kind, host, port, tls| match kind {
+        ServerKind::Imap if imap_host.is_empty() => {
+            imap_host = host;
+            imap_port = port;
+            imap_use_tls = tls;
+        }
+        ServerKind::Smtp if smtp_host.is_empty() => {
+            smtp_host = host;
+            smtp_port = port;
+            smtp_use_tls = tls;
+        }
+        _ => {}
+    });
+
+    if imap_host.is_empty() && smtp_host.is_empty() {
+        return None;
+    }
+    Some(AutoconfigServers {
+        imap_host,
+        imap_port: if imap_port == 0 { 993 } else { imap_port },
+        imap_use_tls,
+        smtp_host,
+        smtp_port: if smtp_port == 0 { 587 } else { smtp_port },
+        smtp_use_tls,
+    })
+}
+
+#[derive(Clone, Copy)]
+enum ServerKind {
+    Imap,
+    Smtp,
+    Other,
+}
+
+/// Walk every `incomingServer` / `outgoingServer` node in a parsed
+/// clientConfig document and yield (kind, hostname, port, tls) to the
+/// caller. Skips entries that don't list both a hostname and a port.
+fn visit_servers<F: FnMut(ServerKind, String, u16, bool)>(
+    doc: &Document,
+    node: NodeId,
+    visit: &mut F,
+) {
+    let kind = if let Some(NodeKind::Element(el)) = doc.node_kind(node) {
+        match el.name.local_name.as_ref() {
+            "incomingServer" => Some(server_kind_from_attr(el, true)),
+            "outgoingServer" => Some(server_kind_from_attr(el, false)),
+            _ => None,
+        }
+    } else {
+        None
+    };
+
+    if let Some(k) = kind {
+        let host = element_text(doc, node, "hostname").unwrap_or_default();
+        let port = element_text(doc, node, "port")
+            .and_then(|p| p.parse::<u16>().ok())
+            .unwrap_or(0);
+        let socket = element_text(doc, node, "socketType").unwrap_or_default();
+        // SSL / TLS / STARTTLS all imply we want TLS on the connection;
+        // "plain" is the only opt-out.
+        let tls = !socket.eq_ignore_ascii_case("plain");
+        if !host.is_empty() {
+            visit(k, host, port, tls);
+        }
+    }
+
+    for child in doc.children(node) {
+        visit_servers(doc, child, visit);
+    }
+}
+
+fn server_kind_from_attr(el: &uppsala::Element, incoming: bool) -> ServerKind {
+    let kind_attr = el
+        .get_attribute("type")
+        .map(|s| s.to_ascii_lowercase())
+        .unwrap_or_default();
+    match (incoming, kind_attr.as_str()) {
+        (true, "imap") => ServerKind::Imap,
+        (false, "smtp") => ServerKind::Smtp,
+        _ => ServerKind::Other,
+    }
+}
+
+fn element_text(doc: &Document, parent: NodeId, local_name: &str) -> Option<String> {
+    for child in doc.children(parent) {
+        if let Some(NodeKind::Element(el)) = doc.node_kind(child) {
+            if el.name.local_name.as_ref() == local_name {
+                let text = doc.text_content_deep(child);
+                let trimmed = text.trim().to_string();
+                if !trimmed.is_empty() {
+                    return Some(trimmed);
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Best-effort MX lookup. Returns the highest-preference MX hostname
+/// for the domain, or `None` if the resolver fails or no records are
+/// returned. Errors are logged at debug level — autoconfig isn't a
+/// must-succeed flow.
+async fn lookup_mx(domain: &str) -> Option<String> {
+    use hickory_resolver::config::{ResolverConfig, ResolverOpts};
+    use hickory_resolver::TokioAsyncResolver;
+
+    let resolver = TokioAsyncResolver::tokio(ResolverConfig::default(), ResolverOpts::default());
+
+    match resolver.mx_lookup(domain).await {
+        Ok(answer) => {
+            let mut records: Vec<_> = answer.iter().collect();
+            records.sort_by_key(|r| r.preference());
+            for r in records {
+                let name = r.exchange().to_ascii().trim_end_matches('.').to_string();
+                if !name.is_empty() && is_valid_domain(&name) {
+                    return Some(name);
+                }
+            }
+            None
+        }
+        Err(e) => {
+            log::debug!("autoconfig: MX lookup failed for {}: {}", domain, e);
+            None
+        }
+    }
+}
+
+/// Conservative domain-name sanity check. We use the result to build
+/// HTTPS URLs, so reject anything that contains characters we don't
+/// expect in a hostname.
+fn is_valid_domain(domain: &str) -> bool {
+    if domain.is_empty() || domain.len() > 253 {
+        return false;
+    }
+    domain
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '.' || c == '-')
+        && !domain.starts_with('.')
+        && !domain.ends_with('.')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE_XML: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<clientConfig version="1.1">
+  <emailProvider id="example.com">
+    <domain>example.com</domain>
+    <displayName>Example</displayName>
+    <incomingServer type="imap">
+      <hostname>imap.example.com</hostname>
+      <port>993</port>
+      <socketType>SSL</socketType>
+      <username>%EMAILADDRESS%</username>
+      <authentication>password-cleartext</authentication>
+    </incomingServer>
+    <outgoingServer type="smtp">
+      <hostname>smtp.example.com</hostname>
+      <port>587</port>
+      <socketType>STARTTLS</socketType>
+      <username>%EMAILADDRESS%</username>
+      <authentication>password-cleartext</authentication>
+    </outgoingServer>
+  </emailProvider>
+</clientConfig>"#;
+
+    #[test]
+    fn parse_thunderbird_xml() {
+        let parsed = parse_clientconfig_xml(SAMPLE_XML).expect("should parse");
+        assert_eq!(parsed.imap_host, "imap.example.com");
+        assert_eq!(parsed.imap_port, 993);
+        assert!(parsed.imap_use_tls);
+        assert_eq!(parsed.smtp_host, "smtp.example.com");
+        assert_eq!(parsed.smtp_port, 587);
+        assert!(parsed.smtp_use_tls);
+    }
+
+    #[test]
+    fn parse_first_imap_server_wins() {
+        // Some ISPs publish multiple incomingServer entries (different
+        // auth schemes, fallback ports). We should take the first one.
+        let xml = r#"<?xml version="1.0"?>
+<clientConfig version="1.1">
+  <emailProvider id="x">
+    <domain>x</domain>
+    <displayName>x</displayName>
+    <incomingServer type="imap">
+      <hostname>imap-primary.example.com</hostname>
+      <port>993</port>
+      <socketType>SSL</socketType>
+    </incomingServer>
+    <incomingServer type="imap">
+      <hostname>imap-fallback.example.com</hostname>
+      <port>143</port>
+      <socketType>STARTTLS</socketType>
+    </incomingServer>
+    <outgoingServer type="smtp">
+      <hostname>smtp.example.com</hostname>
+      <port>587</port>
+      <socketType>STARTTLS</socketType>
+    </outgoingServer>
+  </emailProvider>
+</clientConfig>"#;
+        let parsed = parse_clientconfig_xml(xml).expect("should parse");
+        assert_eq!(parsed.imap_host, "imap-primary.example.com");
+    }
+
+    #[test]
+    fn parse_plaintext_socket_disables_tls() {
+        let xml = r#"<?xml version="1.0"?>
+<clientConfig version="1.1">
+  <emailProvider id="x">
+    <domain>x</domain>
+    <displayName>x</displayName>
+    <incomingServer type="imap">
+      <hostname>imap.example.com</hostname>
+      <port>143</port>
+      <socketType>plain</socketType>
+    </incomingServer>
+    <outgoingServer type="smtp">
+      <hostname>smtp.example.com</hostname>
+      <port>25</port>
+      <socketType>plain</socketType>
+    </outgoingServer>
+  </emailProvider>
+</clientConfig>"#;
+        let parsed = parse_clientconfig_xml(xml).expect("should parse");
+        assert!(!parsed.imap_use_tls);
+        assert!(!parsed.smtp_use_tls);
+    }
+
+    #[test]
+    fn parse_returns_none_for_empty_doc() {
+        let xml = r#"<?xml version="1.0"?><clientConfig version="1.1"/>"#;
+        assert!(parse_clientconfig_xml(xml).is_none());
+    }
+
+    #[test]
+    fn domain_validation() {
+        assert!(is_valid_domain("example.com"));
+        assert!(is_valid_domain("mail.example-server.io"));
+        assert!(!is_valid_domain("example.com/../etc"));
+        assert!(!is_valid_domain(""));
+        assert!(!is_valid_domain(".example.com"));
+        assert!(!is_valid_domain("exam ple.com"));
+    }
+}

--- a/src-tauri/src/mail/autoconfig.rs
+++ b/src-tauri/src/mail/autoconfig.rs
@@ -118,37 +118,56 @@ pub async fn discover(email: &str) -> Result<Option<(AutoconfigServers, &'static
 
 async fn try_fetch_and_parse(http: &reqwest::Client, url: &str) -> Option<AutoconfigServers> {
     log::debug!("autoconfig: GET {}", url);
-    match http.get(url).send().await {
-        Ok(resp) if resp.status().is_success() => {
-            let body = match resp.bytes().await {
-                Ok(b) if b.len() <= MAX_BYTES => b,
-                Ok(_) => {
-                    log::warn!("autoconfig: response too large at {}", url);
-                    return None;
-                }
-                Err(e) => {
-                    log::debug!("autoconfig: body read failed at {}: {}", url, e);
-                    return None;
-                }
-            };
-            let xml = match std::str::from_utf8(&body) {
-                Ok(s) => s,
-                Err(_) => return None,
-            };
-            match parse_clientconfig_xml(xml) {
-                Some(s) => Some(s),
-                None => {
-                    log::debug!("autoconfig: response at {} did not parse", url);
-                    None
-                }
-            }
-        }
-        Ok(resp) => {
-            log::debug!("autoconfig: {} returned {}", url, resp.status());
-            None
+    let resp = match http.get(url).send().await {
+        Ok(r) if r.status().is_success() => r,
+        Ok(r) => {
+            log::debug!("autoconfig: {} returned {}", url, r.status());
+            return None;
         }
         Err(e) => {
             log::debug!("autoconfig: GET failed for {}: {}", url, e);
+            return None;
+        }
+    };
+
+    // Cheap pre-check: if Content-Length is announced and exceeds the
+    // cap, abort before even allocating the buffer.
+    if let Some(len) = resp.content_length() {
+        if len as usize > MAX_BYTES {
+            log::warn!(
+                "autoconfig: response Content-Length {} exceeds cap at {}",
+                len,
+                url
+            );
+            return None;
+        }
+    }
+
+    // Stream the body in chunks and bail as soon as we cross the cap.
+    // Servers that don't send Content-Length (or lie about it) can't
+    // force us into a large allocation this way.
+    use futures::StreamExt;
+    let mut buf: Vec<u8> = Vec::new();
+    let mut stream = resp.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        let chunk = match chunk {
+            Ok(c) => c,
+            Err(e) => {
+                log::debug!("autoconfig: chunk read failed at {}: {}", url, e);
+                return None;
+            }
+        };
+        if buf.len() + chunk.len() > MAX_BYTES {
+            log::warn!("autoconfig: response too large at {}", url);
+            return None;
+        }
+        buf.extend_from_slice(&chunk);
+    }
+    let xml = std::str::from_utf8(&buf).ok()?;
+    match parse_clientconfig_xml(xml) {
+        Some(s) => Some(s),
+        None => {
+            log::debug!("autoconfig: response at {} did not parse", url);
             None
         }
     }

--- a/src-tauri/src/mail/autoconfig.rs
+++ b/src-tauri/src/mail/autoconfig.rs
@@ -95,7 +95,11 @@ pub async fn discover(email: &str) -> Result<Option<(AutoconfigServers, &'static
     // the user's mail is already going through. We don't fabricate ports
     // beyond the IANA-assigned ones.
     if let Some(mx_host) = lookup_mx(domain).await {
-        log::info!("autoconfig: MX for {} -> {}, guessing IMAPS/submission", domain, mx_host);
+        log::info!(
+            "autoconfig: MX for {} -> {}, guessing IMAPS/submission",
+            domain,
+            mx_host
+        );
         return Ok(Some((
             AutoconfigServers {
                 imap_host: mx_host.clone(),
@@ -112,10 +116,7 @@ pub async fn discover(email: &str) -> Result<Option<(AutoconfigServers, &'static
     Ok(None)
 }
 
-async fn try_fetch_and_parse(
-    http: &reqwest::Client,
-    url: &str,
-) -> Option<AutoconfigServers> {
+async fn try_fetch_and_parse(http: &reqwest::Client, url: &str) -> Option<AutoconfigServers> {
     log::debug!("autoconfig: GET {}", url);
     match http.get(url).send().await {
         Ok(resp) if resp.status().is_success() => {

--- a/src-tauri/src/mail/autoconfig.rs
+++ b/src-tauri/src/mail/autoconfig.rs
@@ -273,17 +273,41 @@ fn element_text(doc: &Document, parent: NodeId, local_name: &str) -> Option<Stri
 /// returned. Errors are logged at debug level — autoconfig isn't a
 /// must-succeed flow.
 async fn lookup_mx(domain: &str) -> Option<String> {
-    use hickory_resolver::config::{ResolverConfig, ResolverOpts};
-    use hickory_resolver::TokioAsyncResolver;
+    use hickory_resolver::proto::rr::rdata::MX;
+    use hickory_resolver::proto::rr::RData;
+    use hickory_resolver::Resolver;
 
-    let resolver = TokioAsyncResolver::tokio(ResolverConfig::default(), ResolverOpts::default());
+    // hickory-resolver 0.26 replaced TokioAsyncResolver::tokio() with the
+    // builder-based `Resolver::builder_tokio().build()` flow. Both calls
+    // return Result, but failures here are unrecoverable (no system
+    // resolver) so we just log and bail.
+    let resolver = match Resolver::builder_tokio().and_then(|b| b.build()) {
+        Ok(r) => r,
+        Err(e) => {
+            log::debug!("autoconfig: resolver build failed: {}", e);
+            return None;
+        }
+    };
 
     match resolver.mx_lookup(domain).await {
-        Ok(answer) => {
-            let mut records: Vec<_> = answer.iter().collect();
-            records.sort_by_key(|r| r.preference());
+        Ok(lookup) => {
+            // Lookup::answers() returns the raw Record list; filter to
+            // the MX-typed RData payloads, then sort by preference.
+            // hickory 0.26 exposes Record::data as a public field rather
+            // than the 0.24-era accessor method.
+            let mut records: Vec<&MX> = lookup
+                .answers()
+                .iter()
+                .filter_map(|r| match &r.data {
+                    RData::MX(mx) => Some(mx),
+                    _ => None,
+                })
+                .collect();
+            // hickory 0.26 exposes preference / exchange as public fields
+            // on MX rather than the 0.24 accessor methods.
+            records.sort_by_key(|r| r.preference);
             for r in records {
-                let name = r.exchange().to_ascii().trim_end_matches('.').to_string();
+                let name = r.exchange.to_ascii().trim_end_matches('.').to_string();
                 if !name.is_empty() && is_valid_domain(&name) {
                     return Some(name);
                 }

--- a/src-tauri/src/mail/caldav.rs
+++ b/src-tauri/src/mail/caldav.rs
@@ -208,22 +208,37 @@ impl CalDavClient {
     }
 
     /// Auto-discover CalDAV URL by trying `.well-known/caldav` on the email domain.
-    async fn auto_discover(http: &reqwest::Client, auth: &DavAuth, email: &str) -> Result<String> {
+    pub(crate) async fn auto_discover(
+        http: &reqwest::Client,
+        auth: &DavAuth,
+        email: &str,
+    ) -> Result<String> {
         let domain = email
             .rsplit('@')
             .next()
             .ok_or_else(|| Error::Other("Invalid email for CalDAV discovery".to_string()))?;
+        Self::auto_discover_hosts(http, auth, &[domain.to_string(), format!("mail.{}", domain)])
+            .await
+    }
 
-        // Try the bare domain first, then mail.<domain>
-        let candidates = vec![
-            format!("https://{}/.well-known/caldav", domain),
-            format!("https://mail.{}/.well-known/caldav", domain),
-        ];
-
-        for url in &candidates {
+    /// Same as `auto_discover`, but probes a caller-supplied list of
+    /// hostnames. Used by the Settings auto-discover command (#43) so it
+    /// can also try the IMAP and SMTP server hostnames the user already
+    /// entered, which often differ from the email domain (e.g. an
+    /// `@example.com` mailbox served by `coms.example.org`).
+    pub(crate) async fn auto_discover_hosts(
+        http: &reqwest::Client,
+        auth: &DavAuth,
+        hosts: &[String],
+    ) -> Result<String> {
+        for host in hosts {
+            if host.is_empty() {
+                continue;
+            }
+            let url = format!("https://{}/.well-known/caldav", host);
             log::debug!("caldav: trying auto-discovery at {}", url);
             match Self::apply_auth_static(
-                http.request(reqwest::Method::from_bytes(b"PROPFIND").unwrap(), url),
+                http.request(reqwest::Method::from_bytes(b"PROPFIND").unwrap(), &url),
                 auth,
             )
             .header("Depth", "0")
@@ -236,7 +251,6 @@ impl CalDavClient {
                     let status = resp.status();
                     let final_url = resp.url().clone();
                     if status.is_success() || status.as_u16() == 207 {
-                        // The redirect target (or final URL) is our CalDAV base
                         let port_str = final_url
                             .port()
                             .map(|p| format!(":{}", p))
@@ -244,7 +258,7 @@ impl CalDavClient {
                         let discovered = format!(
                             "{}://{}{}{}",
                             final_url.scheme(),
-                            final_url.host_str().unwrap_or(domain),
+                            final_url.host_str().unwrap_or(host),
                             port_str,
                             final_url.path().trim_end_matches('/')
                         );

--- a/src-tauri/src/mail/caldav.rs
+++ b/src-tauri/src/mail/caldav.rs
@@ -217,8 +217,12 @@ impl CalDavClient {
             .rsplit('@')
             .next()
             .ok_or_else(|| Error::Other("Invalid email for CalDAV discovery".to_string()))?;
-        Self::auto_discover_hosts(http, auth, &[domain.to_string(), format!("mail.{}", domain)])
-            .await
+        Self::auto_discover_hosts(
+            http,
+            auth,
+            &[domain.to_string(), format!("mail.{}", domain)],
+        )
+        .await
     }
 
     /// Same as `auto_discover`, but probes a caller-supplied list of

--- a/src-tauri/src/mail/carddav.rs
+++ b/src-tauri/src/mail/carddav.rs
@@ -300,7 +300,12 @@ pub(crate) async fn auto_discover(
         .rsplit('@')
         .next()
         .ok_or_else(|| Error::Other("Invalid email for CardDAV discovery".to_string()))?;
-    auto_discover_hosts(http, auth, &[domain.to_string(), format!("mail.{}", domain)]).await
+    auto_discover_hosts(
+        http,
+        auth,
+        &[domain.to_string(), format!("mail.{}", domain)],
+    )
+    .await
 }
 
 /// Same as `auto_discover`, but probes a caller-supplied list of

--- a/src-tauri/src/mail/carddav.rs
+++ b/src-tauri/src/mail/carddav.rs
@@ -291,20 +291,34 @@ impl CardDavClient {
 // Auto-discovery
 // ---------------------------------------------------------------------------
 
-async fn auto_discover(http: &reqwest::Client, auth: &DavAuth, email: &str) -> Result<String> {
+pub(crate) async fn auto_discover(
+    http: &reqwest::Client,
+    auth: &DavAuth,
+    email: &str,
+) -> Result<String> {
     let domain = email
         .rsplit('@')
         .next()
         .ok_or_else(|| Error::Other("Invalid email for CardDAV discovery".to_string()))?;
+    auto_discover_hosts(http, auth, &[domain.to_string(), format!("mail.{}", domain)]).await
+}
 
-    let candidates = vec![
-        format!("https://{}/.well-known/carddav", domain),
-        format!("https://mail.{}/.well-known/carddav", domain),
-    ];
-
-    for url in &candidates {
+/// Same as `auto_discover`, but probes a caller-supplied list of
+/// hostnames. Used by the Settings auto-discover command (#43) so it
+/// can also try the IMAP and SMTP server hostnames the user already
+/// entered.
+pub(crate) async fn auto_discover_hosts(
+    http: &reqwest::Client,
+    auth: &DavAuth,
+    hosts: &[String],
+) -> Result<String> {
+    for host in hosts {
+        if host.is_empty() {
+            continue;
+        }
+        let url = format!("https://{}/.well-known/carddav", host);
         log::debug!("carddav: trying auto-discovery at {}", url);
-        let req = http.request(reqwest::Method::from_bytes(b"PROPFIND").unwrap(), url);
+        let req = http.request(reqwest::Method::from_bytes(b"PROPFIND").unwrap(), &url);
         let req = match auth {
             DavAuth::Basic { username, password } => req.basic_auth(username, Some(password)),
             DavAuth::Bearer { token } => req.bearer_auth(token),
@@ -327,7 +341,7 @@ async fn auto_discover(http: &reqwest::Client, auth: &DavAuth, email: &str) -> R
                     let discovered = format!(
                         "{}://{}{}{}",
                         final_url.scheme(),
-                        final_url.host_str().unwrap_or(domain),
+                        final_url.host_str().unwrap_or(host),
                         port_str,
                         final_url.path().trim_end_matches('/')
                     );

--- a/src-tauri/src/mail/graph.rs
+++ b/src-tauri/src/mail/graph.rs
@@ -647,6 +647,92 @@ impl GraphClient {
 
     /// Fetch events in a time range via calendarView.
     /// Uses `Prefer: outlook.timezone="UTC"` so all times come back in UTC.
+    /// Fetch events for a specific calendar via `GET /me/calendars/{id}/calendarView`.
+    /// Same query semantics as `list_events`, just scoped to one
+    /// calendar so multi-calendar accounts (#47) can keep events
+    /// separated. Pagination follows `@odata.nextLink` exactly like
+    /// `list_events`.
+    pub async fn list_events_for_calendar(
+        &self,
+        calendar_id: &str,
+        start: &str,
+        end: &str,
+    ) -> Result<Vec<GraphCalendarEvent>> {
+        let mut events = Vec::new();
+        let mut next_path: Option<String> = None;
+        loop {
+            let resp: serde_json::Value = match next_path.take() {
+                Some(path) => {
+                    let resp = self
+                        .http
+                        .get(&path)
+                        .bearer_auth(&self.access_token)
+                        .header("Prefer", "outlook.timezone=\"UTC\"")
+                        .send()
+                        .await
+                        .map_err(|e| Error::Other(format!("Graph GET failed: {}", e)))?;
+                    let status = resp.status();
+                    let body = resp.text().await.unwrap_or_default();
+                    if !status.is_success() {
+                        return Err(Error::Other(format!(
+                            "Graph GET returned {}: {}",
+                            status,
+                            truncate(&body, 500)
+                        )));
+                    }
+                    serde_json::from_str(&body)
+                        .map_err(|e| Error::Other(format!("Graph JSON parse failed: {}", e)))?
+                }
+                None => {
+                    let url = format!(
+                        "{}/me/calendars/{}/calendarView",
+                        GRAPH_BASE,
+                        urlencoding::encode(calendar_id)
+                    );
+                    let resp = self.http
+                        .get(&url)
+                        .bearer_auth(&self.access_token)
+                        .header("Prefer", "outlook.timezone=\"UTC\"")
+                        .query(&[
+                            ("startDateTime", start),
+                            ("endDateTime", end),
+                            ("$select", "id,subject,bodyPreview,start,end,location,isAllDay,organizer,attendees,iCalUId,recurrence"),
+                            ("$top", "100"),
+                            ("$orderby", "start/dateTime"),
+                        ])
+                        .send()
+                        .await
+                        .map_err(|e| Error::Other(format!("Graph GET /me/calendars/{}/calendarView failed: {}", calendar_id, e)))?;
+                    let status = resp.status();
+                    let body = resp.text().await.unwrap_or_default();
+                    if !status.is_success() {
+                        return Err(Error::Other(format!(
+                            "Graph GET /me/calendars/{}/calendarView returned {}: {}",
+                            calendar_id,
+                            status,
+                            truncate(&body, 500)
+                        )));
+                    }
+                    serde_json::from_str(&body)
+                        .map_err(|e| Error::Other(format!("Graph JSON parse failed: {}", e)))?
+                }
+            };
+            if let Some(items) = resp["value"].as_array() {
+                for e in items {
+                    events.push(parse_graph_event(e));
+                }
+            }
+            let next_link = resp["@odata.nextLink"]
+                .as_str()
+                .map(|s: &str| s.to_string());
+            match next_link {
+                Some(next) => next_path = Some(next),
+                None => break,
+            }
+        }
+        Ok(events)
+    }
+
     pub async fn list_events(&self, start: &str, end: &str) -> Result<Vec<GraphCalendarEvent>> {
         let mut events = Vec::new();
         let mut next_path: Option<String> = None;

--- a/src-tauri/src/mail/imap.rs
+++ b/src-tauri/src/mail/imap.rs
@@ -27,7 +27,7 @@ impl ImapConfig {
             username: account.username.clone(),
             password: account.password.clone(),
             use_tls: account.use_tls,
-            use_xoauth2: account.provider == "o365",
+            use_xoauth2: account.auth_method == "oauth-microsoft",
         }
     }
 }

--- a/src-tauri/src/mail/mod.rs
+++ b/src-tauri/src/mail/mod.rs
@@ -1,3 +1,4 @@
+pub mod autoconfig;
 pub mod caldav;
 pub mod carddav;
 pub mod dav_http;

--- a/src-tauri/src/ops/worker.rs
+++ b/src-tauri/src/ops/worker.rs
@@ -313,10 +313,10 @@ impl AccountWorker {
 
         match op {
             MailOp::SyncAll { current_folder } => {
-                if account.mail_protocol == "graph" {
+                if account.mail_protocol_str() == "graph" {
                     // Graph sync handled by sync_cmd directly
                     return Ok(());
-                } else if account.mail_protocol == "jmap" {
+                } else if account.mail_protocol_str() == "jmap" {
                     let jmap_config =
                         crate::commands::sync_cmd::build_jmap_config(&account).await?;
                     crate::mail::jmap_sync::sync_jmap_account(
@@ -348,7 +348,7 @@ impl AccountWorker {
                 }
             }
             MailOp::SyncFolder { folder_path } => {
-                if account.mail_protocol == "jmap" {
+                if account.mail_protocol_str() == "jmap" {
                     let jmap_config =
                         crate::commands::sync_cmd::build_jmap_config(&account).await?;
                     crate::mail::jmap_sync::sync_jmap_folder_public(
@@ -360,7 +360,7 @@ impl AccountWorker {
                         jmap_config,
                     )
                     .await?;
-                } else if account.mail_protocol == "imap" {
+                } else if account.mail_protocol_str() == "imap" {
                     let imap_config = self.build_imap_config(&account).await?;
                     let db = self.db.clone();
                     let account_id = self.account_id.clone();
@@ -472,7 +472,7 @@ impl AccountWorker {
         &mut self,
         account: &crate::db::accounts::AccountFull,
     ) -> Result<ImapConfig> {
-        let (password, use_xoauth2) = if account.provider == "o365" {
+        let (password, use_xoauth2) = if account.auth_method == "oauth-microsoft" {
             let tokens = crate::oauth::load_tokens(&account.id)?
                 .ok_or_else(|| Error::Other("No O365 tokens".into()))?;
             let refresh = tokens

--- a/src/__tests__/calendar.test.ts
+++ b/src/__tests__/calendar.test.ts
@@ -47,6 +47,9 @@ function setupAccounts() {
     {
       id: "acc1", display_name: "Test", email: "test@test.com",
       provider: "generic", mail_protocol: "jmap" as const, enabled: true,
+      mail_sync_interval_seconds: null,
+      calendar_sync_interval_seconds: null,
+      contacts_sync_interval_seconds: null,
     },
   ];
   accountsStore.activeAccountId = "acc1";

--- a/src/__tests__/message-list-clicks.test.ts
+++ b/src/__tests__/message-list-clicks.test.ts
@@ -45,7 +45,13 @@ function makeSummary(id: string): any {
 function setupStores() {
   const accountsStore = useAccountsStore();
   accountsStore.accounts = [
-    { id: "acc1", display_name: "Test", email: "t@t.com", provider: "generic", mail_protocol: "imap" as const, enabled: true },
+    {
+      id: "acc1", display_name: "Test", email: "t@t.com",
+      provider: "generic", mail_protocol: "imap" as const, enabled: true,
+      mail_sync_interval_seconds: null,
+      calendar_sync_interval_seconds: null,
+      contacts_sync_interval_seconds: null,
+    },
   ];
   accountsStore.activeAccountId = "acc1";
   useFoldersStore().activeFolderPath = "INBOX";

--- a/src/__tests__/messages-selection.test.ts
+++ b/src/__tests__/messages-selection.test.ts
@@ -35,7 +35,13 @@ import * as api from "@/lib/tauri";
 function setup(threading = false) {
   const accountsStore = useAccountsStore();
   accountsStore.accounts = [
-    { id: "acc1", display_name: "Test", email: "test@test.com", provider: "generic", mail_protocol: "imap" as const, enabled: true },
+    {
+      id: "acc1", display_name: "Test", email: "test@test.com",
+      provider: "generic", mail_protocol: "imap" as const, enabled: true,
+      mail_sync_interval_seconds: null,
+      calendar_sync_interval_seconds: null,
+      contacts_sync_interval_seconds: null,
+    },
   ];
   accountsStore.activeAccountId = "acc1";
   const foldersStore = useFoldersStore();

--- a/src/__tests__/regression.test.ts
+++ b/src/__tests__/regression.test.ts
@@ -51,7 +51,13 @@ function makeSummary(id: string, flags: string[] = ["seen"]): any {
 function setupStores(threading = false) {
   const accountsStore = useAccountsStore();
   accountsStore.accounts = [
-    { id: "acc1", display_name: "Test", email: "t@t.com", provider: "generic", mail_protocol: "imap" as const, enabled: true },
+    {
+      id: "acc1", display_name: "Test", email: "t@t.com",
+      provider: "generic", mail_protocol: "imap" as const, enabled: true,
+      mail_sync_interval_seconds: null,
+      calendar_sync_interval_seconds: null,
+      contacts_sync_interval_seconds: null,
+    },
   ];
   accountsStore.activeAccountId = "acc1";
   useFoldersStore().activeFolderPath = "INBOX";

--- a/src/__tests__/server-search.test.ts
+++ b/src/__tests__/server-search.test.ts
@@ -51,6 +51,9 @@ function withActiveAccount() {
       provider: "generic",
       mail_protocol: "imap" as const,
       enabled: true,
+      mail_sync_interval_seconds: null,
+      calendar_sync_interval_seconds: null,
+      contacts_sync_interval_seconds: null,
     },
   ];
   accountsStore.activeAccountId = "acc1";

--- a/src/__tests__/store-listeners.test.ts
+++ b/src/__tests__/store-listeners.test.ts
@@ -66,6 +66,9 @@ describe("Store listener cleanup", () => {
         provider: "generic",
         mail_protocol: "imap" as const,
         enabled: true,
+        mail_sync_interval_seconds: null,
+        calendar_sync_interval_seconds: null,
+        contacts_sync_interval_seconds: null,
       },
     ];
     accountsStore.activeAccountId = "acc1";

--- a/src/__tests__/threads-expansion.test.ts
+++ b/src/__tests__/threads-expansion.test.ts
@@ -40,6 +40,9 @@ function withActiveContext() {
       provider: "generic",
       mail_protocol: "imap" as const,
       enabled: true,
+      mail_sync_interval_seconds: null,
+      calendar_sync_interval_seconds: null,
+      contacts_sync_interval_seconds: null,
     },
   ];
   accountsStore.activeAccountId = "acc1";

--- a/src/components/mail/FolderTree.vue
+++ b/src/components/mail/FolderTree.vue
@@ -209,7 +209,8 @@ function buildParentOptions(): { label: string; value: string }[] {
     }
   }
 
-  for (const acc of accountsStore.accounts) {
+  // Folder picker is mail-only; calendar/contacts-only accounts have no folders to list.
+  for (const acc of accountsStore.mailAccounts) {
     options.push({ label: `${acc.display_name} (root)`, value: `${acc.id}|` });
     addFolders(foldersStore.getAccountFolders(acc.id), acc.id, acc.email, "");
   }
@@ -366,7 +367,7 @@ async function doDeleteFolder() {
 <template>
   <div class="folder-tree" @click="closeContextMenu">
     <div
-      v-for="account in accountsStore.accounts"
+      v-for="account in accountsStore.mailAccounts"
       :key="account.id"
       class="account-section"
     >

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -2,6 +2,7 @@ import { invoke } from "@tauri-apps/api/core";
 import type {
   Account,
   AccountConfig,
+  AutoconfigResult,
   Folder,
   MessagePage,
   MessageBody,
@@ -34,6 +35,26 @@ export async function updateAccount(
 
 export async function deleteAccount(accountId: string): Promise<void> {
   return invoke("delete_account", { accountId });
+}
+
+/// Run Thunderbird-style email autoconfig (Mozilla ISP DB + provider
+/// autoconfig + .well-known + MX fallback) and probe CalDAV / CardDAV
+/// across every candidate hostname. Empty fields in the result mean
+/// "not found" — frontend should only apply non-empty values.
+export async function probeDavEndpoints(
+  email: string,
+  username: string,
+  password: string,
+  imapHost?: string,
+  smtpHost?: string,
+): Promise<AutoconfigResult> {
+  return invoke("probe_dav_endpoints", {
+    email,
+    username,
+    password,
+    imapHost: imapHost || null,
+    smtpHost: smtpHost || null,
+  });
 }
 
 export async function listFolders(accountId: string): Promise<Folder[]> {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -174,6 +174,13 @@ export interface AccountConfig {
   mail_sync_interval_seconds: number | null;
   calendar_sync_interval_seconds: number | null;
   contacts_sync_interval_seconds: number | null;
+  /// Whether a calendar / contacts binding actually exists for this
+  /// account (regardless of its enabled state). Used by the Settings
+  /// edit form to disambiguate standalone CalDAV-only vs CardDAV-only
+  /// accounts even when the user has unchecked the matching Sync flag.
+  /// Backend-populated; treated as read-only in form state.
+  has_calendar_binding: boolean;
+  has_contacts_binding: boolean;
 }
 
 /// Combined result of Thunderbird-style autoconfig + DAV probing.

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -3,8 +3,17 @@ export interface Account {
   display_name: string;
   email: string;
   provider: "generic" | "gmail" | "microsoft365" | "o365";
-  mail_protocol: "imap" | "jmap" | "graph";
+  // Empty string means "no mail binding" — calendar-only / contacts-only
+  // accounts (#43). Existing screens that need a mail account should
+  // filter these out.
+  mail_protocol: "" | "imap" | "jmap" | "graph";
   enabled: boolean;
+  // Phase 4 (#43): per-binding sync intervals exposed on the summary
+  // so periodic-sync timers can pick the right cadence per account
+  // without a separate get_account_config call.
+  mail_sync_interval_seconds: number | null;
+  calendar_sync_interval_seconds: number | null;
+  contacts_sync_interval_seconds: number | null;
 }
 
 export interface QuickFilter {
@@ -138,7 +147,8 @@ export interface AccountConfig {
   display_name: string;
   email: string;
   provider: "generic" | "gmail" | "microsoft365" | "o365";
-  mail_protocol: "imap" | "jmap" | "graph";
+  /// Empty string means "no mail binding" (CalDAV-only / CardDAV-only).
+  mail_protocol: "" | "imap" | "jmap" | "graph";
   imap_host: string;
   imap_port: number;
   smtp_host: string;
@@ -152,8 +162,39 @@ export interface AccountConfig {
   jmap_auth_method: "basic" | "oidc";
   oidc_token_endpoint: string;
   oidc_client_id: string;
+  /// Whether the calendar binding is enabled. Mirrors mail_sync_enabled
+  /// for the calendar service.
   calendar_sync_enabled: boolean;
+  /// Phase 4 (#43): per-binding enabled flags + sync intervals.
+  mail_sync_enabled: boolean;
+  contacts_sync_enabled: boolean;
+  /// Override the default sync cadence (in seconds). `null` keeps the
+  /// service's default (mail handled by IDLE/push, calendar 5 min,
+  /// contacts 30 min).
+  mail_sync_interval_seconds: number | null;
+  calendar_sync_interval_seconds: number | null;
+  contacts_sync_interval_seconds: number | null;
 }
+
+/// Combined result of Thunderbird-style autoconfig + DAV probing.
+/// Empty strings / zero ports mean "not found"; the frontend only
+/// applies non-empty fields to the form. `source` is informational:
+/// "isp-db" | "domain-autoconfig" | "well-known" | "mx" | "".
+export interface AutoconfigResult {
+  imap_host: string;
+  imap_port: number;
+  imap_use_tls: boolean;
+  smtp_host: string;
+  smtp_port: number;
+  smtp_use_tls: boolean;
+  caldav_url: string;
+  carddav_url: string;
+  source: string;
+}
+
+// Old name kept as an alias so existing imports compile while we
+// migrate. New callers should use AutoconfigResult.
+export type DavProbeResult = AutoconfigResult;
 
 export interface FilterRule {
   id: string;

--- a/src/stores/accounts.ts
+++ b/src/stores/accounts.ts
@@ -1,5 +1,5 @@
 import { defineStore } from "pinia";
-import { ref } from "vue";
+import { computed, ref } from "vue";
 import type { Account, AccountConfig } from "@/lib/types";
 import * as api from "@/lib/tauri";
 
@@ -10,6 +10,14 @@ export const useAccountsStore = defineStore("accounts", () => {
 
   const activeAccount = () =>
     accounts.value.find((a) => a.id === activeAccountId.value) ?? null;
+
+  // Phase 4 (#43): standalone CalDAV / CardDAV / JMAP-cal-only accounts
+  // surface with `mail_protocol === ""`. Mail screens iterate this
+  // getter so they don't try to list folders for an account that has no
+  // mail backend.
+  const mailAccounts = computed(() =>
+    accounts.value.filter((a) => a.mail_protocol !== ""),
+  );
 
   async function fetchAccounts() {
     loading.value = true;
@@ -49,6 +57,7 @@ export const useAccountsStore = defineStore("accounts", () => {
     activeAccountId,
     loading,
     activeAccount,
+    mailAccounts,
     fetchAccounts,
     addAccount,
     deleteAccount,

--- a/src/stores/calendar.ts
+++ b/src/stores/calendar.ts
@@ -127,10 +127,11 @@ export const useCalendarStore = defineStore("calendar", () => {
     }
     if (accountId) {
       // Single-account sync used by the per-binding tick (#43): one
-      // account per call so each can run on its own cadence.
+      // account per call so each can run on its own cadence. The
+      // backend emits `calendar-changed` when the sync completes, and
+      // the listener below already triggers fetchCalendars() +
+      // fetchEvents() — so don't run them inline or we'd refresh twice.
       await api.syncCalendars(accountId);
-      await fetchCalendars();
-      await fetchEvents();
       return;
     }
     // Sync all accounts in parallel so a hanging account doesn't block others.

--- a/src/stores/calendar.ts
+++ b/src/stores/calendar.ts
@@ -121,9 +121,17 @@ export const useCalendarStore = defineStore("calendar", () => {
     await fetchEvents();
   }
 
-  async function syncCalendars() {
+  async function syncCalendars(accountId?: string) {
     if (accountsStore.accounts.length === 0) {
       await accountsStore.fetchAccounts();
+    }
+    if (accountId) {
+      // Single-account sync used by the per-binding tick (#43): one
+      // account per call so each can run on its own cadence.
+      await api.syncCalendars(accountId);
+      await fetchCalendars();
+      await fetchEvents();
+      return;
     }
     // Sync all accounts in parallel so a hanging account doesn't block others.
     // Each backend sync_calendars emits "calendar-changed" when done, which
@@ -318,19 +326,46 @@ export const useCalendarStore = defineStore("calendar", () => {
     selectedEvent.value = event;
   }
 
-  // --- Independent calendar sync (5-minute interval) ---
-  // Calendar sync is decoupled from mail sync. It runs on its own timer
-  // so calendar updates don't wait for mail sync to finish.
-  const CALENDAR_SYNC_INTERVAL = 5 * 60 * 1000; // 5 minutes
+  // --- Independent calendar sync ---
+  // Calendar sync is decoupled from mail sync and runs on its own timer.
+  // The timer ticks every minute and evaluates each account's calendar
+  // binding interval (#43): an account whose binding has
+  // sync_interval_seconds=900 syncs every 15 minutes; one with `null`
+  // falls back to DEFAULT_CALENDAR_INTERVAL (5 minutes).
+  const DEFAULT_CALENDAR_INTERVAL_MS = 5 * 60 * 1000;
+  const TICK_MS = 60 * 1000;
   let calendarSyncIntervalId: ReturnType<typeof setInterval> | null = null;
+  const lastCalendarSync = new Map<string, number>();
+
+  // We need access to the accounts store inside the timer. Importing it
+  // at module scope would create a cycle (calendar -> accounts -> ...);
+  // resolve it lazily on first tick instead.
+  async function tick() {
+    const { useAccountsStore } = await import("@/stores/accounts");
+    const accounts = useAccountsStore();
+    const now = Date.now();
+    for (const acc of accounts.accounts) {
+      if (!acc.enabled) continue;
+      const intervalMs =
+        (acc.calendar_sync_interval_seconds ?? 0) > 0
+          ? (acc.calendar_sync_interval_seconds as number) * 1000
+          : DEFAULT_CALENDAR_INTERVAL_MS;
+      const last = lastCalendarSync.get(acc.id) ?? 0;
+      if (now - last < intervalMs) continue;
+      lastCalendarSync.set(acc.id, now);
+      try {
+        await syncCalendars(acc.id);
+      } catch (e) {
+        console.error(`Periodic calendar sync failed for ${acc.id}:`, e);
+      }
+    }
+  }
 
   function startCalendarSync() {
     if (calendarSyncIntervalId) return;
     calendarSyncIntervalId = setInterval(() => {
-      syncCalendars().catch((e) =>
-        console.error("Periodic calendar sync failed:", e),
-      );
-    }, CALENDAR_SYNC_INTERVAL);
+      tick().catch((e) => console.error("Calendar tick failed:", e));
+    }, TICK_MS);
   }
 
   function stopCalendarSync() {

--- a/src/views/ComposeView.vue
+++ b/src/views/ComposeView.vue
@@ -44,6 +44,9 @@ onMounted(async () => {
       error.value = `Failed to load accounts: ${errorMsg}`;
     }
   }
+  // Compose only works for accounts that can send mail. Calendar-/
+  // contacts-only accounts (#43) don't appear in the From dropdown.
+  accounts.value = accounts.value.filter((a) => a.mail_protocol !== "");
   // Set selected account from query param or first account
   if (initialAccountId && accounts.value.some(a => a.id === initialAccountId)) {
     selectedAccountId.value = initialAccountId;

--- a/src/views/ContactsView.vue
+++ b/src/views/ContactsView.vue
@@ -156,7 +156,15 @@ let stopContactsChangedListener: (() => void) | null = null;
 let disposed = false;
 
 async function contactsTick() {
+  // Skip the unconditional fetchBooks() at the end of every tick — it
+  // ran listContactBooks for each account once a minute even when no
+  // sync was due, which churned the UI for no reason. The
+  // `contacts-changed` listener registered in onMounted already
+  // refreshes books whenever the backend persists new data, so we only
+  // need to call fetchBooks here for the (rare) case where a sync ran
+  // *and* its event hasn't already fired refresh logic above.
   const now = Date.now();
+  let synced = false;
   for (const acc of accountsStore.accounts) {
     if (!acc.enabled) continue;
     const intervalMs =
@@ -168,11 +176,16 @@ async function contactsTick() {
     lastContactSync.set(acc.id, now);
     try {
       await api.syncContacts(acc.id);
+      synced = true;
     } catch (e) {
       console.error("Periodic contact sync failed for", acc.id, e);
     }
   }
-  await fetchBooks();
+  // If nothing actually synced this tick, the contacts-changed listener
+  // also has nothing to do — let it sleep.
+  if (synced) {
+    await fetchBooks();
+  }
 }
 
 onMounted(async () => {

--- a/src/views/ContactsView.vue
+++ b/src/views/ContactsView.vue
@@ -143,21 +143,47 @@ const error = ref<string | null>(null);
 
 const syncing = ref(false);
 
-// --- Independent contact sync (30-minute interval, matching Thunderbird) ---
-const CONTACT_SYNC_INTERVAL = 30 * 60 * 1000; // 30 minutes
+// --- Independent contact sync ---
+// Default to 30 minutes (Thunderbird's CardDAV default). Each account's
+// contacts binding can override via `contacts_sync_interval_seconds`
+// (#43). The timer ticks every minute and fires per-account when its
+// interval has elapsed.
+const DEFAULT_CONTACT_INTERVAL_MS = 30 * 60 * 1000;
+const CONTACT_TICK_MS = 60 * 1000;
 let contactSyncIntervalId: ReturnType<typeof setInterval> | null = null;
+const lastContactSync = new Map<string, number>();
 let stopContactsChangedListener: (() => void) | null = null;
 let disposed = false;
+
+async function contactsTick() {
+  const now = Date.now();
+  for (const acc of accountsStore.accounts) {
+    if (!acc.enabled) continue;
+    const intervalMs =
+      (acc.contacts_sync_interval_seconds ?? 0) > 0
+        ? (acc.contacts_sync_interval_seconds as number) * 1000
+        : DEFAULT_CONTACT_INTERVAL_MS;
+    const last = lastContactSync.get(acc.id) ?? 0;
+    if (now - last < intervalMs) continue;
+    lastContactSync.set(acc.id, now);
+    try {
+      await api.syncContacts(acc.id);
+    } catch (e) {
+      console.error("Periodic contact sync failed for", acc.id, e);
+    }
+  }
+  await fetchBooks();
+}
 
 onMounted(async () => {
   // Load local data first, then sync in background
   await fetchBooks();
   syncAllContacts();
 
-  // Start periodic sync
+  // Start periodic sync (per-account cadence via contacts binding)
   contactSyncIntervalId = setInterval(() => {
-    syncAllContacts();
-  }, CONTACT_SYNC_INTERVAL);
+    contactsTick().catch((e) => console.error("Contacts tick failed:", e));
+  }, CONTACT_TICK_MS);
 
   // Listen for backend contacts-changed events
   listen<string>("contacts-changed", async () => {

--- a/src/views/MailView.vue
+++ b/src/views/MailView.vue
@@ -163,7 +163,8 @@ function onOpenMessage(messageId: string) {
 
 // Background prefetch after sync
 async function startBackgroundPrefetch() {
-  for (const account of accountsStore.accounts) {
+  // Skip calendar-/contacts-only accounts (mail_protocol === "" via #43).
+  for (const account of accountsStore.mailAccounts) {
     if (!account.enabled) continue;
     try {
       let fetched = 1;
@@ -206,7 +207,8 @@ function notifyNewMail(accountId: string, count: number) {
 let syncIntervalId: ReturnType<typeof setInterval> | null = null;
 
 async function periodicSync() {
-  for (const account of accountsStore.accounts) {
+  // Skip calendar-/contacts-only accounts (mail_protocol === "" via #43).
+  for (const account of accountsStore.mailAccounts) {
     if (!account.enabled) continue;
     try {
       await api.triggerSync(

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -43,6 +43,45 @@ const error = ref<string | null>(null);
 const editingAccountId = ref<string | null>(null);
 const oauthStatus = ref<string | null>(null);
 const oauthInProgress = ref(false);
+const discoveringDav = ref(false);
+const discoveryNote = ref<string | null>(null);
+
+// Wire form-side number inputs in minutes; convert to/from seconds when
+// reading and writing AccountConfig so the wire format keeps the
+// Tauri-friendly seconds unit.
+function makeMinutesField(key: "calendar_sync_interval_seconds" | "contacts_sync_interval_seconds" | "mail_sync_interval_seconds") {
+  return computed<number | null>({
+    get: () => {
+      const s = form.value[key];
+      return s == null ? null : Math.round(s / 60);
+    },
+    set: (m) => {
+      if (m == null || Number.isNaN(m)) {
+        form.value[key] = null;
+      } else {
+        form.value[key] = Math.max(1, Math.round(m * 60));
+      }
+    },
+  });
+}
+
+const calendarIntervalMinutes = makeMinutesField("calendar_sync_interval_seconds");
+const contactsIntervalMinutes = makeMinutesField("contacts_sync_interval_seconds");
+
+// Whether the current form would result in a calendar / contacts
+// binding once saved. Mirrors derive_bindings on the backend:
+//  - JMAP mail accounts get JMAP calendar + JMAP contacts.
+//  - Gmail (auth_method oauth-google) gets Google APIs for both.
+//  - O365 gets Graph for both.
+//  - Generic IMAP only gets DAV bindings if a caldav_url has been
+//    discovered (or manually filled).
+const hasCalendarBinding = computed(() =>
+  form.value.mail_protocol === "jmap"
+  || form.value.provider === "gmail"
+  || form.value.provider === "o365"
+  || !!form.value.caldav_url,
+);
+const hasContactsBinding = computed(() => hasCalendarBinding.value);
 
 function getInitials(name: string): string {
   const words = name.split(/\s+/);
@@ -69,11 +108,16 @@ const defaultForm = (): AccountConfig => ({
   oidc_token_endpoint: "",
   oidc_client_id: "",
   calendar_sync_enabled: true,
+  mail_sync_enabled: true,
+  contacts_sync_enabled: true,
+  mail_sync_interval_seconds: null,
+  calendar_sync_interval_seconds: null,
+  contacts_sync_interval_seconds: null,
 });
 
 const form = ref<AccountConfig>(defaultForm());
 
-type AccountType = "gmail" | "imap" | "jmap" | "caldav" | "o365";
+type AccountType = "gmail" | "imap" | "jmap" | "caldav" | "carddav" | "o365";
 const accountType = ref<AccountType>("gmail");
 
 function selectAccountType(type: AccountType) {
@@ -116,14 +160,35 @@ function selectAccountType(type: AccountType) {
       f.use_tls = true;
       break;
     case "caldav":
+      // Standalone CalDAV calendar (#43). No mail backend; the bindings
+      // layer skips creating a mail binding when mail_protocol is empty.
       f.provider = "generic";
-      f.mail_protocol = "imap";
+      f.mail_protocol = "";
       f.imap_host = "";
       f.imap_port = 0;
       f.smtp_host = "";
       f.smtp_port = 0;
       f.jmap_url = "";
       f.use_tls = true;
+      // CalDAV-only accounts shouldn't also create a CardDAV contacts
+      // binding by default — disable it explicitly.
+      f.contacts_sync_enabled = false;
+      f.calendar_sync_enabled = true;
+      break;
+    case "carddav":
+      // Standalone CardDAV address book (#43). Same shape as CalDAV but
+      // we toggle the inverse flags so derive_bindings creates only the
+      // contacts binding.
+      f.provider = "generic";
+      f.mail_protocol = "";
+      f.imap_host = "";
+      f.imap_port = 0;
+      f.smtp_host = "";
+      f.smtp_port = 0;
+      f.jmap_url = "";
+      f.use_tls = true;
+      f.contacts_sync_enabled = true;
+      f.calendar_sync_enabled = false;
       break;
   }
 }
@@ -177,14 +242,68 @@ async function openEditForm(id: string) {
       } else {
         oauthStatus.value = null;
       }
-    } else if (config.caldav_url && !config.imap_host) {
+    } else if (config.mail_protocol === "" && config.calendar_sync_enabled) {
+      // Standalone CalDAV calendar account (#43).
       accountType.value = "caldav";
+    } else if (config.mail_protocol === "" && config.contacts_sync_enabled) {
+      // Standalone CardDAV contacts account (#43).
+      accountType.value = "carddav";
     } else {
       accountType.value = "imap";
     }
     showForm.value = true;
   } catch (e) {
     error.value = String(e);
+  }
+}
+
+/// Run Thunderbird-style autoconfig + CalDAV/CardDAV probing for the
+/// current form (#43). Applies any discovered IMAP/SMTP host+port+TLS
+/// settings AND the DAV URL if found. Each piece is independent: a
+/// successful autoconfig with no DAV still pre-fills the mail servers
+/// and vice versa. A summary of what was filled in is shown below the
+/// button.
+async function discoverDavEndpoints() {
+  discoveringDav.value = true;
+  discoveryNote.value = null;
+  try {
+    const result = await api.probeDavEndpoints(
+      form.value.email,
+      form.value.username || form.value.email,
+      form.value.password,
+      form.value.imap_host,
+      form.value.smtp_host,
+    );
+
+    const filled: string[] = [];
+    if (result.imap_host) {
+      form.value.imap_host = result.imap_host;
+      form.value.imap_port = result.imap_port || 993;
+      form.value.use_tls = result.imap_use_tls;
+      filled.push("IMAP");
+    }
+    if (result.smtp_host) {
+      form.value.smtp_host = result.smtp_host;
+      form.value.smtp_port = result.smtp_port || 587;
+      filled.push("SMTP");
+    }
+    const davUrl = result.caldav_url || result.carddav_url;
+    if (davUrl) {
+      form.value.caldav_url = davUrl;
+      if (result.caldav_url) filled.push("CalDAV");
+      if (result.carddav_url) filled.push("CardDAV");
+    }
+
+    if (filled.length === 0) {
+      discoveryNote.value = "No autoconfig data found for this domain.";
+    } else {
+      const sourceLabel = result.source ? ` (via ${result.source})` : "";
+      discoveryNote.value = `Filled ${filled.join(" + ")}${sourceLabel}.`;
+    }
+  } catch (e) {
+    discoveryNote.value = `Discovery failed: ${e}`;
+  } finally {
+    discoveringDav.value = false;
   }
 }
 
@@ -542,11 +661,12 @@ onMounted(() => {
               <label>Account Type</label>
               <div class="type-selector">
                 <button
-                  v-for="t in (['gmail', 'o365', 'imap', 'jmap', 'caldav'] as AccountType[])"
+                  v-for="t in (['gmail', 'o365', 'imap', 'jmap', 'caldav', 'carddav'] as AccountType[])"
                   :key="t"
                   class="type-btn"
                   :class="{ active: accountType === t }"
                   :disabled="!!editingAccountId"
+                  :data-testid="`account-type-${t}`"
                   @click="selectAccountType(t)"
                 >{{ t === 'gmail' ? 'Gmail' : t === 'o365' ? 'Microsoft 365' : t.toUpperCase() }}</button>
               </div>
@@ -702,10 +822,49 @@ onMounted(() => {
               </template>
             </template>
 
-            <template v-if="accountType === 'imap' || accountType === 'caldav'">
+            <!-- For standalone CalDAV / CardDAV the URL is the entire
+                 reason the account exists, so it stays as a manual
+                 input. IMAP accounts go through auto-discovery instead
+                 (button below); the discovered URL drives whether the
+                 calendar / contacts toggles appear in the per-service
+                 section. -->
+            <template v-if="accountType === 'caldav' || accountType === 'carddav'">
               <div class="form-group">
-                <label>CalDAV URL {{ accountType === 'caldav' ? '' : '(optional)' }}</label>
-                <input v-model="form.caldav_url" type="url" placeholder="https://mail.example.com/dav/cal" />
+                <label>{{ accountType === 'carddav' ? 'CardDAV URL' : 'CalDAV URL' }}</label>
+                <input
+                  v-model="form.caldav_url"
+                  type="url"
+                  :placeholder="accountType === 'carddav'
+                    ? 'https://contacts.example.com/dav'
+                    : 'https://mail.example.com/dav/cal'"
+                  :data-testid="`${accountType}-url`"
+                />
+              </div>
+            </template>
+
+            <template v-if="accountType === 'imap'">
+              <div class="form-group">
+                <label>Calendar &amp; Contacts (CalDAV / CardDAV)</label>
+                <div class="dav-discovery-row">
+                  <button
+                    type="button"
+                    class="btn-secondary"
+                    data-testid="dav-discover-btn"
+                    :disabled="discoveringDav || !form.email || !form.password"
+                    @click="discoverDavEndpoints"
+                  >
+                    {{ discoveringDav ? 'Searching...' : (form.caldav_url ? 'Re-run discovery' : 'Auto-discover') }}
+                  </button>
+                  <span v-if="form.caldav_url" class="field-hint dav-discovered-url" data-testid="dav-discovered-url">
+                    Found at {{ form.caldav_url }}
+                  </span>
+                  <span v-else-if="!form.email || !form.password" class="field-hint">
+                    Enter email and password first.
+                  </span>
+                </div>
+                <span v-if="discoveryNote" class="field-hint" data-testid="dav-discovery-note">
+                  {{ discoveryNote }}
+                </span>
               </div>
             </template>
 
@@ -723,18 +882,116 @@ onMounted(() => {
               ></textarea>
             </div>
 
-            <div class="form-group form-group-checkbox">
+            <!-- Per-binding sync controls. Only meaningful for accounts
+                 that have multiple bindings; the standalone CalDAV /
+                 CardDAV tabs hide the irrelevant rows. Visually a
+                 form-group that matches the other sections rather than
+                 a bordered fieldset. -->
+            <div
+              v-if="accountType !== 'caldav' && accountType !== 'carddav'"
+              class="form-group bindings-section"
+              data-testid="binding-controls"
+            >
+              <label class="bindings-section-title">Per-service sync</label>
+
+              <!-- Mail toggle + interval: only show when there's actually
+                   a mail binding. CalDAV/CardDAV-only accounts hide this. -->
+              <div v-if="form.mail_protocol" class="form-group form-group-checkbox">
+                <label class="checkbox-label">
+                  <input
+                    v-model="form.mail_sync_enabled"
+                    type="checkbox"
+                    data-testid="mail-sync-enabled"
+                  />
+                  Sync mail
+                </label>
+                <p class="form-help">
+                  Turn off to keep using calendars and contacts on this server without fetching mail. Useful for JMAP accounts you only treat as a calendar source.
+                </p>
+              </div>
+
+              <div v-if="hasCalendarBinding" class="form-group form-group-checkbox binding-row">
+                <label class="checkbox-label">
+                  <input
+                    v-model="form.calendar_sync_enabled"
+                    type="checkbox"
+                    data-testid="calendar-sync-enabled"
+                  />
+                  Sync calendar
+                </label>
+                <div class="interval-row">
+                  <span>Every</span>
+                  <input
+                    v-model="calendarIntervalMinutes"
+                    type="number"
+                    min="1"
+                    max="1440"
+                    placeholder="5"
+                    class="interval-input"
+                    data-testid="calendar-sync-interval"
+                  />
+                  <span>minutes</span>
+                  <span class="field-hint inline-hint">default 5 if blank</span>
+                </div>
+              </div>
+
+              <div v-if="hasContactsBinding" class="form-group form-group-checkbox binding-row">
+                <label class="checkbox-label">
+                  <input
+                    v-model="form.contacts_sync_enabled"
+                    type="checkbox"
+                    data-testid="contacts-sync-enabled"
+                  />
+                  Sync contacts
+                </label>
+                <div class="interval-row">
+                  <span>Every</span>
+                  <input
+                    v-model="contactsIntervalMinutes"
+                    type="number"
+                    min="1"
+                    max="1440"
+                    placeholder="30"
+                    class="interval-input"
+                    data-testid="contacts-sync-interval"
+                  />
+                  <span>minutes</span>
+                  <span class="field-hint inline-hint">default 30 if blank</span>
+                </div>
+              </div>
+
+              <p class="form-help bindings-footer">
+                When a service is off, the corresponding data is not fetched from the server. Already-synced data remains available offline.
+              </p>
+            </div>
+
+            <!-- For standalone CalDAV/CardDAV the only relevant toggle is
+                 the calendar/contacts one for the matching service. -->
+            <div
+              v-if="accountType === 'caldav'"
+              class="form-group form-group-checkbox"
+            >
               <label class="checkbox-label">
                 <input
                   v-model="form.calendar_sync_enabled"
                   type="checkbox"
                   data-testid="calendar-sync-enabled"
                 />
-                Enable calendar sync for this account
+                Sync calendar
               </label>
-              <p class="form-help">
-                When off, calendars and events are not fetched from the server. Existing calendar data remains available offline.
-              </p>
+            </div>
+            <div
+              v-if="accountType === 'carddav'"
+              class="form-group form-group-checkbox"
+            >
+              <label class="checkbox-label">
+                <input
+                  v-model="form.contacts_sync_enabled"
+                  type="checkbox"
+                  data-testid="contacts-sync-enabled"
+                />
+                Sync contacts
+              </label>
             </div>
           </div>
           <div class="modal-footer">
@@ -1110,6 +1367,67 @@ onMounted(() => {
   font-size: 12px;
   color: var(--color-text-muted);
   line-height: 1.4;
+}
+
+.bindings-section {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.bindings-section-title {
+  /* Mirror .form-group label so this section reads like a labelled field
+     (no border, no fieldset chrome). */
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--color-text);
+}
+
+.binding-row {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.interval-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-left: 24px;
+  font-size: 12px;
+  color: var(--color-text-muted);
+}
+
+.interval-input {
+  /* Override the full-width form input style — the timer field is a
+     short inline number input, not a text field. */
+  width: 64px;
+  height: 28px;
+  padding: 0 8px;
+  font-size: 12px;
+}
+
+.inline-hint {
+  margin-left: 4px;
+  font-style: italic;
+}
+
+.bindings-footer {
+  margin: 4px 0 0 0;
+  font-size: 12px;
+  color: var(--color-text-muted);
+  line-height: 1.4;
+}
+
+.dav-discovery-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.dav-discovered-url {
+  word-break: break-all;
 }
 
 .btn-primary {

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -59,7 +59,12 @@ function makeMinutesField(key: "calendar_sync_interval_seconds" | "contacts_sync
       if (m == null || Number.isNaN(m)) {
         form.value[key] = null;
       } else {
-        form.value[key] = Math.max(1, Math.round(m * 60));
+        // Clamp to a minimum of 1 minute. The browser already enforces
+        // `min="1"` on the input but a programmatic v-model write (or
+        // someone bypassing the input) could otherwise persist
+        // sub-minute values into *_sync_interval_seconds.
+        const minutes = Math.max(1, Math.round(m));
+        form.value[key] = minutes * 60;
       }
     },
   });
@@ -279,13 +284,30 @@ async function discoverDavEndpoints() {
     if (result.imap_host) {
       form.value.imap_host = result.imap_host;
       form.value.imap_port = result.imap_port || 993;
-      form.value.use_tls = result.imap_use_tls;
       filled.push("IMAP");
     }
     if (result.smtp_host) {
       form.value.smtp_host = result.smtp_host;
       form.value.smtp_port = result.smtp_port || 587;
       filled.push("SMTP");
+    }
+    // The wire format carries one shared `use_tls` flag while autoconfig
+    // returns IMAP- and SMTP-specific settings. Only apply it when both
+    // services agree; if they disagree, prefer the more secure value
+    // (don't silently downgrade TLS) and log it.
+    if (result.imap_host && result.smtp_host) {
+      if (result.imap_use_tls === result.smtp_use_tls) {
+        form.value.use_tls = result.imap_use_tls;
+      } else {
+        console.warn(
+          "autoconfig: imap_use_tls / smtp_use_tls disagree; keeping TLS on",
+        );
+        form.value.use_tls = true;
+      }
+    } else if (result.imap_host) {
+      form.value.use_tls = result.imap_use_tls;
+    } else if (result.smtp_host) {
+      form.value.use_tls = result.smtp_use_tls;
     }
     const davUrl = result.caldav_url || result.carddav_url;
     if (davUrl) {

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -118,6 +118,8 @@ const defaultForm = (): AccountConfig => ({
   mail_sync_interval_seconds: null,
   calendar_sync_interval_seconds: null,
   contacts_sync_interval_seconds: null,
+  has_calendar_binding: false,
+  has_contacts_binding: false,
 });
 
 const form = ref<AccountConfig>(defaultForm());
@@ -128,6 +130,16 @@ const accountType = ref<AccountType>("gmail");
 function selectAccountType(type: AccountType) {
   accountType.value = type;
   const f = form.value;
+
+  // Reset per-service flags up front so switching tabs doesn't carry
+  // disabled-state from a previous selection (e.g. picking CardDAV-only
+  // turns calendar_sync_enabled off, then switching back to IMAP must
+  // turn it on again, otherwise the new account would silently skip
+  // calendar sync). Each branch below overrides only what it needs.
+  f.calendar_sync_enabled = true;
+  f.contacts_sync_enabled = true;
+  f.mail_sync_enabled = true;
+
   switch (type) {
     case "gmail":
       f.provider = "gmail";
@@ -176,9 +188,10 @@ function selectAccountType(type: AccountType) {
       f.jmap_url = "";
       f.use_tls = true;
       // CalDAV-only accounts shouldn't also create a CardDAV contacts
-      // binding by default — disable it explicitly.
+      // binding by default — disable it explicitly. The mail toggle
+      // doesn't matter (no mail binding will be derived) but keep it
+      // consistent.
       f.contacts_sync_enabled = false;
-      f.calendar_sync_enabled = true;
       break;
     case "carddav":
       // Standalone CardDAV address book (#43). Same shape as CalDAV but
@@ -192,7 +205,6 @@ function selectAccountType(type: AccountType) {
       f.smtp_port = 0;
       f.jmap_url = "";
       f.use_tls = true;
-      f.contacts_sync_enabled = true;
       f.calendar_sync_enabled = false;
       break;
   }
@@ -247,12 +259,16 @@ async function openEditForm(id: string) {
       } else {
         oauthStatus.value = null;
       }
-    } else if (config.mail_protocol === "" && config.calendar_sync_enabled) {
-      // Standalone CalDAV calendar account (#43).
-      accountType.value = "caldav";
-    } else if (config.mail_protocol === "" && config.contacts_sync_enabled) {
-      // Standalone CardDAV contacts account (#43).
-      accountType.value = "carddav";
+    } else if (config.mail_protocol === "") {
+      // Standalone DAV account (#43). Pick the tab from the binding
+      // shape rather than the sync-enabled flags so toggling "Sync
+      // calendar" / "Sync contacts" doesn't reclassify the account
+      // back to "imap" and hide the URL field.
+      if (config.has_contacts_binding && !config.has_calendar_binding) {
+        accountType.value = "carddav";
+      } else {
+        accountType.value = "caldav";
+      }
     } else {
       accountType.value = "imap";
     }
@@ -323,7 +339,11 @@ async function discoverDavEndpoints() {
       discoveryNote.value = `Filled ${filled.join(" + ")}${sourceLabel}.`;
     }
   } catch (e) {
-    discoveryNote.value = `Discovery failed: ${e}`;
+    // Match the rest of the UI: unwrap Error.message instead of
+    // template-stringifying the raw value, which can render
+    // "[object Object]" when the backend returns a structured error.
+    const msg = e instanceof Error ? e.message : String(e);
+    discoveryNote.value = `Discovery failed: ${msg}`;
   } finally {
     discoveringDav.value = false;
   }


### PR DESCRIPTION
Closes #43 and #47.

Originally scoped to #43, but #47 (multi-calendar Graph sync) was small enough to fold into the same PR — same calendar dispatch surface, same `is_subscribed` plumbing.

Each phase / fix is a separate commit so reviewers can diff in slices.

## Phase 1 — schema parallel population (no behavior change)
- New `service_bindings` table: `(account_id, service, protocol)` with `enabled`, `sync_interval_seconds`, `config_json`.
- New `accounts.auth_method` column.
- One-time migration `service_bindings_initial_populate` derives bindings from existing rows.

## Phase 2 — dispatch reads switch to bindings
- `AccountFull` carries `bindings` + `auth_method`. New helpers `mail_protocol_str()`, `calendar_protocol_str()`, `contacts_protocol_str()`, `mail_binding()`, etc.
- 76 dispatch sites across `calendar.rs`, `contacts.rs`, `sync_cmd.rs`, `mail.rs`, `actions.rs`, `compose.rs`, `filters.rs`, `ops/worker.rs`, `mail/imap.rs` switched from `account.mail_protocol == "X"` / `account.provider == "..."` to the binding-derived helpers.
- `insert_account` / `update_account` rebuild bindings on every save.

## Phase 3 — drop legacy columns
- Drops `provider`, `mail_protocol`, `imap_host`, `imap_port`, `smtp_host`, `smtp_port`, `use_tls`, `jmap_url`, `jmap_auth_method`, `caldav_url`, `calendar_sync_enabled` from `accounts` via a one-time migration.
- `get_account_full` reads only the survivor columns and reconstitutes the legacy `AccountFull` fields from the bindings via `populate_legacy_from_bindings`. Wire format unchanged.
- Typed configs (`ImapBindingConfig`, `JmapBindingConfig`, `DavBindingConfig`) parse `config_json`.

## Phase 4 — close #43, auto-discovery, per-binding sync interval
- New "CalDAV" / "CardDAV" tabs for standalone calendar / address-book accounts (no mail backend).
- "Sync mail" toggle in JMAP form for the JMAP-cal-only case.
- `mail/autoconfig.rs`: Thunderbird-style email autoconfig — Mozilla ISP DB → provider autoconfig → `.well-known` → MX lookup (via `hickory-resolver`) → DAV probing across every candidate hostname. Hardened: 8s timeout, streamed 64KB body cap, conservative domain validation.
- Per-binding sync interval columns surfaced through to the `Account` summary; `stores/calendar.ts` and `ContactsView.vue` replaced their global timers with per-account ticks that respect each binding's cadence.
- `mailAccounts` getter filters out empty `mail_protocol` so calendar-/contacts-only accounts stay out of mail-side UI.
- IMAP form: dropped manual CalDAV URL input; auto-discovery fills it. `add_account` skips the default local calendar when there's no calendar binding.

## CI / review fixups
- Subsequent commits address `cargo fmt`, vue-tsc test fixtures, RUSTSEC-2026-0119 (bumped `hickory-resolver` 0.24 → 0.26 with API migration), and the five Copilot review points (streamed body cap in autoconfig, double-refresh in single-account calendar sync, sub-minute interval bug, dropped SMTP TLS flag, per-tick `fetchBooks` churn).

## Multi-calendar Graph (#47)
- New `GraphClient::list_events_for_calendar(calendar_id, start, end)` hitting `GET /me/calendars/{id}/calendarView`.
- `sync_calendars_graph` now iterates each Graph calendar, skips unsubscribed ones (preserving the user's `is_subscribed` flag across upserts), fetches events scoped to that calendar, and reconciles per-calendar so a delete in one calendar can't wipe events from another.

## Test plan
- [x] `cargo check`, `cargo fmt --check`, `cargo clippy --all-targets`, 220 Rust unit tests (5 new for autoconfig XML parsing) — all clean.
- [x] `pnpm vitest run` + `pnpm exec vue-tsc --noEmit` — 292 tests pass, no type errors.
- [x] Manual smoke test on real DB: existing IMAP+Nextcloud, JMAP-OIDC, O365 Graph accounts continued to work after each phase migration ran.
- [x] Manual: standalone CalDAV-only Nextcloud account adds without phantom mail folders or contacts; per-service toggles only show services that actually exist; auto-discover button fills IMAP+SMTP+CalDAV from ISP DB / MX.
- [ ] Manual: O365 account with multiple calendars renders events in their correct local calendar; unsubscribe a non-default calendar and confirm next sync skips it.