### PR TITLE
fix: release SQLite writer guard before awaiting

### DIFF
--- a/justfile
+++ b/justfile
@@ -148,7 +148,7 @@ build-deb base_image="debian:13":
     docker rm "$CONTAINER_ID"
 
     # Rename DEB files to include distro name
-    distro_tag=$(echo "$DISTRO_NAME" | tr '-' '')
+    distro_tag=$(echo "$DISTRO_NAME" | tr -d '-')
     for f in "$OUTPUT_DIR"/*.deb; do
         [ -f "$f" ] || continue
         basename=$(basename "$f")

--- a/src-tauri/src/commands/calendar.rs
+++ b/src-tauri/src/commands/calendar.rs
@@ -2887,92 +2887,99 @@ pub async fn process_invite_reply(
         return Ok(());
     }
 
-    let conn = state.db.writer().await;
-    let account = db::accounts::get_account_full(&conn, &account_id)?;
+    // Phase 1: update local DB, collect any JMAP push we need to do
+    // afterwards. The writer guard is dropped at the end of this block
+    // so the JMAP network round-trip below doesn't block other writes.
+    struct JmapPush {
+        remote_id: String,
+        attendee_email: String,
+        status: String,
+    }
+    let (account, jmap_push) = {
+        let conn = state.db.writer().await;
+        let account = db::accounts::get_account_full(&conn, &account_id)?;
+        let mut jmap_push: Option<JmapPush> = None;
 
-    for reply in &reply_invites {
-        // Find the local event by UID
-        let event = db::calendar::get_event_by_uid(&conn, &account_id, &reply.uid)?;
-        let Some(event) = event else {
-            log::debug!("process_invite_reply: no local event for UID {}", reply.uid);
-            continue;
-        };
+        for reply in &reply_invites {
+            let event = db::calendar::get_event_by_uid(&conn, &account_id, &reply.uid)?;
+            let Some(event) = event else {
+                log::debug!("process_invite_reply: no local event for UID {}", reply.uid);
+                continue;
+            };
 
-        // Extract the respondent's email and status from the REPLY
-        for attendee in &reply.attendees {
-            let status = &attendee.status;
-            log::info!(
-                "process_invite_reply: {} responded '{}' to event '{}'",
-                attendee.email,
-                status,
-                event.title
-            );
+            for attendee in &reply.attendees {
+                let status = &attendee.status;
+                log::info!(
+                    "process_invite_reply: {} responded '{}' to event '{}'",
+                    attendee.email,
+                    status,
+                    event.title
+                );
 
-            // Update local attendees_json
-            if let Some(ref att_json) = event.attendees_json {
-                if let Ok(mut attendees) = serde_json::from_str::<Vec<serde_json::Value>>(att_json)
-                {
-                    for att in attendees.iter_mut() {
-                        if att["email"].as_str() == Some(&attendee.email) {
-                            att["status"] = serde_json::json!(status);
-                        }
-                    }
-                    let updated_json = serde_json::to_string(&attendees).unwrap_or_default();
-                    conn.execute(
-                        "UPDATE calendar_events SET attendees_json = ?1 WHERE id = ?2",
-                        rusqlite::params![updated_json, event.id],
-                    )
-                    .ok();
-                }
-            }
-
-            // Update on JMAP server if applicable
-            if account.calendar_protocol_str() == "jmap" {
-                if let Some(ref remote_id) = event.remote_id {
-                    let jmap_config =
-                        crate::commands::sync_cmd::build_jmap_config(&account).await?;
-                    // Find participant key by matching email
-                    // We need to fetch the event to find the right participant key
-                    drop(conn);
-                    if let Ok(jmap_conn) =
-                        crate::mail::jmap::JmapConnection::connect(&jmap_config).await
+                if let Some(ref att_json) = event.attendees_json {
+                    if let Ok(mut attendees) =
+                        serde_json::from_str::<Vec<serde_json::Value>>(att_json)
                     {
-                        // Fetch current event to find participant key
-                        if let Ok(events) =
-                            jmap_conn.fetch_calendar_events(&jmap_config, None).await
-                        {
-                            for ev in &events {
-                                if ev.id == *remote_id {
-                                    // Parse attendees to find the key
-                                    if let Some(ref aj) = ev.attendees_json {
-                                        if let Ok(atts) =
-                                            serde_json::from_str::<Vec<serde_json::Value>>(aj)
-                                        {
-                                            for (i, a) in atts.iter().enumerate() {
-                                                if a["email"].as_str() == Some(&attendee.email) {
-                                                    let key = format!("att{}", i);
-                                                    jmap_conn
-                                                        .update_participant_status(
-                                                            &jmap_config,
-                                                            remote_id,
-                                                            &key,
-                                                            status,
-                                                        )
-                                                        .await
-                                                        .ok();
-                                                    break;
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
+                        for att in attendees.iter_mut() {
+                            if att["email"].as_str() == Some(&attendee.email) {
+                                att["status"] = serde_json::json!(status);
                             }
                         }
+                        let updated_json = serde_json::to_string(&attendees).unwrap_or_default();
+                        conn.execute(
+                            "UPDATE calendar_events SET attendees_json = ?1 WHERE id = ?2",
+                            rusqlite::params![updated_json, event.id],
+                        )
+                        .ok();
                     }
-                    return Ok(());
+                }
+
+                if account.calendar_protocol_str() == "jmap" && jmap_push.is_none() {
+                    if let Some(ref remote_id) = event.remote_id {
+                        jmap_push = Some(JmapPush {
+                            remote_id: remote_id.clone(),
+                            attendee_email: attendee.email.clone(),
+                            status: status.clone(),
+                        });
+                    }
                 }
             }
         }
+        (account, jmap_push)
+    };
+
+    // Phase 2: JMAP push without holding the DB writer.
+    if let Some(push) = jmap_push {
+        let jmap_config = crate::commands::sync_cmd::build_jmap_config(&account).await?;
+        if let Ok(jmap_conn) = crate::mail::jmap::JmapConnection::connect(&jmap_config).await {
+            if let Ok(events) = jmap_conn.fetch_calendar_events(&jmap_config, None).await {
+                for ev in &events {
+                    if ev.id != push.remote_id {
+                        continue;
+                    }
+                    let Some(ref aj) = ev.attendees_json else { continue };
+                    let Ok(atts) = serde_json::from_str::<Vec<serde_json::Value>>(aj) else {
+                        continue;
+                    };
+                    for (i, a) in atts.iter().enumerate() {
+                        if a["email"].as_str() == Some(&push.attendee_email) {
+                            let key = format!("att{}", i);
+                            jmap_conn
+                                .update_participant_status(
+                                    &jmap_config,
+                                    &push.remote_id,
+                                    &key,
+                                    &push.status,
+                                )
+                                .await
+                                .ok();
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+        return Ok(());
     }
 
     // Notify frontend to refresh calendar UI

--- a/src-tauri/src/commands/calendar.rs
+++ b/src-tauri/src/commands/calendar.rs
@@ -2958,7 +2958,9 @@ pub async fn process_invite_reply(
                     let Some(ev) = events.iter().find(|e| e.id == push.remote_id) else {
                         continue;
                     };
-                    let Some(ref aj) = ev.attendees_json else { continue };
+                    let Some(ref aj) = ev.attendees_json else {
+                        continue;
+                    };
                     let Ok(atts) = serde_json::from_str::<Vec<serde_json::Value>>(aj) else {
                         continue;
                     };

--- a/src-tauri/src/commands/calendar.rs
+++ b/src-tauri/src/commands/calendar.rs
@@ -2895,10 +2895,10 @@ pub async fn process_invite_reply(
         attendee_email: String,
         status: String,
     }
-    let (account, jmap_push) = {
+    let (account, jmap_pushes) = {
         let conn = state.db.writer().await;
         let account = db::accounts::get_account_full(&conn, &account_id)?;
-        let mut jmap_push: Option<JmapPush> = None;
+        let mut jmap_pushes: Vec<JmapPush> = Vec::new();
 
         for reply in &reply_invites {
             let event = db::calendar::get_event_by_uid(&conn, &account_id, &reply.uid)?;
@@ -2934,9 +2934,9 @@ pub async fn process_invite_reply(
                     }
                 }
 
-                if account.calendar_protocol_str() == "jmap" && jmap_push.is_none() {
+                if account.calendar_protocol_str() == "jmap" {
                     if let Some(ref remote_id) = event.remote_id {
-                        jmap_push = Some(JmapPush {
+                        jmap_pushes.push(JmapPush {
                             remote_id: remote_id.clone(),
                             attendee_email: attendee.email.clone(),
                             status: status.clone(),
@@ -2945,18 +2945,19 @@ pub async fn process_invite_reply(
                 }
             }
         }
-        (account, jmap_push)
+        (account, jmap_pushes)
     };
 
-    // Phase 2: JMAP push without holding the DB writer.
-    if let Some(push) = jmap_push {
+    // Phase 2: JMAP push without holding the DB writer. Each REPLY component
+    // gets pushed; one fetch_calendar_events round-trip is reused for all.
+    if !jmap_pushes.is_empty() {
         let jmap_config = crate::commands::sync_cmd::build_jmap_config(&account).await?;
         if let Ok(jmap_conn) = crate::mail::jmap::JmapConnection::connect(&jmap_config).await {
             if let Ok(events) = jmap_conn.fetch_calendar_events(&jmap_config, None).await {
-                for ev in &events {
-                    if ev.id != push.remote_id {
+                for push in &jmap_pushes {
+                    let Some(ev) = events.iter().find(|e| e.id == push.remote_id) else {
                         continue;
-                    }
+                    };
                     let Some(ref aj) = ev.attendees_json else { continue };
                     let Ok(atts) = serde_json::from_str::<Vec<serde_json::Value>>(aj) else {
                         continue;
@@ -2979,10 +2980,10 @@ pub async fn process_invite_reply(
                 }
             }
         }
-        return Ok(());
     }
 
-    // Notify frontend to refresh calendar UI
+    // Notify frontend to refresh calendar UI. Runs regardless of whether
+    // a JMAP push happened, since phase 1 always updated the local DB.
     use tauri::Emitter as _;
     app.emit("calendar-changed", account_id.as_str()).ok();
 

--- a/src-tauri/src/commands/compose.rs
+++ b/src-tauri/src/commands/compose.rs
@@ -226,10 +226,14 @@ pub async fn send_message(
         match result {
             Ok(()) => {
                 log::info!("Message sent successfully for account {}", account_id_bg);
-                // Remove from outbox on success
-                let conn = db_bg.writer().await;
-                if let Err(e) = crate::ops::offline::mark_completed(&conn, outbox_id) {
-                    log::warn!("Failed to remove sent message from outbox: {}", e);
+                // Each writer acquire is scoped: shadowing the previous
+                // `conn` would NOT drop the old guard before the new
+                // `lock().await`, self-deadlocking on the same mutex.
+                {
+                    let conn = db_bg.writer().await;
+                    if let Err(e) = crate::ops::offline::mark_completed(&conn, outbox_id) {
+                        log::warn!("Failed to remove sent message from outbox: {}", e);
+                    }
                 }
                 app_bg
                     .emit(
@@ -242,11 +246,14 @@ pub async fn send_message(
                     .ok();
 
                 // Auto-collect recipients to "Collected Contacts"
-                let conn = db_bg.writer().await;
-                for addr in &recipients {
-                    if let Err(e) = db::contacts::collect_contact(&conn, &account_id_bg, addr, None)
-                    {
-                        log::warn!("Failed to collect contact '{}': {}", addr, e);
+                {
+                    let conn = db_bg.writer().await;
+                    for addr in &recipients {
+                        if let Err(e) =
+                            db::contacts::collect_contact(&conn, &account_id_bg, addr, None)
+                        {
+                            log::warn!("Failed to collect contact '{}': {}", addr, e);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary

Two write paths held the SQLite writer mutex across an \`.await\`, freezing every other write in the app the moment they ran. Once tripped, the only recovery was an app restart: send hung, account edits hung, set-flags hung, contacts/calendar sync hung.

- \`commands::compose::send_message\` post-send handler rebound \`let conn = db_bg.writer().await\` while the previous guard was still alive. Rust shadowing keeps the old binding live until the new RHS finishes evaluating, so the second \`lock().await\` self-deadlocked the spawned task and left the writer held forever. Each acquire is now in its own scope.
- \`commands::calendar::process_invite_reply\` acquired the writer and then awaited \`build_jmap_config\` plus JMAP HTTP round-trips while still holding it. Local DB updates now run under a scoped guard; the JMAP push runs afterwards with no lock held.

The original trigger in my session was a benign IMAP error (\`STORE +FLAGS (seen) failed: Encountered unexpected parse response\`). The error itself was harmless ("will retry"), but it caused the post-send handler to skip the early-error branch and fall into the shadow-deadlock site. The underlying STORE parse issue is a separate bug (bare lowercase flag names create user keywords instead of system flags), tracked separately.

## Test plan

- [ ] Restart chithi to clear the existing deadlocked task
- [ ] Send an email and confirm the "Sending..." toast clears
- [ ] Edit an account (change port), confirm save returns quickly
- [ ] Mark messages seen/unseen; confirm \`set_flags\` errors still surface in the status bar but the app stays responsive (no hang)
- [ ] Process an invite reply on a JMAP-calendar account and confirm both the local update and the JMAP push happen