### PR TITLE
feat(ui): context-aware View menu + visually consistent panes (#150)

### DIFF
--- a/src/__tests__/menu-bar.test.ts
+++ b/src/__tests__/menu-bar.test.ts
@@ -22,20 +22,40 @@ vi.mock("@tauri-apps/api/window", () => ({
   getCurrentWindow: () => ({ setDecorations: setDecorationsMock }),
 }));
 vi.mock("@tauri-apps/plugin-opener", () => ({ openUrl: openUrlMock }));
+// The calendar store subscribes to the "calendar-changed" event at
+// construction time; without this mock vue-router's first navigation
+// blows up in jsdom because the underlying transformCallback isn't
+// available.
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn().mockResolvedValue(() => {}),
+}));
 
 vi.mock("@/lib/tauri", () => ({
   listTimezones: vi.fn().mockResolvedValue([]),
   getDefaultTimezone: vi.fn().mockResolvedValue("UTC"),
 }));
 
+// Named routes mirror the real router so MenuBar's `route.name`-driven
+// View-menu context picks up "mail" / "calendar" / "contacts" the same
+// way the production app does.
 function makeRouter() {
   return createRouter({
     history: createMemoryHistory(),
     routes: [
-      { path: "/", component: { template: "<div/>" } },
-      { path: "/preferences", component: { template: "<div/>" } },
+      { path: "/", name: "mail", component: { template: "<div/>" } },
+      { path: "/calendar", name: "calendar", component: { template: "<div/>" } },
+      { path: "/contacts", name: "contacts", component: { template: "<div/>" } },
+      { path: "/preferences", name: "preferences", component: { template: "<div/>" } },
     ],
   });
+}
+
+async function mountAt(path: string) {
+  const router = makeRouter();
+  await router.push(path);
+  await router.isReady();
+  const wrapper = mount(MenuBar, { global: { plugins: [router] } });
+  return { wrapper, router };
 }
 
 beforeEach(() => {
@@ -52,15 +72,15 @@ afterEach(() => {
 });
 
 describe("MenuBar", () => {
-  it("renders File / View / Help menu labels", () => {
-    const wrapper = mount(MenuBar, { global: { plugins: [makeRouter()] } });
+  it("renders File / View / Help menu labels on the mail route", async () => {
+    const { wrapper } = await mountAt("/");
     expect(wrapper.text()).toContain("File");
     expect(wrapper.text()).toContain("View");
     expect(wrapper.text()).toContain("Help");
   });
 
   it("Help > About opens the About dialog", async () => {
-    const wrapper = mount(MenuBar, { global: { plugins: [makeRouter()] } });
+    const { wrapper } = await mountAt("/");
     await wrapper.find('.menu-item:nth-of-type(3)').trigger("click");
     await wrapper.find('[data-testid="menu-help-about"]').trigger("click");
     await wrapper.vm.$nextTick();
@@ -97,8 +117,8 @@ describe("MenuBar", () => {
   });
 
   it("View menu shows the four-way radio with None / Right / Bottom / Tabs", async () => {
-    const wrapper = mount(MenuBar, { global: { plugins: [makeRouter()] } });
-    await wrapper.find('.menu-item:nth-of-type(2)').trigger("click");
+    const { wrapper } = await mountAt("/");
+    await wrapper.find('[data-testid="menu-view"]').trigger("click");
     const dropdown = wrapper.find('[data-testid="menu-view-dropdown"]');
     expect(dropdown.text()).toContain("Message Pane");
     expect(dropdown.text()).toContain("None");
@@ -116,8 +136,8 @@ describe("MenuBar", () => {
 
   it("Selecting None hides the pane via setMessageViewMode", async () => {
     const { useUiStore } = await import("@/stores/ui");
-    const wrapper = mount(MenuBar, { global: { plugins: [makeRouter()] } });
-    await wrapper.find('.menu-item:nth-of-type(2)').trigger("click");
+    const { wrapper } = await mountAt("/");
+    await wrapper.find('[data-testid="menu-view"]').trigger("click");
     await wrapper.find('[data-testid="menu-view-position-none"]').trigger("click");
     const ui = useUiStore();
     expect(ui.messageViewMode).toBe("none");
@@ -133,14 +153,14 @@ describe("MenuBar", () => {
   });
 
   it("Ctrl+T toggles threading via the keydown listener", async () => {
-    const wrapper = mount(MenuBar, { global: { plugins: [makeRouter()] } });
+    const { wrapper } = await mountAt("/");
     // We don't have direct access to uiStore here without importing; check
     // via the menu rendering after dispatch.
     const event = new KeyboardEvent("keydown", { key: "t", ctrlKey: true, cancelable: true });
     window.dispatchEvent(event);
     await wrapper.vm.$nextTick();
     // Open View again to inspect the new state of "Threaded View" prefix.
-    await wrapper.find('.menu-item:nth-of-type(2)').trigger("click");
+    await wrapper.find('[data-testid="menu-view"]').trigger("click");
     const threaded = wrapper.find('[data-testid="menu-view-threaded"]');
     // Default threading is enabled; after Ctrl+T it should be off (no checkmark).
     expect(threaded.text()).not.toContain("\u2713");
@@ -164,5 +184,58 @@ describe("MenuBar", () => {
     );
     expect(invokeMock).not.toHaveBeenCalled();
     input.remove();
+  });
+
+  // --- Issue #150: View menu is context-aware ----------------------------
+
+  it("hides the View menu on routes that have no view-menu items", async () => {
+    const { wrapper } = await mountAt("/preferences");
+    expect(wrapper.find('[data-testid="menu-view"]').exists()).toBe(false);
+    // File and Help still render — only the View top-level button is gone.
+    expect(wrapper.text()).toContain("File");
+    expect(wrapper.text()).toContain("Help");
+  });
+
+  it("hides the View menu on the calendar route (toolbar already exposes it)", async () => {
+    // Calendar's Day/Week/Month live in the view's own toolbar; the
+    // menu would just duplicate them, so it's deliberately suppressed.
+    const { wrapper } = await mountAt("/calendar");
+    expect(wrapper.find('[data-testid="menu-view"]').exists()).toBe(false);
+  });
+
+  it("shows Right / Bottom contact-pane options on the contacts route", async () => {
+    const { wrapper } = await mountAt("/contacts");
+    await wrapper.find('[data-testid="menu-view"]').trigger("click");
+    const dropdown = wrapper.find('[data-testid="menu-view-dropdown"]');
+    expect(dropdown.exists()).toBe(true);
+    expect(dropdown.text()).toContain("Contact Pane");
+    expect(dropdown.text()).toContain("Right");
+    expect(dropdown.text()).toContain("Bottom");
+    // Mail-only items must not leak into the contacts context.
+    expect(dropdown.text()).not.toContain("Message Pane");
+    expect(dropdown.text()).not.toContain("Threaded View");
+    // Default contactViewMode is "right" — that row carries the bullet.
+    const right = wrapper.find('[data-testid="menu-view-contact-position-right"]');
+    expect(right.text()).toContain("●");
+  });
+
+  it("selecting Bottom on the contacts route updates the ui store", async () => {
+    const { useUiStore } = await import("@/stores/ui");
+    const { wrapper } = await mountAt("/contacts");
+    await wrapper.find('[data-testid="menu-view"]').trigger("click");
+    await wrapper
+      .find('[data-testid="menu-view-contact-position-bottom"]')
+      .trigger("click");
+    expect(useUiStore().contactViewMode).toBe("bottom");
+  });
+
+  it("does not show contact-pane items on the mail route", async () => {
+    const { wrapper } = await mountAt("/");
+    await wrapper.find('[data-testid="menu-view"]').trigger("click");
+    const dropdown = wrapper.find('[data-testid="menu-view-dropdown"]');
+    expect(dropdown.text()).not.toContain("Contact Pane");
+    expect(
+      dropdown.find('[data-testid="menu-view-contact-position-right"]').exists(),
+    ).toBe(false);
   });
 });

--- a/src/assets/styles/main.css
+++ b/src/assets/styles/main.css
@@ -179,6 +179,27 @@ select {
   color: inherit;
 }
 
+/* === Shared layout: left-pane header (#150) ===
+   Small uppercase label that sits at the top of the calendar /
+   mail / contacts / filters left sidebar. Sized to match the
+   right-pane toolbar height so the bottom border across the two
+   panes forms one continuous strip across the view. */
+.app-sidebar-header {
+  font-size: 10px;
+  font-weight: 700;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  height: 48px;
+  display: flex;
+  align-items: center;
+  padding: 0 16px;
+  border-bottom: 0.8px solid var(--color-border);
+  background: var(--color-bg-secondary);
+  flex-shrink: 0;
+  box-sizing: border-box;
+}
+
 /* === Mobile overrides (<= 720px) === */
 @media (max-width: 720px) {
   body {

--- a/src/assets/styles/main.css
+++ b/src/assets/styles/main.css
@@ -198,6 +198,13 @@ select {
   background: var(--color-bg-secondary);
   flex-shrink: 0;
   box-sizing: border-box;
+  /* The mail FolderTree and contacts books-sidebar both have
+     overflow-y: auto, so the heading would otherwise scroll away
+     with the list. Stick it to the top of the scroll container so
+     it stays aligned with the right-pane toolbar at all times. */
+  position: sticky;
+  top: 0;
+  z-index: 1;
 }
 
 /* === Mobile overrides (<= 720px) === */

--- a/src/components/calendar/CalendarSidebar.vue
+++ b/src/components/calendar/CalendarSidebar.vue
@@ -290,7 +290,7 @@ async function unsubscribeThisCalendar() {
 
 <template>
   <div class="calendar-sidebar">
-    <div class="sidebar-header">CALENDARS</div>
+    <div class="app-sidebar-header">Calendars</div>
     <div class="calendar-list">
       <div
         v-for="cal in calendarStore.calendars"
@@ -469,23 +469,15 @@ async function unsubscribeThisCalendar() {
   display: flex;
   flex-direction: column;
   background: var(--color-bg-secondary);
-  padding: 16px 12px;
 }
 
-.sidebar-header {
-  font-size: 10px;
-  font-weight: 700;
-  color: var(--color-text-muted);
-  text-transform: uppercase;
-  letter-spacing: 1px;
-  padding: 0 4px 12px;
-  border-bottom: 1px solid var(--color-border);
-  margin-bottom: 12px;
-}
-
+/* The sidebar heading is 48px and full-width (no horizontal padding
+   from the parent), matching the right-pane toolbar. Items below get
+   their own padding via .calendar-list. */
 .calendar-list {
   flex: 1;
   overflow-y: auto;
+  padding: 12px;
 }
 
 .calendar-item {

--- a/src/components/common/MenuBar.vue
+++ b/src/components/common/MenuBar.vue
@@ -126,9 +126,11 @@ onUnmounted(() => window.removeEventListener("keydown", onKeyDown));
       </div>
     </div>
 
-    <!-- View menu \u2014 context-aware. Hidden entirely on routes whose
-         view has no toggles (contacts, filters, settings, reader,
-         compose) so the user doesn't open a menu with nothing in it. -->
+    <!-- View menu \u2014 context-aware. Mail and contacts each have
+         their own per-pane toggles; everywhere else (calendar uses
+         its own toolbar, filters / settings / preferences / reader /
+         compose have nothing to toggle) the View top-level button
+         is hidden so the user doesn't open a menu with nothing in it. -->
     <div
       v-if="viewMenuContext"
       class="menu-item"

--- a/src/components/common/MenuBar.vue
+++ b/src/components/common/MenuBar.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
-import { onMounted, onUnmounted, ref } from "vue";
-import { useRouter } from "vue-router";
+import { computed, onMounted, onUnmounted, ref } from "vue";
+import { useRouter, useRoute } from "vue-router";
 import { invoke } from "@tauri-apps/api/core";
-import { useUiStore, type MessageViewMode } from "@/stores/ui";
+import { useUiStore, type ContactViewMode, type MessageViewMode } from "@/stores/ui";
 import {
   dispatch,
   formatShortcut,
@@ -12,8 +12,30 @@ import {
 import AboutDialog from "@/components/common/AboutDialog.vue";
 
 const router = useRouter();
+const route = useRoute();
 const uiStore = useUiStore();
 const openMenu = ref<string | null>(null);
+
+// Which contents the View menu should render — driven by the active
+// route. Mail and contacts both have meaningful per-view toggles
+// (message-pane layout / threading; contact-pane layout). The
+// calendar route deliberately doesn't get a View menu — its toolbar
+// already exposes Day / Week / Month, and surfacing the same options
+// here would just duplicate that selector. Other views (filters,
+// settings, reader, compose) have no view-menu items, so the View
+// top-level button is hidden entirely rather than show an empty
+// dropdown.
+type ViewMenuContext = "mail" | "contacts" | null;
+const viewMenuContext = computed<ViewMenuContext>(() => {
+  switch (route.name) {
+    case "mail":
+      return "mail";
+    case "contacts":
+      return "contacts";
+    default:
+      return null;
+  }
+});
 
 function toggleMenu(name: string) {
   openMenu.value = openMenu.value === name ? null : name;
@@ -42,6 +64,11 @@ function setViewMode(mode: MessageViewMode) {
 
 function toggleThreading() {
   uiStore.setThreading(!uiStore.threadingEnabled);
+  closeMenus();
+}
+
+function setContactViewMode(mode: ContactViewMode) {
+  uiStore.setContactViewMode(mode);
   closeMenus();
 }
 
@@ -99,51 +126,80 @@ onUnmounted(() => window.removeEventListener("keydown", onKeyDown));
       </div>
     </div>
 
-    <!-- View menu -->
-    <div class="menu-item" @click.stop="toggleMenu('view')">
+    <!-- View menu \u2014 context-aware. Hidden entirely on routes whose
+         view has no toggles (contacts, filters, settings, reader,
+         compose) so the user doesn't open a menu with nothing in it. -->
+    <div
+      v-if="viewMenuContext"
+      class="menu-item"
+      data-testid="menu-view"
+      @click.stop="toggleMenu('view')"
+    >
       <span class="menu-label">View</span>
       <div v-if="openMenu === 'view'" class="menu-dropdown" @click.stop data-testid="menu-view-dropdown">
-        <div class="menu-group-heading">Message Pane</div>
-        <button
-          class="menu-action menu-action-radio"
-          data-testid="menu-view-position-none"
-          @click="setViewMode('none')"
-        >
-          <span class="action-prefix">{{ uiStore.messageViewMode === 'none' ? '\u25CF' : '\u00A0' }}</span>
-          <span class="action-label">None</span>
-        </button>
-        <button
-          class="menu-action menu-action-radio"
-          data-testid="menu-view-position-right"
-          @click="setViewMode('right')"
-        >
-          <span class="action-prefix">{{ uiStore.messageViewMode === 'right' ? '\u25CF' : '\u00A0' }}</span>
-          <span class="action-label">Right</span>
-        </button>
-        <button
-          class="menu-action menu-action-radio"
-          data-testid="menu-view-position-bottom"
-          @click="setViewMode('bottom')"
-        >
-          <span class="action-prefix">{{ uiStore.messageViewMode === 'bottom' ? '\u25CF' : '\u00A0' }}</span>
-          <span class="action-label">Bottom</span>
-        </button>
-        <button
-          class="menu-action menu-action-radio"
-          data-testid="menu-view-position-tabs"
-          @click="setViewMode('tab')"
-        >
-          <span class="action-prefix">{{ uiStore.messageViewMode === 'tab' ? '\u25CF' : '\u00A0' }}</span>
-          <span class="action-label">Tabs</span>
-        </button>
+        <template v-if="viewMenuContext === 'mail'">
+          <div class="menu-group-heading">Message Pane</div>
+          <button
+            class="menu-action menu-action-radio"
+            data-testid="menu-view-position-none"
+            @click="setViewMode('none')"
+          >
+            <span class="action-prefix">{{ uiStore.messageViewMode === 'none' ? '\u25CF' : '\u00A0' }}</span>
+            <span class="action-label">None</span>
+          </button>
+          <button
+            class="menu-action menu-action-radio"
+            data-testid="menu-view-position-right"
+            @click="setViewMode('right')"
+          >
+            <span class="action-prefix">{{ uiStore.messageViewMode === 'right' ? '\u25CF' : '\u00A0' }}</span>
+            <span class="action-label">Right</span>
+          </button>
+          <button
+            class="menu-action menu-action-radio"
+            data-testid="menu-view-position-bottom"
+            @click="setViewMode('bottom')"
+          >
+            <span class="action-prefix">{{ uiStore.messageViewMode === 'bottom' ? '\u25CF' : '\u00A0' }}</span>
+            <span class="action-label">Bottom</span>
+          </button>
+          <button
+            class="menu-action menu-action-radio"
+            data-testid="menu-view-position-tabs"
+            @click="setViewMode('tab')"
+          >
+            <span class="action-prefix">{{ uiStore.messageViewMode === 'tab' ? '\u25CF' : '\u00A0' }}</span>
+            <span class="action-label">Tabs</span>
+          </button>
 
-        <div class="menu-separator"></div>
+          <div class="menu-separator"></div>
 
-        <button class="menu-action" data-testid="menu-view-threaded" @click="toggleThreading">
-          <span class="action-prefix">{{ uiStore.threadingEnabled ? '\u2713' : '\u00A0' }}</span>
-          <span class="action-label">Threaded View</span>
-          <span class="action-shortcut">{{ formatShortcut(sc.toggleThreading) }}</span>
-        </button>
+          <button class="menu-action" data-testid="menu-view-threaded" @click="toggleThreading">
+            <span class="action-prefix">{{ uiStore.threadingEnabled ? '\u2713' : '\u00A0' }}</span>
+            <span class="action-label">Threaded View</span>
+            <span class="action-shortcut">{{ formatShortcut(sc.toggleThreading) }}</span>
+          </button>
+        </template>
+
+        <template v-else-if="viewMenuContext === 'contacts'">
+          <div class="menu-group-heading">Contact Pane</div>
+          <button
+            class="menu-action menu-action-radio"
+            data-testid="menu-view-contact-position-right"
+            @click="setContactViewMode('right')"
+          >
+            <span class="action-prefix">{{ uiStore.contactViewMode === 'right' ? '\u25CF' : '\u00A0' }}</span>
+            <span class="action-label">Right</span>
+          </button>
+          <button
+            class="menu-action menu-action-radio"
+            data-testid="menu-view-contact-position-bottom"
+            @click="setContactViewMode('bottom')"
+          >
+            <span class="action-prefix">{{ uiStore.contactViewMode === 'bottom' ? '\u25CF' : '\u00A0' }}</span>
+            <span class="action-label">Bottom</span>
+          </button>
+        </template>
       </div>
     </div>
 

--- a/src/components/mail/FolderTree.vue
+++ b/src/components/mail/FolderTree.vue
@@ -366,6 +366,7 @@ async function doDeleteFolder() {
 
 <template>
   <div class="folder-tree" @click="closeContextMenu">
+    <div class="app-sidebar-header">Mailboxes</div>
     <div
       v-for="account in accountsStore.mailAccounts"
       :key="account.id"

--- a/src/components/mail/Toolbar.vue
+++ b/src/components/mail/Toolbar.vue
@@ -66,13 +66,17 @@ async function markNotSpam() {
 </template>
 
 <style scoped>
+/* Matches the calendar / contacts toolbars in height, padding,
+   background, and border so all three views show a uniform top
+   strip — see #150. */
 .toolbar {
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 6px 12px;
-  background: var(--color-bg);
-  border-bottom: 1px solid var(--color-border);
+  height: 48px;
+  padding: 0 16px;
+  background: var(--color-bg-secondary);
+  border-bottom: 0.8px solid var(--color-border);
   flex-shrink: 0;
 }
 

--- a/src/stores/contacts.ts
+++ b/src/stores/contacts.ts
@@ -1,0 +1,32 @@
+/**
+ * Contacts UI state that needs to survive ContactsView un/remount —
+ * specifically the selected book and contact, so navigating away to
+ * Mail / Calendar and back doesn't lose what the user was looking at
+ * (#150 follow-up). Only stores ids; the actual list of books and
+ * contacts is fetched fresh by ContactsView each time it mounts.
+ */
+import { defineStore } from "pinia";
+import { ref } from "vue";
+
+export const useContactsStore = defineStore("contacts", () => {
+  const selectedBookId = ref<string | null>(null);
+  const selectedContactId = ref<string | null>(null);
+
+  function setSelectedBook(id: string | null) {
+    selectedBookId.value = id;
+    // Switching books invalidates the contact selection since the
+    // contact ids belong to a particular book.
+    selectedContactId.value = null;
+  }
+
+  function setSelectedContact(id: string | null) {
+    selectedContactId.value = id;
+  }
+
+  return {
+    selectedBookId,
+    selectedContactId,
+    setSelectedBook,
+    setSelectedContact,
+  };
+});

--- a/src/stores/ui.ts
+++ b/src/stores/ui.ts
@@ -8,8 +8,8 @@ export type MessageViewMode = "right" | "bottom" | "tab" | "none";
 const VALID_VIEW_MODES: MessageViewMode[] = ["right", "bottom", "tab", "none"];
 
 /// Where the contact card renders relative to the contact list. Mirrors
-/// MessageViewMode but with a smaller set: contacts don't have a tabs
-/// or none mode (selecting a contact always shows it somewhere).
+/// MessageViewMode but with a smaller set: contacts don't have tabs
+/// or a "none" mode (selecting a contact always shows it somewhere).
 export type ContactViewMode = "right" | "bottom";
 
 const VALID_CONTACT_VIEW_MODES: ContactViewMode[] = ["right", "bottom"];

--- a/src/stores/ui.ts
+++ b/src/stores/ui.ts
@@ -7,6 +7,13 @@ export type MessageViewMode = "right" | "bottom" | "tab" | "none";
 
 const VALID_VIEW_MODES: MessageViewMode[] = ["right", "bottom", "tab", "none"];
 
+/// Where the contact card renders relative to the contact list. Mirrors
+/// MessageViewMode but with a smaller set: contacts don't have a tabs
+/// or none mode (selecting a contact always shows it somewhere).
+export type ContactViewMode = "right" | "bottom";
+
+const VALID_CONTACT_VIEW_MODES: ContactViewMode[] = ["right", "bottom"];
+
 const VALID_THEMES: Theme[] = ["system", "light", "dark"];
 export type Theme = "system" | "light" | "dark";
 export type TimeFormat = "auto" | "12" | "24";
@@ -23,6 +30,12 @@ export const useUiStore = defineStore("ui", () => {
     (() => {
       const stored = localStorage.getItem("chithi-message-view-mode") as MessageViewMode | null;
       return stored && VALID_VIEW_MODES.includes(stored) ? stored : "right";
+    })(),
+  );
+  const contactViewMode = ref<ContactViewMode>(
+    (() => {
+      const stored = localStorage.getItem("chithi-contact-view-mode") as ContactViewMode | null;
+      return stored && VALID_CONTACT_VIEW_MODES.includes(stored) ? stored : "right";
     })(),
   );
   const theme = ref<Theme>(
@@ -104,6 +117,11 @@ export const useUiStore = defineStore("ui", () => {
     if (mode !== "none") {
       readerVisible.value = true;
     }
+  }
+
+  function setContactViewMode(mode: ContactViewMode) {
+    contactViewMode.value = mode;
+    localStorage.setItem("chithi-contact-view-mode", mode);
   }
 
   function setTheme(t: Theme) {
@@ -234,12 +252,14 @@ export const useUiStore = defineStore("ui", () => {
     messageListWidth,
     readerVisible,
     messageViewMode,
+    contactViewMode,
     theme,
     resolvedTheme,
     toggleReader,
     showReader,
     hideReader,
     setMessageViewMode,
+    setContactViewMode,
     setTheme,
     setThreading,
     initTheme,

--- a/src/views/ContactsView.vue
+++ b/src/views/ContactsView.vue
@@ -3,7 +3,9 @@ import { ref, computed, onMounted, onUnmounted, watch } from "vue";
 import { storeToRefs } from "pinia";
 import { listen } from "@tauri-apps/api/event";
 import { useAccountsStore } from "@/stores/accounts";
+import { useContactsStore } from "@/stores/contacts";
 import { usePlatformStore } from "@/stores/platform";
+import { useUiStore } from "@/stores/ui";
 import type { ContactBook, Contact } from "@/lib/types";
 import * as api from "@/lib/tauri";
 import { acctColor } from "@/lib/account-colors";
@@ -29,13 +31,20 @@ const PHONE_LABEL_OPTIONS = [
 ];
 
 const accountsStore = useAccountsStore();
+const contactsStore = useContactsStore();
 const platformStore = usePlatformStore();
+const uiStore = useUiStore();
 const { isMobile } = storeToRefs(platformStore);
+// Selected-book / selected-contact state is mirrored from the
+// contacts store so that navigating away to Mail / Calendar and back
+// restores what the user was looking at. Local refs still drive the
+// template — we keep them in sync via watchers below.
+const { selectedBookId: storeSelectedBookId } = storeToRefs(contactsStore);
 
 const contactBooks = ref<ContactBook[]>([]);
 const contacts = ref<Contact[]>([]);
 const searchQuery = ref("");
-const selectedBookId = ref<string | null>(null);
+const selectedBookId = ref<string | null>(storeSelectedBookId.value);
 const selectedContact = ref<Contact | null>(null);
 const showForm = ref(false);
 const showDeleteConfirm = ref(false);
@@ -215,6 +224,13 @@ async function contactsTick() {
 onMounted(async () => {
   // Load local data first, then sync in background
   await fetchBooks();
+  // fetchBooks only mutates selectedBookId when the previously-saved
+  // id is gone, in which case the watcher above triggers the contacts
+  // fetch. When the selection survives (the common case on remount
+  // after navigating back to the contacts view), the value didn't
+  // change so the watcher doesn't fire — call the load explicitly so
+  // the user lands on the same contact they left. (#150)
+  await loadContactsForSelectedBook();
   syncAllContacts();
 
   // Start periodic sync (per-account cadence via contacts binding)
@@ -309,15 +325,37 @@ async function fetchBooks() {
   }
 }
 
-watch(selectedBookId, async (bookId) => {
-  if (bookId) {
-    contacts.value = await api.listContacts(bookId);
-    selectedContact.value = null;
-    // Multi-select state belongs to the previously-shown book; drop
-    // it on book switch so the merge toolbar can't sit visible with
-    // ids that aren't in the current list.
-    selectedContactIds.value = [];
-  }
+async function loadContactsForSelectedBook() {
+  const bookId = selectedBookId.value;
+  if (!bookId) return;
+  contacts.value = await api.listContacts(bookId);
+  // Restore the previously selected contact from the store on remount,
+  // if it still exists in the loaded list. Falls through to null when
+  // the user just switched books or the contact is gone.
+  const wantedId = contactsStore.selectedContactId;
+  selectedContact.value = wantedId
+    ? contacts.value.find((c) => c.id === wantedId) ?? null
+    : null;
+  // Multi-select state belongs to the previously-shown book; drop it
+  // on book switch so the merge toolbar can't sit visible with ids
+  // that aren't in the current list.
+  selectedContactIds.value = [];
+}
+
+watch(selectedBookId, () => {
+  loadContactsForSelectedBook();
+});
+
+// Mirror local selection state into the contacts store so navigating
+// away to Mail / Calendar and back lands us on the same contact (#150).
+// Sync runs in one direction (local → store) because the store fields
+// are never mutated externally; on remount we read them to seed the
+// local refs and the watcher above re-loads contacts.
+watch(selectedBookId, (id) => {
+  if (id !== contactsStore.selectedBookId) contactsStore.setSelectedBook(id);
+});
+watch(selectedContact, (c) => {
+  contactsStore.setSelectedContact(c?.id ?? null);
 });
 
 // Prune `selectedContactIds` against the current contact list whenever
@@ -792,22 +830,13 @@ async function applyMerge() {
 
   <!-- Desktop layout — unchanged -->
   <div v-else class="contacts-view">
-    <!-- Toolbar -->
-    <div class="contacts-toolbar">
-      <button class="btn-new" data-testid="contacts-new-btn" @click="openNewForm">
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" /><circle cx="8.5" cy="7" r="4" /><line x1="20" y1="8" x2="20" y2="14" /><line x1="23" y1="11" x2="17" y2="11" /></svg>
-        New Contact
-      </button>
-      <div class="toolbar-sep"></div>
-      <button class="btn-sync" :disabled="syncing" @click="syncAllContacts">
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" :class="{ spinning: syncing }"><path d="M21 2v6h-6M3 12a9 9 0 0 1 15-6.7L21 8M3 22v-6h6M21 12a9 9 0 0 1-15 6.7L3 16" /></svg>
-        {{ syncing ? "Syncing..." : "Sync" }}
-      </button>
-    </div>
-
-    <div class="contacts-body">
+    <div
+      class="contacts-body"
+      :class="`contacts-layout-${uiStore.contactViewMode}`"
+    >
       <!-- Left: Contact Books -->
       <div class="books-sidebar" data-testid="contacts-book-select">
+        <div class="app-sidebar-header">Address Books</div>
         <div
           v-for="book in contactBooks"
           :key="book.id"
@@ -834,6 +863,31 @@ async function applyMerge() {
         <div v-if="contactBooks.length === 0" class="empty-text">No contact books</div>
       </div>
 
+      <!-- Middle + Right wrapper. Direction toggles via the
+           `contacts-layout-{right,bottom}` class on the parent: row
+           (default) puts the detail card to the right of the list,
+           column drops it underneath. (#150) -->
+      <div class="contacts-main">
+
+      <!-- Toolbar (#150). Lives inside the main pane so the
+           "+ New Contact" button sits above the contact list, mirror-
+           ing how Calendar's "+ Event" sits in its own toolbar. The
+           "ADDRESS BOOKS" header on the left is the visual partner. -->
+      <div class="contacts-toolbar">
+        <button class="btn-new" data-testid="contacts-new-btn" @click="openNewForm">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" /><circle cx="8.5" cy="7" r="4" /><line x1="20" y1="8" x2="20" y2="14" /><line x1="23" y1="11" x2="17" y2="11" /></svg>
+          New Contact
+        </button>
+        <div class="toolbar-sep"></div>
+        <button class="btn-sync" :disabled="syncing" @click="syncAllContacts">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" :class="{ spinning: syncing }"><path d="M21 2v6h-6M3 12a9 9 0 0 1 15-6.7L21 8M3 22v-6h6M21 12a9 9 0 0 1-15 6.7L3 16" /></svg>
+          {{ syncing ? "Syncing..." : "Sync" }}
+        </button>
+      </div>
+
+      <!-- Inner wrapper. Carries the layout-toggle so the toolbar
+           above stays at the top regardless of right-vs-bottom mode. -->
+      <div class="contacts-content">
       <!-- Middle: Contact List -->
       <div class="contact-list-panel">
         <div class="search-bar">
@@ -937,6 +991,8 @@ async function applyMerge() {
         </template>
         <div v-else class="empty-text">Select a contact to view details</div>
       </div>
+      </div><!-- /.contacts-content -->
+      </div><!-- /.contacts-main -->
     </div>
 
     <!-- New/Edit Contact Modal -->
@@ -1283,7 +1339,20 @@ async function applyMerge() {
   background: var(--color-bg-secondary);
   border-right: 0.8px solid var(--color-border);
   overflow-y: auto;
-  padding: 8px;
+  display: flex;
+  flex-direction: column;
+}
+
+/* Inner items get the indent that used to live on .books-sidebar so
+   the .app-sidebar-header above sits flush with the toolbar's left
+   edge instead of being pushed in 8px from the container. (#150) */
+.books-sidebar .book-item,
+.books-sidebar .empty-text {
+  margin: 0 8px;
+}
+.books-sidebar > .book-item:first-of-type,
+.books-sidebar > .app-sidebar-header + .book-item {
+  margin-top: 8px;
 }
 
 .book-item {
@@ -1341,13 +1410,45 @@ async function applyMerge() {
   color: var(--color-text-muted);
 }
 
+/* Wrapper around the toolbar + contact-list + detail panes. The
+   toolbar always sits at the top so its layout never depends on the
+   View > Contact Pane choice (the toggle below applies to
+   .contacts-content, not the .contacts-main wrapper). */
+.contacts-main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+}
+
+/* Inner content frame that the right/bottom layout toggle targets. */
+.contacts-content {
+  flex: 1;
+  display: flex;
+  min-width: 0;
+  min-height: 0;
+}
+.contacts-layout-right .contacts-content {
+  flex-direction: row;
+}
+.contacts-layout-bottom .contacts-content {
+  flex-direction: column;
+}
+
 /* Contact List */
 .contact-list-panel {
   flex: 1;
   display: flex;
   flex-direction: column;
   min-width: 0;
+  min-height: 0;
+}
+.contacts-layout-right .contact-list-panel {
   border-right: 0.8px solid var(--color-border);
+}
+.contacts-layout-bottom .contact-list-panel {
+  border-bottom: 0.8px solid var(--color-border);
 }
 
 .search-bar {
@@ -1419,11 +1520,20 @@ async function applyMerge() {
 .contact-email { font-size: 14px; color: var(--color-text-secondary); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .contact-org { font-size: 12px; color: var(--color-text-muted); }
 
-/* Detail Panel */
+/* Detail Panel. Sized differently per layout mode:
+   - "right": fixed 400px column, list takes the remaining width.
+   - "bottom": flexible split, both panes share the column. */
 .detail-panel {
-  width: 400px;
   flex-shrink: 0;
   overflow-y: auto;
+}
+.contacts-layout-right .detail-panel {
+  width: 400px;
+}
+.contacts-layout-bottom .detail-panel {
+  width: auto;
+  flex: 1;
+  min-height: 0;
 }
 
 .detail-header {

--- a/src/views/ContactsView.vue
+++ b/src/views/ContactsView.vue
@@ -222,15 +222,20 @@ async function contactsTick() {
 }
 
 onMounted(async () => {
-  // Load local data first, then sync in background
+  // Load local data first, then sync in background.
+  const idBefore = selectedBookId.value;
   await fetchBooks();
   // fetchBooks only mutates selectedBookId when the previously-saved
-  // id is gone, in which case the watcher above triggers the contacts
-  // fetch. When the selection survives (the common case on remount
-  // after navigating back to the contacts view), the value didn't
-  // change so the watcher doesn't fire — call the load explicitly so
-  // the user lands on the same contact they left. (#150)
-  await loadContactsForSelectedBook();
+  // id is gone, in which case the watcher above already fires off
+  // the contacts fetch. When the selection survives (the common
+  // case on remount after navigating back to contacts), the value
+  // didn't change so the watcher doesn't fire — call the load
+  // explicitly so the user lands on the same contact they left.
+  // (#150) Skipping it when the id changed avoids an extra
+  // listContacts() round-trip on first-ever mount.
+  if (selectedBookId.value === idBefore) {
+    await loadContactsForSelectedBook();
+  }
   syncAllContacts();
 
   // Start periodic sync (per-account cadence via contacts binding)
@@ -1350,7 +1355,6 @@ async function applyMerge() {
 .books-sidebar .empty-text {
   margin: 0 8px;
 }
-.books-sidebar > .book-item:first-of-type,
 .books-sidebar > .app-sidebar-header + .book-item {
   margin-top: 8px;
 }

--- a/src/views/FiltersView.vue
+++ b/src/views/FiltersView.vue
@@ -213,8 +213,8 @@ const actionFolderOptions = computed(() => [
   <div class="filters-view">
     <!-- Left Panel: filter list -->
     <div class="filters-left">
+      <div class="app-sidebar-header">Filters</div>
       <div class="left-header">
-        <h2 class="left-title">Message Filters</h2>
         <Select
           :model-value="accountsStore.activeAccountId ?? ''"
           :options="accountOptions"
@@ -409,15 +409,7 @@ const actionFolderOptions = computed(() => [
   display: flex;
   flex-direction: column;
   gap: 12px;
-  padding: 16px;
-  border-bottom: 1px solid var(--color-border);
-}
-
-.left-title {
-  font-size: 16px;
-  font-weight: 600;
-  color: var(--color-text);
-  margin: 0;
+  padding: 12px 16px;
 }
 
 .account-select {

--- a/src/views/MailView.vue
+++ b/src/views/MailView.vue
@@ -351,13 +351,21 @@ onUnmounted(() => {
   </div>
 
   <div v-else class="mail-view">
-    <Toolbar />
     <div class="mail-panes">
       <!-- Folder pane -->
       <div class="folder-pane" :style="{ width: uiStore.folderPaneWidth + 'px' }">
         <FolderTree />
       </div>
       <div class="resize-handle" @mousedown="startResize('folder', $event)"></div>
+
+      <!-- Main pane (#150). Toolbar with Compose lives here so the
+           "Compose" button sits above the message list, mirroring how
+           Calendar's "+ Event" sits above the calendar grid. The
+           "MAILBOXES" header inside the folder tree is the visual
+           partner on the left. -->
+      <div class="mail-main">
+        <Toolbar />
+        <div class="mail-content">
 
       <!-- Right mode: message list + reader side by side -->
       <template v-if="uiStore.messageViewMode === 'right'">
@@ -449,6 +457,8 @@ onUnmounted(() => {
           </div>
         </div>
       </template>
+        </div><!-- /.mail-content -->
+      </div><!-- /.mail-main -->
     </div>
   </div>
 </template>
@@ -464,6 +474,22 @@ onUnmounted(() => {
 .mail-panes {
   display: flex;
   flex: 1;
+  min-height: 0;
+}
+
+/* Right side of the folder pane. Stacks the toolbar (with Compose)
+   on top of the message-list / reader content. (#150) */
+.mail-main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+}
+.mail-content {
+  flex: 1;
+  display: flex;
+  min-width: 0;
   min-height: 0;
 }
 


### PR DESCRIPTION
Closes #150.

## Summary

- View menu is now route-aware: hidden on calendar (the toolbar already has Day / Week / Month), hidden on routes with no view-menu items (filters / settings / preferences / reader / compose), shows existing mail items on the mail route, and a new Contact Pane Right / Bottom radio on the contacts route.
- Contacts view honors the new `contactViewMode` setting: detail card to the right of the list, or below it. Persisted to localStorage.
- Standalone DAV / mail / contacts / filters left panes all show a uniform "MAILBOXES" / "ADDRESS BOOKS" / "CALENDARS" / "FILTERS" header at the top, sized to match the right-pane toolbar so the bottom border forms one continuous strip across the view.
- Compose and New Contact buttons moved out of a full-width strip above both panes and into the right-pane toolbar, mirroring how Calendar's "+ Event" sits in its own toolbar.
- All toolbars (mail / calendar / contacts) standardized to the same height, padding, border, and background.
- Bonus: selected contact now survives navigation away and back. New `useContactsStore` holds the selected book + contact id; `ContactsView` mirrors local selection into the store on every change and restores it on remount.

## Test plan

- [x] Mail route shows the View menu with Message Pane radio + Threaded View toggle.
- [x] Calendar route has no View menu (the toolbar in the calendar view shows Day / Week / Month).
- [x] Contacts route shows View > Contact Pane: Right / Bottom. Picking Bottom moves the contact card under the list, Right back to the side. Choice persists across reloads.
- [x] Filters / Settings / Preferences / Reader / Compose routes have no View menu.
- [x] Each of the four views (mail / calendar / contacts / filters) has the same uniform top strip — heading on the left, action button(s) on the right at the same height.
- [ ] Compose lives in the mail toolbar above the message list. New Contact lives in the contacts toolbar above the contact list.
- [x] Open a contact, navigate to Mail, then back to Contacts — the same contact is still selected.
- [ ] Vitest 323 / cargo lib 236 (no Rust changes) / vue-tsc / build all green.