### PR TITLE
feat(meet): Nextcloud Talk + Matrix + Zoom video conferencing (#148)

### DIFF
--- a/src-tauri/src/commands/accounts.rs
+++ b/src-tauri/src/commands/accounts.rs
@@ -228,6 +228,8 @@ pub async fn get_account_config(
         smtp_port: full.smtp_port,
         jmap_url: full.jmap_url,
         caldav_url: full.caldav_url,
+        meet_url: full.meet_url,
+        meet_protocol: full.meet_protocol,
         username: full.username,
         password: String::new(),
         use_tls: full.use_tls,

--- a/src-tauri/src/commands/meet.rs
+++ b/src-tauri/src/commands/meet.rs
@@ -59,9 +59,12 @@ pub async fn meet_talk_login_complete(
     let display = display_name
         .filter(|s| !s.trim().is_empty())
         .unwrap_or_else(|| format!("Talk @ {}", short_host(&creds.server)));
+    // Talk's loginName is a Nextcloud username, not an email. Keep
+    // it in `username`; leave `email` empty so the listing falls
+    // back to the username + "NEXTCLOUD TALK" label.
     let config = db::accounts::AccountConfig {
         display_name: display,
-        email: creds.login_name.clone(),
+        email: String::new(),
         provider: "generic".into(),
         mail_protocol: String::new(),
         imap_host: String::new(),
@@ -162,9 +165,11 @@ pub async fn meet_matrix_login_complete(
     let display = display_name
         .filter(|s| !s.trim().is_empty())
         .unwrap_or_else(|| format!("Matrix ({})", result.user_id));
+    // Matrix MXIDs (`@user:server.tld`) aren't emails. Same
+    // treatment as Talk: empty email, MXID lives in `username`.
     let config = db::accounts::AccountConfig {
         display_name: display,
-        email: result.user_id.clone(),
+        email: String::new(),
         provider: "generic".into(),
         mail_protocol: String::new(),
         imap_host: String::new(),

--- a/src-tauri/src/commands/meet.rs
+++ b/src-tauri/src/commands/meet.rs
@@ -112,6 +112,20 @@ pub struct MatrixLoginStart {
     pub port: u16,
 }
 
+/// Matches the SSO callback timeout in `meet/matrix.rs`. Sessions
+/// older than this in `AppState.matrix_sso_listeners` are
+/// definitely abandoned (the user closed their browser, the app
+/// crashed, etc.) and get dropped on every fresh login_start
+/// call so the map can't grow unboundedly.
+const MATRIX_SSO_LISTENER_TTL: std::time::Duration = std::time::Duration::from_secs(360);
+
+fn evict_stale_matrix_sessions(
+    sessions: &mut std::collections::HashMap<u16, crate::state::MatrixSsoSession>,
+) {
+    let now = std::time::Instant::now();
+    sessions.retain(|_port, s| now.duration_since(s.created) < MATRIX_SSO_LISTENER_TTL);
+}
+
 /// Bind a local listener and return the SSO redirect URL the
 /// frontend should open. The listener is moved into a background
 /// task that waits for the callback (see `meet_matrix_login_complete`).
@@ -120,16 +134,23 @@ pub async fn meet_matrix_login_start(
     state: State<'_, AppState>,
     homeserver_url: String,
 ) -> Result<MatrixLoginStart> {
-    let (url, listener) = meet::matrix::sso_login_start(&homeserver_url)?;
+    let (url, listener, sso_state) = meet::matrix::sso_login_start(&homeserver_url)?;
     let port = listener
         .local_addr()
         .map_err(|e| Error::Other(format!("matrix listener port: {}", e)))?
         .port();
-    state
-        .matrix_sso_listeners
-        .lock()
-        .unwrap()
-        .insert(port, listener);
+    {
+        let mut map = state.matrix_sso_listeners.lock().unwrap();
+        evict_stale_matrix_sessions(&mut map);
+        map.insert(
+            port,
+            crate::state::MatrixSsoSession {
+                created: std::time::Instant::now(),
+                listener,
+                state: sso_state,
+            },
+        );
+    }
     Ok(MatrixLoginStart {
         login_url: url,
         port,
@@ -145,7 +166,7 @@ pub async fn meet_matrix_login_complete(
     port: u16,
     display_name: Option<String>,
 ) -> Result<String> {
-    let listener = state
+    let session = state
         .matrix_sso_listeners
         .lock()
         .unwrap()
@@ -156,9 +177,13 @@ pub async fn meet_matrix_login_complete(
                 port,
             ))
         })?;
-    let token = tokio::task::spawn_blocking(move || meet::matrix::await_login_token(listener))
-        .await
-        .map_err(|e| Error::Other(format!("matrix sso join: {}", e)))??;
+    let listener = session.listener;
+    let expected_state = session.state;
+    let token = tokio::task::spawn_blocking(move || {
+        meet::matrix::await_login_token(listener, &expected_state)
+    })
+    .await
+    .map_err(|e| Error::Other(format!("matrix sso join: {}", e)))??;
     let result = meet::matrix::exchange_login_token(&homeserver_url, &token).await?;
 
     let id = uuid::Uuid::new_v4().to_string();

--- a/src-tauri/src/commands/meet.rs
+++ b/src-tauri/src/commands/meet.rs
@@ -264,6 +264,25 @@ pub struct ZoomLoginStart {
 /// matching `meet_zoom_login_complete`.
 #[tauri::command]
 pub async fn meet_zoom_login_start(state: State<'_, AppState>) -> Result<ZoomLoginStart> {
+    // Evict any session that's still parked on the fixed Zoom
+    // port BEFORE we ask the OS to bind it. Without this, an
+    // abandoned previous flow (browser closed, renderer reload
+    // mid-flow, user cancels) keeps the listener and the next
+    // start fails with EADDRINUSE — and the eviction sweep that
+    // runs after the bind never reaches the stale entry.
+    if let Some(fixed_port) = crate::oauth::ZOOM.redirect_fixed_port {
+        let mut map = state.zoom_oauth_sessions.lock().unwrap();
+        evict_stale_zoom_sessions(&mut map);
+        if let Some(prev) = map.remove(&fixed_port) {
+            log::info!(
+                "meet_zoom_login_start: dropping previous session on port {} (age {:?}) so the new one can bind",
+                fixed_port,
+                std::time::Instant::now().duration_since(prev.created),
+            );
+            // `prev` (and its listener) drop here, releasing the
+            // port before we hit `get_auth_url` below.
+        }
+    }
     let (url, listener, code_verifier, oauth_state) =
         crate::oauth::get_auth_url(&crate::oauth::ZOOM)?;
     let port = listener
@@ -272,7 +291,6 @@ pub async fn meet_zoom_login_start(state: State<'_, AppState>) -> Result<ZoomLog
         .port();
     {
         let mut map = state.zoom_oauth_sessions.lock().unwrap();
-        evict_stale_zoom_sessions(&mut map);
         map.insert(
             port,
             crate::state::ZoomOAuthSession {
@@ -322,15 +340,23 @@ pub async fn meet_zoom_login_complete(
 
     match callback.state.as_deref() {
         Some(s) if s == expected_state => {}
-        Some(s) => {
-            return Err(Error::Other(format!(
-                "Zoom OAuth: state mismatch (expected {}, got {})",
-                expected_state, s
-            )));
+        Some(got) => {
+            // The raw nonces are unguessable random strings — no
+            // value to a human, and confusing in a UI toast.
+            // Log them at debug level for diagnostics; surface a
+            // short message to the user.
+            log::debug!(
+                "zoom oauth state mismatch: expected={} got={}",
+                expected_state,
+                got
+            );
+            return Err(Error::Other(
+                "Zoom sign-in could not be verified — please try again.".into(),
+            ));
         }
         None => {
             return Err(Error::Other(
-                "Zoom OAuth: callback missing required state parameter".into(),
+                "Zoom sign-in could not be verified — please try again.".into(),
             ));
         }
     }

--- a/src-tauri/src/commands/meet.rs
+++ b/src-tauri/src/commands/meet.rs
@@ -236,6 +236,158 @@ pub async fn meet_matrix_login_complete(
     Ok(id)
 }
 
+// --- Zoom OAuth flow (#148) -----------------------------------------------
+//
+// Standard OAuth 2.0 Authorization Code + PKCE against
+// `oauth::ZOOM`. The flow stashes its session (listener + PKCE
+// verifier + state nonce) in `state.zoom_oauth_sessions` between
+// the start and complete commands. The session map is evicted on
+// each insert by the same TTL pattern as the Matrix SSO map.
+
+const ZOOM_OAUTH_TTL: std::time::Duration = std::time::Duration::from_secs(360);
+
+fn evict_stale_zoom_sessions(
+    sessions: &mut std::collections::HashMap<u16, crate::state::ZoomOAuthSession>,
+) {
+    let now = std::time::Instant::now();
+    sessions.retain(|_port, s| now.duration_since(s.created) < ZOOM_OAUTH_TTL);
+}
+
+#[derive(Debug, Serialize)]
+pub struct ZoomLoginStart {
+    pub login_url: String,
+    pub port: u16,
+}
+
+/// Build the Zoom OAuth authorize URL, bind the local callback
+/// listener, and stash the PKCE verifier + state for the
+/// matching `meet_zoom_login_complete`.
+#[tauri::command]
+pub async fn meet_zoom_login_start(state: State<'_, AppState>) -> Result<ZoomLoginStart> {
+    let (url, listener, code_verifier, oauth_state) =
+        crate::oauth::get_auth_url(&crate::oauth::ZOOM)?;
+    let port = listener
+        .local_addr()
+        .map_err(|e| Error::Other(format!("zoom listener port: {}", e)))?
+        .port();
+    {
+        let mut map = state.zoom_oauth_sessions.lock().unwrap();
+        evict_stale_zoom_sessions(&mut map);
+        map.insert(
+            port,
+            crate::state::ZoomOAuthSession {
+                created: std::time::Instant::now(),
+                listener,
+                verifier: code_verifier,
+                state: oauth_state,
+            },
+        );
+    }
+    Ok(ZoomLoginStart {
+        login_url: url,
+        port,
+    })
+}
+
+/// Wait for the Zoom OAuth callback, validate state, exchange
+/// the code for tokens, persist the account row + keyring entry,
+/// return the new account id.
+#[tauri::command]
+pub async fn meet_zoom_login_complete(
+    state: State<'_, AppState>,
+    port: u16,
+    display_name: Option<String>,
+) -> Result<String> {
+    let session = state
+        .zoom_oauth_sessions
+        .lock()
+        .unwrap()
+        .remove(&port)
+        .ok_or_else(|| {
+            Error::Other(format!(
+                "Zoom OAuth: no pending session for port {} — start the flow again",
+                port,
+            ))
+        })?;
+    let crate::state::ZoomOAuthSession {
+        listener,
+        verifier,
+        state: expected_state,
+        ..
+    } = session;
+
+    let callback = tokio::task::spawn_blocking(move || crate::oauth::wait_for_callback(listener))
+        .await
+        .map_err(|e| Error::Other(format!("zoom oauth join: {}", e)))??;
+
+    match callback.state.as_deref() {
+        Some(s) if s == expected_state => {}
+        Some(s) => {
+            return Err(Error::Other(format!(
+                "Zoom OAuth: state mismatch (expected {}, got {})",
+                expected_state, s
+            )));
+        }
+        None => {
+            return Err(Error::Other(
+                "Zoom OAuth: callback missing required state parameter".into(),
+            ));
+        }
+    }
+
+    let tokens = crate::oauth::exchange_code(
+        &crate::oauth::ZOOM,
+        &callback.code,
+        port,
+        verifier.as_deref(),
+    )
+    .await?;
+
+    let id = uuid::Uuid::new_v4().to_string();
+    let display = display_name
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| "Zoom".into());
+    // Zoom is hosted by Zoom — there's no per-user server URL to
+    // remember. The meet binding stores a stable marker URL so
+    // `derive_bindings`'s "both fields set" guard still emits
+    // the binding; `create_url` ignores it.
+    let config = db::accounts::AccountConfig {
+        display_name: display,
+        email: String::new(),
+        provider: "generic".into(),
+        mail_protocol: String::new(),
+        imap_host: String::new(),
+        imap_port: 0,
+        smtp_host: String::new(),
+        smtp_port: 0,
+        jmap_url: String::new(),
+        caldav_url: String::new(),
+        meet_url: "https://zoom.us".into(),
+        meet_protocol: "zoom".into(),
+        username: String::new(),
+        password: String::new(),
+        use_tls: true,
+        signature: String::new(),
+        jmap_auth_method: "basic".into(),
+        oidc_token_endpoint: String::new(),
+        oidc_client_id: String::new(),
+        calendar_sync_enabled: false,
+        mail_sync_enabled: false,
+        contacts_sync_enabled: false,
+        mail_sync_interval_seconds: None,
+        calendar_sync_interval_seconds: None,
+        contacts_sync_interval_seconds: None,
+        has_calendar_binding: false,
+        has_contacts_binding: false,
+    };
+    let conn = state.db.writer().await;
+    db::accounts::insert_account(&conn, &id, &config)?;
+    drop(conn);
+
+    crate::oauth::store_tokens(&id, &tokens)?;
+    Ok(id)
+}
+
 /// Provider-agnostic create. Looks up the account, finds its meet
 /// provider via the registry, and returns the join URL. The event
 /// editor calls this with the event's title as `name`.

--- a/src-tauri/src/commands/meet.rs
+++ b/src-tauri/src/commands/meet.rs
@@ -1,0 +1,238 @@
+//! Tauri commands for the video-conferencing integrations (#148).
+//!
+//! Two browser-assisted auth flows live here, plus a single
+//! protocol-agnostic `meet_create_url` that dispatches via the
+//! `MeetProvider` registry. Settings UI calls the auth pair to
+//! create / pair an account; the event editor calls
+//! `meet_create_url` once the account is set up.
+
+use serde::Serialize;
+use tauri::State;
+
+use crate::db;
+use crate::error::{Error, Result};
+use crate::meet;
+use crate::state::AppState;
+
+/// Wire-format Tauri response for `meet_talk_login_start`. The
+/// frontend opens `login_url` in the user's default browser, then
+/// hands `poll_endpoint` + `poll_token` back to
+/// `meet_talk_login_complete` so the backend can poll until the
+/// user finishes the in-browser login flow.
+#[derive(Debug, Serialize)]
+pub struct TalkLoginStart {
+    pub login_url: String,
+    pub poll_endpoint: String,
+    pub poll_token: String,
+}
+
+#[tauri::command]
+pub async fn meet_talk_login_start(server_url: String) -> Result<TalkLoginStart> {
+    let flow = meet::talk::login_flow_v2_start(&server_url).await?;
+    Ok(TalkLoginStart {
+        login_url: flow.login,
+        poll_endpoint: flow.poll.endpoint,
+        poll_token: flow.poll.token,
+    })
+}
+
+/// Drive Login Flow v2 to completion, then create the local
+/// account row + meet binding + keyring entry. Returns the new
+/// account id so the frontend can navigate back to its detail.
+#[tauri::command]
+pub async fn meet_talk_login_complete(
+    state: State<'_, AppState>,
+    poll_endpoint: String,
+    poll_token: String,
+    display_name: Option<String>,
+) -> Result<String> {
+    let flow = meet::talk::LoginFlowStart {
+        login: String::new(),
+        poll: meet::talk::LoginPoll {
+            token: poll_token,
+            endpoint: poll_endpoint,
+        },
+    };
+    let creds = meet::talk::login_flow_v2_complete(&flow, 300).await?;
+
+    let id = uuid::Uuid::new_v4().to_string();
+    let display = display_name
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| format!("Talk @ {}", short_host(&creds.server)));
+    let config = db::accounts::AccountConfig {
+        display_name: display,
+        email: creds.login_name.clone(),
+        provider: "generic".into(),
+        mail_protocol: String::new(),
+        imap_host: String::new(),
+        imap_port: 0,
+        smtp_host: String::new(),
+        smtp_port: 0,
+        jmap_url: String::new(),
+        caldav_url: String::new(),
+        meet_url: creds.server.clone(),
+        meet_protocol: "talk".into(),
+        username: creds.login_name.clone(),
+        password: String::new(),
+        use_tls: true,
+        signature: String::new(),
+        jmap_auth_method: "basic".into(),
+        oidc_token_endpoint: String::new(),
+        oidc_client_id: String::new(),
+        calendar_sync_enabled: false,
+        mail_sync_enabled: false,
+        contacts_sync_enabled: false,
+        mail_sync_interval_seconds: None,
+        calendar_sync_interval_seconds: None,
+        contacts_sync_interval_seconds: None,
+        has_calendar_binding: false,
+        has_contacts_binding: false,
+    };
+    let conn = state.db.writer().await;
+    db::accounts::insert_account(&conn, &id, &config)?;
+    drop(conn);
+
+    crate::oauth::store_tokens(
+        &id,
+        &crate::oauth::OAuthTokens {
+            access_token: creds.app_password,
+            refresh_token: None,
+            expires_at: None,
+        },
+    )?;
+    Ok(id)
+}
+
+#[derive(Debug, Serialize)]
+pub struct MatrixLoginStart {
+    pub login_url: String,
+    pub port: u16,
+}
+
+/// Bind a local listener and return the SSO redirect URL the
+/// frontend should open. The listener is moved into a background
+/// task that waits for the callback (see `meet_matrix_login_complete`).
+#[tauri::command]
+pub async fn meet_matrix_login_start(
+    state: State<'_, AppState>,
+    homeserver_url: String,
+) -> Result<MatrixLoginStart> {
+    let (url, listener) = meet::matrix::sso_login_start(&homeserver_url)?;
+    let port = listener
+        .local_addr()
+        .map_err(|e| Error::Other(format!("matrix listener port: {}", e)))?
+        .port();
+    state
+        .matrix_sso_listeners
+        .lock()
+        .unwrap()
+        .insert(port, listener);
+    Ok(MatrixLoginStart {
+        login_url: url,
+        port,
+    })
+}
+
+/// Wait for the SSO callback on `port`, exchange the loginToken,
+/// persist the account row + keyring entry, return the account id.
+#[tauri::command]
+pub async fn meet_matrix_login_complete(
+    state: State<'_, AppState>,
+    homeserver_url: String,
+    port: u16,
+    display_name: Option<String>,
+) -> Result<String> {
+    let listener = state
+        .matrix_sso_listeners
+        .lock()
+        .unwrap()
+        .remove(&port)
+        .ok_or_else(|| {
+            Error::Other(format!(
+                "Matrix SSO: no pending listener for port {} — start the flow again",
+                port,
+            ))
+        })?;
+    let token = tokio::task::spawn_blocking(move || meet::matrix::await_login_token(listener))
+        .await
+        .map_err(|e| Error::Other(format!("matrix sso join: {}", e)))??;
+    let result = meet::matrix::exchange_login_token(&homeserver_url, &token).await?;
+
+    let id = uuid::Uuid::new_v4().to_string();
+    let display = display_name
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| format!("Matrix ({})", result.user_id));
+    let config = db::accounts::AccountConfig {
+        display_name: display,
+        email: result.user_id.clone(),
+        provider: "generic".into(),
+        mail_protocol: String::new(),
+        imap_host: String::new(),
+        imap_port: 0,
+        smtp_host: String::new(),
+        smtp_port: 0,
+        jmap_url: String::new(),
+        caldav_url: String::new(),
+        meet_url: result.homeserver.clone(),
+        meet_protocol: "matrix".into(),
+        username: result.user_id.clone(),
+        password: String::new(),
+        use_tls: true,
+        signature: String::new(),
+        jmap_auth_method: "basic".into(),
+        oidc_token_endpoint: String::new(),
+        oidc_client_id: String::new(),
+        calendar_sync_enabled: false,
+        mail_sync_enabled: false,
+        contacts_sync_enabled: false,
+        mail_sync_interval_seconds: None,
+        calendar_sync_interval_seconds: None,
+        contacts_sync_interval_seconds: None,
+        has_calendar_binding: false,
+        has_contacts_binding: false,
+    };
+    let conn = state.db.writer().await;
+    db::accounts::insert_account(&conn, &id, &config)?;
+    drop(conn);
+
+    crate::oauth::store_tokens(
+        &id,
+        &crate::oauth::OAuthTokens {
+            access_token: result.access_token,
+            refresh_token: None,
+            expires_at: None,
+        },
+    )?;
+    Ok(id)
+}
+
+/// Provider-agnostic create. Looks up the account, finds its meet
+/// provider via the registry, and returns the join URL. The event
+/// editor calls this with the event's title as `name`.
+#[tauri::command]
+pub async fn meet_create_url(
+    state: State<'_, AppState>,
+    account_id: String,
+    name: String,
+) -> Result<String> {
+    let account = {
+        let conn = state.db.reader();
+        db::accounts::get_account_full(&conn, &account_id)?
+    };
+    let provider = meet::provider_for(&account).ok_or_else(|| {
+        Error::Other(format!("account {} has no usable meet binding", account_id))
+    })?;
+    provider.create_url(&account, &name).await
+}
+
+/// Strip scheme + path from a URL for use as a fallback display
+/// name. `https://cloud.smolnet.org/` -> `cloud.smolnet.org`.
+fn short_host(url: &str) -> String {
+    url.trim_start_matches("https://")
+        .trim_start_matches("http://")
+        .trim_end_matches('/')
+        .split('/')
+        .next()
+        .unwrap_or(url)
+        .to_string()
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -8,5 +8,6 @@ pub mod contacts;
 pub mod events;
 pub mod filters;
 pub mod mail;
+pub mod meet;
 pub mod oauth;
 pub mod sync_cmd;

--- a/src-tauri/src/commands/sync_cmd.rs
+++ b/src-tauri/src/commands/sync_cmd.rs
@@ -177,6 +177,7 @@ pub(crate) async fn resume_imap_idle_for_account(
         contacts_sync_interval_seconds: account.contacts_sync_interval_seconds,
         has_calendar_binding: account.calendar_binding().is_some(),
         has_contacts_binding: account.contacts_binding().is_some(),
+        meet_protocol: account.meet_protocol_str().to_string(),
     };
 
     start_imap_idle(app, state, &account_summary).await

--- a/src-tauri/src/db/accounts.rs
+++ b/src-tauri/src/db/accounts.rs
@@ -39,6 +39,12 @@ pub struct Account {
     pub has_calendar_binding: bool,
     #[serde(default)]
     pub has_contacts_binding: bool,
+    /// Protocol of the account's enabled meet binding ("talk" /
+    /// "matrix"), or "" when there is none. Lets the calendar
+    /// event editor populate its "Add video link" dropdown with
+    /// just the accounts that can produce one. (#148)
+    #[serde(default)]
+    pub meet_protocol: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -395,7 +401,15 @@ pub fn list_accounts(conn: &Connection) -> Result<Vec<Account>> {
                         WHERE b.account_id = a.id
                           AND b.service = 'contacts'
                           AND b.enabled = 1)
-                    AS has_contacts_binding
+                    AS has_contacts_binding,
+                COALESCE(
+                    (SELECT b.protocol FROM service_bindings b
+                     WHERE b.account_id = a.id
+                       AND b.service = 'meet'
+                       AND b.enabled = 1
+                     LIMIT 1),
+                    ''
+                ) AS meet_protocol
          FROM accounts a
          ORDER BY a.display_name",
     )?;
@@ -421,6 +435,7 @@ pub fn list_accounts(conn: &Connection) -> Result<Vec<Account>> {
                 contacts_sync_interval_seconds: row.get(9)?,
                 has_calendar_binding: row.get(10)?,
                 has_contacts_binding: row.get(11)?,
+                meet_protocol: row.get(12)?,
             })
         })?
         .collect::<std::result::Result<Vec<_>, _>>()?;

--- a/src-tauri/src/db/accounts.rs
+++ b/src-tauri/src/db/accounts.rs
@@ -39,10 +39,12 @@ pub struct Account {
     pub has_calendar_binding: bool,
     #[serde(default)]
     pub has_contacts_binding: bool,
-    /// Protocol of the account's enabled meet binding ("talk" /
-    /// "matrix"), or "" when there is none. Lets the calendar
-    /// event editor populate its "Add video link" dropdown with
-    /// just the accounts that can produce one. (#148)
+    /// Protocol of the account's enabled meet binding (`talk` /
+    /// `matrix` / `zoom` today; whatever providers are listed in
+    /// `meet::registry()` more generally), or `""` when the
+    /// account has no meet binding. Lets the calendar event
+    /// editor populate its "Add video link" dropdown without an
+    /// extra round-trip per row. (#148)
     #[serde(default)]
     pub meet_protocol: String,
 }
@@ -61,13 +63,18 @@ pub struct AccountConfig {
     pub smtp_port: u16,
     pub jmap_url: String,
     pub caldav_url: String,
-    /// Base URL for the meet binding's server (Nextcloud root for
-    /// Talk, homeserver for Matrix). Empty when the account has no
-    /// meet binding. Pairs with `meet_protocol`.
+    /// Server URL the provider keys off. For Talk this is the
+    /// Nextcloud root; for Matrix it's the homeserver. For Zoom
+    /// this is a marker (`https://zoom.us`) since Zoom is a
+    /// hosted service with no per-user URL — `create_url` reads
+    /// the OAuth tokens from the keyring and ignores this. Empty
+    /// when the account has no meet binding. Pairs with
+    /// `meet_protocol`.
     #[serde(default)]
     pub meet_url: String,
-    /// `"talk"` (Nextcloud Talk) or `"matrix"` when the account has
-    /// a meet binding; empty otherwise.
+    /// Provider discriminator: `talk`, `matrix`, `zoom`, or
+    /// whatever else is registered in `meet::registry()`.
+    /// Empty when the account has no meet binding.
     #[serde(default)]
     pub meet_protocol: String,
     pub username: String,

--- a/src-tauri/src/db/accounts.rs
+++ b/src-tauri/src/db/accounts.rs
@@ -55,6 +55,15 @@ pub struct AccountConfig {
     pub smtp_port: u16,
     pub jmap_url: String,
     pub caldav_url: String,
+    /// Base URL for the meet binding's server (Nextcloud root for
+    /// Talk, homeserver for Matrix). Empty when the account has no
+    /// meet binding. Pairs with `meet_protocol`.
+    #[serde(default)]
+    pub meet_url: String,
+    /// `"talk"` (Nextcloud Talk) or `"matrix"` when the account has
+    /// a meet binding; empty otherwise.
+    #[serde(default)]
+    pub meet_protocol: String,
     pub username: String,
     pub password: String,
     pub use_tls: bool,
@@ -122,6 +131,10 @@ pub struct AccountFull {
     pub smtp_port: u16,
     pub jmap_url: String,
     pub caldav_url: String,
+    /// Server URL + protocol for the meet binding (Talk / Matrix).
+    /// Empty when the account has no meet service.
+    pub meet_url: String,
+    pub meet_protocol: String,
     pub username: String,
     pub password: String,
     pub use_tls: bool,
@@ -168,6 +181,22 @@ impl AccountFull {
 
     pub fn contacts_binding(&self) -> Option<&ServiceBinding> {
         self.binding_for("contacts")
+    }
+
+    /// Video-conferencing binding (Nextcloud Talk / Matrix / future
+    /// providers). #148.
+    pub fn meet_binding(&self) -> Option<&ServiceBinding> {
+        self.binding_for("meet")
+    }
+
+    /// Convenience: the `meet` binding's enabled protocol string,
+    /// or `""` when the account has no meet binding or it's been
+    /// disabled. Mirrors `mail_protocol_str` / `calendar_protocol_str`.
+    pub fn meet_protocol_str(&self) -> &str {
+        self.meet_binding()
+            .filter(|b| b.enabled)
+            .map(|b| b.protocol.as_str())
+            .unwrap_or("")
     }
 
     /// Mail protocol as a string slice. Returns `""` for accounts with no
@@ -294,6 +323,21 @@ impl AccountFull {
             .or_else(|| self.contacts_dav_url())
             .unwrap_or_default();
 
+        // #148: meet binding (Nextcloud Talk / Matrix). Surfaces the
+        // server URL + protocol so the Settings edit form can display
+        // them; the actual credential lives in the keyring under the
+        // account id. Read both up front so the borrow on `self`
+        // ends before the writes below.
+        let (meet_url, meet_protocol) = match self.meet_binding() {
+            Some(b) => (
+                b.meet_config().map(|c| c.url).unwrap_or_default(),
+                b.protocol.clone(),
+            ),
+            None => (String::new(), String::new()),
+        };
+        self.meet_url = meet_url;
+        self.meet_protocol = meet_protocol;
+
         self.calendar_sync_enabled = self.calendar_binding().map(|b| b.enabled).unwrap_or(true);
 
         // Phase-4: surface per-binding state on the wire format so the
@@ -411,6 +455,8 @@ pub fn get_account_full(conn: &Connection, id: &str) -> Result<AccountFull> {
                     smtp_port: 587,
                     jmap_url: String::new(),
                     caldav_url: String::new(),
+                    meet_url: String::new(),
+                    meet_protocol: String::new(),
                     password: String::new(),
                     use_tls: true,
                     calendar_sync_enabled: true,
@@ -515,6 +561,8 @@ fn config_to_legacy_fields<'a>(
         oidc_client_id: &config.oidc_client_id,
         caldav_url: &config.caldav_url,
         calendar_sync_enabled: config.calendar_sync_enabled,
+        meet_url: &config.meet_url,
+        meet_protocol: &config.meet_protocol,
         mail_sync_enabled: Some(config.mail_sync_enabled),
         contacts_sync_enabled: Some(config.contacts_sync_enabled),
         mail_sync_interval_seconds: config.mail_sync_interval_seconds,
@@ -640,6 +688,8 @@ mod tests {
             smtp_port: 587,
             jmap_url: String::new(),
             caldav_url: String::new(),
+            meet_url: String::new(),
+            meet_protocol: String::new(),
             username: "user".to_string(),
             password: "secret123".to_string(),
             use_tls: true,

--- a/src-tauri/src/db/schema.rs
+++ b/src-tauri/src/db/schema.rs
@@ -664,6 +664,11 @@ fn populate_service_bindings(conn: &Connection) -> Result<()> {
                 oidc_token_endpoint: &r.oidc_token_endpoint,
                 oidc_client_id: &r.oidc_client_id,
                 caldav_url: &r.caldav_url,
+                // The Phase-1 populate migration runs against rows
+                // that pre-date the meet binding (#148), so emit
+                // nothing for them.
+                meet_url: "",
+                meet_protocol: "",
                 calendar_sync_enabled: r.calendar_sync_enabled,
                 // Migration preserves legacy semantics: mail follows the
                 // row's enabled flag, contacts default to on, no per-binding

--- a/src-tauri/src/db/service_bindings.rs
+++ b/src-tauri/src/db/service_bindings.rs
@@ -242,8 +242,12 @@ pub struct LegacyBindingFields<'a> {
     pub oidc_client_id: &'a str,
     pub caldav_url: &'a str,
     pub calendar_sync_enabled: bool,
-    /// #148: meet binding inputs. Both empty means no meet binding
-    /// is emitted; `meet_protocol` is one of `"talk"` / `"matrix"`.
+    /// #148: meet binding inputs. Both empty means no meet
+    /// binding is emitted. `meet_protocol` carries the
+    /// provider's discriminator (`talk`, `matrix`, `zoom`, …) —
+    /// the actual list is whatever providers `meet::registry()`
+    /// exposes, not enumerated here so the comment doesn't go
+    /// stale on every new provider.
     pub meet_url: &'a str,
     pub meet_protocol: &'a str,
     /// Phase 4 additions. If `None`, falls back to `enabled` for the mail
@@ -343,7 +347,9 @@ pub fn derive_bindings(f: LegacyBindingFields<'_>) -> Vec<ServiceBinding> {
     // an account that has neither (the common case) gets no meet
     // binding, and an inconsistent half-set state is caught by the
     // explicit guard rather than silently emitting a half-broken
-    // entry. Recognised protocols today are "talk" and "matrix".
+    // entry. The protocol value comes from `meet::registry()`
+    // and isn't enumerated here so this comment doesn't drift on
+    // every new provider.
     if !f.meet_url.is_empty() && !f.meet_protocol.is_empty() {
         out.push(ServiceBinding {
             id: format!("{aid}-meet"),

--- a/src-tauri/src/db/service_bindings.rs
+++ b/src-tauri/src/db/service_bindings.rs
@@ -60,6 +60,15 @@ pub struct DavBindingConfig {
     pub url: String,
 }
 
+/// Config payload for a `meet` binding (#148). Talk and Matrix both
+/// store just a base URL here — the credential lives in the keyring
+/// under the account id, not in this config_json.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct MeetBindingConfig {
+    #[serde(default)]
+    pub url: String,
+}
+
 /// A per-service binding that says "this account talks to this protocol for
 /// this service". One identity in the `accounts` table can carry multiple
 /// bindings: a Gmail account has bindings for `mail/imap`, `calendar/google`,
@@ -103,6 +112,15 @@ impl ServiceBinding {
         serde_json::from_str(&self.config_json).map_err(|e| {
             Error::Other(format!(
                 "binding {} has malformed dav config_json: {}",
+                self.id, e
+            ))
+        })
+    }
+
+    pub fn meet_config(&self) -> Result<MeetBindingConfig> {
+        serde_json::from_str(&self.config_json).map_err(|e| {
+            Error::Other(format!(
+                "binding {} has malformed meet config_json: {}",
                 self.id, e
             ))
         })
@@ -224,6 +242,10 @@ pub struct LegacyBindingFields<'a> {
     pub oidc_client_id: &'a str,
     pub caldav_url: &'a str,
     pub calendar_sync_enabled: bool,
+    /// #148: meet binding inputs. Both empty means no meet binding
+    /// is emitted; `meet_protocol` is one of `"talk"` / `"matrix"`.
+    pub meet_url: &'a str,
+    pub meet_protocol: &'a str,
     /// Phase 4 additions. If `None`, falls back to `enabled` for the mail
     /// binding (legacy behavior) or `true` for contacts.
     pub mail_sync_enabled: Option<bool>,
@@ -317,6 +339,23 @@ pub fn derive_bindings(f: LegacyBindingFields<'_>) -> Vec<ServiceBinding> {
         });
     }
 
+    // Meet binding (#148). Emitted only when both fields are set —
+    // an account that has neither (the common case) gets no meet
+    // binding, and an inconsistent half-set state is caught by the
+    // explicit guard rather than silently emitting a half-broken
+    // entry. Recognised protocols today are "talk" and "matrix".
+    if !f.meet_url.is_empty() && !f.meet_protocol.is_empty() {
+        out.push(ServiceBinding {
+            id: format!("{aid}-meet"),
+            account_id: aid.into(),
+            service: "meet".into(),
+            protocol: f.meet_protocol.into(),
+            enabled: f.enabled,
+            sync_interval_seconds: None,
+            config_json: serde_json::json!({ "url": f.meet_url }).to_string(),
+        });
+    }
+
     out
 }
 
@@ -339,6 +378,8 @@ pub fn derive_bindings_from_account(account: &AccountFull) -> Vec<ServiceBinding
         oidc_client_id: &account.oidc_client_id,
         caldav_url: &account.caldav_url,
         calendar_sync_enabled: account.calendar_sync_enabled,
+        meet_url: &account.meet_url,
+        meet_protocol: &account.meet_protocol,
         mail_sync_enabled: None,
         contacts_sync_enabled: None,
         mail_sync_interval_seconds: None,
@@ -664,6 +705,8 @@ mod tests {
             smtp_port: 587,
             jmap_url: String::new(),
             caldav_url: String::new(),
+            meet_url: String::new(),
+            meet_protocol: String::new(),
             username: "user".into(),
             password: String::new(),
             use_tls: true,
@@ -887,6 +930,8 @@ mod tests {
             oidc_client_id: &acc.oidc_client_id,
             caldav_url: &acc.caldav_url,
             calendar_sync_enabled: acc.calendar_sync_enabled,
+            meet_url: &acc.meet_url,
+            meet_protocol: &acc.meet_protocol,
             mail_sync_enabled: Some(false),
             contacts_sync_enabled: None,
             mail_sync_interval_seconds: None,
@@ -922,6 +967,8 @@ mod tests {
             oidc_client_id: &acc.oidc_client_id,
             caldav_url: "https://example.com/dav",
             calendar_sync_enabled: true,
+            meet_url: "",
+            meet_protocol: "",
             mail_sync_enabled: None,
             contacts_sync_enabled: None,
             mail_sync_interval_seconds: Some(120),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,6 +9,7 @@ mod filters;
 mod keyring;
 mod logging;
 mod mail;
+mod meet;
 mod oauth;
 mod ops;
 mod path_validation;
@@ -78,6 +79,11 @@ pub fn run() {
             commands::contacts::get_default_contact_book,
             commands::contacts::set_default_contact_book,
             commands::contacts::sync_contacts,
+            commands::meet::meet_talk_login_start,
+            commands::meet::meet_talk_login_complete,
+            commands::meet::meet_matrix_login_start,
+            commands::meet::meet_matrix_login_complete,
+            commands::meet::meet_create_url,
             commands::sync_cmd::start_idle,
             commands::sync_cmd::stop_idle,
             commands::oauth::oauth_start,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -83,6 +83,8 @@ pub fn run() {
             commands::meet::meet_talk_login_complete,
             commands::meet::meet_matrix_login_start,
             commands::meet::meet_matrix_login_complete,
+            commands::meet::meet_zoom_login_start,
+            commands::meet::meet_zoom_login_complete,
             commands::meet::meet_create_url,
             commands::sync_cmd::start_idle,
             commands::sync_cmd::stop_idle,

--- a/src-tauri/src/meet/matrix.rs
+++ b/src-tauri/src/meet/matrix.rs
@@ -199,7 +199,11 @@ pub async fn exchange_login_token(homeserver_url: &str, login_token: &str) -> Re
     let body = serde_json::json!({
         "type": "m.login.token",
         "token": login_token,
-        "initial_device_display_name": format!("Chithi ({})", USER_AGENT),
+        // USER_AGENT already encodes "Chithi/<version>"; using it
+        // directly as the device label avoids the redundant
+        // "Chithi (Chithi/<version>)" that Matrix clients would
+        // otherwise show in the Active sessions panel.
+        "initial_device_display_name": USER_AGENT,
     });
     let resp = http_client()?
         .post(&url)

--- a/src-tauri/src/meet/matrix.rs
+++ b/src-tauri/src/meet/matrix.rs
@@ -1,0 +1,353 @@
+//! Matrix integration (#148). Used to create a fresh Matrix room
+//! and a corresponding [Element Call][ec] widget so the join URL
+//! can be pasted into a calendar event.
+//!
+//! Auth uses the standard SSO redirect flow:
+//! 1. Bind a local TCP listener on `127.0.0.1:0`.
+//! 2. Build `<homeserver>/_matrix/client/v3/login/sso/redirect?redirectUrl=http://localhost:<port>/`.
+//! 3. User opens that URL in their browser, completes SSO at the
+//!    homeserver / IdP.
+//! 4. Browser redirects to our local listener with `?loginToken=...`.
+//! 5. We exchange the loginToken for an `access_token` via
+//!    `m.login.token`.
+//!
+//! That mirrors what Element Web does and what `matrix.sunet.se`
+//! advertises (`m.login.sso` with `oauth_aware_preferred: true`).
+//!
+//! [ec]: https://github.com/element-hq/element-call
+
+use std::collections::HashMap;
+use std::io::{BufRead, BufReader, Write};
+use std::net::TcpListener;
+use std::time::{Duration, Instant};
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::{Error, Result};
+
+const HTTP_TIMEOUT_SECS: u64 = 30;
+const USER_AGENT: &str = concat!("Chithi/", env!("CARGO_PKG_VERSION"));
+const SSO_CALLBACK_TIMEOUT_SECS: u64 = 300;
+
+fn http_client() -> Result<reqwest::Client> {
+    reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(HTTP_TIMEOUT_SECS))
+        .user_agent(USER_AGENT)
+        .build()
+        .map_err(|e| Error::Other(format!("matrix http client: {}", e)))
+}
+
+/// Result of `m.login.token` exchange. Only carries fields the rest
+/// of the app needs to keep around.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LoginResult {
+    pub access_token: String,
+    pub user_id: String,
+    pub device_id: String,
+    /// The homeserver we logged into. Echoes `well_known.m.homeserver.base_url`
+    /// when the homeserver advertises it; otherwise the user-supplied URL.
+    pub homeserver: String,
+}
+
+/// Start the SSO flow against `homeserver_url` (e.g.
+/// `https://matrix.sunet.se`). Binds a local listener on a random
+/// port, returns the SSO redirect URL the caller should open in the
+/// user's browser plus the listener that will pick up the
+/// `loginToken` callback. The listener is returned so caller code
+/// can hand it to `await_login_token` after telling the frontend
+/// to open the URL.
+pub fn sso_login_start(homeserver_url: &str) -> Result<(String, TcpListener)> {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .map_err(|e| Error::Other(format!("matrix sso bind: {}", e)))?;
+    let port = listener
+        .local_addr()
+        .map_err(|e| Error::Other(format!("matrix sso port: {}", e)))?
+        .port();
+    // Matrix requires `localhost` in the Redirect URL to route back
+    // through the SSO IdP cleanly; some IdPs reject 127.0.0.1.
+    let redirect = format!("http://localhost:{}/", port);
+    let url = format!(
+        "{}/_matrix/client/v3/login/sso/redirect?redirectUrl={}",
+        normalize_base_url(homeserver_url),
+        urlencoding::encode(&redirect),
+    );
+    Ok((url, listener))
+}
+
+/// Wait for the browser to come back with a `loginToken` query
+/// parameter. Five-minute timeout matches the OAuth path so a user
+/// who walked away doesn't leave the listener wedged forever.
+pub fn await_login_token(listener: TcpListener) -> Result<String> {
+    let deadline = Instant::now() + Duration::from_secs(SSO_CALLBACK_TIMEOUT_SECS);
+    listener
+        .set_nonblocking(true)
+        .map_err(|e| Error::Other(format!("matrix sso non-blocking: {}", e)))?;
+
+    let (mut stream, _) = loop {
+        match listener.accept() {
+            Ok(conn) => break conn,
+            Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                if Instant::now() >= deadline {
+                    return Err(Error::Other("Matrix SSO timed out after 5 minutes".into()));
+                }
+                std::thread::sleep(Duration::from_millis(100));
+                continue;
+            }
+            Err(e) => return Err(Error::Other(format!("matrix sso accept: {}", e))),
+        }
+    };
+
+    let mut reader = BufReader::new(
+        stream
+            .try_clone()
+            .map_err(|e| Error::Other(format!("matrix sso stream clone: {}", e)))?,
+    );
+    let mut request_line = String::new();
+    reader
+        .read_line(&mut request_line)
+        .map_err(|e| Error::Other(format!("matrix sso read: {}", e)))?;
+
+    let params: HashMap<String, String> = request_line
+        .split_whitespace()
+        .nth(1)
+        .and_then(|path| path.split('?').nth(1))
+        .map(|query| {
+            query
+                .split('&')
+                .filter_map(|param| {
+                    let mut parts = param.splitn(2, '=');
+                    let key = parts.next()?;
+                    let val = parts.next().unwrap_or("");
+                    let decoded = urlencoding::decode(val)
+                        .unwrap_or_else(|_| val.into())
+                        .into_owned();
+                    Some((key.to_string(), decoded))
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let token = params.get("loginToken").cloned().ok_or_else(|| {
+        Error::Other(format!(
+            "Matrix SSO: callback did not carry loginToken (got: {:?})",
+            params.keys().collect::<Vec<_>>(),
+        ))
+    })?;
+
+    // Ack the browser so the user sees a clean confirmation page.
+    let _ = stream.write_all(
+        b"HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n\
+        <html><body style='font-family:sans-serif;text-align:center;padding:60px'>\
+        <h2>Matrix sign-in successful</h2>\
+        <p>You can close this window and return to Chithi.</p>\
+        </body></html>",
+    );
+    Ok(token)
+}
+
+/// Exchange the SSO `loginToken` for a long-lived `access_token` via
+/// `m.login.token`. The homeserver returned in the response (or the
+/// user-supplied URL if the server didn't echo it) is what we keep
+/// in the account row — that's the authority for subsequent API
+/// calls.
+pub async fn exchange_login_token(homeserver_url: &str, login_token: &str) -> Result<LoginResult> {
+    let url = format!(
+        "{}/_matrix/client/v3/login",
+        normalize_base_url(homeserver_url)
+    );
+    let body = serde_json::json!({
+        "type": "m.login.token",
+        "token": login_token,
+        "initial_device_display_name": format!("Chithi ({})", USER_AGENT),
+    });
+    let resp = http_client()?
+        .post(&url)
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| Error::Other(format!("matrix login request: {}", e)))?;
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        return Err(Error::Other(format!(
+            "matrix login: {} ({})",
+            status,
+            body.chars().take(500).collect::<String>(),
+        )));
+    }
+    let payload: serde_json::Value = resp
+        .json()
+        .await
+        .map_err(|e| Error::Other(format!("matrix login parse: {}", e)))?;
+    let access_token = payload["access_token"]
+        .as_str()
+        .ok_or_else(|| Error::Other("matrix login: missing access_token".into()))?
+        .to_string();
+    let user_id = payload["user_id"]
+        .as_str()
+        .ok_or_else(|| Error::Other("matrix login: missing user_id".into()))?
+        .to_string();
+    let device_id = payload["device_id"].as_str().unwrap_or("").to_string();
+    let homeserver = payload["well_known"]["m.homeserver"]["base_url"]
+        .as_str()
+        .map(|s| s.trim_end_matches('/').to_string())
+        .unwrap_or_else(|| normalize_base_url(homeserver_url));
+    Ok(LoginResult {
+        access_token,
+        user_id,
+        device_id,
+        homeserver,
+    })
+}
+
+/// Create a fresh Matrix room for a meeting and post an
+/// `im.vector.modular.widgets` state event pointing at the
+/// homeserver's Element Call instance. Returns the join URL that
+/// the user should paste into the calendar event.
+///
+/// `room_name` becomes the room's `name` in Matrix (visible in any
+/// Matrix client). `element_call_url` is the base of the Element
+/// Call deployment to use for the widget — defaults to
+/// `https://call.element.io` when None, since that's the public
+/// instance Element ships with.
+pub async fn create_call(
+    homeserver: &str,
+    access_token: &str,
+    room_name: &str,
+    element_call_url: Option<&str>,
+) -> Result<String> {
+    let create_url = format!(
+        "{}/_matrix/client/v3/createRoom",
+        normalize_base_url(homeserver)
+    );
+    let body = serde_json::json!({
+        "name": if room_name.trim().is_empty() { "Meeting" } else { room_name },
+        "preset": "private_chat",
+        "visibility": "private",
+    });
+    let client = http_client()?;
+    let resp = client
+        .post(&create_url)
+        .bearer_auth(access_token)
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| Error::Other(format!("matrix createRoom request: {}", e)))?;
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        return Err(Error::Other(format!(
+            "matrix createRoom: {} ({})",
+            status,
+            body.chars().take(500).collect::<String>(),
+        )));
+    }
+    let payload: serde_json::Value = resp
+        .json()
+        .await
+        .map_err(|e| Error::Other(format!("matrix createRoom parse: {}", e)))?;
+    let room_id = payload["room_id"]
+        .as_str()
+        .ok_or_else(|| Error::Other("matrix createRoom: missing room_id".into()))?
+        .to_string();
+
+    // Attach an Element Call widget so any Matrix client opening the
+    // room sees a one-click join button. Failing to write the widget
+    // doesn't fail the whole call: the room itself is a usable
+    // fallback, and the join URL we return below works without it.
+    let call_base = element_call_url
+        .map(|s| s.trim_end_matches('/').to_string())
+        .unwrap_or_else(|| "https://call.element.io".to_string());
+    let widget_url = format!(
+        "{}/room?roomId={}&embed=true&hideHeader=true",
+        call_base,
+        urlencoding::encode(&room_id),
+    );
+    let widget_state_url = format!(
+        "{}/_matrix/client/v3/rooms/{}/state/im.vector.modular.widgets/{}",
+        normalize_base_url(homeserver),
+        urlencoding::encode(&room_id),
+        urlencoding::encode("element-call"),
+    );
+    let widget_body = serde_json::json!({
+        "type": "m.custom",
+        "url": widget_url,
+        "name": "Element Call",
+        "data": { "domain": call_base },
+    });
+    if let Err(e) = client
+        .put(&widget_state_url)
+        .bearer_auth(access_token)
+        .json(&widget_body)
+        .send()
+        .await
+    {
+        log::warn!(
+            "matrix create_call: widget state event failed (room is still usable): {}",
+            e
+        );
+    }
+
+    Ok(format!(
+        "{}/room/?roomId={}",
+        call_base,
+        urlencoding::encode(&room_id),
+    ))
+}
+
+fn normalize_base_url(server: &str) -> String {
+    server.trim_end_matches('/').to_string()
+}
+
+/// `MeetProvider` implementor for Matrix / Element Call. Stateless;
+/// each `create_url` reads the homeserver from the account's meet
+/// binding and the access token from the keyring.
+pub struct MatrixProvider;
+
+#[async_trait::async_trait]
+impl crate::meet::MeetProvider for MatrixProvider {
+    fn protocol(&self) -> &'static str {
+        "matrix"
+    }
+    fn label(&self) -> &'static str {
+        "Matrix"
+    }
+    async fn create_url(
+        &self,
+        account: &crate::db::accounts::AccountFull,
+        name: &str,
+    ) -> Result<String> {
+        let homeserver = account.meet_url.trim();
+        if homeserver.is_empty() {
+            return Err(Error::Other(
+                "Matrix: account has no homeserver URL configured".into(),
+            ));
+        }
+        let access_token = match crate::oauth::load_tokens(&account.id)? {
+            Some(t) => t.access_token,
+            None => {
+                return Err(Error::Other(
+                    "Matrix: no access token in keyring; sign in again".into(),
+                ));
+            }
+        };
+        create_call(homeserver, &access_token, name, None).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalizes_trailing_slashes() {
+        assert_eq!(
+            normalize_base_url("https://m.example.com/"),
+            "https://m.example.com"
+        );
+        assert_eq!(
+            normalize_base_url("https://m.example.com///"),
+            "https://m.example.com"
+        );
+    }
+}

--- a/src-tauri/src/meet/matrix.rs
+++ b/src-tauri/src/meet/matrix.rs
@@ -29,12 +29,21 @@ const HTTP_TIMEOUT_SECS: u64 = 30;
 const USER_AGENT: &str = concat!("Chithi/", env!("CARGO_PKG_VERSION"));
 const SSO_CALLBACK_TIMEOUT_SECS: u64 = 300;
 
-fn http_client() -> Result<reqwest::Client> {
-    reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(HTTP_TIMEOUT_SECS))
-        .user_agent(USER_AGENT)
-        .build()
-        .map_err(|e| Error::Other(format!("matrix http client: {}", e)))
+/// Single shared `reqwest::Client` for the Matrix module — same
+/// rationale as in `talk.rs`. Lazily initialised on first call.
+fn http_client() -> Result<&'static reqwest::Client> {
+    static CLIENT: std::sync::OnceLock<std::result::Result<reqwest::Client, String>> =
+        std::sync::OnceLock::new();
+    CLIENT
+        .get_or_init(|| {
+            reqwest::Client::builder()
+                .timeout(std::time::Duration::from_secs(HTTP_TIMEOUT_SECS))
+                .user_agent(USER_AGENT)
+                .build()
+                .map_err(|e| format!("matrix http client: {}", e))
+        })
+        .as_ref()
+        .map_err(|e| Error::Other(e.clone()))
 }
 
 /// Result of `m.login.token` exchange. Only carries fields the rest
@@ -51,33 +60,54 @@ pub struct LoginResult {
 
 /// Start the SSO flow against `homeserver_url` (e.g.
 /// `https://matrix.sunet.se`). Binds a local listener on a random
-/// port, returns the SSO redirect URL the caller should open in the
-/// user's browser plus the listener that will pick up the
-/// `loginToken` callback. The listener is returned so caller code
-/// can hand it to `await_login_token` after telling the frontend
-/// to open the URL.
-pub fn sso_login_start(homeserver_url: &str) -> Result<(String, TcpListener)> {
+/// port, generates a random state nonce, and returns the SSO
+/// redirect URL the caller should open in the user's browser
+/// plus the listener and state that will pick up the
+/// `loginToken` callback.
+///
+/// The state nonce is appended to the redirect URL as a query
+/// parameter and validated by `await_login_token` against the
+/// callback's matching `state=` parameter. Without this, any
+/// local process that can guess the callback port could race a
+/// genuine SSO completion by sending its own `loginToken=` and
+/// have us exchange it. The nonce is unguessable (16 random
+/// bytes via the same generator OAuth uses for PKCE verifiers)
+/// so a TOCTOU between `meet_matrix_login_start` (which races
+/// the listener registration) and the legitimate redirect is
+/// what we're actually defending against.
+pub fn sso_login_start(homeserver_url: &str) -> Result<(String, TcpListener, String)> {
     let listener = TcpListener::bind("127.0.0.1:0")
         .map_err(|e| Error::Other(format!("matrix sso bind: {}", e)))?;
     let port = listener
         .local_addr()
         .map_err(|e| Error::Other(format!("matrix sso port: {}", e)))?
         .port();
+    let state = crate::oauth::generate_code_verifier();
     // Matrix requires `localhost` in the Redirect URL to route back
     // through the SSO IdP cleanly; some IdPs reject 127.0.0.1.
-    let redirect = format!("http://localhost:{}/", port);
+    // The state lives as a query param on the redirect URL so it
+    // round-trips back to us as `?loginToken=...&state=<nonce>`.
+    let redirect = format!(
+        "http://localhost:{}/?state={}",
+        port,
+        urlencoding::encode(&state),
+    );
     let url = format!(
         "{}/_matrix/client/v3/login/sso/redirect?redirectUrl={}",
         normalize_base_url(homeserver_url),
         urlencoding::encode(&redirect),
     );
-    Ok((url, listener))
+    Ok((url, listener, state))
 }
 
 /// Wait for the browser to come back with a `loginToken` query
-/// parameter. Five-minute timeout matches the OAuth path so a user
-/// who walked away doesn't leave the listener wedged forever.
-pub fn await_login_token(listener: TcpListener) -> Result<String> {
+/// parameter, validating that its `state=` matches the value we
+/// embedded in `sso_login_start`. Five-minute timeout matches
+/// the OAuth path so a user who walked away doesn't leave the
+/// listener wedged forever. A mismatched / missing state is
+/// surfaced as an error rather than silently exchanged — see
+/// the doc on `sso_login_start` for why this matters.
+pub fn await_login_token(listener: TcpListener, expected_state: &str) -> Result<String> {
     let deadline = Instant::now() + Duration::from_secs(SSO_CALLBACK_TIMEOUT_SECS);
     listener
         .set_nonblocking(true)
@@ -127,6 +157,17 @@ pub fn await_login_token(listener: TcpListener) -> Result<String> {
         })
         .unwrap_or_default();
 
+    // Validate state before pulling the loginToken. A missing or
+    // mismatched state means the callback didn't originate from
+    // our `sso_login_start` — possibly a local process racing the
+    // listener. Return an error rather than exchange an attacker-
+    // supplied loginToken.
+    let got_state = params.get("state").map(|s| s.as_str()).unwrap_or("");
+    if got_state != expected_state {
+        return Err(Error::Other(
+            "Matrix SSO: state mismatch on callback (cancelled or replay)".into(),
+        ));
+    }
     let token = params.get("loginToken").cloned().ok_or_else(|| {
         Error::Other(format!(
             "Matrix SSO: callback did not carry loginToken (got: {:?})",

--- a/src-tauri/src/meet/matrix.rs
+++ b/src-tauri/src/meet/matrix.rs
@@ -200,16 +200,28 @@ pub async fn exchange_login_token(homeserver_url: &str, login_token: &str) -> Re
     })
 }
 
-/// Create a fresh Matrix room for a meeting and post an
-/// `im.vector.modular.widgets` state event pointing at the
-/// homeserver's Element Call instance. Returns the join URL that
-/// the user should paste into the calendar event.
+/// Create a fresh Matrix room for a meeting and post an Element
+/// Call widget state event into it. Returns a `matrix.to` join
+/// URL that opens the user's existing Matrix client (Element Web
+/// at their organization, the desktop app, etc.) on the freshly
+/// created room — the call is then driven by the embedded
+/// widget, which uses the homeserver's own LiveKit SFU advertised
+/// via the [`org.matrix.msc4143.rtc_foci`][rtc-foci] well-known.
+///
+/// We deliberately do **not** return a `https://call.element.io`
+/// URL: that hosts the *frontend* of Element Call but doesn't
+/// know about the user's homeserver, so opening it forced a
+/// second, unrelated login at element.io. The matrix.to redirect
+/// keeps the user on their own infrastructure (#148).
 ///
 /// `room_name` becomes the room's `name` in Matrix (visible in any
-/// Matrix client). `element_call_url` is the base of the Element
-/// Call deployment to use for the widget — defaults to
-/// `https://call.element.io` when None, since that's the public
-/// instance Element ships with.
+/// Matrix client). `element_call_url` is the Element Call frontend
+/// referenced by the widget; defaults to `https://call.element.io`
+/// since that's the canonical implementation. Self-hosted Element
+/// Call instances can be passed here later via a per-account
+/// override if/when we add that setting.
+///
+/// [rtc-foci]: https://github.com/matrix-org/matrix-spec-proposals/pull/4143
 pub async fn create_call(
     homeserver: &str,
     access_token: &str,
@@ -288,11 +300,32 @@ pub async fn create_call(
         );
     }
 
+    // matrix.to URL — the standard cross-client room-link
+    // redirector. Format is `https://matrix.to/#/<roomId>?via=<server>`,
+    // where `<roomId>` is the literal room id including its `!` and
+    // `:` (matrix.to keeps those unencoded by spec) and `via` hints
+    // which homeserver to route through. The homeserver fragment
+    // we extract from the user-supplied URL — for matrix.sunet.se
+    // that's just `matrix.sunet.se`.
+    let via = host_only(homeserver);
     Ok(format!(
-        "{}/room/?roomId={}",
-        call_base,
-        urlencoding::encode(&room_id),
+        "https://matrix.to/#/{}?via={}",
+        room_id,
+        urlencoding::encode(&via),
     ))
+}
+
+/// Pull just the host out of a homeserver URL, so the matrix.to
+/// `via=` parameter gets `matrix.example.com`, not the scheme or
+/// trailing slash. Falls back to the input string for malformed
+/// URLs — matrix.to tolerates that and shows its picker UI.
+fn host_only(url: &str) -> String {
+    url.trim_start_matches("https://")
+        .trim_start_matches("http://")
+        .split('/')
+        .next()
+        .unwrap_or(url)
+        .to_string()
 }
 
 fn normalize_base_url(server: &str) -> String {
@@ -338,6 +371,19 @@ impl crate::meet::MeetProvider for MatrixProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn host_only_strips_scheme_and_path() {
+        assert_eq!(host_only("https://matrix.sunet.se"), "matrix.sunet.se");
+        assert_eq!(host_only("https://matrix.sunet.se/"), "matrix.sunet.se");
+        assert_eq!(
+            host_only("http://matrix.example.org/foo"),
+            "matrix.example.org"
+        );
+        // Pathological input: pass it through so matrix.to can
+        // surface its picker UI rather than crashing the call.
+        assert_eq!(host_only("matrix.sunet.se"), "matrix.sunet.se");
+    }
 
     #[test]
     fn normalizes_trailing_slashes() {

--- a/src-tauri/src/meet/mod.rs
+++ b/src-tauri/src/meet/mod.rs
@@ -5,15 +5,19 @@
 //! - `matrix` — Matrix / Element Call.
 //! - `zoom` — Zoom Marketplace OAuth + Meeting API.
 //!
-//! Both bind to a new `meet` service on the existing service-binding
-//! plumbing (so accounts surface alongside CalDAV / CardDAV-only
-//! accounts), and both use a browser-assisted login flow rather than
-//! ask the user for raw passwords:
-//! - Talk: Nextcloud "Login Flow v2" (poll-based, returns a long-lived
-//!   app password tied to the user).
-//! - Matrix: SSO redirect to the homeserver, captures `loginToken`
-//!   on a local listener, exchanges via `m.login.token` for an
-//!   `access_token`.
+//! All three bind to a new `meet` service on the existing
+//! service-binding plumbing (so accounts surface alongside
+//! CalDAV / CardDAV-only accounts), and all three use a
+//! browser-assisted login flow rather than ask the user for raw
+//! passwords:
+//! - Talk: Nextcloud "Login Flow v2" (poll-based, returns a
+//!   long-lived app password tied to the user).
+//! - Matrix: SSO redirect to the homeserver, captures
+//!   `loginToken` on a local listener, exchanges via
+//!   `m.login.token` for an `access_token`.
+//! - Zoom: standard OAuth 2.0 Authorization Code + PKCE against
+//!   a Marketplace-registered app on a pinned loopback port.
+//!   Tokens auto-refresh on use (60-min access-token lifetime).
 //!
 //! ## Adding a new provider
 //!

--- a/src-tauri/src/meet/mod.rs
+++ b/src-tauri/src/meet/mod.rs
@@ -1,0 +1,80 @@
+//! Video-conferencing integrations (#148).
+//!
+//! Two providers in this slice:
+//! - `talk` — Nextcloud Talk via the OCS Spreed v4 API.
+//! - `matrix` — Matrix / Element Call.
+//!
+//! Both bind to a new `meet` service on the existing service-binding
+//! plumbing (so accounts surface alongside CalDAV / CardDAV-only
+//! accounts), and both use a browser-assisted login flow rather than
+//! ask the user for raw passwords:
+//! - Talk: Nextcloud "Login Flow v2" (poll-based, returns a long-lived
+//!   app password tied to the user).
+//! - Matrix: SSO redirect to the homeserver, captures `loginToken`
+//!   on a local listener, exchanges via `m.login.token` for an
+//!   `access_token`.
+//!
+//! ## Adding a new provider
+//!
+//! 1. Create a module under `meet/` (e.g. `meet/bbb.rs`) with the
+//!    provider's auth flow and create-room logic.
+//! 2. Implement [`MeetProvider`] for a unit struct in that module.
+//!    Auth flows aren't part of the trait because they vary widely
+//!    (poll, SSO redirect, static shared secret); they live as
+//!    free functions on the module and have their own Tauri
+//!    commands wired in `commands/meet.rs`.
+//! 3. Add a constructor entry in [`registry`] so the dispatcher
+//!    knows the new protocol string.
+//!
+//! That's it — the rest of the app reads the `meet` binding through
+//! `provider_for(&account)` and never name-matches on the protocol
+//! string.
+
+use async_trait::async_trait;
+
+use crate::db::accounts::AccountFull;
+use crate::error::Result;
+
+pub mod matrix;
+pub mod talk;
+
+/// Common surface every meet provider exposes once an account has
+/// been authenticated. Auth flow stays per-provider because each
+/// is shaped differently; this trait covers the post-auth actions
+/// the rest of the app needs.
+#[async_trait]
+pub trait MeetProvider: Send + Sync {
+    /// Protocol discriminator stored on the binding row
+    /// (`service_bindings.protocol`).
+    fn protocol(&self) -> &'static str;
+
+    /// Human-readable label for log lines + error messages. Not
+    /// shown directly in the UI today; the frontend has its own
+    /// localized labels.
+    fn label(&self) -> &'static str;
+
+    /// Create a fresh meeting room / call and return the join URL
+    /// the user should put on their calendar event. The caller
+    /// supplies a hint name (often the event title); each provider
+    /// decides whether and how to pass it through.
+    async fn create_url(&self, account: &AccountFull, name: &str) -> Result<String>;
+}
+
+/// Static set of providers compiled into this build. Adding a new
+/// provider = a new line here. Lookup is by protocol string from
+/// the meet binding.
+pub fn registry() -> &'static [&'static dyn MeetProvider] {
+    &[&talk::TalkProvider, &matrix::MatrixProvider]
+}
+
+/// Dispatch helper: find the provider matching the account's enabled
+/// meet binding. Returns `None` when the account has no meet binding
+/// or the protocol is one we don't know about (which would surface
+/// as a config error in the UI).
+pub fn provider_for(account: &AccountFull) -> Option<&'static dyn MeetProvider> {
+    let proto = account.meet_protocol_str();
+    if proto.is_empty() {
+        return None;
+    }
+    registry().iter().copied().find(|p| p.protocol() == proto)
+}

--- a/src-tauri/src/meet/mod.rs
+++ b/src-tauri/src/meet/mod.rs
@@ -1,8 +1,9 @@
 //! Video-conferencing integrations (#148).
 //!
-//! Two providers in this slice:
+//! Three providers in this slice:
 //! - `talk` — Nextcloud Talk via the OCS Spreed v4 API.
 //! - `matrix` — Matrix / Element Call.
+//! - `zoom` — Zoom Marketplace OAuth + Meeting API.
 //!
 //! Both bind to a new `meet` service on the existing service-binding
 //! plumbing (so accounts surface alongside CalDAV / CardDAV-only
@@ -37,6 +38,7 @@ use crate::error::Result;
 
 pub mod matrix;
 pub mod talk;
+pub mod zoom;
 
 /// Common surface every meet provider exposes once an account has
 /// been authenticated. Auth flow stays per-provider because each
@@ -64,7 +66,11 @@ pub trait MeetProvider: Send + Sync {
 /// provider = a new line here. Lookup is by protocol string from
 /// the meet binding.
 pub fn registry() -> &'static [&'static dyn MeetProvider] {
-    &[&talk::TalkProvider, &matrix::MatrixProvider]
+    &[
+        &talk::TalkProvider,
+        &matrix::MatrixProvider,
+        &zoom::ZoomProvider,
+    ]
 }
 
 /// Dispatch helper: find the provider matching the account's enabled

--- a/src-tauri/src/meet/talk.rs
+++ b/src-tauri/src/meet/talk.rs
@@ -1,0 +1,250 @@
+//! Nextcloud Talk integration (#148).
+//!
+//! Two flows:
+//! - `login_flow_v2_start` / `login_flow_v2_poll` implement the
+//!   [Nextcloud Login Flow v2 spec][lf2]. The server hands us a
+//!   browser-facing `login` URL plus a `poll` endpoint+token; we
+//!   open the URL in the user's browser, then poll until the user
+//!   finishes the in-browser flow. The poll response carries a
+//!   long-lived **app password** tied to the user — never the
+//!   real account password — which is what we keep in the keyring.
+//! - `create_room` posts to the OCS Spreed v4 conversation endpoint
+//!   to create a fresh group room and returns the join URL.
+//!
+//! All HTTP calls go through one configured `reqwest::Client` with
+//! a 30-second timeout so a wedged Nextcloud instance can't hang
+//! the UI indefinitely.
+//!
+//! [lf2]: https://docs.nextcloud.com/server/latest/developer_manual/client_apis/LoginFlow/index.html
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::{Error, Result};
+
+const HTTP_TIMEOUT_SECS: u64 = 30;
+const USER_AGENT: &str = concat!("Chithi/", env!("CARGO_PKG_VERSION"));
+
+fn http_client() -> Result<reqwest::Client> {
+    reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(HTTP_TIMEOUT_SECS))
+        .user_agent(USER_AGENT)
+        .build()
+        .map_err(|e| Error::Other(format!("talk http client: {}", e)))
+}
+
+/// Result of `POST /index.php/login/v2`. The `login` URL is what the
+/// user opens in their browser; `poll.token` is what we send back to
+/// `poll.endpoint` until the user finishes.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LoginFlowStart {
+    pub login: String,
+    pub poll: LoginPoll,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LoginPoll {
+    pub token: String,
+    pub endpoint: String,
+}
+
+/// Successful poll result. `app_password` is what we keep in the
+/// keyring; the user's real password is never seen by us.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LoginFlowResult {
+    pub server: String,
+    #[serde(rename = "loginName")]
+    pub login_name: String,
+    #[serde(rename = "appPassword")]
+    pub app_password: String,
+}
+
+/// Kick off Nextcloud Login Flow v2 against `server_url`. The trailing
+/// slash is normalized; the function works for both bare-host
+/// (`https://cloud.example.com`) and path-prefixed installs
+/// (`https://example.com/cloud`).
+pub async fn login_flow_v2_start(server_url: &str) -> Result<LoginFlowStart> {
+    let url = format!("{}/index.php/login/v2", normalize_base_url(server_url));
+    let resp = http_client()?
+        .post(&url)
+        .send()
+        .await
+        .map_err(|e| Error::Other(format!("talk login_flow_v2_start request: {}", e)))?;
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        return Err(Error::Other(format!(
+            "talk login_flow_v2_start: {} ({})",
+            status,
+            body.chars().take(200).collect::<String>(),
+        )));
+    }
+    resp.json::<LoginFlowStart>()
+        .await
+        .map_err(|e| Error::Other(format!("talk login_flow_v2_start parse: {}", e)))
+}
+
+/// Poll the login-flow endpoint once. Returns:
+/// - `Ok(Some(result))` when the user has completed the in-browser
+///   flow and the server has issued credentials.
+/// - `Ok(None)` while the flow is still pending (HTTP 404 per the
+///   spec — Nextcloud uses 404 to mean "not yet").
+/// - `Err(_)` on any other failure.
+pub async fn login_flow_v2_poll(
+    poll_endpoint: &str,
+    poll_token: &str,
+) -> Result<Option<LoginFlowResult>> {
+    let resp = http_client()?
+        .post(poll_endpoint)
+        .form(&[("token", poll_token)])
+        .send()
+        .await
+        .map_err(|e| Error::Other(format!("talk login_flow_v2_poll request: {}", e)))?;
+    if resp.status() == reqwest::StatusCode::NOT_FOUND {
+        return Ok(None);
+    }
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        return Err(Error::Other(format!(
+            "talk login_flow_v2_poll: {} ({})",
+            status,
+            body.chars().take(200).collect::<String>(),
+        )));
+    }
+    let result = resp
+        .json::<LoginFlowResult>()
+        .await
+        .map_err(|e| Error::Other(format!("talk login_flow_v2_poll parse: {}", e)))?;
+    Ok(Some(result))
+}
+
+/// Drive the full Login Flow v2 to completion. Polls every 2 seconds
+/// up to a configurable timeout (default 5 minutes) — long enough
+/// for the user to finish a browser-based SSO redirect, short enough
+/// not to leave the UI hung if they walk away.
+pub async fn login_flow_v2_complete(
+    flow: &LoginFlowStart,
+    timeout_secs: u64,
+) -> Result<LoginFlowResult> {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(timeout_secs.max(30));
+    loop {
+        if let Some(result) = login_flow_v2_poll(&flow.poll.endpoint, &flow.poll.token).await? {
+            return Ok(result);
+        }
+        if std::time::Instant::now() >= deadline {
+            return Err(Error::Other(
+                "Nextcloud Talk sign-in timed out — finish the browser login and try again".into(),
+            ));
+        }
+        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+    }
+}
+
+/// Create a fresh Talk conversation (group room) and return the
+/// browser-facing join URL. `room_name` becomes the conversation
+/// title in Nextcloud Talk; we pick a sensible default if the caller
+/// hands us an empty string.
+pub async fn create_room(
+    server: &str,
+    login_name: &str,
+    app_password: &str,
+    room_name: &str,
+) -> Result<String> {
+    let base = normalize_base_url(server);
+    let url = format!("{}/ocs/v2.php/apps/spreed/api/v4/room", base);
+    let name = if room_name.trim().is_empty() {
+        "Meeting"
+    } else {
+        room_name
+    };
+    let resp = http_client()?
+        .post(&url)
+        .basic_auth(login_name, Some(app_password))
+        .header("OCS-APIRequest", "true")
+        .header("Accept", "application/json")
+        .form(&[
+            ("roomType", "2"), // 2 = group conversation
+            ("roomName", name),
+        ])
+        .send()
+        .await
+        .map_err(|e| Error::Other(format!("talk create_room request: {}", e)))?;
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        return Err(Error::Other(format!(
+            "talk create_room: {} ({})",
+            status,
+            body.chars().take(500).collect::<String>(),
+        )));
+    }
+    // OCS responses wrap the payload as {ocs: {meta: {...}, data: {...}}}.
+    // We only need data.token; the join URL is base + /call/<token>.
+    let payload: serde_json::Value = resp
+        .json()
+        .await
+        .map_err(|e| Error::Other(format!("talk create_room parse: {}", e)))?;
+    let token = payload["ocs"]["data"]["token"].as_str().ok_or_else(|| {
+        Error::Other(format!(
+            "talk create_room: response missing ocs.data.token: {}",
+            payload.to_string().chars().take(300).collect::<String>(),
+        ))
+    })?;
+    Ok(format!("{}/call/{}", base, token))
+}
+
+/// Strip trailing slashes from a Nextcloud base URL so callers can
+/// concatenate paths without producing `//` segments. Empty input
+/// returns empty.
+fn normalize_base_url(server: &str) -> String {
+    server.trim_end_matches('/').to_string()
+}
+
+/// `MeetProvider` implementor for Nextcloud Talk. Stateless — each
+/// `create_url` call reads the account's URL from its meet binding
+/// and the app password from the keyring.
+pub struct TalkProvider;
+
+#[async_trait::async_trait]
+impl crate::meet::MeetProvider for TalkProvider {
+    fn protocol(&self) -> &'static str {
+        "talk"
+    }
+    fn label(&self) -> &'static str {
+        "Nextcloud Talk"
+    }
+    async fn create_url(
+        &self,
+        account: &crate::db::accounts::AccountFull,
+        name: &str,
+    ) -> Result<String> {
+        let url = account.meet_url.trim();
+        if url.is_empty() {
+            return Err(Error::Other(
+                "Nextcloud Talk: account has no server URL configured".into(),
+            ));
+        }
+        let app_password = match crate::oauth::load_tokens(&account.id)? {
+            Some(t) => t.access_token,
+            None => {
+                return Err(Error::Other(
+                    "Nextcloud Talk: no app password in keyring; sign in again".into(),
+                ));
+            }
+        };
+        create_room(url, &account.username, &app_password, name).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalizes_trailing_slashes() {
+        assert_eq!(normalize_base_url("https://x/"), "https://x");
+        assert_eq!(normalize_base_url("https://x///"), "https://x");
+        assert_eq!(normalize_base_url("https://x"), "https://x");
+        assert_eq!(normalize_base_url(""), "");
+    }
+}

--- a/src-tauri/src/meet/talk.rs
+++ b/src-tauri/src/meet/talk.rs
@@ -24,12 +24,26 @@ use crate::error::{Error, Result};
 const HTTP_TIMEOUT_SECS: u64 = 30;
 const USER_AGENT: &str = concat!("Chithi/", env!("CARGO_PKG_VERSION"));
 
-fn http_client() -> Result<reqwest::Client> {
-    reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(HTTP_TIMEOUT_SECS))
-        .user_agent(USER_AGENT)
-        .build()
-        .map_err(|e| Error::Other(format!("talk http client: {}", e)))
+/// Single shared `reqwest::Client` for the whole Talk module so
+/// the connection pool persists across the Login Flow v2 poll
+/// loop (every 2s for up to five minutes per login). Building a
+/// new `Client` for every call would discard the keep-alive
+/// pool and re-do TLS setup each time. Initialised lazily on
+/// first use; if it ever fails to build (TLS init catastrophe)
+/// every call returns the same error.
+fn http_client() -> Result<&'static reqwest::Client> {
+    static CLIENT: std::sync::OnceLock<std::result::Result<reqwest::Client, String>> =
+        std::sync::OnceLock::new();
+    CLIENT
+        .get_or_init(|| {
+            reqwest::Client::builder()
+                .timeout(std::time::Duration::from_secs(HTTP_TIMEOUT_SECS))
+                .user_agent(USER_AGENT)
+                .build()
+                .map_err(|e| format!("talk http client: {}", e))
+        })
+        .as_ref()
+        .map_err(|e| Error::Other(e.clone()))
 }
 
 /// Result of `POST /index.php/login/v2`. The `login` URL is what the

--- a/src-tauri/src/meet/zoom.rs
+++ b/src-tauri/src/meet/zoom.rs
@@ -1,0 +1,139 @@
+//! Zoom integration (#148). Implements the `MeetProvider` trait
+//! against the [Zoom Meeting API][create-meeting] for user-managed
+//! OAuth apps registered on Zoom Marketplace.
+//!
+//! Auth: standard OAuth 2.0 Authorization Code + PKCE. The Tauri
+//! commands in `commands/meet.rs` drive `oauth::get_auth_url` /
+//! `wait_for_callback` / `exchange_code` against `oauth::ZOOM`,
+//! storing the resulting tokens in the keyring under the new
+//! account id.
+//!
+//! Refresh: Zoom access tokens expire after 60 minutes. Each
+//! `create_url` call inspects the cached `expires_at` and runs
+//! `oauth::refresh_access_token(&oauth::ZOOM, refresh_token)`
+//! when the access token is within a minute of expiry. The
+//! refreshed pair is written back to the keyring so the next
+//! call picks them up.
+//!
+//! [create-meeting]: https://developers.zoom.us/docs/api/meetings/methods/#tag/meetings/POST/users/{userId}/meetings
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::{Error, Result};
+
+const HTTP_TIMEOUT_SECS: u64 = 30;
+const USER_AGENT: &str = concat!("Chithi/", env!("CARGO_PKG_VERSION"));
+
+/// Single shared `reqwest::Client` for the Zoom module — same
+/// pattern as in `talk.rs` / `matrix.rs`. Lazily initialised on
+/// first call.
+fn http_client() -> Result<&'static reqwest::Client> {
+    static CLIENT: std::sync::OnceLock<std::result::Result<reqwest::Client, String>> =
+        std::sync::OnceLock::new();
+    CLIENT
+        .get_or_init(|| {
+            reqwest::Client::builder()
+                .timeout(std::time::Duration::from_secs(HTTP_TIMEOUT_SECS))
+                .user_agent(USER_AGENT)
+                .build()
+                .map_err(|e| format!("zoom http client: {}", e))
+        })
+        .as_ref()
+        .map_err(|e| Error::Other(e.clone()))
+}
+
+/// Subset of the create-meeting response we care about.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+struct CreateMeetingResponse {
+    pub id: serde_json::Value,
+    pub join_url: String,
+    #[serde(default)]
+    pub password: String,
+}
+
+/// Create a scheduled meeting on the user's Zoom account and
+/// return the join URL. `topic` becomes the meeting subject in
+/// Zoom (visible in the user's meeting list); we pick a default
+/// when the caller hands us an empty string.
+///
+/// `type=2` is "scheduled meeting"; we leave `start_time` and
+/// `duration` unset so the meeting is open-ended (Zoom treats it
+/// as joinable any time today). A future iteration could plumb
+/// the calendar event's `start` / `end` through.
+pub async fn create_meeting(access_token: &str, topic: &str) -> Result<String> {
+    let topic = if topic.trim().is_empty() {
+        "Meeting"
+    } else {
+        topic
+    };
+    let body = serde_json::json!({
+        "topic": topic,
+        "type": 2,
+        "settings": {
+            "join_before_host": true,
+            "waiting_room": false,
+        },
+    });
+    let resp = http_client()?
+        .post("https://api.zoom.us/v2/users/me/meetings")
+        .bearer_auth(access_token)
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| Error::Other(format!("zoom create_meeting request: {}", e)))?;
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        return Err(Error::Other(format!(
+            "zoom create_meeting: {} ({})",
+            status,
+            body.chars().take(500).collect::<String>(),
+        )));
+    }
+    let payload: CreateMeetingResponse = resp
+        .json()
+        .await
+        .map_err(|e| Error::Other(format!("zoom create_meeting parse: {}", e)))?;
+    Ok(payload.join_url)
+}
+
+/// Get a fresh Zoom access token for `account_id`, refreshing
+/// against `oauth::ZOOM.token_url` when the cached one is
+/// expired (or about to be — `is_expired` carries a 60-second
+/// safety margin). Persists the new pair to the keyring.
+pub async fn get_access_token(account_id: &str) -> Result<String> {
+    let tokens = crate::oauth::load_tokens(account_id)?
+        .ok_or_else(|| Error::Other("Zoom: no tokens in keyring; sign in again".into()))?;
+    if !tokens.is_expired() {
+        return Ok(tokens.access_token);
+    }
+    let refresh_token = tokens.refresh_token.ok_or_else(|| {
+        Error::Other("Zoom: access token expired and no refresh token; sign in again".into())
+    })?;
+    let new_tokens =
+        crate::oauth::refresh_access_token(&crate::oauth::ZOOM, &refresh_token).await?;
+    crate::oauth::store_tokens(account_id, &new_tokens)?;
+    Ok(new_tokens.access_token)
+}
+
+/// `MeetProvider` implementor for Zoom. Stateless — each call
+/// reads tokens from the keyring under the account id.
+pub struct ZoomProvider;
+
+#[async_trait::async_trait]
+impl crate::meet::MeetProvider for ZoomProvider {
+    fn protocol(&self) -> &'static str {
+        "zoom"
+    }
+    fn label(&self) -> &'static str {
+        "Zoom"
+    }
+    async fn create_url(
+        &self,
+        account: &crate::db::accounts::AccountFull,
+        name: &str,
+    ) -> Result<String> {
+        let access_token = get_access_token(&account.id).await?;
+        create_meeting(&access_token, name).await
+    }
+}

--- a/src-tauri/src/oauth.rs
+++ b/src-tauri/src/oauth.rs
@@ -19,6 +19,11 @@ pub struct OAuthProvider {
     pub scopes: &'static [&'static str],
     /// Use PKCE (required for Microsoft public clients)
     pub use_pkce: bool,
+    /// Loopback host the provider expects in the redirect URI.
+    /// Microsoft requires `localhost`; Google accepts either;
+    /// Zoom registers `http://127.0.0.1` and rejects `localhost`.
+    /// Defaults to `"localhost"` for legacy providers.
+    pub redirect_host: &'static str,
 }
 
 pub const GOOGLE: OAuthProvider = OAuthProvider {
@@ -32,6 +37,7 @@ pub const GOOGLE: OAuthProvider = OAuthProvider {
         "https://www.googleapis.com/auth/contacts",
     ],
     use_pkce: true,
+    redirect_host: "localhost",
 };
 
 pub const MICROSOFT: OAuthProvider = OAuthProvider {
@@ -58,11 +64,36 @@ pub const MICROSOFT: OAuthProvider = OAuthProvider {
         "email",
     ],
     use_pkce: true,
+    redirect_host: "localhost",
 };
 
 /// Microsoft Graph scopes — used for a separate token refresh for calendar/contacts.
 pub const MICROSOFT_GRAPH_SCOPES: &str =
     "User.Read Mail.ReadWrite Calendars.ReadWrite Contacts.ReadWrite offline_access";
+
+/// Zoom OAuth (#148, video conferencing). Native app with PKCE —
+/// no client_secret ships in the binary. Registered on Zoom
+/// Marketplace as a "User-managed app" with redirect URI
+/// `http://127.0.0.1` (loopback wildcard — Zoom matches the host
+/// and ignores the port at runtime). Note that Zoom rejects
+/// `http://localhost:N` callbacks, hence `redirect_host` is
+/// `127.0.0.1` here while Microsoft demands `localhost`.
+///
+/// Scope is the granular Zoom 2024+ name for "create user
+/// meetings"; if the Marketplace registration only enabled the
+/// classic `meeting:write:meeting`, the OAuth consent screen
+/// will still work but `create_url` will 401 — flip the scope
+/// name in that case.
+pub const ZOOM: OAuthProvider = OAuthProvider {
+    name: "zoom",
+    client_id: "CxRwHStNQkqPBztEsvSDnA",
+    client_secret: "", // Public client — PKCE only
+    auth_url: "https://zoom.us/oauth/authorize",
+    token_url: "https://zoom.us/oauth/token",
+    scopes: &["meeting:write:meeting:user"],
+    use_pkce: true,
+    redirect_host: "127.0.0.1",
+};
 
 /// Microsoft IMAP/SMTP scopes — used for token refresh for mail access.
 /// Uses outlook.office.com (works for both personal and work/school accounts).
@@ -131,9 +162,10 @@ pub fn get_auth_url(
         .map_err(|e| Error::Other(format!("Failed to get port: {}", e)))?
         .port();
 
-    // Microsoft requires http://localhost (not 127.0.0.1) for native client redirect.
-    // Google works with either. Use localhost for both.
-    let redirect_uri = format!("http://localhost:{}", port);
+    // Per-provider loopback host (see `OAuthProvider.redirect_host`):
+    // Microsoft demands `localhost`, Zoom demands `127.0.0.1`,
+    // Google accepts either.
+    let redirect_uri = format!("http://{}:{}", provider.redirect_host, port);
 
     // Generate a random state parameter for CSRF protection
     let state = generate_code_verifier();
@@ -276,9 +308,10 @@ pub async fn exchange_code(
     port: u16,
     code_verifier: Option<&str>,
 ) -> Result<OAuthTokens> {
-    // Microsoft requires http://localhost (not 127.0.0.1) for native client redirect.
-    // Google works with either. Use localhost for both.
-    let redirect_uri = format!("http://localhost:{}", port);
+    // Per-provider loopback host (see `OAuthProvider.redirect_host`):
+    // Microsoft demands `localhost`, Zoom demands `127.0.0.1`,
+    // Google accepts either.
+    let redirect_uri = format!("http://{}:{}", provider.redirect_host, port);
 
     let mut params = HashMap::new();
     params.insert("client_id", provider.client_id.to_string());

--- a/src-tauri/src/oauth.rs
+++ b/src-tauri/src/oauth.rs
@@ -88,18 +88,16 @@ pub const MICROSOFT_GRAPH_SCOPES: &str =
 /// `http://localhost:N` callbacks, hence `redirect_host` is
 /// `127.0.0.1` here while Microsoft demands `localhost`.
 ///
-/// Scope is the granular Zoom 2024+ name for "create user
-/// meetings"; if the Marketplace registration only enabled the
-/// classic `meeting:write:meeting`, the OAuth consent screen
-/// will still work but `create_url` will 401 — flip the scope
-/// name in that case.
+/// Scope is the granular `meeting:write:meeting` (create user
+/// meetings) — must match what's checked under Marketplace →
+/// Scopes → Meeting on the registered app.
 pub const ZOOM: OAuthProvider = OAuthProvider {
     name: "zoom",
     client_id: "CxRwHStNQkqPBztEsvSDnA",
     client_secret: "", // Public client — PKCE only
     auth_url: "https://zoom.us/oauth/authorize",
     token_url: "https://zoom.us/oauth/token",
-    scopes: &["meeting:write:meeting:user"],
+    scopes: &["meeting:write:meeting"],
     use_pkce: true,
     redirect_host: "127.0.0.1",
     // Pinned port that the Marketplace registration matches

--- a/src-tauri/src/oauth.rs
+++ b/src-tauri/src/oauth.rs
@@ -83,10 +83,17 @@ pub const MICROSOFT_GRAPH_SCOPES: &str =
 /// Zoom OAuth (#148, video conferencing). Native app with PKCE —
 /// no client_secret ships in the binary. Registered on Zoom
 /// Marketplace as a "User-managed app" with redirect URI
-/// `http://127.0.0.1` (loopback wildcard — Zoom matches the host
-/// and ignores the port at runtime). Note that Zoom rejects
-/// `http://localhost:N` callbacks, hence `redirect_host` is
-/// `127.0.0.1` here while Microsoft demands `localhost`.
+/// **`http://127.0.0.1:47832` exactly** — Zoom does *not* honor
+/// RFC 8252's "ignore the port on loopback" rule, so the
+/// registered URI must match the runtime URI character-for-
+/// character (port included). That's why `redirect_fixed_port`
+/// is set: `get_auth_url` binds 47832 specifically. If the port
+/// is held by another process the bind errors out with a clear
+/// message and the user retries.
+///
+/// `localhost` callbacks are rejected by Zoom regardless, hence
+/// `redirect_host` is `127.0.0.1` while Microsoft demands
+/// `localhost`.
 ///
 /// Scope is the granular `meeting:write:meeting` (create user
 /// meetings) — must match what's checked under Marketplace →

--- a/src-tauri/src/oauth.rs
+++ b/src-tauri/src/oauth.rs
@@ -24,6 +24,13 @@ pub struct OAuthProvider {
     /// Zoom registers `http://127.0.0.1` and rejects `localhost`.
     /// Defaults to `"localhost"` for legacy providers.
     pub redirect_host: &'static str,
+    /// Fixed loopback port the provider's redirect URI uses, when
+    /// the provider doesn't honor RFC 8252's "ignore the port on
+    /// loopback" rule and requires an exact match against what's
+    /// registered. `None` lets `get_auth_url` bind a random free
+    /// port (Google / Microsoft). Zoom Marketplace pins
+    /// `http://127.0.0.1:<port>` exactly so we set this for Zoom.
+    pub redirect_fixed_port: Option<u16>,
 }
 
 pub const GOOGLE: OAuthProvider = OAuthProvider {
@@ -38,6 +45,7 @@ pub const GOOGLE: OAuthProvider = OAuthProvider {
     ],
     use_pkce: true,
     redirect_host: "localhost",
+    redirect_fixed_port: None,
 };
 
 pub const MICROSOFT: OAuthProvider = OAuthProvider {
@@ -65,6 +73,7 @@ pub const MICROSOFT: OAuthProvider = OAuthProvider {
     ],
     use_pkce: true,
     redirect_host: "localhost",
+    redirect_fixed_port: None,
 };
 
 /// Microsoft Graph scopes — used for a separate token refresh for calendar/contacts.
@@ -93,6 +102,12 @@ pub const ZOOM: OAuthProvider = OAuthProvider {
     scopes: &["meeting:write:meeting:user"],
     use_pkce: true,
     redirect_host: "127.0.0.1",
+    // Pinned port that the Marketplace registration matches
+    // exactly. If the port is in use at runtime the bind fails
+    // with a clear error and the user retries; the alternative
+    // (registering a range of ports) inflates Marketplace
+    // bookkeeping for marginal benefit on a desktop app.
+    redirect_fixed_port: Some(47832),
 };
 
 /// Microsoft IMAP/SMTP scopes — used for token refresh for mail access.
@@ -155,8 +170,22 @@ impl OAuthTokens {
 pub fn get_auth_url(
     provider: &OAuthProvider,
 ) -> Result<(String, TcpListener, Option<String>, String)> {
-    let listener = TcpListener::bind("127.0.0.1:0")
-        .map_err(|e| Error::Other(format!("Failed to bind local server: {}", e)))?;
+    // Honor the provider's pinned-port setting when present
+    // (Zoom requires an exact-match redirect URI registered in
+    // Marketplace). Otherwise bind a random free port — the
+    // common case for Google / Microsoft.
+    let bind_port = provider.redirect_fixed_port.unwrap_or(0);
+    let listener = TcpListener::bind(format!("127.0.0.1:{}", bind_port))
+        .map_err(|e| {
+            if provider.redirect_fixed_port.is_some() {
+                Error::Other(format!(
+                    "{} requires loopback port {} but it's already in use ({}). Close the program holding it and retry.",
+                    provider.name, bind_port, e,
+                ))
+            } else {
+                Error::Other(format!("Failed to bind local server: {}", e))
+            }
+        })?;
     let port = listener
         .local_addr()
         .map_err(|e| Error::Other(format!("Failed to get port: {}", e)))?

--- a/src-tauri/src/oauth.rs
+++ b/src-tauri/src/oauth.rs
@@ -93,7 +93,17 @@ pub const MICROSOFT_GRAPH_SCOPES: &str =
 /// Scopes → Meeting on the registered app.
 pub const ZOOM: OAuthProvider = OAuthProvider {
     name: "zoom",
-    client_id: "CxRwHStNQkqPBztEsvSDnA",
+    // Build-time override via `CHITHI_ZOOM_CLIENT_ID`. Each fork
+    // / deployment registers its own User-managed app on Zoom
+    // Marketplace and ships the client_id via build env. The
+    // baked-in default is the SUNET-organisation registration
+    // for upstream Chithi development; admin-pre-approval gating
+    // means a fresh Zoom account + Marketplace registration is
+    // typically the path of least resistance for forks.
+    client_id: match option_env!("CHITHI_ZOOM_CLIENT_ID") {
+        Some(s) => s,
+        None => "CxRwHStNQkqPBztEsvSDnA",
+    },
     client_secret: "", // Public client — PKCE only
     auth_url: "https://zoom.us/oauth/authorize",
     token_url: "https://zoom.us/oauth/token",

--- a/src-tauri/src/oauth.rs
+++ b/src-tauri/src/oauth.rs
@@ -93,16 +93,15 @@ pub const MICROSOFT_GRAPH_SCOPES: &str =
 /// Scopes → Meeting on the registered app.
 pub const ZOOM: OAuthProvider = OAuthProvider {
     name: "zoom",
-    // Build-time override via `CHITHI_ZOOM_CLIENT_ID`. Each fork
-    // / deployment registers its own User-managed app on Zoom
-    // Marketplace and ships the client_id via build env. The
-    // baked-in default is the SUNET-organisation registration
-    // for upstream Chithi development; admin-pre-approval gating
-    // means a fresh Zoom account + Marketplace registration is
-    // typically the path of least resistance for forks.
+    // Build-time override via `CHITHI_ZOOM_CLIENT_ID`. The baked-
+    // in default is a free-tier Marketplace registration without
+    // admin-approval gating, so out-of-the-box `cargo run` works
+    // without an env var. Forks shipping under their own Zoom
+    // organisation register their own app and pass that through
+    // the env at build time.
     client_id: match option_env!("CHITHI_ZOOM_CLIENT_ID") {
         Some(s) => s,
-        None => "CxRwHStNQkqPBztEsvSDnA",
+        None => "NvT2nsWbS1Whhgut4Tr8_A",
     },
     client_secret: "", // Public client — PKCE only
     auth_url: "https://zoom.us/oauth/authorize",

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -42,6 +42,12 @@ pub struct AppState {
     /// dialog. The renderer only ever sees the token, so a compromised
     /// renderer cannot ask the backend to read arbitrary files.
     pub attachments: std::sync::Mutex<HashMap<String, PathBuf>>,
+    /// In-flight Matrix SSO listeners, keyed by the local-port the
+    /// frontend will pass back to `meet_matrix_login_complete`.
+    /// `meet_matrix_login_start` parks one here when it returns the
+    /// SSO redirect URL; the complete call removes and consumes it.
+    /// (#148)
+    pub matrix_sso_listeners: std::sync::Mutex<HashMap<u16, std::net::TcpListener>>,
 }
 
 impl AppState {
@@ -66,6 +72,7 @@ impl AppState {
             op_senders: std::sync::Mutex::new(HashMap::new()),
             data_dir,
             attachments: std::sync::Mutex::new(HashMap::new()),
+            matrix_sso_listeners: std::sync::Mutex::new(HashMap::new()),
         })
     }
 

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -49,6 +49,11 @@ pub struct AppState {
     /// and the random state nonce that the legitimate SSO
     /// callback must echo back. (#148)
     pub matrix_sso_listeners: std::sync::Mutex<HashMap<u16, MatrixSsoSession>>,
+    /// In-flight Zoom OAuth sessions. Same shape as the Matrix
+    /// SSO map but additionally carries the PKCE code verifier
+    /// (Zoom is a public OAuth client and uses PKCE rather than
+    /// a client_secret). (#148)
+    pub zoom_oauth_sessions: std::sync::Mutex<HashMap<u16, ZoomOAuthSession>>,
 }
 
 /// One in-flight Matrix SSO login. Lives in
@@ -57,6 +62,16 @@ pub struct AppState {
 pub struct MatrixSsoSession {
     pub created: std::time::Instant,
     pub listener: std::net::TcpListener,
+    pub state: String,
+}
+
+/// One in-flight Zoom OAuth login. Same shape as the Matrix
+/// session but with the PKCE code verifier alongside the state
+/// nonce, since Zoom is a public OAuth client.
+pub struct ZoomOAuthSession {
+    pub created: std::time::Instant,
+    pub listener: std::net::TcpListener,
+    pub verifier: Option<String>,
     pub state: String,
 }
 
@@ -83,6 +98,7 @@ impl AppState {
             data_dir,
             attachments: std::sync::Mutex::new(HashMap::new()),
             matrix_sso_listeners: std::sync::Mutex::new(HashMap::new()),
+            zoom_oauth_sessions: std::sync::Mutex::new(HashMap::new()),
         })
     }
 

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -42,12 +42,22 @@ pub struct AppState {
     /// dialog. The renderer only ever sees the token, so a compromised
     /// renderer cannot ask the backend to read arbitrary files.
     pub attachments: std::sync::Mutex<HashMap<String, PathBuf>>,
-    /// In-flight Matrix SSO listeners, keyed by the local-port the
+    /// In-flight Matrix SSO sessions, keyed by the local-port the
     /// frontend will pass back to `meet_matrix_login_complete`.
-    /// `meet_matrix_login_start` parks one here when it returns the
-    /// SSO redirect URL; the complete call removes and consumes it.
-    /// (#148)
-    pub matrix_sso_listeners: std::sync::Mutex<HashMap<u16, std::net::TcpListener>>,
+    /// Each entry carries the bound `TcpListener`, a creation
+    /// timestamp (so abandoned flows are evicted on next insert),
+    /// and the random state nonce that the legitimate SSO
+    /// callback must echo back. (#148)
+    pub matrix_sso_listeners: std::sync::Mutex<HashMap<u16, MatrixSsoSession>>,
+}
+
+/// One in-flight Matrix SSO login. Lives in
+/// `AppState.matrix_sso_listeners` between the `_start` and
+/// `_complete` Tauri commands.
+pub struct MatrixSsoSession {
+    pub created: std::time::Instant,
+    pub listener: std::net::TcpListener,
+    pub state: String,
 }
 
 impl AppState {

--- a/src/__tests__/calendar.test.ts
+++ b/src/__tests__/calendar.test.ts
@@ -53,6 +53,7 @@ function setupAccounts() {
       username: "",
       has_calendar_binding: false,
       has_contacts_binding: false,
+      meet_protocol: "",
     },
   ];
   accountsStore.activeAccountId = "acc1";

--- a/src/__tests__/message-list-clicks.test.ts
+++ b/src/__tests__/message-list-clicks.test.ts
@@ -54,6 +54,7 @@ function setupStores() {
       username: "",
       has_calendar_binding: false,
       has_contacts_binding: false,
+      meet_protocol: "",
     },
   ];
   accountsStore.activeAccountId = "acc1";

--- a/src/__tests__/messages-selection.test.ts
+++ b/src/__tests__/messages-selection.test.ts
@@ -44,6 +44,7 @@ function setup(threading = false) {
       username: "",
       has_calendar_binding: false,
       has_contacts_binding: false,
+      meet_protocol: "",
     },
   ];
   accountsStore.activeAccountId = "acc1";

--- a/src/__tests__/regression.test.ts
+++ b/src/__tests__/regression.test.ts
@@ -60,6 +60,7 @@ function setupStores(threading = false) {
       username: "",
       has_calendar_binding: false,
       has_contacts_binding: false,
+      meet_protocol: "",
     },
   ];
   accountsStore.activeAccountId = "acc1";

--- a/src/__tests__/server-search.test.ts
+++ b/src/__tests__/server-search.test.ts
@@ -57,6 +57,7 @@ function withActiveAccount() {
       username: "",
       has_calendar_binding: false,
       has_contacts_binding: false,
+      meet_protocol: "",
     },
   ];
   accountsStore.activeAccountId = "acc1";

--- a/src/__tests__/store-listeners.test.ts
+++ b/src/__tests__/store-listeners.test.ts
@@ -72,6 +72,7 @@ describe("Store listener cleanup", () => {
       username: "",
       has_calendar_binding: false,
       has_contacts_binding: false,
+      meet_protocol: "",
       },
     ];
     accountsStore.activeAccountId = "acc1";

--- a/src/__tests__/threads-expansion.test.ts
+++ b/src/__tests__/threads-expansion.test.ts
@@ -46,6 +46,7 @@ function withActiveContext() {
       username: "",
       has_calendar_binding: false,
       has_contacts_binding: false,
+      meet_protocol: "",
     },
   ];
   accountsStore.activeAccountId = "acc1";

--- a/src/components/calendar/EventForm.vue
+++ b/src/components/calendar/EventForm.vue
@@ -56,15 +56,11 @@ async function addVideoLink(accountId: string) {
   meetError.value = null;
   try {
     const url = await api.meetCreateUrl(accountId, title.value || "Meeting");
-    // Convention: the URL goes into `location` (modern calendar
-    // clients render it as a clickable Join link there) and we
-    // also prepend a "Join: <url>" line to the description so
-    // calendars without rich location rendering still show it
-    // in the body. If location already has something, append
-    // newline-separated.
-    location.value = location.value
-      ? `${location.value}\n${url}`
-      : url;
+    // `location` is an <input type="text"> — newlines aren't
+    // preserved there, so we replace the field outright rather
+    // than appending. The full link history lives in
+    // `description` (a textarea), where multi-line works.
+    location.value = url;
     description.value = description.value
       ? `Join: ${url}\n\n${description.value}`
       : `Join: ${url}`;

--- a/src/components/calendar/EventForm.vue
+++ b/src/components/calendar/EventForm.vue
@@ -36,6 +36,46 @@ const defaultStart = props.initialStart
   : new Date();
 const defaultEnd = new Date(defaultStart.getTime() + 60 * 60 * 1000);
 
+/// Accounts that can produce a meeting URL (#148). Pulled from the
+/// account summary's `meet_protocol` so we can label the dropdown
+/// with "Nextcloud Talk" / "Matrix" alongside the account name.
+const meetAccountOptions = computed(() =>
+  accountsStore.accounts
+    .filter((a) => a.meet_protocol === "talk" || a.meet_protocol === "matrix")
+    .map((a) => ({
+      value: a.id,
+      label: `${a.display_name || a.email || a.id} (${a.meet_protocol === "talk" ? "Nextcloud Talk" : "Matrix"})`,
+    })),
+);
+const generatingMeetUrl = ref(false);
+const meetError = ref<string | null>(null);
+
+async function addVideoLink(accountId: string) {
+  if (!accountId || generatingMeetUrl.value) return;
+  generatingMeetUrl.value = true;
+  meetError.value = null;
+  try {
+    const url = await api.meetCreateUrl(accountId, title.value || "Meeting");
+    // Convention: the URL goes into `location` (modern calendar
+    // clients render it as a clickable Join link there) and we
+    // also prepend a "Join: <url>" line to the description so
+    // calendars without rich location rendering still show it
+    // in the body. If location already has something, append
+    // newline-separated.
+    location.value = location.value
+      ? `${location.value}\n${url}`
+      : url;
+    description.value = description.value
+      ? `Join: ${url}\n\n${description.value}`
+      : `Join: ${url}`;
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    meetError.value = `Could not create meeting: ${msg}`;
+  } finally {
+    generatingMeetUrl.value = false;
+  }
+}
+
 const title = ref("");
 const startDate = ref(toDateInTimezone(defaultStart, uiStore.displayTimezone));
 const startTime = ref(toTimeInTimezone(defaultStart, uiStore.displayTimezone));
@@ -194,6 +234,35 @@ async function save() {
         <div class="form-group">
           <label>Location</label>
           <input v-model="location" type="text" placeholder="Add location" data-testid="event-form-location" />
+          <!-- #148: one-click video conference. Only renders when
+               at least one account has a meet binding configured
+               in Settings. Picking an entry creates the room /
+               call on that provider and appends the join URL to
+               this Location field plus a Join: line in the
+               description below. -->
+          <div
+            v-if="meetAccountOptions.length > 0"
+            class="meet-row"
+            data-testid="event-form-meet-row"
+          >
+            <button
+              v-for="opt in meetAccountOptions"
+              :key="opt.value"
+              type="button"
+              class="meet-btn"
+              :disabled="generatingMeetUrl"
+              :data-testid="`event-form-meet-${opt.value}`"
+              @click="addVideoLink(opt.value)"
+            >
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <polygon points="23 7 16 12 23 17 23 7" /><rect x="1" y="5" width="15" height="14" rx="2" ry="2" />
+              </svg>
+              {{ generatingMeetUrl ? "Creating…" : `Add ${opt.label}` }}
+            </button>
+          </div>
+          <span v-if="meetError" class="meet-error" data-testid="event-form-meet-error">
+            {{ meetError }}
+          </span>
         </div>
 
         <div class="form-group">
@@ -229,6 +298,39 @@ async function save() {
 </template>
 
 <style scoped>
+/* "Add video conference" buttons under the Location input (#148). */
+.meet-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 6px;
+}
+.meet-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  font-size: 11px;
+  border-radius: 12px;
+  border: 1px solid var(--color-border);
+  background: var(--color-bg-secondary);
+  color: var(--color-text);
+  cursor: pointer;
+}
+.meet-btn:hover {
+  background: var(--color-bg-hover);
+}
+.meet-btn:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+.meet-error {
+  display: block;
+  margin-top: 6px;
+  font-size: 11px;
+  color: var(--color-danger, #c0392b);
+}
+
 .event-form-overlay {
   position: fixed;
   top: 0; left: 0; right: 0; bottom: 0;

--- a/src/components/calendar/EventForm.vue
+++ b/src/components/calendar/EventForm.vue
@@ -39,12 +39,22 @@ const defaultEnd = new Date(defaultStart.getTime() + 60 * 60 * 1000);
 /// Accounts that can produce a meeting URL (#148). Pulled from the
 /// account summary's `meet_protocol` so we can label the dropdown
 /// with "Nextcloud Talk" / "Matrix" alongside the account name.
+/// Map `meet_protocol` values to the human-readable label that
+/// goes on the "Add <provider>" buttons. Adding a new provider
+/// = one new entry in this map; rest of the component picks it
+/// up from `meetAccountOptions`.
+const MEET_PROTOCOL_LABELS: Record<string, string> = {
+  talk: "Nextcloud Talk",
+  matrix: "Matrix",
+  zoom: "Zoom",
+};
+
 const meetAccountOptions = computed(() =>
   accountsStore.accounts
-    .filter((a) => a.meet_protocol === "talk" || a.meet_protocol === "matrix")
+    .filter((a) => a.meet_protocol in MEET_PROTOCOL_LABELS)
     .map((a) => ({
       value: a.id,
-      label: `${a.display_name || a.email || a.id} (${a.meet_protocol === "talk" ? "Nextcloud Talk" : "Matrix"})`,
+      label: `${a.display_name || a.email || a.id} (${MEET_PROTOCOL_LABELS[a.meet_protocol]})`,
     })),
 );
 const generatingMeetUrl = ref(false);

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -507,6 +507,68 @@ export async function syncContacts(accountId: string): Promise<void> {
   return invoke("sync_contacts", { accountId });
 }
 
+// Meet (video conferencing — #148). Two browser-assisted login
+// flows + one provider-agnostic create-URL. Talk uses Nextcloud
+// Login Flow v2 (poll-based), Matrix uses SSO redirect to a local
+// listener. Both end with a stored account row + keyring entry.
+
+export interface TalkLoginStart {
+  login_url: string;
+  poll_endpoint: string;
+  poll_token: string;
+}
+
+export async function meetTalkLoginStart(
+  serverUrl: string,
+): Promise<TalkLoginStart> {
+  return invoke("meet_talk_login_start", { serverUrl });
+}
+
+export async function meetTalkLoginComplete(
+  pollEndpoint: string,
+  pollToken: string,
+  displayName?: string,
+): Promise<string> {
+  return invoke("meet_talk_login_complete", {
+    pollEndpoint,
+    pollToken,
+    displayName: displayName ?? null,
+  });
+}
+
+export interface MatrixLoginStart {
+  login_url: string;
+  port: number;
+}
+
+export async function meetMatrixLoginStart(
+  homeserverUrl: string,
+): Promise<MatrixLoginStart> {
+  return invoke("meet_matrix_login_start", { homeserverUrl });
+}
+
+export async function meetMatrixLoginComplete(
+  homeserverUrl: string,
+  port: number,
+  displayName?: string,
+): Promise<string> {
+  return invoke("meet_matrix_login_complete", {
+    homeserverUrl,
+    port,
+    displayName: displayName ?? null,
+  });
+}
+
+/// Provider-agnostic create — picks the registry entry matching
+/// the account's meet binding. Returns the join URL the event
+/// editor should drop into the event's location field.
+export async function meetCreateUrl(
+  accountId: string,
+  name: string,
+): Promise<string> {
+  return invoke("meet_create_url", { accountId, name });
+}
+
 // IDLE
 export async function startIdle(): Promise<void> {
   return invoke("start_idle");

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -559,6 +559,28 @@ export async function meetMatrixLoginComplete(
   });
 }
 
+/// Zoom OAuth (#148). Hosted by Zoom — no per-user server URL,
+/// just an OAuth Authorization Code + PKCE round-trip against
+/// the Marketplace-registered app.
+export interface ZoomLoginStart {
+  login_url: string;
+  port: number;
+}
+
+export async function meetZoomLoginStart(): Promise<ZoomLoginStart> {
+  return invoke("meet_zoom_login_start");
+}
+
+export async function meetZoomLoginComplete(
+  port: number,
+  displayName?: string,
+): Promise<string> {
+  return invoke("meet_zoom_login_complete", {
+    port,
+    displayName: displayName ?? null,
+  });
+}
+
 /// Provider-agnostic create — picks the registry entry matching
 /// the account's meet binding. Returns the join URL the event
 /// editor should drop into the event's location field.

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -507,10 +507,13 @@ export async function syncContacts(accountId: string): Promise<void> {
   return invoke("sync_contacts", { accountId });
 }
 
-// Meet (video conferencing — #148). Two browser-assisted login
-// flows + one provider-agnostic create-URL. Talk uses Nextcloud
-// Login Flow v2 (poll-based), Matrix uses SSO redirect to a local
-// listener. Both end with a stored account row + keyring entry.
+// Meet (video conferencing — #148). One browser-assisted login
+// flow per provider (Talk / Matrix / Zoom today; the set is
+// driven by `meet::registry()` on the backend) plus one
+// provider-agnostic create-URL. Talk uses Nextcloud Login Flow
+// v2 (poll-based), Matrix uses SSO redirect to a local listener,
+// Zoom uses OAuth 2.0 Authorization Code + PKCE. All end with a
+// stored account row + keyring entry.
 
 export interface TalkLoginStart {
   login_url: string;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -29,7 +29,7 @@ export interface Account {
   // "matrix"), empty when there is none. Lets the calendar event
   // editor populate its "Add video link" dropdown without an
   // extra round-trip per row.
-  meet_protocol: "" | "talk" | "matrix";
+  meet_protocol: "" | "talk" | "matrix" | "zoom";
 }
 
 export interface QuickFilter {
@@ -178,7 +178,7 @@ export interface AccountConfig {
   /// One of `"talk"` / `"matrix"` when the account has a meet
   /// binding, empty otherwise. Picked by which Settings tab the
   /// user signed in through.
-  meet_protocol: "" | "talk" | "matrix";
+  meet_protocol: "" | "talk" | "matrix" | "zoom";
   username: string;
   password: string;
   use_tls: boolean;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -166,6 +166,14 @@ export interface AccountConfig {
   smtp_port: number;
   jmap_url: string;
   caldav_url: string;
+  /// #148. Server URL for the video-conferencing binding
+  /// (Nextcloud Talk root or Matrix homeserver). Empty when the
+  /// account has no meet binding. Pairs with `meet_protocol`.
+  meet_url: string;
+  /// One of `"talk"` / `"matrix"` when the account has a meet
+  /// binding, empty otherwise. Picked by which Settings tab the
+  /// user signed in through.
+  meet_protocol: "" | "talk" | "matrix";
   username: string;
   password: string;
   use_tls: boolean;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -25,10 +25,11 @@ export interface Account {
   // existence-only flags would always say true for both).
   has_calendar_binding: boolean;
   has_contacts_binding: boolean;
-  // #148. Protocol of the account's enabled meet binding ("talk" /
-  // "matrix"), empty when there is none. Lets the calendar event
-  // editor populate its "Add video link" dropdown without an
-  // extra round-trip per row.
+  // #148. Protocol of the account's enabled meet binding —
+  // `talk`, `matrix`, `zoom`, or whatever else is registered
+  // in `meet::registry()` — empty when there is none. Lets the
+  // calendar event editor populate its "Add video link"
+  // dropdown without an extra round-trip per row.
   meet_protocol: "" | "talk" | "matrix" | "zoom";
 }
 
@@ -171,13 +172,17 @@ export interface AccountConfig {
   smtp_port: number;
   jmap_url: string;
   caldav_url: string;
-  /// #148. Server URL for the video-conferencing binding
-  /// (Nextcloud Talk root or Matrix homeserver). Empty when the
-  /// account has no meet binding. Pairs with `meet_protocol`.
+  /// #148. Server URL the provider keys off. Nextcloud root for
+  /// Talk, homeserver for Matrix. For Zoom this is a marker
+  /// (`https://zoom.us`) since Zoom is a hosted service with no
+  /// per-user URL — `create_url` reads the OAuth token from the
+  /// keyring and ignores this. Empty when the account has no
+  /// meet binding.
   meet_url: string;
-  /// One of `"talk"` / `"matrix"` when the account has a meet
-  /// binding, empty otherwise. Picked by which Settings tab the
-  /// user signed in through.
+  /// Provider discriminator chosen by the Settings tab the user
+  /// signed in through. The set in this union is whatever the
+  /// `meet::registry()` exposes today; empty when there's no
+  /// meet binding.
   meet_protocol: "" | "talk" | "matrix" | "zoom";
   username: string;
   password: string;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -25,6 +25,11 @@ export interface Account {
   // existence-only flags would always say true for both).
   has_calendar_binding: boolean;
   has_contacts_binding: boolean;
+  // #148. Protocol of the account's enabled meet binding ("talk" /
+  // "matrix"), empty when there is none. Lets the calendar event
+  // editor populate its "Add video link" dropdown without an
+  // extra round-trip per row.
+  meet_protocol: "" | "talk" | "matrix";
 }
 
 export interface QuickFilter {

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -33,6 +33,8 @@ function accountTypeLabelLong(t: AccountType): string {
       return "Nextcloud Talk";
     case "matrix":
       return "Matrix";
+    case "zoom":
+      return "Zoom";
     default:
       return t.toUpperCase();
   }
@@ -63,6 +65,8 @@ function accountTypeLabel(acc: {
       return "Nextcloud Talk";
     case "matrix":
       return "Matrix";
+    case "zoom":
+      return "Zoom";
     default:
       return "";
   }
@@ -205,7 +209,10 @@ const hasContactsBinding = computed(() => hasCalendarBinding.value);
 /// signature / per-service-sync sections that are meaningless
 /// for these accounts. (#148)
 const isMeetTab = computed(
-  () => accountType.value === "talk" || accountType.value === "matrix",
+  () =>
+    accountType.value === "talk"
+    || accountType.value === "matrix"
+    || accountType.value === "zoom",
 );
 
 function getInitials(name: string): string {
@@ -254,7 +261,8 @@ type AccountType =
   | "carddav"
   | "o365"
   | "talk"
-  | "matrix";
+  | "matrix"
+  | "zoom";
 const accountType = ref<AccountType>("gmail");
 
 function selectAccountType(type: AccountType) {
@@ -357,11 +365,14 @@ function selectAccountType(type: AccountType) {
       break;
     case "talk":
     case "matrix":
+    case "zoom":
       // Video-conferencing accounts (#148). No mail / calendar /
       // contacts bindings — only meet. The actual creation goes
       // through a browser-assisted login flow rather than the
-      // shared modal save path, so the form data here is only used
-      // to seed defaults for the URL input.
+      // shared modal save path, so the form data here is only
+      // used to seed defaults for the URL input. Zoom in
+      // particular has no per-user server URL (Zoom hosts it),
+      // so the URL input doesn't render for that tab.
       f.provider = "generic";
       f.mail_protocol = "";
       f.imap_host = "";
@@ -425,6 +436,8 @@ function accountTypeDescription(t: AccountType): string {
       return "Video conferencing on a Nextcloud server";
     case "matrix":
       return "Video conferencing via Matrix / Element Call";
+    case "zoom":
+      return "Video conferencing via Zoom";
   }
 }
 
@@ -482,13 +495,17 @@ async function openEditForm(id: string) {
       } else {
         oauthStatus.value = null;
       }
-    } else if (config.meet_protocol === "talk" || config.meet_protocol === "matrix") {
-      // Meet-only accounts (Talk / Matrix) come through the
-      // browser-assisted login and have no mail / calendar /
+    } else if (
+      config.meet_protocol === "talk"
+      || config.meet_protocol === "matrix"
+      || config.meet_protocol === "zoom"
+    ) {
+      // Meet-only accounts (Talk / Matrix / Zoom) come through
+      // the browser-assisted login and have no mail / calendar /
       // contacts bindings. Detected before the DAV branch
-      // because both have `mail_protocol === ""` — without this
-      // a Matrix account would be misclassified as CalDAV and
-      // the form would hide the URL + Sign-in row. (#148)
+      // because all have `mail_protocol === ""` — without this
+      // a meet account would be misclassified as CalDAV and the
+      // form would hide the URL + Sign-in row. (#148)
       accountType.value = config.meet_protocol;
     } else if (config.mail_protocol === "") {
       // Standalone DAV account (#43). Pick the tab from the binding
@@ -915,6 +932,34 @@ async function signInWithMatrix() {
   }
 }
 
+async function signInWithZoom() {
+  // Zoom is hosted by Zoom — there's no per-user URL to type in
+  // first. Just kick off the OAuth flow against the Marketplace-
+  // registered Chithi app and store the resulting tokens. (#148)
+  if (meetSigningIn.value) return;
+  meetSigningIn.value = true;
+  error.value = null;
+  try {
+    const start = await api.meetZoomLoginStart();
+    await openUrl(start.login_url);
+    const accountId = await api.meetZoomLoginComplete(
+      start.port,
+      form.value.display_name || undefined,
+    );
+    await accountsStore.fetchAccounts();
+    showForm.value = false;
+    editingAccountId.value = null;
+    resetDefaultBookState();
+    router.push("/");
+    void accountId;
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    error.value = `Zoom sign-in failed: ${msg}`;
+  } finally {
+    meetSigningIn.value = false;
+  }
+}
+
 // Onboarding hands off via ?addAccount=<provider>. Auto-open the new-account
 // form with the matching provider preselected.
 onMounted(() => {
@@ -930,6 +975,7 @@ onMounted(() => {
     carddav: "carddav",
     talk: "talk",
     matrix: "matrix",
+    zoom: "zoom",
   };
   const type = mapped[want];
   if (!type) return;
@@ -1103,7 +1149,7 @@ onMounted(() => {
           <p class="picker-help">Pick the kind of account you want to add. You can add more later.</p>
           <div class="picker-grid">
             <button
-              v-for="t in (['gmail', 'o365', 'imap', 'jmap', 'caldav', 'carddav', 'talk', 'matrix'] as AccountType[])"
+              v-for="t in (['gmail', 'o365', 'imap', 'jmap', 'caldav', 'carddav', 'talk', 'matrix', 'zoom'] as AccountType[])"
               :key="t"
               class="picker-card"
               :data-testid="`picker-${t}`"
@@ -1153,8 +1199,11 @@ onMounted(() => {
                  of the form, since neither account type has any
                  mail / calendar / contacts surface to configure
                  here. -->
-            <template v-if="accountType === 'talk' || accountType === 'matrix'">
-              <div class="form-group">
+            <template v-if="accountType === 'talk' || accountType === 'matrix' || accountType === 'zoom'">
+              <!-- URL input hidden on Zoom because Zoom is hosted —
+                   there's no per-user server to type. Talk and
+                   Matrix both need the user's instance URL. -->
+              <div v-if="accountType !== 'zoom'" class="form-group">
                 <label>{{ accountType === 'matrix' ? 'Homeserver URL' : 'Nextcloud URL' }}</label>
                 <input
                   v-model="form.meet_url"
@@ -1181,22 +1230,40 @@ onMounted(() => {
                 <button
                   type="button"
                   class="btn-oauth"
-                  :disabled="meetSigningIn || !form.meet_url"
+                  :disabled="meetSigningIn || (accountType !== 'zoom' && !form.meet_url)"
                   :data-testid="`${accountType}-signin-btn`"
-                  @click="accountType === 'talk' ? signInWithTalk() : signInWithMatrix()"
+                  @click="
+                    accountType === 'talk'
+                      ? signInWithTalk()
+                      : accountType === 'matrix'
+                        ? signInWithMatrix()
+                        : signInWithZoom()
+                  "
                 >
                   <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
                     <rect x="3" y="11" width="18" height="11" rx="2" ry="2" /><path d="M7 11V7a5 5 0 0 1 10 0v4" />
                   </svg>
-                  {{ meetSigningIn ? 'Waiting for browser…' : (accountType === 'matrix' ? 'Sign in with Matrix' : 'Sign in with Nextcloud') }}
+                  {{
+                    meetSigningIn
+                      ? 'Waiting for browser…'
+                      : accountType === 'matrix'
+                        ? 'Sign in with Matrix'
+                        : accountType === 'zoom'
+                          ? 'Sign in with Zoom'
+                          : 'Sign in with Nextcloud'
+                  }}
                 </button>
                 <span class="field-hint">
-                  Opens your browser to authenticate. Your real password never reaches Chithi — we keep a long-lived app token tied to this device.
+                  Opens your browser to authenticate. {{
+                    accountType === 'zoom'
+                      ? 'Chithi receives an OAuth token tied to your Zoom account.'
+                      : 'Your real password never reaches Chithi — we keep a long-lived app token tied to this device.'
+                  }}
                 </span>
               </div>
               <div v-else class="form-group">
                 <span class="field-hint">
-                  To re-authenticate, delete this account and add it again. The session token is stored once and stays valid until you sign out from the {{ accountType === 'matrix' ? 'Matrix' : 'Nextcloud' }} server.
+                  To re-authenticate, delete this account and add it again. The session token is stored once and stays valid until you sign out from the {{ accountType === 'matrix' ? 'Matrix' : accountType === 'zoom' ? 'Zoom' : 'Nextcloud' }} server.
                 </span>
               </div>
             </template>

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -182,6 +182,8 @@ const defaultForm = (): AccountConfig => ({
   smtp_port: 587,
   jmap_url: "",
   caldav_url: "",
+  meet_url: "",
+  meet_protocol: "",
   username: "",
   password: "",
   use_tls: true,

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -199,6 +199,15 @@ const hasCalendarBinding = computed(() =>
 );
 const hasContactsBinding = computed(() => hasCalendarBinding.value);
 
+/// Convenience: this account-type tab has no email identity and
+/// no password — auth is browser-assisted, the loginName / MXID
+/// goes into `username`. Lets the form hide email / password /
+/// signature / per-service-sync sections that are meaningless
+/// for these accounts. (#148)
+const isMeetTab = computed(
+  () => accountType.value === "talk" || accountType.value === "matrix",
+);
+
 function getInitials(name: string): string {
   const words = name.split(/\s+/);
   if (words.length >= 2) return (words[0][0] + words[1][0]).toUpperCase();
@@ -1172,13 +1181,15 @@ onMounted(() => {
               </div>
             </template>
 
-            <!-- DAV-only accounts have no mail identity, so they skip
-                 the email field and use an explicit username for the
-                 server's Basic auth. The mail tabs keep email as the
-                 default login (the saveAccount fallback fills
-                 username from email when blank). -->
+            <!-- DAV-only and meet-only accounts have no mail
+                 identity, so they skip the email field. DAV uses an
+                 explicit username for Basic auth; meet (Talk /
+                 Matrix) gets the loginName / MXID via its
+                 browser-assisted login. The mail tabs keep email
+                 as the default login (the saveAccount fallback
+                 fills username from email when blank). -->
             <div
-              v-if="accountType !== 'caldav' && accountType !== 'carddav'"
+              v-if="accountType !== 'caldav' && accountType !== 'carddav' && !isMeetTab"
               class="form-group"
             >
               <label>Email Address</label>
@@ -1204,7 +1215,7 @@ onMounted(() => {
                 Login name for the {{ accountType === 'carddav' ? 'CardDAV' : 'CalDAV' }} server.
               </span>
             </div>
-            <div v-if="accountType !== 'o365' && !(accountType === 'jmap' && form.jmap_auth_method === 'oidc')" class="form-group">
+            <div v-if="accountType !== 'o365' && !(accountType === 'jmap' && form.jmap_auth_method === 'oidc') && !isMeetTab" class="form-group">
               <label>{{ accountType === 'gmail' ? 'App Password' : 'Password' }}</label>
               <PasswordInput
                 v-model="form.password"
@@ -1409,7 +1420,7 @@ onMounted(() => {
               <div class="info-box">Gmail uses IMAP (imap.gmail.com:993) and SMTP (smtp.gmail.com:587). Sign in with Google above to authorize access.</div>
             </template>
 
-            <div class="form-group">
+            <div v-if="!isMeetTab" class="form-group">
               <label>Email Signature</label>
               <textarea
                 v-model="form.signature"
@@ -1425,7 +1436,7 @@ onMounted(() => {
                  form-group that matches the other sections rather than
                  a bordered fieldset. -->
             <div
-              v-if="accountType !== 'caldav' && accountType !== 'carddav'"
+              v-if="accountType !== 'caldav' && accountType !== 'carddav' && !isMeetTab"
               class="form-group bindings-section"
               data-testid="binding-controls"
             >
@@ -1559,7 +1570,15 @@ onMounted(() => {
           </div>
           <div class="modal-footer">
             <button class="btn-secondary" @click="cancelForm">Cancel</button>
-            <button class="btn-primary" :disabled="saving" @click="saveAccount">
+            <!-- New meet accounts persist through the Sign-in
+                 button above; no separate Save step. Editing
+                 keeps Save so the user can rename the account. -->
+            <button
+              v-if="!isMeetTab || editingAccountId"
+              class="btn-primary"
+              :disabled="saving"
+              @click="saveAccount"
+            >
               {{ saving ? "Saving..." : (editingAccountId ? "Save" : "Add Account") }}
             </button>
           </div>

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -482,6 +482,14 @@ async function openEditForm(id: string) {
       } else {
         oauthStatus.value = null;
       }
+    } else if (config.meet_protocol === "talk" || config.meet_protocol === "matrix") {
+      // Meet-only accounts (Talk / Matrix) come through the
+      // browser-assisted login and have no mail / calendar /
+      // contacts bindings. Detected before the DAV branch
+      // because both have `mail_protocol === ""` — without this
+      // a Matrix account would be misclassified as CalDAV and
+      // the form would hide the URL + Sign-in row. (#148)
+      accountType.value = config.meet_protocol;
     } else if (config.mail_protocol === "") {
       // Standalone DAV account (#43). Pick the tab from the binding
       // shape rather than the sync-enabled flags so toggling "Sync
@@ -1162,7 +1170,14 @@ onMounted(() => {
                     : 'Base URL of your Nextcloud server. Login Flow v2 will open in your browser.' }}
                 </span>
               </div>
-              <div class="form-group">
+              <!-- Sign-in button only shows on the new-account
+                   flow. The login flow always inserts a fresh
+                   account row (it can't update an existing one),
+                   so on edit we hide the button to avoid
+                   duplicating the account when the user clicks
+                   it. Re-auth of an existing meet account is a
+                   delete-and-add operation today. -->
+              <div v-if="!editingAccountId" class="form-group">
                 <button
                   type="button"
                   class="btn-oauth"
@@ -1177,6 +1192,11 @@ onMounted(() => {
                 </button>
                 <span class="field-hint">
                   Opens your browser to authenticate. Your real password never reaches Chithi — we keep a long-lived app token tied to this device.
+                </span>
+              </div>
+              <div v-else class="form-group">
+                <span class="field-hint">
+                  To re-authenticate, delete this account and add it again. The session token is stored once and stays valid until you sign out from the {{ accountType === 'matrix' ? 'Matrix' : 'Nextcloud' }} server.
                 </span>
               </div>
             </template>

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -87,6 +87,12 @@ const themeLabel = computed(() =>
   uiStore.theme === "dark" ? "Dark" : "Light",
 );
 const showForm = ref(false);
+// First step of "Add Account": pick a type. Replaces the cramped
+// in-modal tab row with a dialog that lists the eight account
+// types as cards grouped by service area, and on pick opens the
+// existing edit form pre-set to that type. Edit-existing skips
+// this step. (#148 cleanup)
+const showPicker = ref(false);
 const showDeleteConfirm = ref(false);
 const deletingAccountId = ref<string | null>(null);
 const saving = ref(false);
@@ -367,16 +373,50 @@ function selectAccountType(type: AccountType) {
 
 function openNewForm() {
   editingAccountId.value = null;
-  form.value = defaultForm();
-  accountType.value = "gmail";
-  selectAccountType("gmail");
   resetDefaultBookState();
+  error.value = null;
+  showPicker.value = true;
+}
+
+/// Step 2 of the Add-account flow: type is chosen, set up the
+/// form and open it. Closes the picker.
+function pickAccountType(type: AccountType) {
+  form.value = defaultForm();
+  accountType.value = type;
+  selectAccountType(type);
   // Pre-load the cross-account book list so the create-flow dropdowns
   // are populated for users who already have an account with synced
   // books and want to point a new account at one of them.
   loadAvailableBooks();
+  showPicker.value = false;
   showForm.value = true;
-  error.value = null;
+}
+
+function cancelPicker() {
+  showPicker.value = false;
+}
+
+/// Brief subtitle shown under each card in the picker dialog.
+/// Kept terse — the card's title already says what the type is.
+function accountTypeDescription(t: AccountType): string {
+  switch (t) {
+    case "gmail":
+      return "Mail, calendar and contacts via Google";
+    case "o365":
+      return "Mail, calendar and contacts via Microsoft 365";
+    case "imap":
+      return "Generic IMAP / SMTP mail account";
+    case "jmap":
+      return "JMAP mail (e.g. Fastmail, Stalwart)";
+    case "caldav":
+      return "Standalone calendar via CalDAV";
+    case "carddav":
+      return "Standalone contacts via CardDAV";
+    case "talk":
+      return "Video conferencing on a Nextcloud server";
+    case "matrix":
+      return "Video conferencing via Matrix / Element Call";
+  }
 }
 
 async function openEditForm(id: string) {
@@ -870,11 +910,15 @@ onMounted(() => {
     gmail: "gmail",
     imap: "imap",
     caldav: "caldav",
+    carddav: "carddav",
+    talk: "talk",
+    matrix: "matrix",
   };
   const type = mapped[want];
   if (!type) return;
-  openNewForm();
-  selectAccountType(type);
+  // Deep-link path skips the picker and lands directly on the
+  // form for the requested type — onboarding has already chosen.
+  pickAccountType(type);
 });
 </script>
 
@@ -990,7 +1034,7 @@ onMounted(() => {
       <h1 class="settings-title">Settings</h1>
 
       <div class="section-header">
-        <h2 class="section-title">Email Accounts</h2>
+        <h2 class="section-title">Accounts</h2>
         <button class="btn-add" @click="openNewForm">
           + Add Account
         </button>
@@ -1030,6 +1074,36 @@ onMounted(() => {
     </div>
   </div>
 
+  <!-- Step 1 of Add Account: pick a type. (#148 cleanup) -->
+  <Teleport to="body">
+    <div v-if="showPicker" class="modal-overlay" @click.self="cancelPicker">
+      <div class="modal modal-picker" data-testid="account-type-picker">
+        <div class="modal-header">
+          <h3>Add Account</h3>
+          <button class="modal-close" @click="cancelPicker">&times;</button>
+        </div>
+        <div class="modal-body">
+          <p class="picker-help">Pick the kind of account you want to add. You can add more later.</p>
+          <div class="picker-grid">
+            <button
+              v-for="t in (['gmail', 'o365', 'imap', 'jmap', 'caldav', 'carddav', 'talk', 'matrix'] as AccountType[])"
+              :key="t"
+              class="picker-card"
+              :data-testid="`picker-${t}`"
+              @click="pickAccountType(t)"
+            >
+              <span class="picker-card-title">{{ accountTypeLabelLong(t) }}</span>
+              <span class="picker-card-desc">{{ accountTypeDescription(t) }}</span>
+            </button>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button class="btn-secondary" @click="cancelPicker">Cancel</button>
+        </div>
+      </div>
+    </div>
+  </Teleport>
+
   <!-- Add/Edit Account Modal (shared by mobile + desktop) -->
   <Teleport to="body">
       <div v-if="showForm" class="modal-overlay" @click.self="cancelForm">
@@ -1041,18 +1115,14 @@ onMounted(() => {
           <div class="modal-body">
             <div v-if="error" class="form-error">{{ error }}</div>
 
+            <!-- Account type is now picked via the picker dialog
+                 before this modal opens (#148 cleanup). Show a
+                 read-only label here so the user knows what they
+                 picked / which kind of account they're editing. -->
             <div class="form-group">
               <label>Account Type</label>
-              <div class="type-selector">
-                <button
-                  v-for="t in (['gmail', 'o365', 'imap', 'jmap', 'caldav', 'carddav', 'talk', 'matrix'] as AccountType[])"
-                  :key="t"
-                  class="type-btn"
-                  :class="{ active: accountType === t }"
-                  :disabled="!!editingAccountId"
-                  :data-testid="`account-type-${t}`"
-                  @click="selectAccountType(t)"
-                >{{ accountTypeLabelLong(t) }}</button>
+              <div class="type-readonly" data-testid="account-type-readonly">
+                {{ accountTypeLabelLong(accountType) }}
               </div>
             </div>
 
@@ -1811,6 +1881,58 @@ onMounted(() => {
 .type-btn:disabled {
   opacity: 0.5;
   cursor: default;
+}
+
+/* Read-only label that replaces the per-type tab row inside the
+   form modal once the picker has chosen the type. (#148) */
+.type-readonly {
+  padding: 8px 12px;
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  background: var(--color-bg-secondary);
+  color: var(--color-text);
+  font-size: 13px;
+  font-weight: 500;
+}
+
+/* Account-type picker (#148 cleanup). Two-column card grid. */
+.modal-picker {
+  max-width: 600px;
+}
+.picker-help {
+  margin: 0 0 12px;
+  font-size: 13px;
+  color: var(--color-text-muted);
+}
+.picker-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+}
+.picker-card {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 12px 14px;
+  text-align: left;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background 0.1s, border-color 0.1s;
+}
+.picker-card:hover {
+  background: var(--color-bg-hover);
+  border-color: var(--color-accent);
+}
+.picker-card-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--color-text);
+}
+.picker-card-desc {
+  font-size: 12px;
+  color: var(--color-text-muted);
 }
 
 .signature-textarea {

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -43,6 +43,7 @@ function accountTypeLabel(acc: {
   mail_protocol?: string;
   has_calendar_binding?: boolean;
   has_contacts_binding?: boolean;
+  meet_protocol?: string;
 }): string {
   if (acc.provider === "gmail") return "GMAIL";
   if (acc.provider === "o365") return "MICROSOFT 365";
@@ -56,7 +57,15 @@ function accountTypeLabel(acc: {
   if (hasCal && hasCon) return "Calendar and Contacts";
   if (hasCal) return "Calendar";
   if (hasCon) return "Contacts";
-  return "";
+  // Meet-only accounts (#148). Same user-visible naming approach.
+  switch (acc.meet_protocol) {
+    case "talk":
+      return "Nextcloud Talk";
+    case "matrix":
+      return "Matrix";
+    default:
+      return "";
+  }
 }
 
 /// Secondary line for the settings account list. Standalone CalDAV /

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -19,6 +19,25 @@ const platformStore = usePlatformStore();
 const uiStore = useUiStore();
 const { isMobile } = storeToRefs(platformStore);
 
+/// Long-form label for the type-selector buttons in the modal.
+/// Mostly the same as `accountTypeLabel` for the listing, but the
+/// modal is wider and benefits from "Nextcloud Talk" and "Matrix"
+/// spelled out instead of an upper-case acronym.
+function accountTypeLabelLong(t: AccountType): string {
+  switch (t) {
+    case "gmail":
+      return "Gmail";
+    case "o365":
+      return "Microsoft 365";
+    case "talk":
+      return "Nextcloud Talk";
+    case "matrix":
+      return "Matrix";
+    default:
+      return t.toUpperCase();
+  }
+}
+
 function accountTypeLabel(acc: {
   provider?: string;
   mail_protocol?: string;
@@ -203,7 +222,15 @@ const defaultForm = (): AccountConfig => ({
 
 const form = ref<AccountConfig>(defaultForm());
 
-type AccountType = "gmail" | "imap" | "jmap" | "caldav" | "carddav" | "o365";
+type AccountType =
+  | "gmail"
+  | "imap"
+  | "jmap"
+  | "caldav"
+  | "carddav"
+  | "o365"
+  | "talk"
+  | "matrix";
 const accountType = ref<AccountType>("gmail");
 
 function selectAccountType(type: AccountType) {
@@ -303,6 +330,28 @@ function selectAccountType(type: AccountType) {
       f.jmap_url = "";
       f.use_tls = true;
       f.calendar_sync_enabled = false;
+      break;
+    case "talk":
+    case "matrix":
+      // Video-conferencing accounts (#148). No mail / calendar /
+      // contacts bindings — only meet. The actual creation goes
+      // through a browser-assisted login flow rather than the
+      // shared modal save path, so the form data here is only used
+      // to seed defaults for the URL input.
+      f.provider = "generic";
+      f.mail_protocol = "";
+      f.imap_host = "";
+      f.imap_port = 0;
+      f.smtp_host = "";
+      f.smtp_port = 0;
+      f.jmap_url = "";
+      f.caldav_url = "";
+      f.use_tls = true;
+      f.calendar_sync_enabled = false;
+      f.contacts_sync_enabled = false;
+      f.mail_sync_enabled = false;
+      f.meet_url = "";
+      f.meet_protocol = type;
       break;
   }
 }
@@ -728,6 +777,78 @@ async function doDelete() {
   deletingAccountId.value = null;
 }
 
+// --- Video conferencing (#148) -------------------------------------------
+//
+// Both providers use a browser-assisted login flow. The two-step
+// pattern matches what we already do for Gmail / O365 OAuth: start
+// returns a URL, we open it via the shell-opener, then a second
+// call drives the flow to completion and persists the account.
+const meetSigningIn = ref(false);
+
+async function signInWithTalk() {
+  if (meetSigningIn.value) return;
+  if (!form.value.meet_url.trim()) {
+    error.value = "Enter your Nextcloud server URL first";
+    return;
+  }
+  meetSigningIn.value = true;
+  error.value = null;
+  try {
+    const start = await api.meetTalkLoginStart(form.value.meet_url.trim());
+    await openUrl(start.login_url);
+    const accountId = await api.meetTalkLoginComplete(
+      start.poll_endpoint,
+      start.poll_token,
+      form.value.display_name || undefined,
+    );
+    await accountsStore.fetchAccounts();
+    showForm.value = false;
+    editingAccountId.value = null;
+    resetDefaultBookState();
+    // Drop the user back on the main app with the new account's
+    // calendars / contacts visible (Talk has neither, but the
+    // listing still updates).
+    router.push("/");
+    void accountId;
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    error.value = `Nextcloud Talk sign-in failed: ${msg}`;
+  } finally {
+    meetSigningIn.value = false;
+  }
+}
+
+async function signInWithMatrix() {
+  if (meetSigningIn.value) return;
+  if (!form.value.meet_url.trim()) {
+    error.value = "Enter your Matrix homeserver URL first";
+    return;
+  }
+  meetSigningIn.value = true;
+  error.value = null;
+  try {
+    const homeserver = form.value.meet_url.trim();
+    const start = await api.meetMatrixLoginStart(homeserver);
+    await openUrl(start.login_url);
+    const accountId = await api.meetMatrixLoginComplete(
+      homeserver,
+      start.port,
+      form.value.display_name || undefined,
+    );
+    await accountsStore.fetchAccounts();
+    showForm.value = false;
+    editingAccountId.value = null;
+    resetDefaultBookState();
+    router.push("/");
+    void accountId;
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    error.value = `Matrix sign-in failed: ${msg}`;
+  } finally {
+    meetSigningIn.value = false;
+  }
+}
+
 // Onboarding hands off via ?addAccount=<provider>. Auto-open the new-account
 // form with the matching provider preselected.
 onMounted(() => {
@@ -915,14 +1036,14 @@ onMounted(() => {
               <label>Account Type</label>
               <div class="type-selector">
                 <button
-                  v-for="t in (['gmail', 'o365', 'imap', 'jmap', 'caldav', 'carddav'] as AccountType[])"
+                  v-for="t in (['gmail', 'o365', 'imap', 'jmap', 'caldav', 'carddav', 'talk', 'matrix'] as AccountType[])"
                   :key="t"
                   class="type-btn"
                   :class="{ active: accountType === t }"
                   :disabled="!!editingAccountId"
                   :data-testid="`account-type-${t}`"
                   @click="selectAccountType(t)"
-                >{{ t === 'gmail' ? 'Gmail' : t === 'o365' ? 'Microsoft 365' : t.toUpperCase() }}</button>
+                >{{ accountTypeLabelLong(t) }}</button>
               </div>
             </div>
 
@@ -930,6 +1051,48 @@ onMounted(() => {
               <label>Account Name</label>
               <input v-model="form.display_name" type="text" :placeholder="accountType === 'caldav' ? 'My Calendar' : 'e.g., Personal, Work'" />
             </div>
+
+            <!-- Video-conferencing tabs (#148). One URL field + a
+                 browser-assisted sign-in button replaces the rest
+                 of the form, since neither account type has any
+                 mail / calendar / contacts surface to configure
+                 here. -->
+            <template v-if="accountType === 'talk' || accountType === 'matrix'">
+              <div class="form-group">
+                <label>{{ accountType === 'matrix' ? 'Homeserver URL' : 'Nextcloud URL' }}</label>
+                <input
+                  v-model="form.meet_url"
+                  type="url"
+                  :placeholder="accountType === 'matrix'
+                    ? 'https://matrix.example.org'
+                    : 'https://cloud.example.org'"
+                  :data-testid="`${accountType}-url`"
+                />
+                <span class="field-hint">
+                  {{ accountType === 'matrix'
+                    ? 'Base URL of your Matrix homeserver. SSO will open in your browser.'
+                    : 'Base URL of your Nextcloud server. Login Flow v2 will open in your browser.' }}
+                </span>
+              </div>
+              <div class="form-group">
+                <button
+                  type="button"
+                  class="btn-oauth"
+                  :disabled="meetSigningIn || !form.meet_url"
+                  :data-testid="`${accountType}-signin-btn`"
+                  @click="accountType === 'talk' ? signInWithTalk() : signInWithMatrix()"
+                >
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+                    <rect x="3" y="11" width="18" height="11" rx="2" ry="2" /><path d="M7 11V7a5 5 0 0 1 10 0v4" />
+                  </svg>
+                  {{ meetSigningIn ? 'Waiting for browser…' : (accountType === 'matrix' ? 'Sign in with Matrix' : 'Sign in with Nextcloud') }}
+                </button>
+                <span class="field-hint">
+                  Opens your browser to authenticate. Your real password never reaches Chithi — we keep a long-lived app token tied to this device.
+                </span>
+              </div>
+            </template>
+
             <!-- DAV-only accounts have no mail identity, so they skip
                  the email field and use an explicit username for the
                  server's Basic auth. The mail tabs keep email as the

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -92,10 +92,11 @@ const themeLabel = computed(() =>
 );
 const showForm = ref(false);
 // First step of "Add Account": pick a type. Replaces the cramped
-// in-modal tab row with a dialog that lists the eight account
-// types as cards grouped by service area, and on pick opens the
-// existing edit form pre-set to that type. Edit-existing skips
-// this step. (#148 cleanup)
+// in-modal tab row with a dialog that lists every supported
+// account type (currently nine — Gmail / O365 / IMAP / JMAP /
+// CalDAV / CardDAV / Talk / Matrix / Zoom) as cards grouped by
+// service area, and on pick opens the existing edit form pre-set
+// to that type. Edit-existing skips this step. (#148 cleanup)
 const showPicker = ref(false);
 const showDeleteConfirm = ref(false);
 const deletingAccountId = ref<string | null>(null);
@@ -862,10 +863,13 @@ async function doDelete() {
 
 // --- Video conferencing (#148) -------------------------------------------
 //
-// Both providers use a browser-assisted login flow. The two-step
-// pattern matches what we already do for Gmail / O365 OAuth: start
-// returns a URL, we open it via the shell-opener, then a second
-// call drives the flow to completion and persists the account.
+// All meet providers (Talk, Matrix, Zoom, …) use a browser-assisted
+// login flow. The two-step pattern matches what we already do for
+// Gmail / O365 OAuth: start returns a URL, we open it via the
+// shell-opener, then a second call drives the flow to completion
+// and persists the account. Each provider has its own pair of
+// signInWith* functions because the shapes differ (Talk polls,
+// Matrix waits for an SSO redirect, Zoom is OAuth+PKCE).
 const meetSigningIn = ref(false);
 
 async function signInWithTalk() {


### PR DESCRIPTION
Closes part of #148 (Talk + Matrix + Zoom; the remaining providers from the issue ship as follow-ups).

## Summary

- **Backend**: new `meet` service binding alongside `mail` / `calendar` / `contacts`. Three providers behind a `MeetProvider` trait + registry — adding more is one trait impl + one registry line.
  - **Nextcloud Talk** — Login Flow v2 (poll-based browser auth, returns a long-lived app password, real password never seen by us). Room creation hits the OCS Spreed v4 endpoint.
  - **Matrix / Element Call** — SSO redirect to the homeserver, captures `loginToken` on a local listener, exchanges via `m.login.token` for an access token. Room creation calls `createRoom` and posts an `im.vector.modular.widgets` state event so any Matrix client opening the room gets a one-click join. Returns a `matrix.to` URL so the link opens in the user's existing Matrix client (their org's Element Web, etc.) rather than dead-ending at `app.element.io`.
  - **Zoom** — Marketplace OAuth 2.0 with PKCE (no client_secret in the binary). Pinned loopback port `47832` because Zoom doesn't honor RFC 8252's "ignore the port on loopback" rule. Refresh-on-use against `https://zoom.us/oauth/token`. Meeting creation hits `/v2/users/me/meetings`. The default `client_id` is a free-tier Marketplace app so out-of-the-box `cargo run` works without admin approval; forks under their own Zoom org override via `CHITHI_ZOOM_CLIENT_ID` at build time.
- **OAuth core** (`src/oauth.rs`): `OAuthProvider` gains `redirect_host` (Microsoft demands `localhost`, Zoom demands `127.0.0.1`) and `redirect_fixed_port` (Zoom requires exact-match), so the existing PKCE machinery works for all three providers without per-call hacks.
- **Settings**: three new account types (`talk`, `matrix`, `zoom`) in a redesigned Add-account flow. The previously crowded in-modal tab row is replaced with a flat picker dialog (cards, two columns, one-line descriptions). Edit-existing skips the picker and opens the form directly. Email / password / signature / per-service-sync sections hidden on meet tabs.
- **Event editor**: "Add video conference" buttons under the Location field, one per configured Talk / Matrix / Zoom account. Clicking creates a fresh room / call / meeting and replaces the Location field + prepends a `Join: <url>` line to the description.
- Credentials live in the existing keyring under the account id (same pattern as Gmail / O365 OAuth tokens). Matrix SSO sessions and Zoom OAuth sessions are TTL-evicted on each new flow so abandoned logins can't leak listeners.

## Adding a new provider

`src-tauri/src/meet/mod.rs` doc explains it in detail. Short version: write a module under `meet/`, implement the trait, append one line to `registry()` and one to the `MEET_PROTOCOL_LABELS` map in `EventForm.vue`. Auth flow stays per-provider as free functions because the shapes are genuinely different (poll vs SSO redirect vs OAuth+PKCE).

## What's not in this PR

- BigBlueButton, Edumeet, Jitsi public, Google Meet, Microsoft Teams — separate PRs.
- iCalendar `CONFERENCE` property round-trip on CalDAV / JMAP sync — uses `location` + `description` for now since they sync today.
- Zoom Marketplace publication / HTTPS bounce — pinned to dev-mode app today; production publication needs an HTTPS callback URL the project doesn't host yet.
- Tests for the auth flows themselves (the network-shaped ones) — would need mock servers; deferred.

## Test plan

- [x] Add a Nextcloud Talk account against `cloud.smolnet.org` via the picker → "Sign in with Nextcloud" → browser opens → finish login → modal closes, account appears labelled "Nextcloud Talk".
- [x] Add a Matrix account against `matrix.sunet.se` similarly. SSO completes, account appears labelled "Matrix". Join links open in Element Web at the user's homeserver, not `app.element.io`.
- [x] Add a Zoom account via the picker → "Sign in with Zoom" → browser opens to Zoom OAuth → grant → account appears labelled "Zoom". Pinned port `47832` matches the Marketplace registration.
- [x] Open the calendar event editor → "Add … (Nextcloud Talk)" / "Add … (Matrix)" / "Add … (Zoom)" buttons visible under Location → click → URL appears in Location and a `Join:` line in the description.
- [x] Save the event → CalDAV / JMAP / Graph sync preserves the URL in `location` + `description`.
- [x] Picker dialog: 9 cards, two columns, descriptions readable. Cancel returns to the accounts list with no half-state.
- [x] Edit an existing account: opens form directly with read-only "Account Type" label, no picker.

vue-tsc / vitest (323) / cargo lib (247, +3) / build all green.