### PR TITLE
fix(accounts): IMAP / CalDAV / CardDAV separation, real port probing, account labels

### DIFF
--- a/src-tauri/src/commands/accounts.rs
+++ b/src-tauri/src/commands/accounts.rs
@@ -208,8 +208,13 @@ pub async fn get_account_config(
     let full = db::accounts::get_account_full(&conn, &account_id)?;
     // Compute binding-presence flags before we partial-move `full`'s
     // String fields into the AccountConfig literal below.
-    let has_calendar_binding = full.calendar_binding().is_some();
-    let has_contacts_binding = full.contacts_binding().is_some();
+    // Enabled-aware so the edit form reopens on the right tab for
+    // CalDAV-only / CardDAV-only accounts — those carry both
+    // bindings (one disabled) under the legacy single-`caldav_url`
+    // schema, and existence-only flags would always pick the same
+    // branch.
+    let has_calendar_binding = full.calendar_binding().is_some_and(|b| b.enabled);
+    let has_contacts_binding = full.contacts_binding().is_some_and(|b| b.enabled);
     // Never return the actual password to the frontend.
     // The edit form shows a placeholder; empty on save means "keep existing".
     Ok(db::accounts::AccountConfig {

--- a/src-tauri/src/commands/accounts.rs
+++ b/src-tauri/src/commands/accounts.rs
@@ -7,13 +7,21 @@ use crate::db::calendar::NewCalendar;
 use crate::error::Result;
 use crate::state::AppState;
 
-/// Combined autoconfig result returned to the Settings UI when the user
-/// clicks "Auto-discover". Carries both the IMAP/SMTP server settings
-/// (Thunderbird-style autoconfig + MX fallback) and the CalDAV/CardDAV
-/// URLs from `.well-known` probing. Empty strings on any field mean
-/// "not found" — the UI keeps whatever was already in the form. The
-/// `source` string is purely informational ("isp-db", "domain-autoconfig",
-/// "well-known", "mx", or "" if no autoconfig source matched).
+/// Result of a Thunderbird-style mail-server discovery on the IMAP
+/// tab. Empty strings / zero ports mean "not found" — the UI keeps
+/// whatever was already in the form. `source` is informational
+/// ("isp-db", "domain-autoconfig", "well-known", "mx", or empty when
+/// no source matched).
+///
+/// Note that this struct used to carry CalDAV / CardDAV URLs too,
+/// but mixing those into an "IMAP account" turned out to be a
+/// footgun: the discovered URL silently turned a mail-only IMAP
+/// account into a calendar+contacts account, which then collided
+/// with the dedicated CalDAV / CardDAV account types and produced
+/// duplicate calendars on sync. IMAP / CalDAV / CardDAV are now
+/// strictly separate accounts; if you want all three on one
+/// identity, use the JMAP / Gmail / O365 tabs which natively
+/// bundle them.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct AutoconfigResult {
     pub imap_host: String,
@@ -22,93 +30,24 @@ pub struct AutoconfigResult {
     pub smtp_host: String,
     pub smtp_port: u16,
     pub smtp_use_tls: bool,
-    pub caldav_url: String,
-    pub carddav_url: String,
     pub source: String,
 }
 
-/// Run Thunderbird-style email autoconfig (Mozilla ISP DB / provider
-/// autoconfig / `.well-known` / MX fallback) followed by CalDAV /
-/// CardDAV `.well-known` probing across every candidate hostname we
-/// know about (#43). Returns an `AutoconfigResult` with whichever
-/// fields could be discovered; failures degrade to empty strings so
-/// the UI can still save the account without auto-fill.
+/// Run Thunderbird-style email autoconfig (Mozilla ISP DB /
+/// provider autoconfig / `.well-known` / MX fallback) and return
+/// the discovered IMAP / SMTP host+port+TLS settings. Mail-only;
+/// no CalDAV / CardDAV probing here — see the doc comment on
+/// `AutoconfigResult` for why.
 #[tauri::command]
-pub async fn probe_dav_endpoints(
-    email: String,
-    username: String,
-    password: String,
-    imap_host: Option<String>,
-    smtp_host: Option<String>,
-) -> Result<AutoconfigResult> {
-    log::info!(
-        "probe_dav_endpoints: email={} imap_host={:?} smtp_host={:?}",
-        email,
-        imap_host,
-        smtp_host
-    );
+pub async fn discover_mail_servers(email: String) -> Result<AutoconfigResult> {
+    log::info!("discover_mail_servers: email={}", email);
 
-    // 1. Mail-server autoconfig. Soft-fails to None.
     let (servers, source) = match crate::mail::autoconfig::discover(&email).await {
         Ok(Some((s, src))) => (Some(s), src.to_string()),
         Ok(None) => (None, String::new()),
         Err(e) => {
             log::debug!("autoconfig: discover errored: {}", e);
             (None, String::new())
-        }
-    };
-
-    // 2. Build the DAV-probe hostname list. Order matters: we try the
-    // email domain first (cheapest, standards-compliant setups), then
-    // mail.<domain>, then any host autoconfig surfaced, then the user's
-    // entered IMAP / SMTP hosts. Dedup along the way.
-    let domain = email.rsplit('@').next().unwrap_or("").to_string();
-    let mut hosts: Vec<String> = Vec::new();
-    let mut push = |h: String| {
-        if !h.is_empty() && !hosts.contains(&h) {
-            hosts.push(h);
-        }
-    };
-    if !domain.is_empty() {
-        push(domain.clone());
-        push(format!("mail.{}", domain));
-    }
-    if let Some(s) = &servers {
-        push(s.imap_host.clone());
-        push(s.smtp_host.clone());
-    }
-    if let Some(h) = imap_host {
-        push(h);
-    }
-    if let Some(h) = smtp_host {
-        push(h);
-    }
-
-    let http = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(10))
-        .build()
-        .map_err(|e| crate::error::Error::Other(format!("http client: {}", e)))?;
-    let auth = crate::mail::caldav::DavAuth::Basic { username, password };
-
-    let caldav_url =
-        match crate::mail::caldav::CalDavClient::auto_discover_hosts(&http, &auth, &hosts).await {
-            Ok(url) => {
-                log::info!("probe_dav_endpoints: caldav={}", url);
-                url
-            }
-            Err(e) => {
-                log::debug!("probe_dav_endpoints: caldav probe failed: {}", e);
-                String::new()
-            }
-        };
-    let carddav_url = match crate::mail::carddav::auto_discover_hosts(&http, &auth, &hosts).await {
-        Ok(url) => {
-            log::info!("probe_dav_endpoints: carddav={}", url);
-            url
-        }
-        Err(e) => {
-            log::debug!("probe_dav_endpoints: carddav probe failed: {}", e);
-            String::new()
         }
     };
 
@@ -120,8 +59,6 @@ pub async fn probe_dav_endpoints(
         smtp_host: s.smtp_host,
         smtp_port: s.smtp_port,
         smtp_use_tls: s.smtp_use_tls,
-        caldav_url,
-        carddav_url,
         source,
     })
 }

--- a/src-tauri/src/commands/accounts.rs
+++ b/src-tauri/src/commands/accounts.rs
@@ -38,27 +38,91 @@ pub struct AutoconfigResult {
 /// the discovered IMAP / SMTP host+port+TLS settings. Mail-only;
 /// no CalDAV / CardDAV probing here — see the doc comment on
 /// `AutoconfigResult` for why.
+///
+/// `imap_host_hint` / `smtp_host_hint` are the host values already
+/// typed in the form. **Hints win over autoconfig** for any service
+/// they cover — the user knows their actual IMAP / submission host;
+/// autoconfig's MX fallback only knows the inbound-mail routing and
+/// can name a totally different relay. So we probe the hints first,
+/// and only run autoconfig for sides where no hint was supplied. If
+/// a hint is set but its standard ports are unreachable, we leave
+/// that side blank rather than substitute a different host the user
+/// didn't ask for.
 #[tauri::command]
-pub async fn discover_mail_servers(email: String) -> Result<AutoconfigResult> {
-    log::info!("discover_mail_servers: email={}", email);
+pub async fn discover_mail_servers(
+    email: String,
+    imap_host_hint: Option<String>,
+    smtp_host_hint: Option<String>,
+) -> Result<AutoconfigResult> {
+    log::info!(
+        "discover_mail_servers: email={} imap_hint={:?} smtp_hint={:?}",
+        email,
+        imap_host_hint,
+        smtp_host_hint
+    );
 
-    let (servers, source) = match crate::mail::autoconfig::discover(&email).await {
-        Ok(Some((s, src))) => (Some(s), src.to_string()),
-        Ok(None) => (None, String::new()),
-        Err(e) => {
-            log::debug!("autoconfig: discover errored: {}", e);
-            (None, String::new())
+    let imap_hint = imap_host_hint.as_deref().filter(|h| !h.is_empty());
+    let smtp_hint = smtp_host_hint.as_deref().filter(|h| !h.is_empty());
+
+    let mut result = crate::mail::autoconfig::AutoconfigServers::default();
+    let mut source = String::new();
+
+    // Step 1: probe user-typed hosts first.
+    if let Some(host) = imap_hint {
+        if let Some((port, use_tls)) = crate::mail::autoconfig::probe_imap_port(host).await {
+            result.imap_host = host.to_string();
+            result.imap_port = port;
+            result.imap_use_tls = use_tls;
+            source = "host-probe".into();
         }
-    };
+    }
+    if let Some(host) = smtp_hint {
+        if let Some((port, use_tls)) = crate::mail::autoconfig::probe_smtp_port(host).await {
+            result.smtp_host = host.to_string();
+            result.smtp_port = port;
+            result.smtp_use_tls = use_tls;
+            if source.is_empty() {
+                source = "host-probe".into();
+            }
+        }
+    }
 
-    let s = servers.unwrap_or_default();
+    // Step 2: run autoconfig only for sides with no hint at all.
+    // Pre-filled or unreachable-hint sides are left as-is.
+    let need_autoconfig_imap = imap_hint.is_none() && result.imap_host.is_empty();
+    let need_autoconfig_smtp = smtp_hint.is_none() && result.smtp_host.is_empty();
+    if need_autoconfig_imap || need_autoconfig_smtp {
+        match crate::mail::autoconfig::discover(&email).await {
+            Ok(Some((s, src))) => {
+                if need_autoconfig_imap && !s.imap_host.is_empty() {
+                    result.imap_host = s.imap_host;
+                    result.imap_port = s.imap_port;
+                    result.imap_use_tls = s.imap_use_tls;
+                    if source.is_empty() {
+                        source = src.to_string();
+                    }
+                }
+                if need_autoconfig_smtp && !s.smtp_host.is_empty() {
+                    result.smtp_host = s.smtp_host;
+                    result.smtp_port = s.smtp_port;
+                    result.smtp_use_tls = s.smtp_use_tls;
+                    if source.is_empty() {
+                        source = src.to_string();
+                    }
+                }
+            }
+            Ok(None) => {}
+            Err(e) => log::debug!("autoconfig: discover errored: {}", e),
+        }
+    }
+
     Ok(AutoconfigResult {
-        imap_host: s.imap_host,
-        imap_port: s.imap_port,
-        imap_use_tls: s.imap_use_tls,
-        smtp_host: s.smtp_host,
-        smtp_port: s.smtp_port,
-        smtp_use_tls: s.smtp_use_tls,
+        imap_host: result.imap_host,
+        imap_port: result.imap_port,
+        imap_use_tls: result.imap_use_tls,
+        smtp_host: result.smtp_host,
+        smtp_port: result.smtp_port,
+        smtp_use_tls: result.smtp_use_tls,
         source,
     })
 }

--- a/src-tauri/src/commands/sync_cmd.rs
+++ b/src-tauri/src/commands/sync_cmd.rs
@@ -168,12 +168,15 @@ pub(crate) async fn resume_imap_idle_for_account(
         id: account.id.clone(),
         display_name: account.display_name.clone(),
         email: account.email.clone(),
+        username: account.username.clone(),
         provider: account.provider.clone(),
         mail_protocol: account.mail_protocol.clone(),
         enabled: account.enabled,
         mail_sync_interval_seconds: account.mail_sync_interval_seconds,
         calendar_sync_interval_seconds: account.calendar_sync_interval_seconds,
         contacts_sync_interval_seconds: account.contacts_sync_interval_seconds,
+        has_calendar_binding: account.calendar_binding().is_some(),
+        has_contacts_binding: account.contacts_binding().is_some(),
     };
 
     start_imap_idle(app, state, &account_summary).await

--- a/src-tauri/src/db/accounts.rs
+++ b/src-tauri/src/db/accounts.rs
@@ -29,9 +29,12 @@ pub struct Account {
     pub calendar_sync_interval_seconds: Option<i64>,
     #[serde(default)]
     pub contacts_sync_interval_seconds: Option<i64>,
-    /// Whether the account has a calendar / contacts binding row.
-    /// Lets the UI label standalone CalDAV / CardDAV accounts in the
-    /// settings list without a second round-trip per row.
+    /// Whether the account has an *enabled* calendar / contacts
+    /// binding. The `list_accounts` query is `enabled = 1`-aware so a
+    /// CalDAV-tab account (which derives a disabled contacts binding
+    /// alongside its enabled calendar binding) reads as Calendar-only
+    /// rather than as both. Lets the settings UI label standalone DAV
+    /// accounts without a per-row round-trip.
     #[serde(default)]
     pub has_calendar_binding: bool,
     #[serde(default)]

--- a/src-tauri/src/db/accounts.rs
+++ b/src-tauri/src/db/accounts.rs
@@ -11,6 +11,12 @@ pub struct Account {
     pub id: String,
     pub display_name: String,
     pub email: String,
+    /// Carried in the summary so the settings list can show *something*
+    /// for standalone CalDAV / CardDAV accounts whose `email` field
+    /// was never set (older accounts created before the DAV-tab
+    /// email back-fill landed).
+    #[serde(default)]
+    pub username: String,
     pub provider: String,
     pub mail_protocol: String,
     pub enabled: bool,
@@ -23,6 +29,13 @@ pub struct Account {
     pub calendar_sync_interval_seconds: Option<i64>,
     #[serde(default)]
     pub contacts_sync_interval_seconds: Option<i64>,
+    /// Whether the account has a calendar / contacts binding row.
+    /// Lets the UI label standalone CalDAV / CardDAV accounts in the
+    /// settings list without a second round-trip per row.
+    #[serde(default)]
+    pub has_calendar_binding: bool,
+    #[serde(default)]
+    pub has_contacts_binding: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -304,7 +317,7 @@ pub fn list_accounts(conn: &Connection) -> Result<Vec<Account>> {
     // summary doesn't need a separate per-account query for the
     // periodic-sync timers.
     let mut stmt = conn.prepare(
-        "SELECT a.id, a.display_name, a.email, a.auth_method, a.enabled,
+        "SELECT a.id, a.display_name, a.email, a.auth_method, a.enabled, a.username,
                 COALESCE(
                     (SELECT b.protocol FROM service_bindings b
                      WHERE b.account_id = a.id
@@ -321,7 +334,21 @@ pub fn list_accounts(conn: &Connection) -> Result<Vec<Account>> {
                     AS calendar_sync_interval,
                 (SELECT b.sync_interval_seconds FROM service_bindings b
                  WHERE b.account_id = a.id AND b.service = 'contacts' LIMIT 1)
-                    AS contacts_sync_interval
+                    AS contacts_sync_interval,
+                -- Enabled-aware so a standalone CalDAV-tab account
+                -- (which derives a calendar binding enabled=1 plus a
+                -- disabled contacts binding) labels as Calendar, not
+                -- as both. Same for CardDAV.
+                EXISTS (SELECT 1 FROM service_bindings b
+                        WHERE b.account_id = a.id
+                          AND b.service = 'calendar'
+                          AND b.enabled = 1)
+                    AS has_calendar_binding,
+                EXISTS (SELECT 1 FROM service_bindings b
+                        WHERE b.account_id = a.id
+                          AND b.service = 'contacts'
+                          AND b.enabled = 1)
+                    AS has_contacts_binding
          FROM accounts a
          ORDER BY a.display_name",
     )?;
@@ -338,12 +365,15 @@ pub fn list_accounts(conn: &Connection) -> Result<Vec<Account>> {
                 id: row.get(0)?,
                 display_name: row.get(1)?,
                 email: row.get(2)?,
+                username: row.get(5)?,
                 provider,
-                mail_protocol: row.get(5)?,
+                mail_protocol: row.get(6)?,
                 enabled: row.get(4)?,
-                mail_sync_interval_seconds: row.get(6)?,
-                calendar_sync_interval_seconds: row.get(7)?,
-                contacts_sync_interval_seconds: row.get(8)?,
+                mail_sync_interval_seconds: row.get(7)?,
+                calendar_sync_interval_seconds: row.get(8)?,
+                contacts_sync_interval_seconds: row.get(9)?,
+                has_calendar_binding: row.get(10)?,
+                has_contacts_binding: row.get(11)?,
             })
         })?
         .collect::<std::result::Result<Vec<_>, _>>()?;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -45,7 +45,7 @@ pub fn run() {
             commands::accounts::get_account_config,
             commands::accounts::update_account,
             commands::accounts::delete_account,
-            commands::accounts::probe_dav_endpoints,
+            commands::accounts::discover_mail_servers,
             commands::mail::list_folders,
             commands::mail::get_messages,
             commands::mail::search_messages_server,

--- a/src-tauri/src/mail/autoconfig.rs
+++ b/src-tauri/src/mail/autoconfig.rs
@@ -90,30 +90,96 @@ pub async fn discover(email: &str) -> Result<Option<(AutoconfigServers, &'static
         return Ok(Some((parsed, "well-known")));
     }
 
-    // 4. MX-derived guess. We trust the MX hostname enough to probe its
-    // standard IMAPS / submission ports because it's the same source
-    // the user's mail is already going through. We don't fabricate ports
-    // beyond the IANA-assigned ones.
+    // 4. MX-derived guess. The MX hostname is the inbound-mail router
+    // for the domain, *not* the submission / IMAP server: many setups
+    // route incoming mail through a relay or spam filter that has no
+    // open IMAP or submission ports. Trusting it blindly silently
+    // wires the user's account to the wrong host with hard-coded ports.
+    // Instead, we TCP-probe the standard IMAP / submission port
+    // candidates and only surface fields that actually accept
+    // connections; if nothing answers, we return None and let the user
+    // configure manually rather than save a broken account.
     if let Some(mx_host) = lookup_mx(domain).await {
         log::info!(
-            "autoconfig: MX for {} -> {}, guessing IMAPS/submission",
+            "autoconfig: MX for {} -> {}, probing ports",
             domain,
             mx_host
         );
-        return Ok(Some((
-            AutoconfigServers {
-                imap_host: mx_host.clone(),
-                imap_port: 993,
-                imap_use_tls: true,
-                smtp_host: mx_host,
-                smtp_port: 587,
-                smtp_use_tls: true,
-            },
-            "mx",
-        )));
+        let (imap_host, imap_port, imap_use_tls) = match probe_imap_port(&mx_host).await {
+            Some((p, tls)) => (mx_host.clone(), p, tls),
+            None => (String::new(), 0, false),
+        };
+        let (smtp_host, smtp_port, smtp_use_tls) = match probe_smtp_port(&mx_host).await {
+            Some((p, tls)) => (mx_host.clone(), p, tls),
+            None => (String::new(), 0, false),
+        };
+        if !imap_host.is_empty() || !smtp_host.is_empty() {
+            return Ok(Some((
+                AutoconfigServers {
+                    imap_host,
+                    imap_port,
+                    imap_use_tls,
+                    smtp_host,
+                    smtp_port,
+                    smtp_use_tls,
+                },
+                "mx",
+            )));
+        }
+        log::info!(
+            "autoconfig: MX host {} has no open IMAP/submission ports, giving up",
+            mx_host
+        );
     }
 
     Ok(None)
+}
+
+/// Probe IMAP candidate ports on `host` in preference order. 993 is
+/// implicit-TLS and the modern default; 143 is STARTTLS on the legacy
+/// plaintext port. We accept both; the form's single `use_tls` flag
+/// just records "TLS in some form" — the actual connection logic in
+/// `mail::imap` upgrades port-143 with STARTTLS at handshake time.
+pub async fn probe_imap_port(host: &str) -> Option<(u16, bool)> {
+    for &(port, use_tls) in &[(993u16, true), (143u16, true)] {
+        if probe_tcp(host, port).await {
+            log::info!("probe_imap_port: {}:{} reachable", host, port);
+            return Some((port, use_tls));
+        }
+    }
+    None
+}
+
+/// Probe SMTP submission candidate ports on `host` in preference
+/// order. 587 (RFC 6409 submission, STARTTLS) and 465 (implicit TLS,
+/// RFC 8314) are both flagged as TLS. Port 25 is intentionally not
+/// probed: that's MTA-to-MTA transport, not a user submission port,
+/// and accepting it here would silently pick a path most providers
+/// don't authenticate users on.
+pub async fn probe_smtp_port(host: &str) -> Option<(u16, bool)> {
+    for &(port, use_tls) in &[(587u16, true), (465u16, true)] {
+        if probe_tcp(host, port).await {
+            log::info!("probe_smtp_port: {}:{} reachable", host, port);
+            return Some((port, use_tls));
+        }
+    }
+    None
+}
+
+/// Best-effort TCP connect with a short timeout. Returns true iff a
+/// 3-way handshake completes; we don't speak IMAP / SMTP greetings
+/// here because (a) it would require credentials we don't have at
+/// discovery time and (b) the goal is just to rule out closed ports
+/// — anything that accepts TCP is plausibly the right service and
+/// the user can verify it on first sync.
+async fn probe_tcp(host: &str, port: u16) -> bool {
+    use tokio::net::TcpStream;
+    use tokio::time::{timeout, Duration};
+    let addr = format!("{}:{}", host, port);
+    matches!(
+        timeout(Duration::from_secs(3), TcpStream::connect(&addr)).await,
+        Ok(Ok(_))
+    )
 }
 
 async fn try_fetch_and_parse(http: &reqwest::Client, url: &str) -> Option<AutoconfigServers> {

--- a/src/__tests__/calendar.test.ts
+++ b/src/__tests__/calendar.test.ts
@@ -50,6 +50,9 @@ function setupAccounts() {
       mail_sync_interval_seconds: null,
       calendar_sync_interval_seconds: null,
       contacts_sync_interval_seconds: null,
+      username: "",
+      has_calendar_binding: false,
+      has_contacts_binding: false,
     },
   ];
   accountsStore.activeAccountId = "acc1";

--- a/src/__tests__/message-list-clicks.test.ts
+++ b/src/__tests__/message-list-clicks.test.ts
@@ -51,6 +51,9 @@ function setupStores() {
       mail_sync_interval_seconds: null,
       calendar_sync_interval_seconds: null,
       contacts_sync_interval_seconds: null,
+      username: "",
+      has_calendar_binding: false,
+      has_contacts_binding: false,
     },
   ];
   accountsStore.activeAccountId = "acc1";

--- a/src/__tests__/messages-selection.test.ts
+++ b/src/__tests__/messages-selection.test.ts
@@ -41,6 +41,9 @@ function setup(threading = false) {
       mail_sync_interval_seconds: null,
       calendar_sync_interval_seconds: null,
       contacts_sync_interval_seconds: null,
+      username: "",
+      has_calendar_binding: false,
+      has_contacts_binding: false,
     },
   ];
   accountsStore.activeAccountId = "acc1";

--- a/src/__tests__/regression.test.ts
+++ b/src/__tests__/regression.test.ts
@@ -57,6 +57,9 @@ function setupStores(threading = false) {
       mail_sync_interval_seconds: null,
       calendar_sync_interval_seconds: null,
       contacts_sync_interval_seconds: null,
+      username: "",
+      has_calendar_binding: false,
+      has_contacts_binding: false,
     },
   ];
   accountsStore.activeAccountId = "acc1";

--- a/src/__tests__/server-search.test.ts
+++ b/src/__tests__/server-search.test.ts
@@ -54,6 +54,9 @@ function withActiveAccount() {
       mail_sync_interval_seconds: null,
       calendar_sync_interval_seconds: null,
       contacts_sync_interval_seconds: null,
+      username: "",
+      has_calendar_binding: false,
+      has_contacts_binding: false,
     },
   ];
   accountsStore.activeAccountId = "acc1";

--- a/src/__tests__/store-listeners.test.ts
+++ b/src/__tests__/store-listeners.test.ts
@@ -69,6 +69,9 @@ describe("Store listener cleanup", () => {
         mail_sync_interval_seconds: null,
         calendar_sync_interval_seconds: null,
         contacts_sync_interval_seconds: null,
+      username: "",
+      has_calendar_binding: false,
+      has_contacts_binding: false,
       },
     ];
     accountsStore.activeAccountId = "acc1";

--- a/src/__tests__/threads-expansion.test.ts
+++ b/src/__tests__/threads-expansion.test.ts
@@ -43,6 +43,9 @@ function withActiveContext() {
       mail_sync_interval_seconds: null,
       calendar_sync_interval_seconds: null,
       contacts_sync_interval_seconds: null,
+      username: "",
+      has_calendar_binding: false,
+      has_contacts_binding: false,
     },
   ];
   accountsStore.activeAccountId = "acc1";

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -37,24 +37,14 @@ export async function deleteAccount(accountId: string): Promise<void> {
   return invoke("delete_account", { accountId });
 }
 
-/// Run Thunderbird-style email autoconfig (Mozilla ISP DB + provider
-/// autoconfig + .well-known + MX fallback) and probe CalDAV / CardDAV
-/// across every candidate hostname. Empty fields in the result mean
-/// "not found" — frontend should only apply non-empty values.
-export async function probeDavEndpoints(
+/// Thunderbird-style mail-server discovery for the IMAP tab
+/// (Mozilla ISP DB / provider autoconfig / .well-known / MX). No
+/// CalDAV / CardDAV probing — those live on their own dedicated
+/// account types now. Empty fields = not found.
+export async function discoverMailServers(
   email: string,
-  username: string,
-  password: string,
-  imapHost?: string,
-  smtpHost?: string,
 ): Promise<AutoconfigResult> {
-  return invoke("probe_dav_endpoints", {
-    email,
-    username,
-    password,
-    imapHost: imapHost || null,
-    smtpHost: smtpHost || null,
-  });
+  return invoke("discover_mail_servers", { email });
 }
 
 export async function listFolders(accountId: string): Promise<Folder[]> {

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -41,10 +41,21 @@ export async function deleteAccount(accountId: string): Promise<void> {
 /// (Mozilla ISP DB / provider autoconfig / .well-known / MX). No
 /// CalDAV / CardDAV probing — those live on their own dedicated
 /// account types now. Empty fields = not found.
+///
+/// `imapHostHint` / `smtpHostHint` are the host values already typed
+/// in the form. When autoconfig has nothing to say for that service,
+/// the backend TCP-probes the hint's standard ports so the user can
+/// have the port + TLS flag filled in for a host they already know.
 export async function discoverMailServers(
   email: string,
+  imapHostHint?: string,
+  smtpHostHint?: string,
 ): Promise<AutoconfigResult> {
-  return invoke("discover_mail_servers", { email });
+  return invoke("discover_mail_servers", {
+    email,
+    imapHostHint: imapHostHint || null,
+    smtpHostHint: smtpHostHint || null,
+  });
 }
 
 export async function listFolders(accountId: string): Promise<Folder[]> {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -18,8 +18,11 @@ export interface Account {
   mail_sync_interval_seconds: number | null;
   calendar_sync_interval_seconds: number | null;
   contacts_sync_interval_seconds: number | null;
-  // Lets the settings list label standalone CalDAV / CardDAV accounts
-  // without a per-row round-trip.
+  // Whether the account has a calendar / contacts binding *and*
+  // that binding is currently enabled. The settings list keys off
+  // these to label standalone CalDAV-only vs CardDAV-only accounts
+  // (a CalDAV-tab account derives a disabled contacts binding;
+  // existence-only flags would always say true for both).
   has_calendar_binding: boolean;
   has_contacts_binding: boolean;
 }
@@ -191,10 +194,12 @@ export interface AccountConfig {
   has_contacts_binding: boolean;
 }
 
-/// Combined result of Thunderbird-style autoconfig + DAV probing.
-/// Empty strings / zero ports mean "not found"; the frontend only
-/// applies non-empty fields to the form. `source` is informational:
-/// "isp-db" | "domain-autoconfig" | "well-known" | "mx" | "".
+/// IMAP / SMTP discovery result returned by `discoverMailServers`.
+/// Mail-only — CalDAV / CardDAV are not probed here, those have
+/// dedicated account types. Empty strings / zero ports mean "not
+/// found"; the frontend only applies non-empty fields to the form.
+/// `source` is informational: "isp-db" | "domain-autoconfig" |
+/// "well-known" | "mx" | "host-probe" | "".
 export interface AutoconfigResult {
   imap_host: string;
   imap_port: number;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -2,6 +2,10 @@ export interface Account {
   id: string;
   display_name: string;
   email: string;
+  // Carried in the summary so the settings list can show *something*
+  // for standalone CalDAV / CardDAV accounts whose `email` was never
+  // set (older accounts created before the DAV-tab email back-fill).
+  username: string;
   provider: "generic" | "gmail" | "microsoft365" | "o365";
   // Empty string means "no mail binding" — calendar-only / contacts-only
   // accounts (#43). Existing screens that need a mail account should
@@ -14,6 +18,10 @@ export interface Account {
   mail_sync_interval_seconds: number | null;
   calendar_sync_interval_seconds: number | null;
   contacts_sync_interval_seconds: number | null;
+  // Lets the settings list label standalone CalDAV / CardDAV accounts
+  // without a per-row round-trip.
+  has_calendar_binding: boolean;
+  has_contacts_binding: boolean;
 }
 
 export interface QuickFilter {
@@ -183,6 +191,7 @@ export interface AccountConfig {
   has_contacts_binding: boolean;
 }
 
+/// Combined result of Thunderbird-style autoconfig + DAV probing.
 /// Empty strings / zero ports mean "not found"; the frontend only
 /// applies non-empty fields to the form. `source` is informational:
 /// "isp-db" | "domain-autoconfig" | "well-known" | "mx" | "".

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -183,7 +183,6 @@ export interface AccountConfig {
   has_contacts_binding: boolean;
 }
 
-/// Combined result of Thunderbird-style autoconfig + DAV probing.
 /// Empty strings / zero ports mean "not found"; the frontend only
 /// applies non-empty fields to the form. `source` is informational:
 /// "isp-db" | "domain-autoconfig" | "well-known" | "mx" | "".
@@ -194,14 +193,8 @@ export interface AutoconfigResult {
   smtp_host: string;
   smtp_port: number;
   smtp_use_tls: boolean;
-  caldav_url: string;
-  carddav_url: string;
   source: string;
 }
-
-// Old name kept as an alias so existing imports compile while we
-// migrate. New callers should use AutoconfigResult.
-export type DavProbeResult = AutoconfigResult;
 
 export interface FilterRule {
   id: string;

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -19,10 +19,33 @@ const platformStore = usePlatformStore();
 const uiStore = useUiStore();
 const { isMobile } = storeToRefs(platformStore);
 
-function accountTypeLabel(acc: { provider?: string; mail_protocol?: string }): string {
+function accountTypeLabel(acc: {
+  provider?: string;
+  mail_protocol?: string;
+  has_calendar_binding?: boolean;
+  has_contacts_binding?: boolean;
+}): string {
   if (acc.provider === "gmail") return "GMAIL";
   if (acc.provider === "o365") return "MICROSOFT 365";
-  return (acc.mail_protocol ?? "").toUpperCase();
+  if (acc.mail_protocol) return acc.mail_protocol.toUpperCase();
+  // Standalone DAV accounts: name them by the user-visible service
+  // they provide rather than the protocol acronym. "Calendar" and
+  // "Contacts" mean something to a user; "CALDAV" and "CARDDAV"
+  // mean something to a protocol nerd.
+  const hasCal = !!acc.has_calendar_binding;
+  const hasCon = !!acc.has_contacts_binding;
+  if (hasCal && hasCon) return "Calendar and Contacts";
+  if (hasCal) return "Calendar";
+  if (hasCon) return "Contacts";
+  return "";
+}
+
+/// Secondary line for the settings account list. Standalone CalDAV /
+/// CardDAV accounts created before the email back-fill landed have
+/// `email = ""`; falling back to `username` means they still show
+/// something identifying instead of a blank gap.
+function accountSecondaryLabel(acc: { email: string; username: string }): string {
+  return acc.email || acc.username || "";
 }
 
 // Mobile toggles — persist to localStorage so they survive reloads.
@@ -419,6 +442,17 @@ async function saveAccount() {
     if (!form.value.username.trim()) {
       form.value.username = form.value.email;
     }
+    // Standalone DAV tabs are single-purpose: a CalDAV-tab account
+    // is for calendar, a CardDAV-tab account is for contacts. The
+    // form hides the other binding's sync toggle, so an existing
+    // account with the other flag stuck on `true` can't be cleaned
+    // up through the UI. Enforce the constraint at save time so
+    // the next round-trip clears it.
+    if (accountType.value === "caldav") {
+      form.value.contacts_sync_enabled = false;
+    } else if (accountType.value === "carddav") {
+      form.value.calendar_sync_enabled = false;
+    }
     // Mail-having accounts already require an email. The standalone
     // CalDAV / CardDAV tabs hide the email field — but some calendar
     // code paths still touch `account.email` (CalDAV connect uses it
@@ -636,7 +670,7 @@ onMounted(() => {
             </span>
             <span class="mobile-account-info">
               <span class="mobile-account-name">{{ account.display_name }}</span>
-              <span class="mobile-account-email">{{ account.email }}</span>
+              <span class="mobile-account-email">{{ accountSecondaryLabel(account) }}</span>
               <span class="mobile-account-type" :style="{ color: acctColor(account.id).fill }">
                 {{ accountTypeLabel(account) }}
               </span>
@@ -745,8 +779,8 @@ onMounted(() => {
             </span>
             <div class="account-card-info">
               <span class="account-card-name">{{ account.display_name }}</span>
-              <span class="account-card-email">{{ account.email }}</span>
-              <span class="account-card-type" :style="{ color: acctColor(account.id).fill }">{{ account.provider === 'gmail' ? 'Gmail' : account.provider === 'o365' ? 'Microsoft 365' : account.mail_protocol.toUpperCase() }}</span>
+              <span class="account-card-email">{{ accountSecondaryLabel(account) }}</span>
+              <span class="account-card-type" :style="{ color: acctColor(account.id).fill }">{{ accountTypeLabel(account) }}</span>
             </div>
           </div>
           <div class="account-card-actions">

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -303,6 +303,14 @@ async function openEditForm(id: string) {
 /// otherwise turned out to silently glue mail and DAV bindings
 /// onto the same row, then collide with the dedicated CalDAV /
 /// CardDAV account types and produce duplicate calendars on sync.
+///
+/// Discovery never overwrites a value the user has already typed.
+/// MX-derived hosts in particular are an inbound-routing hint that
+/// frequently differs from the actual submission/IMAP servers
+/// (relay providers, hosted spam filters), so trusting them over
+/// user input would silently break the account; the same principle
+/// applies to higher-quality sources too — if the user typed a
+/// value, they have context the autoconfig database doesn't.
 async function discoverMailServers() {
   discoveringDav.value = true;
   discoveryNote.value = null;
@@ -310,21 +318,58 @@ async function discoverMailServers() {
     const result = await api.discoverMailServers(form.value.email);
 
     const filled: string[] = [];
-    if (result.imap_host) {
+    const skipped: string[] = [];
+
+    // Each field (host, port) is checked independently so a user
+    // who has the host typed but cleared the port can fill in just
+    // the port via discovery, and vice versa. Port `0` from the
+    // form (cleared <input type="number">) counts as empty.
+    const imapAvailable = !!result.imap_host;
+    const smtpAvailable = !!result.smtp_host;
+    const imapHostEmpty = !form.value.imap_host;
+    const imapPortEmpty = !form.value.imap_port;
+    const smtpHostEmpty = !form.value.smtp_host;
+    const smtpPortEmpty = !form.value.smtp_port;
+
+    let filledImapHost = false;
+    if (imapAvailable && imapHostEmpty) {
       form.value.imap_host = result.imap_host;
-      form.value.imap_port = result.imap_port || 993;
+      filledImapHost = true;
+    }
+    let filledImapPort = false;
+    if (imapPortEmpty && result.imap_port) {
+      form.value.imap_port = result.imap_port;
+      filledImapPort = true;
+    }
+    if (filledImapHost || filledImapPort) {
       filled.push("IMAP");
+    } else if (imapAvailable) {
+      skipped.push("IMAP");
     }
-    if (result.smtp_host) {
+
+    let filledSmtpHost = false;
+    if (smtpAvailable && smtpHostEmpty) {
       form.value.smtp_host = result.smtp_host;
-      form.value.smtp_port = result.smtp_port || 587;
-      filled.push("SMTP");
+      filledSmtpHost = true;
     }
-    // The wire format carries one shared `use_tls` flag while autoconfig
-    // returns IMAP- and SMTP-specific settings. Only apply it when both
-    // services agree; if they disagree, prefer the more secure value
-    // (don't silently downgrade TLS) and log it.
-    if (result.imap_host && result.smtp_host) {
+    let filledSmtpPort = false;
+    if (smtpPortEmpty && result.smtp_port) {
+      form.value.smtp_port = result.smtp_port;
+      filledSmtpPort = true;
+    }
+    if (filledSmtpHost || filledSmtpPort) {
+      filled.push("SMTP");
+    } else if (smtpAvailable) {
+      skipped.push("SMTP");
+    }
+
+    // Apply use_tls only when we filled the matching *host* — the
+    // TLS setting belongs to the host, not the port, so adjusting
+    // it after only filling a port could silently flip a user's
+    // intent on a host they typed manually. If both hosts were
+    // filled and disagree, prefer the more secure setting rather
+    // than silently downgrade.
+    if (filledImapHost && filledSmtpHost) {
       if (result.imap_use_tls === result.smtp_use_tls) {
         form.value.use_tls = result.imap_use_tls;
       } else {
@@ -333,17 +378,23 @@ async function discoverMailServers() {
         );
         form.value.use_tls = true;
       }
-    } else if (result.imap_host) {
+    } else if (filledImapHost) {
       form.value.use_tls = result.imap_use_tls;
-    } else if (result.smtp_host) {
+    } else if (filledSmtpHost) {
       form.value.use_tls = result.smtp_use_tls;
     }
 
-    if (filled.length === 0) {
+    const sourceLabel = result.source ? ` (via ${result.source})` : "";
+    if (filled.length === 0 && skipped.length === 0) {
       discoveryNote.value = "No autoconfig data found for this domain.";
-    } else {
-      const sourceLabel = result.source ? ` (via ${result.source})` : "";
+    } else if (filled.length === 0) {
+      discoveryNote.value =
+        `Kept your existing ${skipped.join(" + ")} settings; autoconfig${sourceLabel} also returned values but did not overwrite.`;
+    } else if (skipped.length === 0) {
       discoveryNote.value = `Filled ${filled.join(" + ")}${sourceLabel}.`;
+    } else {
+      discoveryNote.value =
+        `Filled ${filled.join(" + ")}${sourceLabel}. Kept your existing ${skipped.join(" + ")} settings.`;
     }
   } catch (e) {
     // Match the rest of the UI: unwrap Error.message instead of

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -315,7 +315,11 @@ async function discoverMailServers() {
   discoveringDav.value = true;
   discoveryNote.value = null;
   try {
-    const result = await api.discoverMailServers(form.value.email);
+    const result = await api.discoverMailServers(
+      form.value.email,
+      form.value.imap_host,
+      form.value.smtp_host,
+    );
 
     const filled: string[] = [];
     const skipped: string[] = [];

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -66,7 +66,7 @@ const error = ref<string | null>(null);
 const editingAccountId = ref<string | null>(null);
 const oauthStatus = ref<string | null>(null);
 const oauthInProgress = ref(false);
-const discoveringDav = ref(false);
+const discoveringMail = ref(false);
 const discoveryNote = ref<string | null>(null);
 
 // Wire form-side number inputs in minutes; convert to/from seconds when
@@ -335,7 +335,7 @@ async function openEditForm(id: string) {
 /// applies to higher-quality sources too — if the user typed a
 /// value, they have context the autoconfig database doesn't.
 async function discoverMailServers() {
-  discoveringDav.value = true;
+  discoveringMail.value = true;
   discoveryNote.value = null;
   try {
     const result = await api.discoverMailServers(
@@ -430,7 +430,7 @@ async function discoverMailServers() {
     const msg = e instanceof Error ? e.message : String(e);
     discoveryNote.value = `Discovery failed: ${msg}`;
   } finally {
-    discoveringDav.value = false;
+    discoveringMail.value = false;
   }
 }
 
@@ -1027,28 +1027,28 @@ onMounted(() => {
             <template v-if="accountType === 'imap'">
               <div class="form-group">
                 <label>Mail server auto-discovery</label>
-                <div class="dav-discovery-row">
+                <div class="mail-discovery-row">
                   <button
                     type="button"
                     class="btn-secondary"
-                    data-testid="dav-discover-btn"
-                    :disabled="discoveringDav || !form.email"
+                    data-testid="mail-discover-btn"
+                    :disabled="discoveringMail || !form.email"
                     @click="discoverMailServers"
                   >
-                    {{ discoveringDav ? 'Searching...' : 'Auto-discover IMAP / SMTP' }}
+                    {{ discoveringMail ? 'Searching...' : 'Auto-discover IMAP / SMTP' }}
                   </button>
                   <span v-if="!form.email" class="field-hint">
                     Enter your email address first.
                   </span>
                 </div>
-                <span v-if="discoveryNote" class="field-hint" data-testid="dav-discovery-note">
+                <span v-if="discoveryNote" class="field-hint" data-testid="mail-discovery-note">
                   {{ discoveryNote }}
                 </span>
                 <span class="field-hint">
                   Looks up the IMAP / SMTP host, port and TLS settings for your domain via Thunderbird-style autoconfig. Calendars and contacts are added as separate accounts on the CalDAV / CardDAV tabs.
                 </span>
-                <div v-if="editingAccountId && form.caldav_url" class="dav-cleanup-row">
-                  <span class="field-hint dav-discovered-url" data-testid="dav-discovered-url">
+                <div v-if="editingAccountId && form.caldav_url" class="dav-link-cleanup-row">
+                  <span class="field-hint dav-link-hint" data-testid="dav-link-hint">
                     This account is also linked to {{ form.caldav_url }}.
                   </span>
                   <button
@@ -1614,14 +1614,14 @@ onMounted(() => {
   line-height: 1.4;
 }
 
-.dav-discovery-row {
+.mail-discovery-row {
   display: flex;
   align-items: center;
   gap: 10px;
   flex-wrap: wrap;
 }
 
-.dav-discovered-url {
+.dav-link-hint {
   word-break: break-all;
 }
 

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -168,12 +168,30 @@ function selectAccountType(type: AccountType) {
     case "imap":
       f.provider = "generic";
       f.mail_protocol = "imap";
+      // Switching from Gmail / O365 leaves their pre-filled hosts
+      // in the form; clear them so the user starts on an empty
+      // server for a generic IMAP account they're meant to fill in
+      // manually (or via auto-discover).
+      if (!editingAccountId.value) {
+        f.imap_host = "";
+        f.imap_port = 993;
+        f.smtp_host = "";
+        f.smtp_port = 587;
+      }
       f.jmap_url = "";
       f.use_tls = true;
       break;
     case "jmap":
       f.provider = "generic";
       f.mail_protocol = "jmap";
+      // Same logic: any IMAP host pre-filled by Gmail / O365 / a
+      // previous IMAP click is irrelevant for JMAP, clear it.
+      if (!editingAccountId.value) {
+        f.imap_host = "";
+        f.imap_port = 0;
+        f.smtp_host = "";
+        f.smtp_port = 0;
+      }
       f.use_tls = true;
       break;
     case "caldav":
@@ -278,23 +296,18 @@ async function openEditForm(id: string) {
   }
 }
 
-/// Run Thunderbird-style autoconfig + CalDAV/CardDAV probing for the
-/// current form (#43). Applies any discovered IMAP/SMTP host+port+TLS
-/// settings AND the DAV URL if found. Each piece is independent: a
-/// successful autoconfig with no DAV still pre-fills the mail servers
-/// and vice versa. A summary of what was filled in is shown below the
-/// button.
-async function discoverDavEndpoints() {
+/// Thunderbird-style mail-server autodiscovery for the IMAP tab.
+/// Applies any discovered IMAP/SMTP host+port+TLS settings to the
+/// form. CalDAV / CardDAV are intentionally not probed here: an
+/// IMAP account is mail-only by design now, and pretending
+/// otherwise turned out to silently glue mail and DAV bindings
+/// onto the same row, then collide with the dedicated CalDAV /
+/// CardDAV account types and produce duplicate calendars on sync.
+async function discoverMailServers() {
   discoveringDav.value = true;
   discoveryNote.value = null;
   try {
-    const result = await api.probeDavEndpoints(
-      form.value.email,
-      form.value.username || form.value.email,
-      form.value.password,
-      form.value.imap_host,
-      form.value.smtp_host,
-    );
+    const result = await api.discoverMailServers(form.value.email);
 
     const filled: string[] = [];
     if (result.imap_host) {
@@ -324,12 +337,6 @@ async function discoverDavEndpoints() {
       form.value.use_tls = result.imap_use_tls;
     } else if (result.smtp_host) {
       form.value.use_tls = result.smtp_use_tls;
-    }
-    const davUrl = result.caldav_url || result.carddav_url;
-    if (davUrl) {
-      form.value.caldav_url = davUrl;
-      if (result.caldav_url) filled.push("CalDAV");
-      if (result.carddav_url) filled.push("CardDAV");
     }
 
     if (filled.length === 0) {
@@ -930,27 +937,40 @@ onMounted(() => {
 
             <template v-if="accountType === 'imap'">
               <div class="form-group">
-                <label>Calendar &amp; Contacts (CalDAV / CardDAV)</label>
+                <label>Mail server auto-discovery</label>
                 <div class="dav-discovery-row">
                   <button
                     type="button"
                     class="btn-secondary"
                     data-testid="dav-discover-btn"
-                    :disabled="discoveringDav || !form.email || !form.password"
-                    @click="discoverDavEndpoints"
+                    :disabled="discoveringDav || !form.email"
+                    @click="discoverMailServers"
                   >
-                    {{ discoveringDav ? 'Searching...' : (form.caldav_url ? 'Re-run discovery' : 'Auto-discover') }}
+                    {{ discoveringDav ? 'Searching...' : 'Auto-discover IMAP / SMTP' }}
                   </button>
-                  <span v-if="form.caldav_url" class="field-hint dav-discovered-url" data-testid="dav-discovered-url">
-                    Found at {{ form.caldav_url }}
-                  </span>
-                  <span v-else-if="!form.email || !form.password" class="field-hint">
-                    Enter email and password first.
+                  <span v-if="!form.email" class="field-hint">
+                    Enter your email address first.
                   </span>
                 </div>
                 <span v-if="discoveryNote" class="field-hint" data-testid="dav-discovery-note">
                   {{ discoveryNote }}
                 </span>
+                <span class="field-hint">
+                  Looks up the IMAP / SMTP host, port and TLS settings for your domain via Thunderbird-style autoconfig. Calendars and contacts are added as separate accounts on the CalDAV / CardDAV tabs.
+                </span>
+                <div v-if="editingAccountId && form.caldav_url" class="dav-cleanup-row">
+                  <span class="field-hint dav-discovered-url" data-testid="dav-discovered-url">
+                    This account is also linked to {{ form.caldav_url }}.
+                  </span>
+                  <button
+                    type="button"
+                    class="btn-secondary"
+                    data-testid="dav-unlink-btn"
+                    @click="form.caldav_url = ''"
+                  >
+                    Unlink calendar / contacts
+                  </button>
+                </div>
               </div>
             </template>
 


### PR DESCRIPTION
## Summary

Four-commit chain that splits IMAP from DAV cleanly, replaces the autoconfig MX-guessing with real port probing, and fixes the settings list labels for standalone DAV accounts.

1. **Strict IMAP / CalDAV / CardDAV separation** — IMAP-tab discovery no longer probes DAV; the silent auto-link that produced duplicate calendars is gone. Existing accounts with stale \`caldav_url\` from the old behavior get an "Unlink calendar / contacts" button. Tab-switch on new accounts clears Gmail / O365 pre-filled hosts when switching to IMAP / JMAP.
2. **Autoconfig never overwrites user-typed values** — only empty fields get filled, host and port checked independently, partial-fill messages reflect what was kept vs filled.
3. **Real port probing + host hints** — MX-fallback path TCP-probes 993 / 143 (IMAP) and 587 / 465 (SMTP) and only returns ports that actually answer. \`discover_mail_servers\` takes \`imap_host_hint\` / \`smtp_host_hint\`; hints win over autoconfig so a typed \`coms.smolnet.org\` isn't overridden by some MX relay.
4. **Account list labels** — standalone DAV accounts now read "Calendar" / "Contacts" / "Calendar and Contacts" using enabled-aware binding flags. \`saveAccount\` enforces the single-purpose-tab rule so legacy accounts with a stuck flag clean up on next save.

## Test plan

- [x] Create a fresh IMAP account, click Auto-discover IMAP / SMTP — only IMAP / SMTP get filled, no calendar / contacts binding gets created.
- [ ] Open an existing IMAP account that's been auto-linked to CalDAV — the new "Unlink calendar / contacts" button shows and clears the linkage on save.
- [x] Type a custom SMTP host, leave IMAP empty, click discover — only IMAP gets filled, SMTP stays as typed.
- [x] Empty port on a typed IMAP host, click discover — port gets filled (host probe), host stays.
- [x] Configure both IMAP and SMTP hosts, click discover — only those hosts are probed; no MX path runs.
- [x] CalDAV-tab account labels as "Calendar"; CardDAV-tab as "Contacts"; older auto-linked IMAP+DAV accounts re-save and label correctly.
- [x] Switching from Gmail to IMAP on a new-account dialog clears the imap.gmail.com / smtp.gmail.com pre-fills.

\`cargo fmt\` / \`cargo clippy --all-targets -D warnings\` / \`cargo test --lib\` (236, serial) / \`vue-tsc\` / \`vitest\` (310) / \`npm run build\` all green.