### PR TITLE
fix(caldav): username field, sync short-circuit, Windows tz, ghost events

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -601,6 +601,7 @@ dependencies = [
  "urlencoding",
  "utf7-imap",
  "uuid",
+ "windows-timezones",
 ]
 
 [[package]]
@@ -6751,6 +6752,12 @@ checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
 dependencies = [
  "windows-link 0.1.3",
 ]
+
+[[package]]
+name = "windows-timezones"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53bce119c4ac0adfe0945781383966cc9838c853c2876fa3bf71662d76df4ef2"
 
 [[package]]
 name = "windows-version"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -50,6 +50,9 @@ base64 = "0.22"
 rand = "0.9"
 # Pure-Rust DNS resolver for MX-record lookup during email autoconfig (#43).
 hickory-resolver = "0.26"
+# CLDR windowsZones table for converting Microsoft display names
+# (e.g. "W. Europe Standard Time") to IANA timezone IDs.
+windows-timezones = "0.5"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/src-tauri/src/calendar/timezone.rs
+++ b/src-tauri/src/calendar/timezone.rs
@@ -45,9 +45,13 @@ pub fn to_utc(datetime: &str, tzid: &str) -> String {
         }
     }
 
-    // Naive datetime + IANA timezone → convert via chrono-tz
-    if !tzid.is_empty() {
-        if let Ok(tz) = tzid.parse::<chrono_tz::Tz>() {
+    // Naive datetime + IANA timezone → convert via chrono-tz.
+    // Microsoft Graph and Outlook iCal exports carry Windows timezone
+    // names (e.g. "W. Europe Standard Time") rather than IANA — map them
+    // to IANA before parsing so chrono-tz can pick the right zone.
+    let resolved_tzid = windows_to_iana(tzid).unwrap_or(tzid);
+    if !resolved_tzid.is_empty() {
+        if let Ok(tz) = resolved_tzid.parse::<chrono_tz::Tz>() {
             if let Ok(naive) = chrono::NaiveDateTime::parse_from_str(dt, "%Y-%m-%dT%H:%M:%S") {
                 use chrono::TimeZone;
                 match tz.from_local_datetime(&naive) {
@@ -92,6 +96,27 @@ pub fn to_utc(datetime: &str, tzid: &str) -> String {
     format!("{}Z", dt)
 }
 
+/// Map a Windows timezone display name (as used by Microsoft Graph,
+/// Outlook iCal exports, and Exchange ActiveSync) to the equivalent
+/// IANA timezone identifier. Returns `None` for names that don't
+/// match any Windows zone — callers should fall back to passing the
+/// input straight through to chrono-tz so already-IANA strings still
+/// work.
+///
+/// Backed by the `windows-timezones` crate, which embeds the Unicode
+/// CLDR `windowsZones.xml` mapping. Bumping that crate picks up any
+/// new Windows zones automatically.
+pub(crate) fn windows_to_iana(name: &str) -> Option<&'static str> {
+    use std::str::FromStr;
+    let trimmed = name.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    windows_timezones::WindowsTimezone::from_str(trimmed)
+        .ok()
+        .map(|wt| wt.tzdb_id())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -132,6 +157,34 @@ mod tests {
             to_utc("2026-04-14T14:00:00", "Europe/Stockholm"),
             "2026-04-14T12:00:00Z"
         );
+    }
+
+    #[test]
+    fn test_windows_w_europe_resolves_to_berlin() {
+        // Microsoft Graph / Outlook iCal exports use Windows zone names
+        // like "W. Europe Standard Time" which chrono-tz can't parse.
+        // The mapping should resolve them so 14:00 in Berlin (CEST in
+        // April) lands at 12:00 UTC.
+        assert_eq!(
+            to_utc("2026-04-14T14:00:00", "W. Europe Standard Time"),
+            "2026-04-14T12:00:00Z"
+        );
+    }
+
+    #[test]
+    fn test_windows_pacific_resolves_to_la() {
+        // Pacific Standard Time → Los Angeles (PDT in April = UTC-7).
+        assert_eq!(
+            to_utc("2026-04-14T05:00:00", "Pacific Standard Time"),
+            "2026-04-14T12:00:00Z"
+        );
+    }
+
+    #[test]
+    fn test_windows_utc_alias() {
+        // Plain "UTC" name from Graph (when Prefer header is set) just
+        // round-trips through Etc/UTC.
+        assert_eq!(to_utc("2026-04-14T12:00:00", "UTC"), "2026-04-14T12:00:00Z");
     }
 
     #[test]

--- a/src-tauri/src/commands/calendar.rs
+++ b/src-tauri/src/commands/calendar.rs
@@ -1425,8 +1425,15 @@ async fn sync_calendars_caldav(
         account_id
     );
 
-    // Build a mapping from remote calendar href to local calendar ID
-    let mut remote_to_local: std::collections::HashMap<String, String> =
+    // Build a mapping from remote calendar href to (local id, is_subscribed)
+    // — same shape as sync_calendars_graph (#47). The is_subscribed flag
+    // is preserved across re-syncs by upsert_calendar_by_remote_id, so
+    // we read it back from the DB after upserting and use it below to
+    // skip event sync for calendars the user has unsubscribed from.
+    // Without this skip, unsubscribing a calendar drops its events
+    // (via unsubscribe_calendar) but the very next sync re-pulls them
+    // and they show up as "ghost" events.
+    let mut remote_to_local: std::collections::HashMap<String, (String, bool)> =
         std::collections::HashMap::new();
 
     {
@@ -1437,12 +1444,29 @@ async fn sync_calendars_caldav(
             let local_id = db::calendar::upsert_calendar_by_remote_id(
                 &conn, account_id, &cal.href, &cal.name, color, is_default,
             )?;
-            remote_to_local.insert(cal.href.clone(), local_id);
+            let subscribed: bool = conn
+                .query_row(
+                    "SELECT is_subscribed FROM calendars WHERE id = ?1",
+                    rusqlite::params![local_id],
+                    |row| row.get(0),
+                )
+                .unwrap_or(true);
+            remote_to_local.insert(cal.href.clone(), (local_id, subscribed));
         }
     }
 
-    // Step 2: For each calendar, fetch events and upsert into local DB
+    // Step 2: For each subscribed calendar, fetch events and upsert into local DB
     for cal in &caldav_calendars {
+        let Some((local_cal_id, subscribed)) = remote_to_local.get(&cal.href) else {
+            continue;
+        };
+        if !subscribed {
+            log::debug!(
+                "sync_calendars_caldav: skipping unsubscribed calendar '{}'",
+                cal.name
+            );
+            continue;
+        }
         let caldav_events = match client.fetch_events(&cal.href).await {
             Ok(evts) => evts,
             Err(e) => {
@@ -1460,8 +1484,6 @@ async fn sync_calendars_caldav(
             caldav_events.len(),
             cal.name
         );
-
-        let local_cal_id = remote_to_local.get(&cal.href).cloned().unwrap_or_default();
 
         let conn = state.db.writer().await;
         for ev in &caldav_events {
@@ -1568,7 +1590,7 @@ async fn sync_calendars_caldav(
                 // Find the remote calendar href for this event's local calendar
                 let remote_cal_href = remote_to_local
                     .iter()
-                    .find(|(_, local_id)| **local_id == ev.calendar_id)
+                    .find(|(_, (local_id, _))| *local_id == ev.calendar_id)
                     .map(|(remote_href, _)| remote_href.clone())
                     .unwrap_or_default();
 

--- a/src-tauri/src/commands/calendar.rs
+++ b/src-tauri/src/commands/calendar.rs
@@ -1444,13 +1444,16 @@ async fn sync_calendars_caldav(
             let local_id = db::calendar::upsert_calendar_by_remote_id(
                 &conn, account_id, &cal.href, &cal.name, color, is_default,
             )?;
-            let subscribed: bool = conn
-                .query_row(
-                    "SELECT is_subscribed FROM calendars WHERE id = ?1",
-                    rusqlite::params![local_id],
-                    |row| row.get(0),
-                )
-                .unwrap_or(true);
+            // Propagate the read error rather than swallowing it as
+            // `subscribed = true`: the row was just upserted above so a
+            // failure here means the DB itself is misbehaving and the
+            // sync should abort rather than blindly re-pull events the
+            // user has unsubscribed from.
+            let subscribed: bool = conn.query_row(
+                "SELECT is_subscribed FROM calendars WHERE id = ?1",
+                rusqlite::params![local_id],
+                |row| row.get(0),
+            )?;
             remote_to_local.insert(cal.href.clone(), (local_id, subscribed));
         }
     }

--- a/src-tauri/src/commands/sync_cmd.rs
+++ b/src-tauri/src/commands/sync_cmd.rs
@@ -238,6 +238,18 @@ pub async fn trigger_sync(
         }
     };
 
+    // Calendar-only / contacts-only / mail-disabled accounts have no
+    // mail binding, so there is nothing to dispatch here. Return early
+    // before the IMAP fallback at the bottom of the protocol chain
+    // tries to connect with an empty hostname.
+    if account.mail_protocol_str().is_empty() {
+        log::debug!(
+            "trigger_sync: account {} has no enabled mail binding, skipping",
+            account_id
+        );
+        return Ok(());
+    }
+
     let suspended_idle = if account.mail_protocol_str() == "imap"
         && should_suspend_idle_for_imap_operation(&account.auth_method)
     {
@@ -386,6 +398,17 @@ pub async fn sync_folder(
         let conn = state.db.reader();
         db::accounts::get_account_full(&conn, &account_id)?
     };
+
+    // Per-folder sync only makes sense for mail accounts. If there's no
+    // enabled mail binding (DAV-only / mail-disabled JMAP) just return
+    // a zero new-message count.
+    if account.mail_protocol_str().is_empty() {
+        log::debug!(
+            "sync_folder: account {} has no enabled mail binding, skipping",
+            account_id
+        );
+        return Ok(0);
+    }
 
     // sync-started is emitted by each protocol-specific path below, so the
     // activity store sees exactly one start per sync (sync_graph_account,

--- a/src-tauri/src/db/calendar.rs
+++ b/src-tauri/src/db/calendar.rs
@@ -271,6 +271,13 @@ pub fn list_events(
     start: &str,
     end: &str,
 ) -> Result<Vec<CalendarEvent>> {
+    // Single-shot events are filtered to those that overlap the visible
+    // window. Recurring events (`recurrence_rule` non-empty) ALWAYS pass
+    // through regardless of their master row's date range — their
+    // occurrences are computed by the frontend's expandRRule, and the
+    // master row's start_time can be years before the visible window.
+    // Without this carve-out, an event whose RRULE master sits in 2021
+    // never reaches expandRRule when the user views 2026.
     let (query, do_calendar_filter) = if calendar_id.is_some() {
         (
             "SELECT id, account_id, calendar_id, uid, title, description, location,
@@ -279,7 +286,8 @@ pub fn list_events(
                     ical_data, remote_id, etag
              FROM calendar_events
              WHERE account_id = ?1 AND calendar_id = ?2
-               AND start_time < ?4 AND end_time > ?3
+               AND ((start_time < ?4 AND end_time > ?3)
+                    OR (recurrence_rule IS NOT NULL AND recurrence_rule != ''))
              ORDER BY start_time ASC",
             true,
         )
@@ -291,7 +299,8 @@ pub fn list_events(
                     ical_data, remote_id, etag
              FROM calendar_events
              WHERE account_id = ?1
-               AND start_time < ?3 AND end_time > ?2
+               AND ((start_time < ?3 AND end_time > ?2)
+                    OR (recurrence_rule IS NOT NULL AND recurrence_rule != ''))
              ORDER BY start_time ASC",
             false,
         )

--- a/src/__tests__/calendar.test.ts
+++ b/src/__tests__/calendar.test.ts
@@ -211,6 +211,27 @@ describe("Calendar store", () => {
       expect(store.visibleEvents.length).toBe(2);
     });
 
+    it("should drop events whose calendar isn't in the subscribed list (ghost-event regression)", async () => {
+      // Reproduces the bug fixed in #134: a CalDAV calendar the user
+      // unsubscribed from no longer appears in `calendars`, but its
+      // events lingered in `events` from previous syncs and rendered
+      // anyway. visibleEvents must filter against the loaded
+      // (subscribed-only) calendar list.
+      setupAccounts();
+      const store = useCalendarStore();
+      store.calendars = [
+        { id: "cal1", account_id: "acc1", name: "Subscribed", color: "#000", is_default: true, remote_id: null, is_subscribed: true },
+      ];
+      store.events = [
+        makeEvent("e1", "Live", "2026-04-07T10:00:00Z", "2026-04-07T11:00:00Z", { calendar_id: "cal1" }),
+        // Event whose calendar isn't in the sidebar list -> ghost.
+        makeEvent("ghost", "Phantom", "2026-04-07T12:00:00Z", "2026-04-07T13:00:00Z", { calendar_id: "cal-removed" }),
+      ];
+      store.currentDate = "2026-04-07";
+
+      expect(store.visibleEvents.map(e => e.title)).toEqual(["Live"]);
+    });
+
     it("should persist hidden calendars to localStorage", () => {
       // Regression: hiddenCalendarIds must survive reloads.
       setupAccounts();

--- a/src/__tests__/calendar.test.ts
+++ b/src/__tests__/calendar.test.ts
@@ -175,6 +175,14 @@ describe("Calendar store", () => {
     it("should filter out events from hidden calendars", async () => {
       setupAccounts();
       const store = useCalendarStore();
+      // visibleEvents now also drops events whose calendar isn't in
+      // the (subscribed-only) sidebar list — we have to populate
+      // `calendars` so the test's events have a matching entry to
+      // hit the hidden-id check below.
+      store.calendars = [
+        { id: "cal1", account_id: "acc1", name: "One", color: "#000", is_default: true, remote_id: null, is_subscribed: true },
+        { id: "cal2", account_id: "acc1", name: "Two", color: "#000", is_default: false, remote_id: null, is_subscribed: true },
+      ];
       store.events = [
         makeEvent("e1", "Visible", "2026-04-07T10:00:00Z", "2026-04-07T11:00:00Z", { calendar_id: "cal1" }),
         makeEvent("e2", "Hidden", "2026-04-07T12:00:00Z", "2026-04-07T13:00:00Z", { calendar_id: "cal2" }),
@@ -188,6 +196,10 @@ describe("Calendar store", () => {
     it("should toggle visibility back on", async () => {
       setupAccounts();
       const store = useCalendarStore();
+      store.calendars = [
+        { id: "cal1", account_id: "acc1", name: "One", color: "#000", is_default: true, remote_id: null, is_subscribed: true },
+        { id: "cal2", account_id: "acc1", name: "Two", color: "#000", is_default: false, remote_id: null, is_subscribed: true },
+      ];
       store.events = [
         makeEvent("e1", "A", "2026-04-07T10:00:00Z", "2026-04-07T11:00:00Z", { calendar_id: "cal1" }),
         makeEvent("e2", "B", "2026-04-07T12:00:00Z", "2026-04-07T13:00:00Z", { calendar_id: "cal2" }),

--- a/src/stores/calendar.ts
+++ b/src/stores/calendar.ts
@@ -57,7 +57,16 @@ export const useCalendarStore = defineStore("calendar", () => {
     const rangeEnd = new Date(range.end);
     const result: CalendarEvent[] = [];
 
+    // Drop events whose calendar isn't in the (subscribed-only)
+    // calendar list. Without this filter, events linger from
+    // calendars the user unsubscribed from in the past — the next
+    // backend sync re-pulls them and they become "ghost" events
+    // visible in the grid even though the calendar is hidden in the
+    // sidebar.
+    const visibleCalendarIds = new Set(calendars.value.map((c) => c.id));
+
     for (const e of events.value) {
+      if (!visibleCalendarIds.has(e.calendar_id)) continue;
       if (hiddenCalendarIds.value.includes(e.calendar_id)) continue;
 
       if (e.recurrence_rule) {

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -357,6 +357,22 @@ async function saveAccount() {
     if (!form.value.username.trim()) {
       form.value.username = form.value.email;
     }
+    // Mail-having accounts already require an email. The standalone
+    // CalDAV / CardDAV tabs hide the email field — but some calendar
+    // code paths still touch `account.email` (CalDAV connect uses it
+    // for domain extraction during auto-discovery, attendee match in
+    // ical.rs uses it as the local identity), so back-fill from
+    // username when it looks like one. Falls back to a deterministic
+    // local-only string so the field is never blank.
+    if (
+      (accountType.value === "caldav" || accountType.value === "carddav") &&
+      !form.value.email.trim()
+    ) {
+      const u = form.value.username.trim();
+      form.value.email = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(u)
+        ? u
+        : `${u || "dav"}@local`;
+    }
     if (editingAccountId.value) {
       await api.updateAccount(editingAccountId.value, form.value);
       await accountsStore.fetchAccounts();

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -718,9 +718,37 @@ onMounted(() => {
               <label>Account Name</label>
               <input v-model="form.display_name" type="text" :placeholder="accountType === 'caldav' ? 'My Calendar' : 'e.g., Personal, Work'" />
             </div>
-            <div v-if="accountType !== 'caldav'" class="form-group">
+            <!-- DAV-only accounts have no mail identity, so they skip
+                 the email field and use an explicit username for the
+                 server's Basic auth. The mail tabs keep email as the
+                 default login (the saveAccount fallback fills
+                 username from email when blank). -->
+            <div
+              v-if="accountType !== 'caldav' && accountType !== 'carddav'"
+              class="form-group"
+            >
               <label>Email Address</label>
-              <input v-model="form.email" type="email" placeholder="user@example.com" />
+              <input
+                v-model="form.email"
+                type="email"
+                placeholder="user@example.com"
+                data-testid="account-email"
+              />
+            </div>
+            <div
+              v-if="accountType === 'caldav' || accountType === 'carddav'"
+              class="form-group"
+            >
+              <label>Username</label>
+              <input
+                v-model="form.username"
+                type="text"
+                placeholder="Login name on the DAV server"
+                data-testid="account-username"
+              />
+              <span class="field-hint">
+                Login name for the {{ accountType === 'carddav' ? 'CardDAV' : 'CalDAV' }} server.
+              </span>
             </div>
             <div v-if="accountType !== 'o365' && !(accountType === 'jmap' && form.jmap_auth_method === 'oidc')" class="form-group">
               <label>{{ accountType === 'gmail' ? 'App Password' : 'Password' }}</label>


### PR DESCRIPTION
Five fixes to the CalDAV-only flow that landed in #126.

## Summary
- **DAV form**: CalDAV/CardDAV tabs were missing a Username input. Save defaulted \`username = email\` but email was hidden too, so Basic auth went out with empty username and the server rejected. Now hidden email + visible Username on DAV-only tabs.
- **\`trigger_sync\`/\`sync_folder\`**: calendar-only accounts (\`mail_protocol_str() == ""\`) fell through the protocol chain and hit IMAP with \`host = ""\` -> "failed to lookup address information". Early-return when there's no mail binding.
- **Windows timezones**: \`"W. Europe Standard Time"\` and friends from Microsoft Graph / Outlook iCal weren't parseable by chrono-tz. Added \`windows-timezones\` crate (CLDR-backed) and a \`windows_to_iana\` resolver in front of the chrono-tz parse.
- **Ghost events**: \`visibleEvents\` only filtered by localStorage \`hiddenCalendarIds\`, so events from calendars the user previously unsubscribed from kept rendering after the next sync re-pulled them. Now also filtered against the visible (subscribed-only) calendar list.
- **\`sync_calendars_caldav\`**: now reads \`is_subscribed\` after upsert and skips event fetch for unsubscribed calendars (mirrors the #47 fix in \`sync_calendars_graph\`), so unsubscribe + re-sync no longer reanimates events.

## Test plan
- [x] \`cargo fmt --check\`, \`cargo clippy --all-targets\`, 223 Rust unit tests
- [x] \`pnpm exec vue-tsc --noEmit\`, 292 JS tests
- [x] Manual: known-bad reproduction (CalDAV-only account hits StatusBar Sync) no longer logs DNS error
- [x] Manual: Windows-tz Graph events resolve to local time correctly