### PR TITLE
fix(mail): widen checkbox hit target in message list

### DIFF
--- a/src/components/mail/MessageList.vue
+++ b/src/components/mail/MessageList.vue
@@ -142,7 +142,7 @@ const DRAG_THRESHOLD = 5; // pixels before drag starts
 
 function onDragMouseDown(event: MouseEvent, messageId: string) {
   if (event.button !== 0) return;
-  if ((event.target as HTMLElement).closest(".row-checkbox")) return;
+  if ((event.target as HTMLElement).closest(".col-check")) return;
   dragStartPos.value = { x: event.clientX, y: event.clientY };
   dragSourceId.value = messageId;
 
@@ -576,7 +576,11 @@ function resolveFolderName(path: string): string {
   <div class="message-list" data-testid="message-list" @click.left="closeContextMenu">
     <QuickFilterBar v-if="messagesStore.quickFilterVisible" />
     <div class="column-headers">
-      <div class="col col-check">
+      <div
+        class="col col-check"
+        data-testid="select-all-cell"
+        @click.stop="toggleSelectAll"
+      >
         <input
           type="checkbox"
           class="row-checkbox"
@@ -855,11 +859,13 @@ function resolveFolderName(path: string): string {
 }
 
 .col-check {
-  width: 20px;
+  width: 28px;
   flex-shrink: 0;
   display: flex;
   align-items: center;
   justify-content: center;
+  cursor: pointer;
+  align-self: stretch;
 }
 
 .row-checkbox {

--- a/src/components/mail/MessageListItem.vue
+++ b/src/components/mail/MessageListItem.vue
@@ -133,7 +133,11 @@ function onPointerUp() {
     :class="{ active, selected, unread: isUnread(message.flags) }"
     @dblclick="emit('open')"
   >
-    <div class="col col-check">
+    <div
+      class="col col-check"
+      data-testid="msg-check-cell"
+      @click.stop="emit('toggle')"
+    >
       <input
         type="checkbox"
         class="row-checkbox"
@@ -311,12 +315,14 @@ function onPointerUp() {
 }
 
 .col-check {
-  width: 20px;
+  width: 28px;
   flex-shrink: 0;
   display: flex;
   align-items: center;
   justify-content: center;
   padding: 0;
+  cursor: pointer;
+  align-self: stretch;
 }
 
 .row-checkbox {

--- a/src/components/mail/ThreadRow.vue
+++ b/src/components/mail/ThreadRow.vue
@@ -58,7 +58,11 @@ function isReply(): boolean {
     :class="{ active, selected, unread: hasUnread() }"
     @dblclick="$emit('open')"
   >
-    <div class="col col-check">
+    <div
+      class="col col-check"
+      data-testid="thread-check-cell"
+      @click.stop="$emit('toggleSelect')"
+    >
       <input
         type="checkbox"
         class="row-checkbox"
@@ -143,12 +147,14 @@ function isReply(): boolean {
 }
 
 .col-check {
-  width: 20px;
+  width: 28px;
   flex-shrink: 0;
   display: flex;
   align-items: center;
   justify-content: center;
   padding: 0;
+  cursor: pointer;
+  align-self: stretch;
 }
 
 .row-checkbox {


### PR DESCRIPTION
## Summary
- The `.col-check` cell was 20px wide but the `<input>` inside was only 13×13 px. Clicking inside the cell but outside the input bubbled to the row's `@click` handler and replaced the entire selection, undoing prior multi-select.
- Made the full cell the toggle target (`@click.stop="emit('toggle')"` on the cell), widened to 28px, added `cursor: pointer`, and stretched the cell vertically so the whole row height is forgiving.
- Same fix applied to `MessageListItem.vue`, `ThreadRow.vue`, and the select-all header in `MessageList.vue`. Also broadened the drag-suppression check from `.row-checkbox` to `.col-check` so a mousedown anywhere in the cell doesn't initiate a drag.

## Test plan
- [x] Build passes (`pnpm run build`)
- [x] Manual: clicking anywhere in the leftmost cell toggles the row's checkbox without clearing existing multi-selection
- [x] Manual: shift-click and ctrl-click still extend/toggle as expected
- [x] Manual: clicking the checkbox itself still toggles (no double-toggle from event bubbling)
- [x] Manual: drag-to-move still works when starting from the row body, not from the checkbox column