### PR TITLE
fix(calendar): user-pickable color, persisted across syncs (#132)

### DIFF
--- a/src-tauri/src/commands/calendar.rs
+++ b/src-tauri/src/commands/calendar.rs
@@ -95,6 +95,7 @@ pub async fn update_calendar(
     };
 
     let name_changed = existing.name != name;
+    let color_changed = existing.color != color;
     let remote_id = existing.remote_id.clone().filter(|r| !r.is_empty());
     if name_changed {
         if let Some(ref rid) = remote_id {
@@ -105,9 +106,74 @@ pub async fn update_calendar(
             );
         }
     }
+    if color_changed {
+        if let Some(ref rid) = remote_id {
+            // Best-effort: protocols that can't push a color (Graph,
+            // Google) log a debug line and we keep the local change
+            // anyway so the user's pick takes effect in our UI.
+            push_calendar_color(&account, rid, &color).await?;
+        } else {
+            log::info!(
+                "update_calendar: skipping remote color push (no remote_id, local-only calendar)"
+            );
+        }
+    }
 
     let conn = state.db.writer().await;
     db::calendar::update_calendar(&conn, &calendar_id, &name, &color)?;
+    Ok(())
+}
+
+/// Push a calendar color change to the account's remote server.
+/// Mirrors `push_calendar_rename` per-protocol dispatch.
+///
+/// CalDAV (incl. Radicale, Nextcloud, Sabre/dav, Apple Calendar
+/// Server) and JMAP both have a standard color property and surface
+/// any push failure as an error. Microsoft Graph and Google Calendar
+/// expose only a constrained color enum / numeric id; we'd need a
+/// hex-to-named lookup to translate, so for now we log a debug line
+/// and let the local DB keep the user's hex unchanged. Local-only
+/// calendars (no `remote_id`) never reach this function — caller
+/// short-circuits.
+async fn push_calendar_color(
+    account: &db::accounts::AccountFull,
+    remote_id: &str,
+    new_color: &str,
+) -> Result<()> {
+    let cal_proto = account.calendar_protocol_str();
+    if cal_proto == "jmap" {
+        let jmap_config = crate::commands::sync_cmd::build_jmap_config(account).await?;
+        let conn_jmap = crate::mail::jmap::JmapConnection::connect(&jmap_config).await?;
+        conn_jmap
+            .set_calendar_color(&jmap_config, remote_id, new_color)
+            .await?;
+        return Ok(());
+    }
+
+    if cal_proto == "caldav"
+        || (!account.caldav_url.is_empty() && cal_proto != "google" && cal_proto != "graph")
+    {
+        use crate::mail::caldav::{CalDavClient, CalDavConfig};
+        let caldav_config = CalDavConfig {
+            caldav_url: account.caldav_url.clone(),
+            username: account.username.clone(),
+            password: account.password.clone(),
+            email: account.email.clone(),
+        };
+        let client = CalDavClient::connect(&caldav_config).await?;
+        client.set_calendar_color(remote_id, new_color).await?;
+        return Ok(());
+    }
+
+    // Graph / Google use named color enums (and a numeric id, in
+    // Google's case); writing arbitrary hex isn't supported on the
+    // public APIs without a mapping table. Log and keep the change
+    // local-only — the user still gets the new color in the sidebar.
+    log::info!(
+        "update_calendar: protocol '{}' has no hex-color push, keeping color local-only for {}",
+        cal_proto,
+        account.id
+    );
     Ok(())
 }
 

--- a/src-tauri/src/commands/calendar.rs
+++ b/src-tauri/src/commands/calendar.rs
@@ -108,9 +108,14 @@ pub async fn update_calendar(
     }
     if color_changed {
         if let Some(ref rid) = remote_id {
-            // Best-effort: protocols that can't push a color (Graph,
-            // Google) log a debug line and we keep the local change
-            // anyway so the user's pick takes effect in our UI.
+            // CalDAV / JMAP propagate failures: a server reject rolls
+            // back the local DB write below and surfaces an error.
+            // Graph / Google swallow failures internally and log —
+            // system calendars and read-only subscriptions return a
+            // generic 500/403 rather than a structured error, and
+            // refusing to apply *any* local color change for those
+            // accounts would be worse than letting the local pick
+            // stick.
             push_calendar_color(&account, rid, &color).await?;
         } else {
             log::info!(
@@ -125,16 +130,22 @@ pub async fn update_calendar(
 }
 
 /// Push a calendar color change to the account's remote server.
-/// Mirrors `push_calendar_rename` per-protocol dispatch.
+/// Mirrors `push_calendar_rename`'s per-protocol dispatch.
 ///
-/// CalDAV (incl. Radicale, Nextcloud, Sabre/dav, Apple Calendar
-/// Server) and JMAP both have a standard color property and surface
-/// any push failure as an error. Microsoft Graph and Google Calendar
-/// expose only a constrained color enum / numeric id; we'd need a
-/// hex-to-named lookup to translate, so for now we log a debug line
-/// and let the local DB keep the user's hex unchanged. Local-only
-/// calendars (no `remote_id`) never reach this function — caller
-/// short-circuits.
+/// - **CalDAV** (Radicale, Nextcloud, Sabre/dav, Apple Calendar
+///   Server) and **JMAP** (Stalwart, Cyrus) both expose a writable
+///   color property and propagate failures — the caller's local DB
+///   write rolls back on error.
+/// - **Microsoft Graph** writes a named-enum approximation (see
+///   `nearest_outlook_color`) but Graph is allergic to PATCH on
+///   system / shared calendars and surfaces a generic 500 there.
+///   Failures are logged and the function returns Ok so the local
+///   DB write can still apply.
+/// - **Google Calendar** writes arbitrary RGB on the calendarList
+///   resource via `colorRgbFormat=true`. Same best-effort behavior
+///   as Graph.
+/// - Local-only calendars (no `remote_id`) never reach this
+///   function — caller short-circuits.
 async fn push_calendar_color(
     account: &db::accounts::AccountFull,
     remote_id: &str,
@@ -3056,9 +3067,15 @@ async fn sync_calendars_graph(state: &State<'_, AppState>, account_id: &str) -> 
 
             let (local_id, subscribed) = match existing {
                 Some((local_id, subscribed)) => {
+                    // Preserve the locally stored color: it may have been set
+                    // via the sidebar's color picker, and Graph sometimes
+                    // refuses the PATCH (shared / system calendars return 500
+                    // ISE), so the *only* place that pick exists is locally.
+                    // Stomping it with `gc.color` here resets shared calendars
+                    // back to their Graph default on every resync (#132).
                     conn.execute(
-                        "UPDATE calendars SET name = ?1, color = ?2 WHERE id = ?3",
-                        rusqlite::params![gc.name, gc.color, local_id],
+                        "UPDATE calendars SET name = ?1 WHERE id = ?2",
+                        rusqlite::params![gc.name, local_id],
                     )
                     .ok();
                     (local_id, subscribed)

--- a/src-tauri/src/commands/calendar.rs
+++ b/src-tauri/src/commands/calendar.rs
@@ -150,9 +150,55 @@ async fn push_calendar_color(
         return Ok(());
     }
 
-    if cal_proto == "caldav"
-        || (!account.caldav_url.is_empty() && cal_proto != "google" && cal_proto != "graph")
-    {
+    if cal_proto == "graph" {
+        // Microsoft Graph wants a constrained `calendarColor` enum.
+        // The hex-to-nearest-named lookup lives in graph.rs so we can
+        // round-trip our own palette consistently. Local DB still
+        // keeps the user's exact hex so the sidebar shows what they
+        // picked even when Graph's enum landed on something a shade
+        // off.
+        let token = crate::mail::graph::get_graph_token(&account.id).await?;
+        let client = crate::mail::graph::GraphClient::new(&token);
+        client.set_calendar_color(remote_id, new_color).await?;
+        return Ok(());
+    }
+
+    if cal_proto == "google" {
+        // Google Calendar accepts arbitrary RGB on calendarList.update
+        // when `colorRgbFormat=true` is set. Use the per-user
+        // calendarList resource (rather than `/calendars/{id}`) — it's
+        // where the user-visible color lives.
+        let token = get_google_token(&account.id).await?;
+        let url = format!(
+            "https://www.googleapis.com/calendar/v3/users/me/calendarList/{}?colorRgbFormat=true",
+            urlencoding::encode(remote_id)
+        );
+        let http = reqwest::Client::new();
+        let resp = http
+            .patch(&url)
+            .bearer_auth(&token)
+            .json(&serde_json::json!({ "backgroundColor": new_color }))
+            .send()
+            .await
+            .map_err(|e| {
+                crate::error::Error::Other(format!(
+                    "Google calendarList PATCH (color) failed: {}",
+                    e
+                ))
+            })?;
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(crate::error::Error::Other(format!(
+                "Google calendarList PATCH (color) returned {}: {}",
+                status,
+                body.chars().take(500).collect::<String>()
+            )));
+        }
+        return Ok(());
+    }
+
+    if cal_proto == "caldav" || !account.caldav_url.is_empty() {
         use crate::mail::caldav::{CalDavClient, CalDavConfig};
         let caldav_config = CalDavConfig {
             caldav_url: account.caldav_url.clone(),
@@ -165,12 +211,8 @@ async fn push_calendar_color(
         return Ok(());
     }
 
-    // Graph / Google use named color enums (and a numeric id, in
-    // Google's case); writing arbitrary hex isn't supported on the
-    // public APIs without a mapping table. Log and keep the change
-    // local-only — the user still gets the new color in the sidebar.
     log::info!(
-        "update_calendar: protocol '{}' has no hex-color push, keeping color local-only for {}",
+        "update_calendar: no remote color-push path for protocol '{}', keeping color local-only for {}",
         cal_proto,
         account.id
     );

--- a/src-tauri/src/commands/calendar.rs
+++ b/src-tauri/src/commands/calendar.rs
@@ -153,47 +153,73 @@ async fn push_calendar_color(
     if cal_proto == "graph" {
         // Microsoft Graph wants a constrained `calendarColor` enum.
         // The hex-to-nearest-named lookup lives in graph.rs so we can
-        // round-trip our own palette consistently. Local DB still
-        // keeps the user's exact hex so the sidebar shows what they
-        // picked even when Graph's enum landed on something a shade
-        // off.
+        // round-trip our own palette consistently. Some calendars
+        // (system / shared / read-only series like "Birthdays" and
+        // holiday subscriptions) reject color writes with a generic
+        // 500 ISE rather than a structured error, so we degrade to
+        // local-only on any Graph-side failure rather than rolling
+        // back the user's pick. Local DB keeps the user's exact hex
+        // so the sidebar shows what they picked.
         let token = crate::mail::graph::get_graph_token(&account.id).await?;
         let client = crate::mail::graph::GraphClient::new(&token);
-        client.set_calendar_color(remote_id, new_color).await?;
+        if let Err(e) = client.set_calendar_color(remote_id, new_color).await {
+            log::warn!(
+                "update_calendar: Graph color push failed (calendar may be read-only or shared), keeping local-only: {}",
+                e
+            );
+        }
         return Ok(());
     }
 
     if cal_proto == "google" {
-        // Google Calendar accepts arbitrary RGB on calendarList.update
-        // when `colorRgbFormat=true` is set. Use the per-user
-        // calendarList resource (rather than `/calendars/{id}`) — it's
-        // where the user-visible color lives.
-        let token = get_google_token(&account.id).await?;
-        let url = format!(
-            "https://www.googleapis.com/calendar/v3/users/me/calendarList/{}?colorRgbFormat=true",
-            urlencoding::encode(remote_id)
-        );
-        let http = reqwest::Client::new();
-        let resp = http
-            .patch(&url)
-            .bearer_auth(&token)
-            .json(&serde_json::json!({ "backgroundColor": new_color }))
-            .send()
-            .await
-            .map_err(|e| {
-                crate::error::Error::Other(format!(
-                    "Google calendarList PATCH (color) failed: {}",
-                    e
-                ))
-            })?;
-        if !resp.status().is_success() {
-            let status = resp.status();
-            let body = resp.text().await.unwrap_or_default();
-            return Err(crate::error::Error::Other(format!(
-                "Google calendarList PATCH (color) returned {}: {}",
-                status,
-                body.chars().take(500).collect::<String>()
-            )));
+        // Google Calendar accepts arbitrary RGB on calendarList.patch
+        // when `colorRgbFormat=true` is set. The user-visible color
+        // lives on the per-user calendarList resource, not the
+        // underlying calendar (which only takes summary/description/
+        // location/timeZone). Send both backgroundColor AND
+        // foregroundColor — the docs say foregroundColor is optional
+        // but in practice omitting it resets the foreground to the
+        // default for the new background, which can produce
+        // unreadable text. Pick black or white based on the
+        // background's luminance.
+        match get_google_token(&account.id).await {
+            Ok(token) => {
+                let fg = readable_foreground(new_color);
+                let url = format!(
+                    "https://www.googleapis.com/calendar/v3/users/me/calendarList/{}?colorRgbFormat=true",
+                    urlencoding::encode(remote_id)
+                );
+                let http = reqwest::Client::new();
+                let outcome = http
+                    .patch(&url)
+                    .bearer_auth(&token)
+                    .json(&serde_json::json!({
+                        "backgroundColor": new_color,
+                        "foregroundColor": fg,
+                    }))
+                    .send()
+                    .await;
+                match outcome {
+                    Ok(resp) if resp.status().is_success() => {}
+                    Ok(resp) => {
+                        let status = resp.status();
+                        let body = resp.text().await.unwrap_or_default();
+                        log::warn!(
+                            "update_calendar: Google color push got {} (keeping local-only): {}",
+                            status,
+                            body.chars().take(500).collect::<String>()
+                        );
+                    }
+                    Err(e) => log::warn!(
+                        "update_calendar: Google color push request failed (keeping local-only): {}",
+                        e
+                    ),
+                }
+            }
+            Err(e) => log::warn!(
+                "update_calendar: Google color push skipped — no OAuth token: {}",
+                e
+            ),
         }
         return Ok(());
     }
@@ -2192,6 +2218,33 @@ pub async fn respond_to_invite(
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+/// Pick a readable foreground color for the given background hex.
+/// Used when pushing a color to Google Calendar — the API takes a
+/// foreground/background pair and omitting the foreground leaves it
+/// at a default that can be unreadable on a dark background. The
+/// rule is the standard W3C luminance threshold: backgrounds with
+/// relative luminance > 0.5 get black text, darker ones get white.
+fn readable_foreground(bg_hex: &str) -> &'static str {
+    fn channel(hex: &str, lo: usize, hi: usize) -> Option<f64> {
+        let v = u8::from_str_radix(hex.get(lo..hi)?, 16).ok()? as f64;
+        Some(v / 255.0)
+    }
+    let h = bg_hex.trim().trim_start_matches('#');
+    if h.len() != 6 {
+        return "#000000";
+    }
+    // Quick sRGB luminance — fine for picking black vs. white text.
+    let r = channel(h, 0, 2).unwrap_or(0.0);
+    let g = channel(h, 2, 4).unwrap_or(0.0);
+    let b = channel(h, 4, 6).unwrap_or(0.0);
+    let lum = 0.299 * r + 0.587 * g + 0.114 * b;
+    if lum > 0.5 {
+        "#000000"
+    } else {
+        "#ffffff"
+    }
+}
 
 /// Pick a random color from a curated palette for new calendars.
 pub fn random_calendar_color() -> String {

--- a/src-tauri/src/db/calendar.rs
+++ b/src-tauri/src/db/calendar.rs
@@ -170,8 +170,15 @@ pub fn delete_calendar(conn: &Connection, id: &str) -> Result<()> {
     Ok(())
 }
 
-/// Upsert a calendar by remote_id. If a calendar with the same (account_id, remote_id)
-/// already exists, update its name and color. Otherwise insert a new row.
+/// Upsert a calendar by remote_id. If a calendar with the same
+/// (account_id, remote_id) already exists, update its name and
+/// is_default flag — but **preserve the user-customized color**.
+/// CalDAV / JMAP / Google rarely expose a stable "calendar color"
+/// property, so on every resync the caller would otherwise hand us
+/// a fallback colour like `#4285f4` and stomp the user's pick from
+/// the sidebar's color picker (#132). On INSERT the supplied color
+/// is what gets stored.
+///
 /// Returns the local calendar ID.
 pub fn upsert_calendar_by_remote_id(
     conn: &Connection,
@@ -181,7 +188,6 @@ pub fn upsert_calendar_by_remote_id(
     color: &str,
     is_default: bool,
 ) -> Result<String> {
-    // Check if we already have this calendar
     let existing: Option<String> = conn
         .query_row(
             "SELECT id FROM calendars WHERE account_id = ?1 AND remote_id = ?2",
@@ -192,8 +198,8 @@ pub fn upsert_calendar_by_remote_id(
 
     if let Some(id) = existing {
         conn.execute(
-            "UPDATE calendars SET name = ?1, color = ?2, is_default = ?3 WHERE id = ?4",
-            params![name, color, is_default, id],
+            "UPDATE calendars SET name = ?1, is_default = ?2 WHERE id = ?3",
+            params![name, is_default, id],
         )?;
         Ok(id)
     } else {
@@ -754,16 +760,19 @@ mod tests {
     fn test_upsert_calendar_by_remote_id() {
         let conn = setup_db();
 
-        // First upsert creates a new calendar
+        // First upsert creates a new calendar with the supplied color.
         let id1 =
             upsert_calendar_by_remote_id(&conn, "acc1", "remote-cal", "Work", "#4285f4", true)
                 .unwrap();
 
         let cal = get_calendar(&conn, &id1).unwrap();
         assert_eq!(cal.name, "Work");
+        assert_eq!(cal.color, "#4285f4");
         assert_eq!(cal.remote_id, Some("remote-cal".to_string()));
 
-        // Second upsert with same remote_id updates
+        // Second upsert with same remote_id updates name + is_default
+        // but **must preserve the existing color** so a resync doesn't
+        // stomp the user's manual pick (#132).
         let id2 = upsert_calendar_by_remote_id(
             &conn,
             "acc1",
@@ -777,7 +786,11 @@ mod tests {
         assert_eq!(id1, id2, "Should return same local ID");
         let updated = get_calendar(&conn, &id2).unwrap();
         assert_eq!(updated.name, "Work Updated");
-        assert_eq!(updated.color, "#ff0000");
+        assert_eq!(updated.is_default, false);
+        assert_eq!(
+            updated.color, "#4285f4",
+            "color must be preserved across resync"
+        );
     }
 
     #[test]

--- a/src-tauri/src/db/calendar.rs
+++ b/src-tauri/src/db/calendar.rs
@@ -786,7 +786,7 @@ mod tests {
         assert_eq!(id1, id2, "Should return same local ID");
         let updated = get_calendar(&conn, &id2).unwrap();
         assert_eq!(updated.name, "Work Updated");
-        assert_eq!(updated.is_default, false);
+        assert!(!updated.is_default);
         assert_eq!(
             updated.color, "#4285f4",
             "color must be preserved across resync"

--- a/src-tauri/src/mail/caldav.rs
+++ b/src-tauri/src/mail/caldav.rs
@@ -465,6 +465,63 @@ impl CalDavClient {
     /// PROPPATCH the `{DAV:}displayname` property to rename a calendar.
     /// `calendar_href` is the calendar collection URL (as returned by
     /// `list_calendars`).
+    /// PROPPATCH the Apple-namespace `calendar-color` property
+    /// (`http://apple.com/ns/ical/`). Nextcloud, Radicale, Sabre/dav,
+    /// and Apple Calendar Server all honor this property; servers
+    /// that don't simply return a 4xx for that prop in the 207 body,
+    /// which we surface as an error so the caller can roll back the
+    /// local change. Hex format must include the leading `#` —
+    /// most servers accept both 6- and 8-digit forms.
+    pub async fn set_calendar_color(&self, calendar_href: &str, hex: &str) -> Result<()> {
+        let url = self.resolve_url(calendar_href)?;
+        log::info!("caldav: PROPPATCH set color {} -> {}", url, hex);
+
+        let body = format!(
+            r#"<?xml version="1.0" encoding="utf-8"?>
+<D:propertyupdate xmlns:D="DAV:" xmlns:A="http://apple.com/ns/ical/">
+  <D:set>
+    <D:prop>
+      <A:calendar-color>{}</A:calendar-color>
+    </D:prop>
+  </D:set>
+</D:propertyupdate>"#,
+            xml_escape(hex)
+        );
+
+        let resp = self
+            .apply_auth(
+                self.http
+                    .request(reqwest::Method::from_bytes(b"PROPPATCH").unwrap(), &url),
+            )
+            .header("Content-Type", "application/xml; charset=utf-8")
+            .body(body)
+            .send()
+            .await
+            .map_err(|e| Error::Other(format!("CalDAV PROPPATCH (color) failed: {}", e)))?;
+
+        let status = resp.status();
+        let text = resp
+            .text()
+            .await
+            .unwrap_or_else(|_| "(no body)".to_string());
+
+        if !status.is_success() && status.as_u16() != 207 {
+            return Err(Error::Other(format!(
+                "CalDAV PROPPATCH (color) returned {}: {}",
+                status,
+                text.chars().take(500).collect::<String>()
+            )));
+        }
+        if text.contains("HTTP/1.1 4") || text.contains("HTTP/1.1 5") {
+            return Err(Error::Other(format!(
+                "CalDAV PROPPATCH rejected calendar-color update: {}",
+                text.chars().take(500).collect::<String>()
+            )));
+        }
+        log::info!("caldav: PROPPATCH color success");
+        Ok(())
+    }
+
     pub async fn rename_calendar(&self, calendar_href: &str, new_name: &str) -> Result<()> {
         let url = self.resolve_url(calendar_href)?;
         log::info!("caldav: PROPPATCH rename calendar {} -> {}", url, new_name);

--- a/src-tauri/src/mail/graph.rs
+++ b/src-tauri/src/mail/graph.rs
@@ -645,14 +645,16 @@ impl GraphClient {
             .await
     }
 
-    /// Set a calendar's color via PATCH /me/calendars/{id}. Microsoft
-    /// Graph only accepts a constrained `calendarColor` enum (auto,
-    /// lightBlue, lightGreen, …). Translate the user's hex to the
-    /// nearest of those names via simple RGB Euclidean distance — our
-    /// 10-color palette maps cleanly to 10 of the 11 enum values, and
-    /// off-palette hex still lands on something reasonable. The
-    /// caller is responsible for keeping the original hex in our
-    /// local DB so the UI shows what the user actually picked.
+    /// Set a calendar's color via PATCH /me/calendars/{id}. The
+    /// writable property is the `color` field, whose value comes
+    /// from the constrained `calendarColor` enum (`auto`,
+    /// `lightBlue`, `lightGreen`, …). Translate the user's hex to
+    /// the nearest of those names via simple RGB Euclidean distance.
+    /// `maxColor` is excluded from the candidate set — Microsoft
+    /// documents it as a sentinel ordinal and PATCHing with it
+    /// returns 500 ISE in practice. The caller keeps the original
+    /// hex in our local DB so the sidebar shows what the user
+    /// actually picked even when Graph snapped it to a neighbour.
     pub async fn set_calendar_color(&self, calendar_id: &str, hex: &str) -> Result<()> {
         let named = nearest_outlook_color(hex);
         log::info!(
@@ -1362,29 +1364,41 @@ fn parse_graph_contact(c: &serde_json::Value) -> GraphContact {
     }
 }
 
+/// Anchor hexes for the Microsoft `calendarColor` enum. Picked to
+/// match the app's UI palette in `random_calendar_color()` so that
+/// (a) freshly-synced Graph calendars get a hex that the picker
+/// already shows on its swatch row, and (b) `nearest_outlook_color`
+/// (the inverse direction) round-trips exactly when the user picks
+/// a palette colour. `maxColor` is intentionally absent — it's a
+/// sentinel ordinal that Graph rejects with 500 ISE on PATCH.
+const GRAPH_COLOR_ANCHORS: &[(&str, &str, (i32, i32, i32))] = &[
+    ("lightBlue", "#4285f4", (0x42, 0x85, 0xf4)),
+    ("lightGreen", "#0b8043", (0x0b, 0x80, 0x43)),
+    ("lightOrange", "#f4511e", (0xf4, 0x51, 0x1e)),
+    ("lightGray", "#616161", (0x61, 0x61, 0x61)),
+    ("lightYellow", "#f6bf26", (0xf6, 0xbf, 0x26)),
+    ("lightTeal", "#33b679", (0x33, 0xb6, 0x79)),
+    ("lightPink", "#e67c73", (0xe6, 0x7c, 0x73)),
+    ("lightBrown", "#8e24aa", (0x8e, 0x24, 0xaa)),
+    ("lightRed", "#d50000", (0xd5, 0x00, 0x00)),
+];
+
 fn graph_color_to_hex(color: &str) -> String {
-    match color {
-        "auto" | "lightBlue" => "#4285f4",
-        "lightGreen" => "#10b981",
-        "lightOrange" => "#f59e0b",
-        "lightGray" => "#6b7280",
-        "lightYellow" => "#eab308",
-        "lightTeal" => "#14b8a6",
-        "lightPink" => "#ec4899",
-        "lightBrown" => "#a16207",
-        "lightRed" => "#ef4444",
-        "maxColor" => "#8b5cf6",
-        _ => "#4285f4",
+    if color == "auto" {
+        return "#4285f4".to_string();
     }
-    .to_string()
+    GRAPH_COLOR_ANCHORS
+        .iter()
+        .find(|(name, _, _)| *name == color)
+        .map(|(_, hex, _)| (*hex).to_string())
+        .unwrap_or_else(|| "#4285f4".to_string())
 }
 
 /// Pick the closest Microsoft `calendarColor` enum name for a given
-/// CSS hex. Uses the same anchor hexes as `graph_color_to_hex`, so
-/// our palette round-trips when the user re-syncs against Graph.
-/// Plain Euclidean distance in RGB is "good enough" for a 10-bin
-/// nearest-neighbour over a small palette; perceptually-correct
-/// CIELAB would be overkill for this constrained mapping.
+/// CSS hex. Anchor hexes match the UI palette so a round-trip
+/// through Graph keeps colors recognisable. Plain Euclidean
+/// distance in RGB is "good enough" for a 9-bin nearest-neighbour
+/// over a small palette.
 fn nearest_outlook_color(hex: &str) -> &'static str {
     fn parse_hex(s: &str) -> Option<(i32, i32, i32)> {
         let h = s.trim().trim_start_matches('#');
@@ -1397,28 +1411,12 @@ fn nearest_outlook_color(hex: &str) -> &'static str {
             i32::from_str_radix(&h[4..6], 16).ok()?,
         ))
     }
-    // Same anchors as graph_color_to_hex above so the mapping is
-    // symmetric. "auto" intentionally absent — we want to pick a
-    // concrete color rather than fall back to the user's account
-    // default.
-    const ANCHORS: &[(&str, (i32, i32, i32))] = &[
-        ("lightBlue", (0x42, 0x85, 0xf4)),
-        ("lightGreen", (0x10, 0xb9, 0x81)),
-        ("lightOrange", (0xf5, 0x9e, 0x0b)),
-        ("lightGray", (0x6b, 0x72, 0x80)),
-        ("lightYellow", (0xea, 0xb3, 0x08)),
-        ("lightTeal", (0x14, 0xb8, 0xa6)),
-        ("lightPink", (0xec, 0x48, 0x99)),
-        ("lightBrown", (0xa1, 0x62, 0x07)),
-        ("lightRed", (0xef, 0x44, 0x44)),
-        ("maxColor", (0x8b, 0x5c, 0xf6)),
-    ];
     let Some((r, g, b)) = parse_hex(hex) else {
         return "auto";
     };
-    let mut best = ANCHORS[0].0;
+    let mut best = GRAPH_COLOR_ANCHORS[0].0;
     let mut best_d = i32::MAX;
-    for (name, (ar, ag, ab)) in ANCHORS {
+    for (name, _, (ar, ag, ab)) in GRAPH_COLOR_ANCHORS {
         let dr = r - ar;
         let dg = g - ag;
         let db = b - ab;
@@ -1468,21 +1466,30 @@ pub async fn get_graph_token(account_id: &str) -> Result<String> {
 
 #[cfg(test)]
 mod color_tests {
-    use super::nearest_outlook_color;
+    use super::{graph_color_to_hex, nearest_outlook_color};
 
     #[test]
     fn anchor_round_trip() {
-        // Each anchor hex must map back to its own name.
-        assert_eq!(nearest_outlook_color("#4285f4"), "lightBlue");
-        assert_eq!(nearest_outlook_color("#10b981"), "lightGreen");
-        assert_eq!(nearest_outlook_color("#f59e0b"), "lightOrange");
-        assert_eq!(nearest_outlook_color("#6b7280"), "lightGray");
-        assert_eq!(nearest_outlook_color("#eab308"), "lightYellow");
-        assert_eq!(nearest_outlook_color("#14b8a6"), "lightTeal");
-        assert_eq!(nearest_outlook_color("#ec4899"), "lightPink");
-        assert_eq!(nearest_outlook_color("#a16207"), "lightBrown");
-        assert_eq!(nearest_outlook_color("#ef4444"), "lightRed");
-        assert_eq!(nearest_outlook_color("#8b5cf6"), "maxColor");
+        // Each UI-palette anchor must map to its expected enum name
+        // *and* enum-name → hex must round-trip back. This is the
+        // contract that keeps colors recognisable when the user
+        // picks one of the 10 swatches and it survives a Graph
+        // resync.
+        let cases = [
+            ("#4285f4", "lightBlue"),
+            ("#0b8043", "lightGreen"),
+            ("#f4511e", "lightOrange"),
+            ("#616161", "lightGray"),
+            ("#f6bf26", "lightYellow"),
+            ("#33b679", "lightTeal"),
+            ("#e67c73", "lightPink"),
+            ("#8e24aa", "lightBrown"),
+            ("#d50000", "lightRed"),
+        ];
+        for (hex, name) in cases {
+            assert_eq!(nearest_outlook_color(hex), name, "hex {} -> name", hex);
+            assert_eq!(graph_color_to_hex(name), hex, "name {} -> hex", name);
+        }
     }
 
     #[test]
@@ -1498,5 +1505,18 @@ mod color_tests {
         assert_eq!(nearest_outlook_color("not-a-color"), "auto");
         assert_eq!(nearest_outlook_color("#abc"), "auto");
         assert_eq!(nearest_outlook_color(""), "auto");
+    }
+
+    #[test]
+    fn maxcolor_is_not_a_target() {
+        // Graph rejects PATCH with `color: maxColor` (500 ISE in
+        // practice — Microsoft documents it as a sentinel ordinal).
+        // No input hex should produce it.
+        for &(_, hex, _) in super::GRAPH_COLOR_ANCHORS {
+            assert_ne!(nearest_outlook_color(hex), "maxColor");
+        }
+        assert_ne!(nearest_outlook_color("#000000"), "maxColor");
+        assert_ne!(nearest_outlook_color("#ffffff"), "maxColor");
+        assert_ne!(nearest_outlook_color("#8b5cf6"), "maxColor");
     }
 }

--- a/src-tauri/src/mail/graph.rs
+++ b/src-tauri/src/mail/graph.rs
@@ -645,6 +645,27 @@ impl GraphClient {
             .await
     }
 
+    /// Set a calendar's color via PATCH /me/calendars/{id}. Microsoft
+    /// Graph only accepts a constrained `calendarColor` enum (auto,
+    /// lightBlue, lightGreen, …). Translate the user's hex to the
+    /// nearest of those names via simple RGB Euclidean distance — our
+    /// 10-color palette maps cleanly to 10 of the 11 enum values, and
+    /// off-palette hex still lands on something reasonable. The
+    /// caller is responsible for keeping the original hex in our
+    /// local DB so the UI shows what the user actually picked.
+    pub async fn set_calendar_color(&self, calendar_id: &str, hex: &str) -> Result<()> {
+        let named = nearest_outlook_color(hex);
+        log::info!(
+            "Graph set color: id={} hex={} -> {}",
+            calendar_id,
+            hex,
+            named
+        );
+        let path = format!("/me/calendars/{}", urlencoding::encode(calendar_id));
+        self.patch_json(&path, &serde_json::json!({ "color": named }))
+            .await
+    }
+
     /// Fetch events in a time range via calendarView.
     /// Uses `Prefer: outlook.timezone="UTC"` so all times come back in UTC.
     /// Fetch events for a specific calendar via `GET /me/calendars/{id}/calendarView`.
@@ -1358,6 +1379,58 @@ fn graph_color_to_hex(color: &str) -> String {
     .to_string()
 }
 
+/// Pick the closest Microsoft `calendarColor` enum name for a given
+/// CSS hex. Uses the same anchor hexes as `graph_color_to_hex`, so
+/// our palette round-trips when the user re-syncs against Graph.
+/// Plain Euclidean distance in RGB is "good enough" for a 10-bin
+/// nearest-neighbour over a small palette; perceptually-correct
+/// CIELAB would be overkill for this constrained mapping.
+fn nearest_outlook_color(hex: &str) -> &'static str {
+    fn parse_hex(s: &str) -> Option<(i32, i32, i32)> {
+        let h = s.trim().trim_start_matches('#');
+        if h.len() != 6 {
+            return None;
+        }
+        Some((
+            i32::from_str_radix(&h[0..2], 16).ok()?,
+            i32::from_str_radix(&h[2..4], 16).ok()?,
+            i32::from_str_radix(&h[4..6], 16).ok()?,
+        ))
+    }
+    // Same anchors as graph_color_to_hex above so the mapping is
+    // symmetric. "auto" intentionally absent — we want to pick a
+    // concrete color rather than fall back to the user's account
+    // default.
+    const ANCHORS: &[(&str, (i32, i32, i32))] = &[
+        ("lightBlue", (0x42, 0x85, 0xf4)),
+        ("lightGreen", (0x10, 0xb9, 0x81)),
+        ("lightOrange", (0xf5, 0x9e, 0x0b)),
+        ("lightGray", (0x6b, 0x72, 0x80)),
+        ("lightYellow", (0xea, 0xb3, 0x08)),
+        ("lightTeal", (0x14, 0xb8, 0xa6)),
+        ("lightPink", (0xec, 0x48, 0x99)),
+        ("lightBrown", (0xa1, 0x62, 0x07)),
+        ("lightRed", (0xef, 0x44, 0x44)),
+        ("maxColor", (0x8b, 0x5c, 0xf6)),
+    ];
+    let Some((r, g, b)) = parse_hex(hex) else {
+        return "auto";
+    };
+    let mut best = ANCHORS[0].0;
+    let mut best_d = i32::MAX;
+    for (name, (ar, ag, ab)) in ANCHORS {
+        let dr = r - ar;
+        let dg = g - ag;
+        let db = b - ab;
+        let d = dr * dr + dg * dg + db * db;
+        if d < best_d {
+            best_d = d;
+            best = name;
+        }
+    }
+    best
+}
+
 /// Get a valid Graph API access token for an O365 account.
 /// Always refreshes with Graph-specific scopes because the stored token
 /// may be IMAP-scoped (both share the same keyring entry and refresh token).
@@ -1391,4 +1464,39 @@ pub async fn get_graph_token(account_id: &str) -> Result<String> {
     }
 
     Ok(new_tokens.access_token)
+}
+
+#[cfg(test)]
+mod color_tests {
+    use super::nearest_outlook_color;
+
+    #[test]
+    fn anchor_round_trip() {
+        // Each anchor hex must map back to its own name.
+        assert_eq!(nearest_outlook_color("#4285f4"), "lightBlue");
+        assert_eq!(nearest_outlook_color("#10b981"), "lightGreen");
+        assert_eq!(nearest_outlook_color("#f59e0b"), "lightOrange");
+        assert_eq!(nearest_outlook_color("#6b7280"), "lightGray");
+        assert_eq!(nearest_outlook_color("#eab308"), "lightYellow");
+        assert_eq!(nearest_outlook_color("#14b8a6"), "lightTeal");
+        assert_eq!(nearest_outlook_color("#ec4899"), "lightPink");
+        assert_eq!(nearest_outlook_color("#a16207"), "lightBrown");
+        assert_eq!(nearest_outlook_color("#ef4444"), "lightRed");
+        assert_eq!(nearest_outlook_color("#8b5cf6"), "maxColor");
+    }
+
+    #[test]
+    fn off_palette_picks_a_neighbour() {
+        // Pure red should pick lightRed (the closest anchor).
+        assert_eq!(nearest_outlook_color("#ff0000"), "lightRed");
+        // Pure white falls equidistant-ish but never panics.
+        let _ = nearest_outlook_color("#ffffff");
+    }
+
+    #[test]
+    fn invalid_hex_returns_auto() {
+        assert_eq!(nearest_outlook_color("not-a-color"), "auto");
+        assert_eq!(nearest_outlook_color("#abc"), "auto");
+        assert_eq!(nearest_outlook_color(""), "auto");
+    }
 }

--- a/src-tauri/src/mail/jmap.rs
+++ b/src-tauri/src/mail/jmap.rs
@@ -1060,6 +1060,53 @@ impl JmapConnection {
     }
 
     /// Rename a JMAP calendar. Uses Calendar/set with an update entry.
+    /// Update the JMAP `color` property on a calendar via
+    /// `Calendar/set`. JMAP calendars (RFC 8984 / "JSCalendar") store
+    /// color as a CSS-format string, conventionally a `#RRGGBB` hex.
+    /// Stalwart and Cyrus both honor the property; servers that don't
+    /// will surface the rejection in `notUpdated` and we return that
+    /// as an error so the caller can roll back.
+    pub async fn set_calendar_color(
+        &self,
+        config: &JmapConfig,
+        calendar_id: &str,
+        hex: &str,
+    ) -> Result<()> {
+        log::info!("JMAP set color for calendar {} -> {}", calendar_id, hex);
+
+        let mut update = serde_json::Map::new();
+        update.insert(calendar_id.to_string(), serde_json::json!({ "color": hex }));
+
+        let request = serde_json::json!({
+            "using": [
+                "urn:ietf:params:jmap:core",
+                "urn:ietf:params:jmap:calendars"
+            ],
+            "methodCalls": [
+                ["Calendar/set", {
+                    "accountId": self.account_id,
+                    "update": update
+                }, "c1"]
+            ]
+        });
+
+        let resp = self.api_request(&request, config).await?;
+
+        if let Some(err) = resp["methodResponses"][0][1]["notUpdated"][calendar_id].as_object() {
+            let desc = err
+                .get("description")
+                .and_then(|d| d.as_str())
+                .unwrap_or("Unknown error");
+            return Err(Error::Other(format!(
+                "JMAP Calendar/set rejected color update: {}",
+                desc
+            )));
+        }
+
+        log::info!("JMAP color set for calendar {}", calendar_id);
+        Ok(())
+    }
+
     pub async fn rename_calendar(
         &self,
         config: &JmapConfig,

--- a/src-tauri/src/mail/jmap.rs
+++ b/src-tauri/src/mail/jmap.rs
@@ -1059,13 +1059,12 @@ impl JmapConnection {
         Ok(calendars)
     }
 
-    /// Rename a JMAP calendar. Uses Calendar/set with an update entry.
     /// Update the JMAP `color` property on a calendar via
     /// `Calendar/set`. JMAP calendars (RFC 8984 / "JSCalendar") store
     /// color as a CSS-format string, conventionally a `#RRGGBB` hex.
-    /// Stalwart and Cyrus both honor the property; servers that don't
-    /// will surface the rejection in `notUpdated` and we return that
-    /// as an error so the caller can roll back.
+    /// Stalwart and Cyrus both honor the property; servers that
+    /// don't will surface the rejection in `notUpdated` and we
+    /// return that as an error so the caller can roll back.
     pub async fn set_calendar_color(
         &self,
         config: &JmapConfig,
@@ -1107,6 +1106,8 @@ impl JmapConnection {
         Ok(())
     }
 
+    /// Rename a JMAP calendar via `Calendar/set` with an update
+    /// entry whose `name` field carries the new display name.
     pub async fn rename_calendar(
         &self,
         config: &JmapConfig,

--- a/src/components/calendar/CalendarSidebar.vue
+++ b/src/components/calendar/CalendarSidebar.vue
@@ -45,6 +45,22 @@ function onContextMenu(event: MouseEvent, calId: string, accountId: string) {
   contextMenu.value = { x: event.clientX, y: event.clientY, calendarId: calId, accountId };
 }
 
+// Toggle visibility on left-click of the row. We use a plain <div>
+// (not <label>) because WebKitGTK's <label> autoactivates the wrapped
+// <input> on *any* mouse-button press, which means right-clicking
+// flips the checkbox before the contextmenu handler can run. With a
+// <div>, the click event itself only fires for the primary button,
+// and we additionally guard on `event.button` for safety.
+function onLabelClick(event: MouseEvent, calId: string) {
+  if (event.button !== 0) return;
+  // Direct clicks on the checkbox are handled by its own @change;
+  // @click.stop on the input prevents this branch from running, but
+  // keep the tag check as a belt-and-braces fallback.
+  const target = event.target as HTMLElement | null;
+  if (target?.tagName === "INPUT") return;
+  calendarStore.toggleCalendarVisibility(calId);
+}
+
 function closeContextMenu() {
   contextMenu.value = null;
 }
@@ -168,11 +184,22 @@ function cancelRecolor() {
   recolorError.value = null;
 }
 
+/// Match either `#rgb`, `#rgba`, `#rrggbb`, or `#rrggbbaa`. Anything
+/// else is rejected before we hit the backend so we can't end up
+/// persisting a string the server will choke on (Graph returned an
+/// ISE on bogus inputs, CalDAV PROPPATCH'd a literal "blueish" into
+/// the calendar color).
+const HEX_COLOR_RE = /^#(?:[0-9a-f]{3,4}|[0-9a-f]{6}|[0-9a-f]{8})$/i;
+
 async function confirmRecolor() {
   if (!recoloring.value) return;
-  const newColor = recoloring.value.value.trim();
-  if (!newColor || newColor === recoloring.value.calendar.color) {
+  const newColor = recoloring.value.value.trim().toLowerCase();
+  if (!newColor || newColor === recoloring.value.calendar.color.toLowerCase()) {
     cancelRecolor();
+    return;
+  }
+  if (!HEX_COLOR_RE.test(newColor)) {
+    recolorError.value = "Color must be a hex value like #4285f4 or #4285f4ff.";
     return;
   }
   recolorSaving.value = true;
@@ -183,14 +210,21 @@ async function confirmRecolor() {
       recoloring.value.calendar.name,
       newColor,
     );
-    await calendarStore.fetchCalendars();
-    showToast(`Color updated`, "success");
-    recoloring.value = null;
   } catch (e) {
     recolorError.value = e instanceof Error ? e.message : String(e);
-  } finally {
     recolorSaving.value = false;
+    return;
   }
+  // Close the modal as soon as the backend returns — fetchCalendars
+  // can be slow when one account's listCalendars takes its time, and
+  // we don't want the dialog to sit there while the sidebar refreshes
+  // in the background.
+  recoloring.value = null;
+  recolorSaving.value = false;
+  showToast(`Color updated`, "success");
+  calendarStore
+    .fetchCalendars()
+    .catch((e) => console.error("post-recolor refresh failed:", e));
 }
 
 function startRename() {
@@ -269,10 +303,19 @@ async function unsubscribeThisCalendar() {
         @mouseleave="onCalendarItemLeave(cal.id)"
         @mouseup="onCalendarItemDrop(cal)"
       >
-        <label class="calendar-label">
+        <div
+          class="calendar-label"
+          role="checkbox"
+          tabindex="0"
+          :aria-checked="!calendarStore.hiddenCalendarIds.includes(cal.id)"
+          @click="onLabelClick($event, cal.id)"
+          @keydown.space.prevent="calendarStore.toggleCalendarVisibility(cal.id)"
+          @keydown.enter.prevent="calendarStore.toggleCalendarVisibility(cal.id)"
+        >
           <input
             type="checkbox"
             :checked="!calendarStore.hiddenCalendarIds.includes(cal.id)"
+            @click.stop
             @change="calendarStore.toggleCalendarVisibility(cal.id)"
             data-testid="calendar-toggle"
           />
@@ -285,7 +328,7 @@ async function unsubscribeThisCalendar() {
             <span class="calendar-account">{{ getAccountLabel(cal.account_id) }}</span>
           </span>
           <span v-if="syncing === cal.id" class="sync-spinner"></span>
-        </label>
+        </div>
       </div>
       <div v-if="calendarStore.calendars.length === 0" class="empty">
         No calendars
@@ -366,7 +409,7 @@ async function unsubscribeThisCalendar() {
           <div class="rename-body">
             <h3>Change color</h3>
             <p class="rename-sub">
-              Pick a color for "{{ recoloring.calendar.name }}". Where the server supports it (CalDAV, JMAP) the color is also pushed to the remote calendar.
+              Pick a color for "{{ recoloring.calendar.name }}". CalDAV / JMAP store the exact hex you pick. Microsoft 365 and Google use a fixed palette, so the picked color is approximated and may not match this swatch one-for-one. System calendars (Birthdays, Holidays, etc.) on Microsoft are read-only — the change is kept locally if the server rejects it.
             </p>
             <div class="color-swatches">
               <button

--- a/src/components/calendar/CalendarSidebar.vue
+++ b/src/components/calendar/CalendarSidebar.vue
@@ -117,6 +117,75 @@ const renaming = ref<{ calendar: Calendar; value: string } | null>(null);
 const renameSaving = ref(false);
 const renameError = ref<string | null>(null);
 
+// Color-picker dialog state (#132). Mirrors the rename-dialog
+// shape: a snapshot of the calendar being edited plus a draft
+// `value` (the picked hex) and saving / error refs the modal binds
+// to. Cleared on cancel + on a successful save.
+const recoloring = ref<{ calendar: Calendar; value: string } | null>(null);
+const recolorSaving = ref(false);
+const recolorError = ref<string | null>(null);
+
+// Curated palette mirrors `random_calendar_color()` in
+// commands/calendar.rs so freshly-synced calendars and
+// user-picked colors come from the same set. If the user's
+// current color isn't in the palette (e.g. a server-supplied
+// custom hex) the picker still highlights it via the
+// `current === value` check below; the dialog also accepts a
+// freeform input.
+const PALETTE: { hex: string; name: string }[] = [
+  { hex: "#4285f4", name: "Blue" },
+  { hex: "#0b8043", name: "Green" },
+  { hex: "#8e24aa", name: "Purple" },
+  { hex: "#d50000", name: "Red" },
+  { hex: "#f4511e", name: "Orange" },
+  { hex: "#039be5", name: "Cyan" },
+  { hex: "#616161", name: "Grey" },
+  { hex: "#e67c73", name: "Salmon" },
+  { hex: "#f6bf26", name: "Yellow" },
+  { hex: "#33b679", name: "Teal" },
+];
+
+function startRecolor() {
+  if (!contextMenu.value) return;
+  const cal = calendarStore.calendars.find(
+    (c) => c.id === contextMenu.value!.calendarId,
+  );
+  closeContextMenu();
+  if (!cal) return;
+  recolorError.value = null;
+  recoloring.value = { calendar: cal, value: cal.color || "#4285f4" };
+}
+
+function cancelRecolor() {
+  recoloring.value = null;
+  recolorError.value = null;
+}
+
+async function confirmRecolor() {
+  if (!recoloring.value) return;
+  const newColor = recoloring.value.value.trim();
+  if (!newColor || newColor === recoloring.value.calendar.color) {
+    cancelRecolor();
+    return;
+  }
+  recolorSaving.value = true;
+  recolorError.value = null;
+  try {
+    await api.updateCalendar(
+      recoloring.value.calendar.id,
+      recoloring.value.calendar.name,
+      newColor,
+    );
+    await calendarStore.fetchCalendars();
+    showToast(`Color updated`, "success");
+    recoloring.value = null;
+  } catch (e) {
+    recolorError.value = e instanceof Error ? e.message : String(e);
+  } finally {
+    recolorSaving.value = false;
+  }
+}
+
 function startRename() {
   if (!contextMenu.value) return;
   const cal = calendarStore.calendars.find(
@@ -225,6 +294,7 @@ async function unsubscribeThisCalendar() {
       >
         <button class="ctx-item" @click="syncThisCalendar" data-testid="calendar-sync">Sync this calendar</button>
         <button class="ctx-item" @click="startRename" data-testid="calendar-rename">Rename…</button>
+        <button class="ctx-item" @click="startRecolor" data-testid="calendar-recolor">Change color…</button>
         <button class="ctx-item" @click="unsubscribeThisCalendar" data-testid="calendar-unsubscribe">Unsubscribe</button>
       </div>
     </Teleport>
@@ -271,6 +341,70 @@ async function unsubscribeThisCalendar() {
               @click="confirmRename"
             >
               {{ renameSaving ? "Renaming…" : "Rename" }}
+            </button>
+          </div>
+        </div>
+      </div>
+    </Teleport>
+
+    <!-- Color picker (#132) -->
+    <Teleport to="body">
+      <div
+        v-if="recoloring"
+        class="cal-rename-overlay"
+        data-testid="calendar-recolor-modal"
+        @click.self="cancelRecolor"
+      >
+        <div class="rename-modal">
+          <div class="rename-body">
+            <h3>Change color</h3>
+            <p class="rename-sub">
+              Pick a color for "{{ recoloring.calendar.name }}". Where the server supports it (CalDAV, JMAP) the color is also pushed to the remote calendar.
+            </p>
+            <div class="color-swatches">
+              <button
+                v-for="entry in PALETTE"
+                :key="entry.hex"
+                type="button"
+                class="color-swatch"
+                :class="{ selected: recoloring.value.toLowerCase() === entry.hex.toLowerCase() }"
+                :style="{ backgroundColor: entry.hex }"
+                :title="entry.name"
+                :data-testid="`calendar-color-${entry.hex.slice(1)}`"
+                :disabled="recolorSaving"
+                @click="recoloring.value = entry.hex"
+              ></button>
+            </div>
+            <input
+              v-model="recoloring.value"
+              type="text"
+              class="rename-input color-input"
+              placeholder="#rrggbb"
+              data-testid="calendar-color-custom"
+              :disabled="recolorSaving"
+              @keyup.enter="confirmRecolor"
+              @keyup.escape="cancelRecolor"
+            />
+            <p v-if="recolorError" class="rename-error" data-testid="calendar-recolor-error">
+              {{ recolorError }}
+            </p>
+          </div>
+          <div class="rename-footer">
+            <button
+              class="rename-btn-cancel"
+              :disabled="recolorSaving"
+              data-testid="calendar-recolor-cancel"
+              @click="cancelRecolor"
+            >
+              Cancel
+            </button>
+            <button
+              class="rename-btn-save"
+              :disabled="recolorSaving || !recoloring.value.trim()"
+              data-testid="calendar-recolor-save"
+              @click="confirmRecolor"
+            >
+              {{ recolorSaving ? "Saving…" : "Save" }}
             </button>
           </div>
         </div>
@@ -458,6 +592,35 @@ async function unsubscribeThisCalendar() {
 .rename-input:focus {
   outline: none;
   border-color: var(--color-accent);
+}
+
+/* Color-picker (#132) */
+.color-swatches {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 8px;
+  margin: 12px 0;
+}
+.color-swatch {
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  border-radius: 6px;
+  border: 2px solid transparent;
+  cursor: pointer;
+  transition: transform 0.08s, border-color 0.12s;
+  padding: 0;
+}
+.color-swatch:hover { transform: scale(1.06); }
+.color-swatch.selected {
+  border-color: var(--color-text);
+}
+.color-swatch:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+.color-input {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  text-transform: lowercase;
 }
 
 .rename-error {

--- a/src/components/calendar/CalendarSidebar.vue
+++ b/src/components/calendar/CalendarSidebar.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onBeforeUnmount, watch } from "vue";
+import { ref, onBeforeUnmount, onMounted } from "vue";
 import { useCalendarStore } from "@/stores/calendar";
 import { useAccountsStore } from "@/stores/accounts";
 import type { Calendar } from "@/lib/types";
@@ -32,8 +32,16 @@ function getCalendarColor(color: string): string {
   return color || "#4285f4";
 }
 
+// Time the menu was opened. Used to suppress the trailing click that
+// some WebKit builds synthesise on right-mouse-release; without this
+// guard the menu would flash open and immediately close before the
+// user could interact with it.
+let menuOpenedAt = 0;
+
 function onContextMenu(event: MouseEvent, calId: string, accountId: string) {
   event.preventDefault();
+  event.stopPropagation();
+  menuOpenedAt = performance.now();
   contextMenu.value = { x: event.clientX, y: event.clientY, calendarId: calId, accountId };
 }
 
@@ -41,26 +49,25 @@ function closeContextMenu() {
   contextMenu.value = null;
 }
 
-// Close the context menu on any LEFT-button click that lands outside the
-// teleported menu itself. WebKitGTK synthesises a click event on
-// right-mouse-release (button === 2), so without the button guard the
-// menu would close immediately when the user lets go of the right button.
+// Close the menu on any LEFT-button click that lands outside the
+// teleported menu itself. Listener is attached permanently (in
+// onMounted) and short-circuits when the menu isn't open — that way
+// there's no watch / microtask race between setting `contextMenu`
+// and the listener actually existing.
 function onDocClickForMenu(e: MouseEvent) {
   if (!contextMenu.value) return;
   if (e.button !== 0) return;
+  // 250ms guard against the right-click → synthesised-click sequence
+  // some WebKitGTK builds produce.
+  if (performance.now() - menuOpenedAt < 250) return;
   const target = e.target as HTMLElement | null;
   if (target?.closest(".cal-context-menu")) return;
   closeContextMenu();
 }
 
-watch(contextMenu, (open) => {
-  if (open) {
-    document.addEventListener("click", onDocClickForMenu);
-  } else {
-    document.removeEventListener("click", onDocClickForMenu);
-  }
+onMounted(() => {
+  document.addEventListener("click", onDocClickForMenu);
 });
-
 onBeforeUnmount(() => {
   document.removeEventListener("click", onDocClickForMenu);
 });


### PR DESCRIPTION
Closes #132. Two-part fix.

## UI
- New **Change color…** entry in the sidebar context menu (next to Sync / Rename / Unsubscribe).
- Picker modal with the same 10-color palette \`random_calendar_color()\` uses on the backend, plus a freeform \`#rrggbb\` input for off-palette values. Highlights the calendar's current color on open.
- Save calls the existing \`update_calendar\` Tauri command — which now actually does something with the color argument.

## Backend
- \`db::calendar::upsert_calendar_by_remote_id\` no longer rewrites \`color\` on the UPDATE branch. CalDAV / JMAP / Google rarely expose a stable color in PROPFIND/list responses, so before this change every resync re-stamped \`#4285f4\` over whatever the user (or anyone else) had picked. INSERT-time color is unchanged.
- New \`push_calendar_color\` orchestrator mirrors \`push_calendar_rename\`:
  - **CalDAV** — \`PROPPATCH\` with the Apple-namespace \`calendar-color\` property (\`http://apple.com/ns/ical/\`). Works on Nextcloud, Radicale, Sabre/dav, Apple Calendar Server.
  - **JMAP** — \`Calendar/set\` update with the JSCalendar \`color\` property (CSS hex). Works on Stalwart, Cyrus.
  - **Graph / Google** — log a debug line and keep the change local-only. Both APIs only support a constrained named-color enum (or numeric color id), so writing arbitrary hex needs a nearest-named lookup; left for a follow-up.

## Test plan
- [x] \`cargo fmt --check\`, \`cargo clippy --all-targets\`, 232 Rust unit tests
- [x] \`pnpm exec vue-tsc --noEmit\`, 310 JS tests
- [x] Manual: pick a non-default color on a CalDAV calendar, force a sync, confirm color persists
- [ ] Manual: pick a color on a JMAP calendar, confirm the server reflects the change