### PR TITLE
fix(contacts): dedupe address books in sidebar (#130)

### DIFF
--- a/src/views/ContactsView.vue
+++ b/src/views/ContactsView.vue
@@ -239,6 +239,12 @@ async function syncAllContacts() {
   }
 }
 
+// Monotonic token: the latest fetchBooks() invocation wins. An
+// earlier-started call that resolves later is dropped before its
+// `contactBooks.value = next` write so stale data can't overwrite
+// fresh data.
+let fetchBooksSeq = 0;
+
 async function fetchBooks() {
   // Build the list in a local then commit it once at the end. Two
   // concurrent fetchBooks calls (e.g. one from contacts-changed while
@@ -246,6 +252,8 @@ async function fetchBooks() {
   // appends into the shared `contactBooks.value`, producing duplicates
   // in the sidebar (#130). Dedupe by id along the way as a belt-and-
   // braces guard.
+  fetchBooksSeq++;
+  const ourSeq = fetchBooksSeq;
   const seen = new Set<string>();
   const next: ContactBook[] = [];
   for (const account of accountsStore.accounts) {
@@ -260,9 +268,20 @@ async function fetchBooks() {
       console.error("Failed to fetch contact books:", e);
     }
   }
+  // Drop this result if a newer fetchBooks() has already started; the
+  // newer call's commit is authoritative.
+  if (ourSeq !== fetchBooksSeq) return;
   contactBooks.value = next;
-  if (contactBooks.value.length > 0 && !selectedBookId.value) {
-    selectedBookId.value = contactBooks.value[0].id;
+  // Validate the current selection against the new list — the user's
+  // previously-selected book might have been removed (unsubscribed,
+  // account deleted, etc). Fall back to the first available book or
+  // clear the selection so subsequent listContacts() calls don't fire
+  // against a dead id.
+  const stillExists =
+    selectedBookId.value !== null &&
+    next.some((b) => b.id === selectedBookId.value);
+  if (!stillExists) {
+    selectedBookId.value = next.length > 0 ? next[0].id : null;
   }
 }
 

--- a/src/views/ContactsView.vue
+++ b/src/views/ContactsView.vue
@@ -240,15 +240,27 @@ async function syncAllContacts() {
 }
 
 async function fetchBooks() {
-  contactBooks.value = [];
+  // Build the list in a local then commit it once at the end. Two
+  // concurrent fetchBooks calls (e.g. one from contacts-changed while
+  // another is mid-flight after a manual sync) used to interleave
+  // appends into the shared `contactBooks.value`, producing duplicates
+  // in the sidebar (#130). Dedupe by id along the way as a belt-and-
+  // braces guard.
+  const seen = new Set<string>();
+  const next: ContactBook[] = [];
   for (const account of accountsStore.accounts) {
     try {
       const books = await api.listContactBooks(account.id);
-      contactBooks.value = contactBooks.value.concat(books);
+      for (const b of books) {
+        if (seen.has(b.id)) continue;
+        seen.add(b.id);
+        next.push(b);
+      }
     } catch (e) {
       console.error("Failed to fetch contact books:", e);
     }
   }
+  contactBooks.value = next;
   if (contactBooks.value.length > 0 && !selectedBookId.value) {
     selectedBookId.value = contactBooks.value[0].id;
   }


### PR DESCRIPTION
Closes #130.

## Summary
- The sidebar showed each address book multiple times. The DB was clean — only the UI was duplicating.
- Root cause: \`fetchBooks()\` is called from \`onMounted\`, \`contactsTick\`, the \`contacts-changed\` listener, every CRUD op, and \`syncAllContacts\`. It reset \`contactBooks.value = []\` then appended per-account. Two calls running concurrently shared the same reactive ref and interleaved their per-account appends, producing duplicates.
- Fix: build the list in a local array, dedupe by id along the way, and assign once to \`contactBooks.value\` at the end. Subsequent calls cleanly replace the prior list instead of stacking on top of it.

## Test plan
- [x] \`pnpm vitest run\` (293), \`pnpm exec vue-tsc --noEmit\` clean
- [x] Manual: open Contacts view, force a sync, confirm each book appears exactly once