### PR TITLE
feat(contacts): multi-select + field-by-field merge picker (#129)

### DIFF
--- a/src/__tests__/contact-merge.test.ts
+++ b/src/__tests__/contact-merge.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect } from "vitest";
+import {
+  mergeContacts,
+  defaultChoices,
+  applyMergeChoices,
+  buildListItems,
+} from "@/lib/contact-merge";
+import type { Contact } from "@/lib/types";
+
+function makeContact(overrides: Partial<Contact>): Contact {
+  return {
+    id: "c1",
+    book_id: "book1",
+    uid: "uid-c1",
+    display_name: "",
+    emails_json: "[]",
+    phones_json: "[]",
+    addresses_json: "[]",
+    organization: null,
+    title: null,
+    notes: null,
+    vcard_data: null,
+    remote_id: null,
+    etag: null,
+    ...overrides,
+  } as Contact;
+}
+
+describe("mergeContacts", () => {
+  it("keeps the primary's identity fields", () => {
+    const a = makeContact({ id: "a", uid: "uid-a", remote_id: "rem-a", etag: "et-a", book_id: "b1" });
+    const b = makeContact({ id: "b", uid: "uid-b", remote_id: "rem-b", etag: "et-b", book_id: "b1" });
+    const merged = mergeContacts(a, b);
+    expect(merged.id).toBe("a");
+    expect(merged.uid).toBe("uid-a");
+    expect(merged.remote_id).toBe("rem-a");
+    expect(merged.etag).toBe("et-a");
+    expect(merged.book_id).toBe("b1");
+  });
+
+  it("primary atomic fields win when populated", () => {
+    const a = makeContact({ display_name: "Alice", organization: "Acme", title: "Engineer" });
+    const b = makeContact({ display_name: "Alicia", organization: "Beta", title: "Manager" });
+    const merged = mergeContacts(a, b);
+    expect(merged.display_name).toBe("Alice");
+    expect(merged.organization).toBe("Acme");
+    expect(merged.title).toBe("Engineer");
+  });
+
+  it("falls through to secondary when primary's atomic field is empty", () => {
+    const a = makeContact({ display_name: "Alice", organization: "", title: null });
+    const b = makeContact({ display_name: "Alicia", organization: "Beta", title: "Manager" });
+    const merged = mergeContacts(a, b);
+    // display_name stays primary (non-empty)
+    expect(merged.display_name).toBe("Alice");
+    // organization / title fall through
+    expect(merged.organization).toBe("Beta");
+    expect(merged.title).toBe("Manager");
+  });
+
+  it("unions emails and dedupes case-insensitively", () => {
+    const a = makeContact({
+      emails_json: JSON.stringify([
+        { email: "a@example.com", label: "work" },
+      ]),
+    });
+    const b = makeContact({
+      emails_json: JSON.stringify([
+        { email: "A@Example.com", label: "home" }, // duplicate of a@example.com (different case)
+        { email: "b@example.com", label: "other" },
+      ]),
+    });
+    const merged = mergeContacts(a, b);
+    const emails = JSON.parse(merged.emails_json);
+    expect(emails).toHaveLength(2);
+    expect(emails[0].email).toBe("a@example.com"); // primary's casing wins
+    expect(emails[1].email).toBe("b@example.com");
+  });
+
+  it("unions phones and preserves order primary-then-secondary", () => {
+    const a = makeContact({
+      phones_json: JSON.stringify([{ number: "+1-555-1111", label: "mobile" }]),
+    });
+    const b = makeContact({
+      phones_json: JSON.stringify([
+        { number: "+1-555-1111", label: "work" }, // dup
+        { number: "+1-555-2222", label: "work" },
+      ]),
+    });
+    const merged = mergeContacts(a, b);
+    const phones = JSON.parse(merged.phones_json);
+    expect(phones).toHaveLength(2);
+    expect(phones[0].number).toBe("+1-555-1111");
+    expect(phones[1].number).toBe("+1-555-2222");
+  });
+
+  it("concatenates notes with a separator when both differ", () => {
+    const a = makeContact({ notes: "Met at conference 2024." });
+    const b = makeContact({ notes: "Likes hiking." });
+    const merged = mergeContacts(a, b);
+    expect(merged.notes).toBe("Met at conference 2024.\n---\nLikes hiking.");
+  });
+
+  it("keeps the single non-empty notes when only one side has them", () => {
+    const a = makeContact({ notes: null });
+    const b = makeContact({ notes: "Likes hiking." });
+    expect(mergeContacts(a, b).notes).toBe("Likes hiking.");
+
+    const c = makeContact({ notes: "Met at conference 2024." });
+    const d = makeContact({ notes: "" });
+    expect(mergeContacts(c, d).notes).toBe("Met at conference 2024.");
+  });
+
+  it("does not duplicate identical notes", () => {
+    const a = makeContact({ notes: "Same note." });
+    const b = makeContact({ notes: "Same note." });
+    expect(mergeContacts(a, b).notes).toBe("Same note.");
+  });
+
+  it("survives malformed JSON in either list (treats as empty)", () => {
+    const a = makeContact({ emails_json: "not json" });
+    const b = makeContact({
+      emails_json: JSON.stringify([{ email: "b@example.com", label: "work" }]),
+    });
+    const merged = mergeContacts(a, b);
+    const emails = JSON.parse(merged.emails_json);
+    expect(emails).toHaveLength(1);
+    expect(emails[0].email).toBe("b@example.com");
+  });
+
+  it("dedupes addresses by serialized payload", () => {
+    const sameAddr = { street: "1 Main", city: "Town", country: "US" };
+    const a = makeContact({ addresses_json: JSON.stringify([sameAddr]) });
+    const b = makeContact({
+      addresses_json: JSON.stringify([sameAddr, { street: "2 Other", city: "Town", country: "US" }]),
+    });
+    const merged = mergeContacts(a, b);
+    const addrs = JSON.parse(merged.addresses_json);
+    expect(addrs).toHaveLength(2);
+  });
+});
+
+describe("defaultChoices / applyMergeChoices", () => {
+  it("defaults atomic fields to keeper when populated, loser when keeper is empty", () => {
+    const k = makeContact({ display_name: "Alice", organization: "", title: null });
+    const l = makeContact({ display_name: "Alicia", organization: "Beta", title: "Manager" });
+    const c = defaultChoices(k, l);
+    expect(c.display_name).toBe("keeper");
+    expect(c.organization).toBe("loser");
+    expect(c.title).toBe("loser");
+  });
+
+  it("defaults notes to 'both' only when both sides have non-empty differing notes", () => {
+    expect(defaultChoices(
+      makeContact({ notes: "A" }),
+      makeContact({ notes: "B" }),
+    ).notes).toBe("both");
+    expect(defaultChoices(
+      makeContact({ notes: "" }),
+      makeContact({ notes: "B" }),
+    ).notes).toBe("loser");
+    expect(defaultChoices(
+      makeContact({ notes: "Same" }),
+      makeContact({ notes: "Same" }),
+    ).notes).toBe("keeper");
+  });
+
+  it("user can override an atomic field to the loser's value", () => {
+    const k = makeContact({ display_name: "Alice", organization: "Acme" });
+    const l = makeContact({ display_name: "Alicia Smith", organization: "Beta" });
+    const c = defaultChoices(k, l);
+    c.display_name = "loser";
+    const merged = applyMergeChoices(k, l, c);
+    expect(merged.display_name).toBe("Alicia Smith");
+    // Untouched: still keeper
+    expect(merged.organization).toBe("Acme");
+  });
+
+  it("notes 'keeper' / 'loser' / 'both' produce the three expected results", () => {
+    const k = makeContact({ notes: "Met at conf." });
+    const l = makeContact({ notes: "Likes hiking." });
+    const c = defaultChoices(k, l);
+    c.notes = "keeper";
+    expect(applyMergeChoices(k, l, c).notes).toBe("Met at conf.");
+    c.notes = "loser";
+    expect(applyMergeChoices(k, l, c).notes).toBe("Likes hiking.");
+    c.notes = "both";
+    expect(applyMergeChoices(k, l, c).notes).toBe("Met at conf.\n---\nLikes hiking.");
+  });
+
+  it("excludes a list item the user unchecks", () => {
+    const k = makeContact({
+      emails_json: JSON.stringify([{ email: "alice@a.com", label: "work" }]),
+    });
+    const l = makeContact({
+      emails_json: JSON.stringify([{ email: "alice@b.com", label: "home" }]),
+    });
+    const c = defaultChoices(k, l);
+    expect(c.emails).toHaveLength(2);
+    // User unchecks the loser's email.
+    c.emails[1].include = false;
+    const merged = applyMergeChoices(k, l, c);
+    expect(JSON.parse(merged.emails_json)).toEqual([
+      { email: "alice@a.com", label: "work" },
+    ]);
+  });
+
+  it("buildListItems annotates each entry with its source side and dedupes case-insensitively", () => {
+    const items = buildListItems(
+      JSON.stringify([{ email: "k@x.com" }]),
+      JSON.stringify([{ email: "K@X.com" }, { email: "l2@x.com" }]),
+      (it) => String(it.email ?? ""),
+    );
+    expect(items).toHaveLength(2); // "K@X.com" collapses against "k@x.com"
+    expect(items[0].source).toBe("keeper");
+    expect(items[0].item.email).toBe("k@x.com"); // keeper's casing wins
+    expect(items[1].source).toBe("loser");
+    expect(items[1].item.email).toBe("l2@x.com");
+    expect(items.every((i) => i.include)).toBe(true);
+  });
+
+  it("identity fields always come from keeper regardless of choices", () => {
+    const k = makeContact({ id: "k", uid: "uid-k", remote_id: "r-k", etag: "e-k" });
+    const l = makeContact({ id: "l", uid: "uid-l", remote_id: "r-l", etag: "e-l" });
+    const c = defaultChoices(k, l);
+    // Even with every choice flipped to the loser, identity stays.
+    c.display_name = "loser";
+    c.organization = "loser";
+    c.title = "loser";
+    c.notes = "loser";
+    const merged = applyMergeChoices(k, l, c);
+    expect(merged.id).toBe("k");
+    expect(merged.uid).toBe("uid-k");
+    expect(merged.remote_id).toBe("r-k");
+    expect(merged.etag).toBe("e-k");
+  });
+});

--- a/src/lib/contact-merge.ts
+++ b/src/lib/contact-merge.ts
@@ -1,0 +1,193 @@
+/**
+ * Contact-merge helpers (#129).
+ *
+ * Pure functions extracted from ContactsView.vue so the merge rules
+ * can be unit-tested without mounting the component. The view imports
+ * `mergeContacts` and uses its result as the input to
+ * `api.updateContact` for the merge primary, then deletes the
+ * secondary.
+ *
+ * Merge policy: "primary wins" on atomic fields, with empty-string
+ * fallthrough to the secondary so the loser's value still surfaces
+ * when the primary has nothing. Lists (emails, phones, addresses)
+ * are unioned with case-folded dedup. Notes concatenate when both
+ * sides differ.
+ */
+
+import type { Contact } from "./types";
+
+interface EmailEntry { email?: string; label?: string }
+interface PhoneEntry { number?: string; label?: string }
+
+/// Which side a field-by-field merge should pull a value from.
+/// "keeper" = the contact whose id / remote_id / etag survive the
+/// merge. "loser" = the one being deleted. "both" only applies to
+/// notes — concatenate the two with a separator.
+export type AtomicSide = "keeper" | "loser";
+export type NotesSide = "keeper" | "loser" | "both";
+
+/// One entry in the unioned list shown in the picker. Each item
+/// carries the source side (so the UI can show a label) and an
+/// `include` flag for the checkbox.
+export interface MergeListItem {
+  source: AtomicSide;
+  include: boolean;
+  /// Raw item from the original JSON (email entry, phone entry, …).
+  item: Record<string, unknown>;
+}
+
+/// Full picker state. The dialog populates this from the two
+/// contacts; `applyMergeChoices` consumes it to produce the
+/// surviving record.
+export interface MergeChoices {
+  display_name: AtomicSide;
+  organization: AtomicSide;
+  title: AtomicSide;
+  notes: NotesSide;
+  emails: MergeListItem[];
+  phones: MergeListItem[];
+  addresses: MergeListItem[];
+}
+
+function trimOrNull(s: string | null | undefined): string | null {
+  const t = (s ?? "").trim();
+  return t.length > 0 ? t : null;
+}
+
+function side(
+  choice: AtomicSide,
+  keeper: string | null | undefined,
+  loser: string | null | undefined,
+): string | null {
+  // If the picked side is empty, fall through to the other so the
+  // user never ends up with a blank field as a side effect of the
+  // dialog defaulting to one side.
+  const picked = choice === "keeper" ? keeper : loser;
+  const fallback = choice === "keeper" ? loser : keeper;
+  return trimOrNull(picked) ?? trimOrNull(fallback);
+}
+
+function mergeNotes(
+  choice: NotesSide,
+  keeper: string | null | undefined,
+  loser: string | null | undefined,
+): string | null {
+  const k = trimOrNull(keeper);
+  const l = trimOrNull(loser);
+  switch (choice) {
+    case "keeper":
+      return k ?? l;
+    case "loser":
+      return l ?? k;
+    case "both": {
+      if (!k) return l;
+      if (!l || k === l) return k;
+      return `${k}\n---\n${l}`;
+    }
+  }
+}
+
+function parseList<T = Record<string, unknown>>(json: string): T[] {
+  try {
+    const parsed = JSON.parse(json);
+    return Array.isArray(parsed) ? (parsed as T[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+/// Build a default `MergeListItem[]` for a list field (emails /
+/// phones / addresses): union of keeper + loser, deduped by the
+/// supplied canonical key, with all entries pre-checked. Keeper's
+/// items come first so the picker UI shows them on top.
+export function buildListItems(
+  keeperJson: string,
+  loserJson: string,
+  key: (item: Record<string, unknown>) => string,
+): MergeListItem[] {
+  const items: MergeListItem[] = [];
+  const seen = new Set<string>();
+  const push = (raw: Record<string, unknown>, source: AtomicSide) => {
+    const k = key(raw).trim().toLowerCase();
+    if (!k || seen.has(k)) return;
+    seen.add(k);
+    items.push({ source, include: true, item: raw });
+  };
+  for (const it of parseList(keeperJson)) push(it, "keeper");
+  for (const it of parseList(loserJson)) push(it, "loser");
+  return items;
+}
+
+/// Turn an opinion-laden `MergeChoices` into the final Contact
+/// record that gets pushed via `update_contact`. Identity fields
+/// (id, book_id, uid, remote_id, etag, vcard_data) always come
+/// from `keeper` so the merged record points at the existing
+/// remote object.
+export function applyMergeChoices(
+  keeper: Contact,
+  loser: Contact,
+  choices: MergeChoices,
+): Contact {
+  return {
+    ...keeper,
+    display_name:
+      side(choices.display_name, keeper.display_name, loser.display_name)
+      ?? keeper.display_name,
+    organization: side(choices.organization, keeper.organization, loser.organization),
+    title: side(choices.title, keeper.title, loser.title),
+    notes: mergeNotes(choices.notes, keeper.notes, loser.notes),
+    emails_json: JSON.stringify(
+      choices.emails.filter((it) => it.include).map((it) => it.item),
+    ),
+    phones_json: JSON.stringify(
+      choices.phones.filter((it) => it.include).map((it) => it.item),
+    ),
+    addresses_json: JSON.stringify(
+      choices.addresses.filter((it) => it.include).map((it) => it.item),
+    ),
+  };
+}
+
+/// Default choices for two contacts: keeper-wins on each atomic
+/// field unless the keeper's value is empty (then default to the
+/// loser); `notes` defaults to `both` only when both sides have
+/// non-empty differing notes, otherwise keeper. List items default
+/// to all included.
+export function defaultChoices(keeper: Contact, loser: Contact): MergeChoices {
+  const pick = (a: string | null | undefined, b: string | null | undefined): AtomicSide =>
+    trimOrNull(a) ? "keeper" : trimOrNull(b) ? "loser" : "keeper";
+
+  const k = trimOrNull(keeper.notes);
+  const l = trimOrNull(loser.notes);
+  const notes: NotesSide = !k ? "loser" : !l || k === l ? "keeper" : "both";
+
+  return {
+    display_name: pick(keeper.display_name, loser.display_name),
+    organization: pick(keeper.organization, loser.organization),
+    title: pick(keeper.title, loser.title),
+    notes,
+    emails: buildListItems(
+      keeper.emails_json,
+      loser.emails_json,
+      (it) => String((it as EmailEntry).email ?? ""),
+    ),
+    phones: buildListItems(
+      keeper.phones_json,
+      loser.phones_json,
+      (it) => String((it as PhoneEntry).number ?? ""),
+    ),
+    addresses: buildListItems(
+      keeper.addresses_json,
+      loser.addresses_json,
+      (it) => JSON.stringify(it),
+    ),
+  };
+}
+
+/// Convenience wrapper: legacy API that auto-resolves to keeper-wins
+/// defaults. Kept so the existing call site can stay compact in the
+/// non-interactive code path; callers that want field-by-field
+/// control should use `defaultChoices` + `applyMergeChoices`.
+export function mergeContacts(keeper: Contact, loser: Contact): Contact {
+  return applyMergeChoices(keeper, loser, defaultChoices(keeper, loser));
+}

--- a/src/lib/contact-merge.ts
+++ b/src/lib/contact-merge.ts
@@ -2,16 +2,20 @@
  * Contact-merge helpers (#129).
  *
  * Pure functions extracted from ContactsView.vue so the merge rules
- * can be unit-tested without mounting the component. The view imports
- * `mergeContacts` and uses its result as the input to
- * `api.updateContact` for the merge primary, then deletes the
- * secondary.
+ * can be unit-tested without mounting the component. The view's
+ * field-by-field picker imports `defaultChoices` (to seed the
+ * dialog) and `applyMergeChoices` (to derive the surviving record
+ * once the user confirms). `mergeContacts` is a legacy wrapper
+ * around `applyMergeChoices(defaultChoices(...))` kept for callers
+ * that just want the keeper-wins-with-dedup behaviour.
  *
- * Merge policy: "primary wins" on atomic fields, with empty-string
- * fallthrough to the secondary so the loser's value still surfaces
- * when the primary has nothing. Lists (emails, phones, addresses)
- * are unioned with case-folded dedup. Notes concatenate when both
- * sides differ.
+ * Merge policy: "keeper wins" on atomic fields, with empty-string
+ * fall-through to the loser so the picked side never produces a
+ * blank field as a side effect of the dialog default. Lists
+ * (emails, phones, addresses) are unioned with case-folded dedup
+ * on the canonical key, with each item flagged include/exclude in
+ * `MergeChoices`. Notes get a 3-way `keeper | loser | both` choice;
+ * "both" concatenates with a `\n---\n` separator.
  */
 
 import type { Contact } from "./types";

--- a/src/views/ContactsView.vue
+++ b/src/views/ContactsView.vue
@@ -7,6 +7,11 @@ import { usePlatformStore } from "@/stores/platform";
 import type { ContactBook, Contact } from "@/lib/types";
 import * as api from "@/lib/tauri";
 import { acctColor } from "@/lib/account-colors";
+import {
+  applyMergeChoices,
+  defaultChoices,
+  type MergeChoices,
+} from "@/lib/contact-merge";
 import Select from "@/components/common/Select.vue";
 import MobileAppBar from "@/components/mobile/MobileAppBar.vue";
 import MobileIconButton from "@/components/mobile/MobileIconButton.vue";
@@ -140,6 +145,22 @@ const formBookId = ref("");
 const editingContactId = ref<string | null>(null);
 const saving = ref(false);
 const error = ref<string | null>(null);
+
+// Multi-select state (#129). The detail panel still shows the
+// most-recently-clicked contact (`selectedContact`), but the contact
+// list also tracks an ordered set of selected ids so the user can
+// pick TWO entries with Ctrl/Cmd-click and merge them. The first id
+// in the array becomes the "keeper" — its identity (id, remote_id,
+// etag) survives the merge.
+const selectedContactIds = ref<string[]>([]);
+
+// Merge dialog state. `mergePair` is the keeper / loser pair the
+// user committed to (snapshotted from selectedContactIds when they
+// clicked the toolbar button), and `mergeChoices` drives every
+// radio / checkbox in the field-picker dialog.
+const mergePair = ref<{ keeper: Contact; loser: Contact } | null>(null);
+const mergeChoices = ref<MergeChoices | null>(null);
+const merging = ref(false);
 
 const syncing = ref(false);
 
@@ -311,8 +332,65 @@ function parsePhones(json: string): { number: string; label: string }[] {
   try { return JSON.parse(json); } catch { return []; }
 }
 
-function selectContact(contact: Contact) {
+function selectContact(contact: Contact, event?: MouseEvent) {
+  // Ctrl/Cmd-click toggles the contact in the multi-select set without
+  // disturbing the others. A plain click resets the selection to just
+  // this contact (matching the long-standing single-select behavior
+  // for users who never use the merge flow).
   selectedContact.value = contact;
+  if (event && (event.ctrlKey || event.metaKey)) {
+    const idx = selectedContactIds.value.indexOf(contact.id);
+    if (idx === -1) {
+      selectedContactIds.value = [...selectedContactIds.value, contact.id];
+    } else {
+      selectedContactIds.value = selectedContactIds.value.filter(
+        (id) => id !== contact.id,
+      );
+    }
+  } else {
+    selectedContactIds.value = [contact.id];
+  }
+}
+
+/// Whether the multi-select toolbar's "Merge" action is enabled.
+/// Only fires when exactly two contacts are selected AND both belong
+/// to the same address book — cross-book merges aren't supported
+/// because the loser's deletion would have to land on a different
+/// remote and the surviving vCard would have to be rewritten across
+/// two backends.
+const canMergeSelected = computed(() => {
+  if (selectedContactIds.value.length !== 2) return false;
+  const [a, b] = selectedContactIds.value
+    .map((id) => contacts.value.find((c) => c.id === id))
+    .filter((c): c is Contact => !!c);
+  if (!a || !b) return false;
+  return a.book_id === b.book_id;
+});
+
+const selectedContactNames = computed(() =>
+  selectedContactIds.value
+    .map((id) => contacts.value.find((c) => c.id === id)?.display_name ?? "")
+    .filter((s) => s.length > 0),
+);
+
+function clearSelection() {
+  selectedContactIds.value = selectedContact.value
+    ? [selectedContact.value.id]
+    : [];
+}
+
+/// Open the field-picker dialog for the two currently-selected
+/// contacts. The first selected becomes the keeper; the second is
+/// the loser. Snapshot the pair so subsequent selection changes
+/// don't yank the dialog out from under the user.
+function startMerge() {
+  if (!canMergeSelected.value) return;
+  const [keeperId, loserId] = selectedContactIds.value;
+  const keeper = contacts.value.find((c) => c.id === keeperId);
+  const loser = contacts.value.find((c) => c.id === loserId);
+  if (!keeper || !loser) return;
+  mergePair.value = { keeper, loser };
+  mergeChoices.value = defaultChoices(keeper, loser);
 }
 
 function splitDisplayName(name: string): { first: string; middle: string; last: string } {
@@ -431,6 +509,78 @@ async function doDelete() {
 
 function getAccountName(accountId: string): string {
   return accountsStore.accounts.find((a) => a.id === accountId)?.display_name ?? "";
+}
+
+// ---------- Merge (#129) ----------------------------------------------------
+
+function cancelMerge() {
+  mergePair.value = null;
+  mergeChoices.value = null;
+}
+
+/// Compute the surviving contact from the user's choices. Lives as a
+/// computed so the dialog reflects checkbox/radio changes
+/// immediately. Returns null while no pair is open.
+const mergePreview = computed(() => {
+  if (!mergePair.value || !mergeChoices.value) return null;
+  return applyMergeChoices(
+    mergePair.value.keeper,
+    mergePair.value.loser,
+    mergeChoices.value,
+  );
+});
+
+/// Whether the keeper / loser disagree on a given atomic field. The
+/// dialog only renders a radio when this is true; otherwise the
+/// resolved value is shown read-only.
+function fieldsDiffer(
+  a: string | null | undefined,
+  b: string | null | undefined,
+): boolean {
+  const at = (a ?? "").trim();
+  const bt = (b ?? "").trim();
+  return at.length > 0 && bt.length > 0 && at !== bt;
+}
+
+function emailItemKey(it: { item: Record<string, unknown> }): string {
+  return String((it.item as { email?: string }).email ?? "");
+}
+function phoneItemKey(it: { item: Record<string, unknown> }): string {
+  return String((it.item as { number?: string }).number ?? "");
+}
+function addressItemDisplay(it: { item: Record<string, unknown> }): string {
+  return JSON.stringify(it.item);
+}
+
+/// Apply the merge: push the surviving contact, then delete the
+/// loser. Order matters — if delete fired first and update failed
+/// we'd lose data with no merged target on the server.
+async function applyMerge() {
+  if (!mergePair.value || !mergePreview.value) return;
+  merging.value = true;
+  error.value = null;
+  try {
+    const surviving = mergePreview.value;
+    const loserId = mergePair.value.loser.id;
+    await api.updateContact(surviving);
+    await api.deleteContact(loserId);
+    if (
+      selectedContact.value?.id === loserId
+      || selectedContact.value?.id === surviving.id
+    ) {
+      selectedContact.value = surviving;
+    }
+    selectedContactIds.value = [surviving.id];
+    if (selectedBookId.value) {
+      contacts.value = await api.listContacts(selectedBookId.value);
+    }
+    mergePair.value = null;
+    mergeChoices.value = null;
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : String(e);
+  } finally {
+    merging.value = false;
+  }
 }
 </script>
 
@@ -651,14 +801,44 @@ function getAccountName(accountId: string): string {
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8" /><line x1="21" y1="21" x2="16.65" y2="16.65" /></svg>
           <input v-model="searchQuery" type="text" placeholder="Search contacts..." data-testid="contacts-search" />
         </div>
+        <!-- Multi-select merge toolbar (#129). Visible whenever 2+
+             contacts are picked via Ctrl/Cmd-click; the Merge button
+             only enables when exactly two are selected within the
+             same book. -->
+        <div
+          v-if="selectedContactIds.length >= 2"
+          class="merge-toolbar"
+          data-testid="merge-toolbar"
+        >
+          <span class="merge-toolbar-text">
+            {{ selectedContactIds.length }} selected{{
+              selectedContactNames.length >= 2
+                ? `: ${selectedContactNames[0]} + ${selectedContactNames[1]}`
+                : ""
+            }}
+          </span>
+          <button
+            class="merge-toolbar-btn"
+            data-testid="merge-toolbar-btn"
+            :disabled="!canMergeSelected"
+            :title="canMergeSelected
+              ? 'Merge the two selected contacts'
+              : 'Pick two contacts in the same address book to merge'"
+            @click="startMerge"
+          >Merge</button>
+          <button class="merge-toolbar-cancel" @click="clearSelection">Clear</button>
+        </div>
         <div class="contact-list">
           <div
             v-for="contact in filteredContacts"
             :key="contact.id"
             class="contact-row"
-            :class="{ active: selectedContact?.id === contact.id }"
+            :class="{
+              active: selectedContact?.id === contact.id,
+              picked: selectedContactIds.includes(contact.id),
+            }"
             :data-testid="`contact-${contact.id}`"
-            @click="selectContact(contact)"
+            @click="selectContact(contact, $event)"
           >
             <div
               class="contact-avatar"
@@ -812,6 +992,177 @@ function getAccountName(accountId: string): string {
           <div class="modal-footer">
             <button class="btn-cancel" @click="showDeleteConfirm = false">Cancel</button>
             <button class="btn-delete" @click="doDelete">Delete</button>
+          </div>
+        </div>
+      </div>
+    </Teleport>
+
+    <!-- Merge: field-by-field picker dialog (#129) -->
+    <Teleport to="body">
+      <div
+        v-if="mergePair && mergeChoices"
+        class="modal-overlay"
+        data-testid="merge-dialog"
+        @click.self="cancelMerge"
+      >
+        <div class="modal modal-lg">
+          <div class="modal-header">
+            <h3>Merge contacts</h3>
+            <button class="modal-close" @click="cancelMerge">&times;</button>
+          </div>
+          <div class="modal-body merge-dialog-body">
+            <p class="merge-picker-hint">
+              Keeping <strong>{{ mergePair.keeper.display_name }}</strong>'s identity. <strong>{{ mergePair.loser.display_name }}</strong> will be deleted after the merge. Pick which value to keep for any field where the two disagree.
+            </p>
+            <div v-if="error" class="form-error" data-testid="merge-error">{{ error }}</div>
+
+            <!-- Atomic field rows. We only render a chooser when both
+                 sides have non-empty differing values; if one side
+                 is empty the merged value is forced to the non-empty
+                 side and the row stays read-only. -->
+            <fieldset class="merge-field" data-testid="merge-field-name">
+              <legend>Name</legend>
+              <template v-if="fieldsDiffer(mergePair.keeper.display_name, mergePair.loser.display_name)">
+                <label class="merge-radio">
+                  <input
+                    type="radio"
+                    value="keeper"
+                    v-model="mergeChoices.display_name"
+                    data-testid="merge-name-keeper"
+                  />
+                  <span>{{ mergePair.keeper.display_name }}</span>
+                </label>
+                <label class="merge-radio">
+                  <input
+                    type="radio"
+                    value="loser"
+                    v-model="mergeChoices.display_name"
+                    data-testid="merge-name-loser"
+                  />
+                  <span>{{ mergePair.loser.display_name }}</span>
+                </label>
+              </template>
+              <span v-else class="merge-resolved">{{ mergePreview?.display_name || "—" }}</span>
+            </fieldset>
+
+            <fieldset class="merge-field" data-testid="merge-field-org">
+              <legend>Organization</legend>
+              <template v-if="fieldsDiffer(mergePair.keeper.organization, mergePair.loser.organization)">
+                <label class="merge-radio">
+                  <input type="radio" value="keeper" v-model="mergeChoices.organization" />
+                  <span>{{ mergePair.keeper.organization }}</span>
+                </label>
+                <label class="merge-radio">
+                  <input type="radio" value="loser" v-model="mergeChoices.organization" />
+                  <span>{{ mergePair.loser.organization }}</span>
+                </label>
+              </template>
+              <span v-else class="merge-resolved">{{ mergePreview?.organization || "—" }}</span>
+            </fieldset>
+
+            <fieldset class="merge-field" data-testid="merge-field-title">
+              <legend>Title</legend>
+              <template v-if="fieldsDiffer(mergePair.keeper.title, mergePair.loser.title)">
+                <label class="merge-radio">
+                  <input type="radio" value="keeper" v-model="mergeChoices.title" />
+                  <span>{{ mergePair.keeper.title }}</span>
+                </label>
+                <label class="merge-radio">
+                  <input type="radio" value="loser" v-model="mergeChoices.title" />
+                  <span>{{ mergePair.loser.title }}</span>
+                </label>
+              </template>
+              <span v-else class="merge-resolved">{{ mergePreview?.title || "—" }}</span>
+            </fieldset>
+
+            <fieldset class="merge-field" data-testid="merge-field-notes">
+              <legend>Notes</legend>
+              <template v-if="fieldsDiffer(mergePair.keeper.notes, mergePair.loser.notes)">
+                <label class="merge-radio">
+                  <input type="radio" value="keeper" v-model="mergeChoices.notes" />
+                  <span class="merge-notes-snippet">{{ mergePair.keeper.notes }}</span>
+                </label>
+                <label class="merge-radio">
+                  <input type="radio" value="loser" v-model="mergeChoices.notes" />
+                  <span class="merge-notes-snippet">{{ mergePair.loser.notes }}</span>
+                </label>
+                <label class="merge-radio">
+                  <input type="radio" value="both" v-model="mergeChoices.notes" />
+                  <span>Combine both</span>
+                </label>
+              </template>
+              <span v-else class="merge-resolved merge-notes-snippet">{{ mergePreview?.notes || "—" }}</span>
+            </fieldset>
+
+            <!-- List rows. Each item is a checkbox; default is "keep all".
+                 Source label shows which contact contributed it. -->
+            <fieldset
+              v-if="mergeChoices.emails.length"
+              class="merge-field"
+              data-testid="merge-field-emails"
+            >
+              <legend>Emails</legend>
+              <label
+                v-for="(it, idx) in mergeChoices.emails"
+                :key="emailItemKey(it) + '-' + idx"
+                class="merge-checkbox"
+              >
+                <input type="checkbox" v-model="it.include" />
+                <span class="merge-source-tag" :class="`source-${it.source}`">
+                  {{ it.source === "keeper" ? mergePair.keeper.display_name : mergePair.loser.display_name }}
+                </span>
+                <span>{{ String(it.item.label || "") }}: {{ String(it.item.email || "") }}</span>
+              </label>
+            </fieldset>
+
+            <fieldset
+              v-if="mergeChoices.phones.length"
+              class="merge-field"
+              data-testid="merge-field-phones"
+            >
+              <legend>Phones</legend>
+              <label
+                v-for="(it, idx) in mergeChoices.phones"
+                :key="phoneItemKey(it) + '-' + idx"
+                class="merge-checkbox"
+              >
+                <input type="checkbox" v-model="it.include" />
+                <span class="merge-source-tag" :class="`source-${it.source}`">
+                  {{ it.source === "keeper" ? mergePair.keeper.display_name : mergePair.loser.display_name }}
+                </span>
+                <span>{{ String(it.item.label || "") }}: {{ String(it.item.number || "") }}</span>
+              </label>
+            </fieldset>
+
+            <fieldset
+              v-if="mergeChoices.addresses.length"
+              class="merge-field"
+              data-testid="merge-field-addresses"
+            >
+              <legend>Addresses</legend>
+              <label
+                v-for="(it, idx) in mergeChoices.addresses"
+                :key="addressItemDisplay(it) + '-' + idx"
+                class="merge-checkbox"
+              >
+                <input type="checkbox" v-model="it.include" />
+                <span class="merge-source-tag" :class="`source-${it.source}`">
+                  {{ it.source === "keeper" ? mergePair.keeper.display_name : mergePair.loser.display_name }}
+                </span>
+                <span class="merge-address-snippet">{{ addressItemDisplay(it) }}</span>
+              </label>
+            </fieldset>
+          </div>
+          <div class="modal-footer">
+            <button class="btn-cancel" :disabled="merging" @click="cancelMerge">Cancel</button>
+            <button
+              class="btn-save"
+              data-testid="merge-confirm-btn"
+              :disabled="merging"
+              @click="applyMerge"
+            >
+              {{ merging ? "Merging…" : "Merge" }}
+            </button>
           </div>
         </div>
       </div>
@@ -1422,5 +1773,134 @@ function getAccountName(accountId: string): string {
 
 .index-rail a:active {
   color: var(--color-accent);
+}
+
+/* Merge UI (#129) ---------------------------------------------------------*/
+
+/* Multi-select toolbar above the contact list. Flat strip that
+   appears the moment a second contact is picked via Ctrl/Cmd-click. */
+.merge-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  background: var(--color-bg-secondary);
+  border-top: 0.8px solid var(--color-border);
+  border-bottom: 0.8px solid var(--color-border);
+  font-size: 13px;
+}
+.merge-toolbar-text {
+  flex: 1;
+  color: var(--color-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.merge-toolbar-btn {
+  height: 28px;
+  padding: 0 12px;
+  border-radius: 4px;
+  background: var(--color-accent);
+  color: #fff;
+  font-size: 13px;
+  font-weight: 500;
+}
+.merge-toolbar-btn:disabled {
+  background: var(--color-border);
+  color: var(--color-text-muted);
+  cursor: not-allowed;
+}
+.merge-toolbar-cancel {
+  height: 28px;
+  padding: 0 10px;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--color-text-muted);
+  font-size: 13px;
+}
+.merge-toolbar-cancel:hover { color: var(--color-text); }
+
+/* Picked-state highlight for rows in the contact list. Distinct
+   from `.active` (which marks the row currently shown in the
+   detail panel) so multi-select state stays visible. */
+.contact-row.picked {
+  outline: 2px solid var(--color-accent);
+  outline-offset: -2px;
+}
+
+.merge-picker-hint {
+  margin: 0 0 12px 0;
+  font-size: 13px;
+  color: var(--color-text-muted);
+  line-height: 1.4;
+}
+
+/* Field-picker dialog */
+.modal-lg { width: 640px; max-width: 96vw; }
+.merge-dialog-body {
+  max-height: 70vh;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.merge-field {
+  border: 0.8px solid var(--color-border);
+  border-radius: 6px;
+  padding: 8px 12px 10px 12px;
+  margin: 0;
+}
+.merge-field legend {
+  padding: 0 6px;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--color-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.merge-radio,
+.merge-checkbox {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 4px 0;
+  font-size: 13px;
+  color: var(--color-text);
+  cursor: pointer;
+}
+.merge-radio input,
+.merge-checkbox input {
+  margin-top: 2px;
+}
+.merge-resolved {
+  display: block;
+  font-size: 13px;
+  color: var(--color-text);
+  padding: 4px 0;
+  word-break: break-word;
+}
+.merge-notes-snippet {
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.merge-source-tag {
+  font-size: 11px;
+  font-weight: 500;
+  padding: 1px 6px;
+  border-radius: 3px;
+  flex-shrink: 0;
+}
+.merge-source-tag.source-keeper {
+  background: rgba(21, 93, 252, 0.12);
+  color: var(--color-accent);
+}
+.merge-source-tag.source-loser {
+  background: rgba(140, 140, 140, 0.18);
+  color: var(--color-text-muted);
+}
+.merge-address-snippet {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+  word-break: break-all;
 }
 </style>

--- a/src/views/ContactsView.vue
+++ b/src/views/ContactsView.vue
@@ -161,6 +161,9 @@ const selectedContactIds = ref<string[]>([]);
 const mergePair = ref<{ keeper: Contact; loser: Contact } | null>(null);
 const mergeChoices = ref<MergeChoices | null>(null);
 const merging = ref(false);
+// Dedicated error state so a stale `error` from the create/edit form
+// can't bleed into a freshly-opened merge dialog and vice versa.
+const mergeError = ref<string | null>(null);
 
 const syncing = ref(false);
 
@@ -310,6 +313,23 @@ watch(selectedBookId, async (bookId) => {
   if (bookId) {
     contacts.value = await api.listContacts(bookId);
     selectedContact.value = null;
+    // Multi-select state belongs to the previously-shown book; drop
+    // it on book switch so the merge toolbar can't sit visible with
+    // ids that aren't in the current list.
+    selectedContactIds.value = [];
+  }
+});
+
+// Prune `selectedContactIds` against the current contact list whenever
+// it changes (e.g. after a sync or a CRUD op deletes one of the picked
+// contacts). Without this the toolbar can stay visible referencing
+// gone-from-the-DOM rows, with `canMergeSelected` permanently false.
+watch(contacts, (next) => {
+  if (selectedContactIds.value.length === 0) return;
+  const visible = new Set(next.map((c) => c.id));
+  const pruned = selectedContactIds.value.filter((id) => visible.has(id));
+  if (pruned.length !== selectedContactIds.value.length) {
+    selectedContactIds.value = pruned;
   }
 });
 
@@ -389,6 +409,7 @@ function startMerge() {
   const keeper = contacts.value.find((c) => c.id === keeperId);
   const loser = contacts.value.find((c) => c.id === loserId);
   if (!keeper || !loser) return;
+  mergeError.value = null;
   mergePair.value = { keeper, loser };
   mergeChoices.value = defaultChoices(keeper, loser);
 }
@@ -516,6 +537,7 @@ function getAccountName(accountId: string): string {
 function cancelMerge() {
   mergePair.value = null;
   mergeChoices.value = null;
+  mergeError.value = null;
 }
 
 /// Compute the surviving contact from the user's choices. Lives as a
@@ -558,29 +580,46 @@ function addressItemDisplay(it: { item: Record<string, unknown> }): string {
 async function applyMerge() {
   if (!mergePair.value || !mergePreview.value) return;
   merging.value = true;
-  error.value = null;
+  mergeError.value = null;
+  const surviving = mergePreview.value;
+  const loserId = mergePair.value.loser.id;
   try {
-    const surviving = mergePreview.value;
-    const loserId = mergePair.value.loser.id;
     await api.updateContact(surviving);
     await api.deleteContact(loserId);
-    if (
-      selectedContact.value?.id === loserId
-      || selectedContact.value?.id === surviving.id
-    ) {
-      selectedContact.value = surviving;
-    }
-    selectedContactIds.value = [surviving.id];
-    if (selectedBookId.value) {
-      contacts.value = await api.listContacts(selectedBookId.value);
-    }
-    mergePair.value = null;
-    mergeChoices.value = null;
   } catch (e) {
-    error.value = e instanceof Error ? e.message : String(e);
-  } finally {
+    // Update or delete failed — keep the dialog open so the user
+    // can retry or cancel without losing the field choices.
+    mergeError.value = e instanceof Error ? e.message : String(e);
     merging.value = false;
+    return;
   }
+
+  // Network ops succeeded. Close the dialog *now* so a stuck refresh
+  // (or a refresh failure) can't leave the dialog open and tempt the
+  // user into clicking Merge a second time — which would attempt to
+  // delete the already-deleted loser.
+  mergePair.value = null;
+  mergeChoices.value = null;
+  if (
+    selectedContact.value?.id === loserId
+    || selectedContact.value?.id === surviving.id
+  ) {
+    selectedContact.value = surviving;
+  }
+  selectedContactIds.value = [surviving.id];
+
+  // Best-effort refresh of the visible list. If listContacts throws,
+  // log it but don't surface a user-facing error: the merge already
+  // committed on the server and the list will catch up on the next
+  // sync or book switch.
+  if (selectedBookId.value) {
+    try {
+      contacts.value = await api.listContacts(selectedBookId.value);
+    } catch (e) {
+      console.error("Post-merge refresh failed:", e);
+    }
+  }
+  merging.value = false;
 }
 </script>
 
@@ -1014,7 +1053,7 @@ async function applyMerge() {
             <p class="merge-picker-hint">
               Keeping <strong>{{ mergePair.keeper.display_name }}</strong>'s identity. <strong>{{ mergePair.loser.display_name }}</strong> will be deleted after the merge. Pick which value to keep for any field where the two disagree.
             </p>
-            <div v-if="error" class="form-error" data-testid="merge-error">{{ error }}</div>
+            <div v-if="mergeError" class="form-error" data-testid="merge-error">{{ mergeError }}</div>
 
             <!-- Atomic field rows. We only render a chooser when both
                  sides have non-empty differing values; if one side


### PR DESCRIPTION
First slice of #129 (proper contact list management). Lets the user collapse two duplicate contacts in the same address book through a field-by-field picker. The remaining items in the issue — unified search across all books, favorites — will follow as separate PRs.

## UX
- **Multi-select** in the contact list. Plain click selects one (existing behavior); Ctrl / Cmd + click toggles a contact in / out of the multi-select set. The detail panel keeps showing the most recently clicked entry.
- A **selection toolbar** appears above the list at 2+ picked contacts, with a Merge button (enabled only when exactly two are picked in the same book) and a Clear action.
- **Field-by-field picker dialog** replaces the old auto-confirm preview:
  - Atomic fields (name, organization, title) get a radio when keeper and loser disagree on a non-empty value; otherwise the resolved value renders read-only.
  - Notes get a 3-way radio: keeper alone / loser alone / combine with separator.
  - Email / phone / address lists render as checkbox lists with a coloured source tag so the user can see which contact contributed each entry. All items default to checked.
- First-selected becomes the **keeper** — its \`id\` / \`uid\` / \`remote_id\` / \`etag\` survive, so the backend's \`update_contact\` pushes a single coherent vCard to the existing remote object. To merge in the other direction, re-select in the opposite order.

## Merge policy (in \`src/lib/contact-merge.ts\`)
| Field | Rule |
|---|---|
| \`id\`, \`book_id\`, \`uid\`, \`remote_id\`, \`etag\` | always keeper |
| \`display_name\`, \`organization\`, \`title\` | user picks via radio when both sides differ; if the picked side is empty, fall through to the other so the user never ends up with a blank field as a side effect of the dialog default |
| \`notes\` | 3-way radio: keeper / loser / \`${keeper}\\n---\\n${loser}\` for the "both" choice |
| \`emails_json\`, \`phones_json\`, \`addresses_json\` | union of keeper + loser, deduped case-insensitively on the canonical key (email / phone / serialised address), keeper's items first; user can uncheck individual entries |

## Apply path
\`api.updateContact(merged_keeper)\` followed by \`api.deleteContact(loser)\`. Order matters — if delete fired first and update failed we'd lose data with no merged target on the server. The existing CRUD commands cover every sync type (CardDAV, JMAP, Google, Graph, local), so no new backend surface is needed.

## Out of scope
- **Cross-book merge** — the loser's deletion would have to land on a different remote and the surviving vCard would have to be rewritten across two backends.
- **Mobile multi-select** — desktop only for now (the mobile flat list doesn't have selection state plumbed through).
- **Unified search and favorites** — separate PRs against #129.

## Test plan
- [x] \`pnpm exec vue-tsc --noEmit\` clean
- [x] \`pnpm vitest run\` (310 tests, +17 new for merge primitives covering identity preservation, fall-through, 3-way notes, dedup, list exclusion, malformed JSON, address dedup)
- [x] Manual: Ctrl-click two duplicates, click Merge, pick keeper's name and loser's organization, uncheck a duplicate phone, confirm — both contacts collapse on the server and locally; the surviving record reflects the picked field choices.