### PR TITLE
fix(ci): drop pip cache from docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,7 +34,10 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-          cache: pip
+      # Single-package install; not worth wiring `cache: pip`,
+      # which would need a `requirements.txt` we'd otherwise have
+      # nothing to put in. If the build slows down enough for it
+      # to matter, pin via web/requirements.txt at that point.
       - run: pip install --upgrade mkdocs-material
       # `--strict` turns broken links / missing nav entries into
       # build failures so a doc-rot PR fails CI before deploy.


### PR DESCRIPTION
Three Docs runs failed with `No file matched to [**/requirements.txt or **/pyproject.toml]` — `setup-python@v5`'s `cache: pip` needs a requirements file to key on, which we don't have. Drop the cache; single-package install isn't worth it.

Once this lands and the workflow succeeds, the second half of the puzzle (Pages still 404'ing) is on the repo-settings side: **Settings → Pages → Source: GitHub Actions, Custom domain: chithi.org, Enforce HTTPS**. Without that, even a green workflow has nowhere to deploy.