### PR TITLE
fix(calendar): center current time in viewport on open

### DIFF
--- a/src/components/calendar/WeekView.vue
+++ b/src/components/calendar/WeekView.vue
@@ -16,7 +16,7 @@
 // the grid region drops from ~216 → ~32 leaf nodes; first mail→calendar
 // nav is ~390 ms in the same profile. Combined with <KeepAlive> in
 // App.vue, subsequent mail↔calendar swaps are essentially free (~1-2 ms).
-import { computed, onMounted, onUnmounted, ref, nextTick } from "vue";
+import { computed, onMounted, onActivated, onUnmounted, ref, nextTick } from "vue";
 import { useCalendarStore } from "@/stores/calendar";
 import { useUiStore } from "@/stores/ui";
 import {
@@ -452,20 +452,27 @@ function onColumnDrop(day: Date, e: MouseEvent) {
 // .current-hour label stay accurate. The interval is per-instance; stored
 // so we can clear it on unmount and not leak when the view toggles
 // between week/day and month.
-onMounted(async () => {
+async function centerOnNow() {
   now.value = new Date();
+  await nextTick();
+  if (!gridRef.value) return;
+  const hour = getHourInTimezone(now.value.toISOString(), uiStore.displayTimezone);
+  const minutes = getMinutesInTimezone(now.value.toISOString(), uiStore.displayTimezone);
+  const nowPx = (hour + minutes / 60) * HOUR_HEIGHT;
+  gridRef.value.scrollTop = Math.max(0, nowPx - gridRef.value.clientHeight / 2);
+}
+
+onMounted(() => {
   nowIntervalId = setInterval(() => {
     now.value = new Date();
   }, 60000);
-
-  await nextTick();
-  if (gridRef.value) {
-    const hour = getHourInTimezone(now.value.toISOString(), uiStore.displayTimezone);
-    const minutes = getMinutesInTimezone(now.value.toISOString(), uiStore.displayTimezone);
-    const nowPx = (hour + minutes / 60) * HOUR_HEIGHT;
-    gridRef.value.scrollTop = Math.max(0, nowPx - gridRef.value.clientHeight / 2);
-  }
+  centerOnNow();
 });
+
+// CalendarView is wrapped in <KeepAlive>, so navigating away and back
+// reactivates this cached subtree without re-mounting; re-center so the
+// view doesn't reopen at a stale scroll position.
+onActivated(centerOnNow);
 
 onUnmounted(() => {
   if (nowIntervalId !== null) {

--- a/src/components/calendar/WeekView.vue
+++ b/src/components/calendar/WeekView.vue
@@ -447,8 +447,8 @@ function onColumnDrop(day: Date, e: MouseEvent) {
   });
 }
 
-// Scroll to current hour (or 8 AM if before that) on mount, and refresh
-// the "now" ref once per minute so the red current-time line and
+// Center the current time in the viewport on mount, and refresh the
+// "now" ref once per minute so the red current-time line and
 // .current-hour label stay accurate. The interval is per-instance; stored
 // so we can clear it on unmount and not leak when the view toggles
 // between week/day and month.
@@ -460,8 +460,10 @@ onMounted(async () => {
 
   await nextTick();
   if (gridRef.value) {
-    const scrollToHour = Math.max(getHourInTimezone(now.value.toISOString(), uiStore.displayTimezone) - 2, 0);
-    gridRef.value.scrollTop = HOUR_HEIGHT * scrollToHour;
+    const hour = getHourInTimezone(now.value.toISOString(), uiStore.displayTimezone);
+    const minutes = getMinutesInTimezone(now.value.toISOString(), uiStore.displayTimezone);
+    const nowPx = (hour + minutes / 60) * HOUR_HEIGHT;
+    gridRef.value.scrollTop = Math.max(0, nowPx - gridRef.value.clientHeight / 2);
   }
 });
 

--- a/src/views/CalendarView.vue
+++ b/src/views/CalendarView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onMounted, ref, computed, watch } from "vue";
+import { onMounted, nextTick, ref, computed, watch } from "vue";
 import { storeToRefs } from "pinia";
 import { useCalendarStore } from "@/stores/calendar";
 import { useAccountsStore } from "@/stores/accounts";
@@ -190,6 +190,25 @@ function nowTopOffset(): number {
   const minutes = now.getHours() * 60 + now.getMinutes();
   return (minutes / 60) * HOUR_ROW;
 }
+
+const dayGridRef = ref<HTMLElement | null>(null);
+const weekGridRef = ref<HTMLElement | null>(null);
+
+function scrollMobileToNow(el: HTMLElement | null) {
+  if (!el) return;
+  const target = nowTopOffset() - el.clientHeight / 2;
+  el.scrollTop = Math.max(0, target);
+}
+
+watch(
+  () => calendarStore.viewMode,
+  async (mode) => {
+    if (mode !== "day" && mode !== "week") return;
+    await nextTick();
+    scrollMobileToNow(mode === "day" ? dayGridRef.value : weekGridRef.value);
+  },
+  { immediate: true },
+);
 
 function setMobileViewMode(mode: CalendarViewMode) {
   calendarStore.setViewMode(mode);
@@ -394,7 +413,7 @@ onMounted(() => {
     </div>
 
     <!-- DAY VIEW -->
-    <div v-if="calendarStore.viewMode === 'day'" class="day-view">
+    <div v-if="calendarStore.viewMode === 'day'" ref="dayGridRef" class="day-view">
       <div
         v-if="allDayEventsForDay(new Date(calendarStore.currentDate)).length"
         class="all-day-strip"
@@ -486,7 +505,7 @@ onMounted(() => {
         </button>
       </div>
 
-      <div class="week-grid">
+      <div ref="weekGridRef" class="week-grid">
         <div class="hour-column">
           <div v-for="h in WEEK_HOURS" :key="h" class="hour-slot">
             <span class="hour-label">{{ h.toString().padStart(2, "0") }}</span>

--- a/src/views/CalendarView.vue
+++ b/src/views/CalendarView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onMounted, nextTick, ref, computed, watch } from "vue";
+import { onMounted, onActivated, nextTick, ref, computed, watch } from "vue";
 import { storeToRefs } from "pinia";
 import { useCalendarStore } from "@/stores/calendar";
 import { useAccountsStore } from "@/stores/accounts";
@@ -191,24 +191,38 @@ function nowTopOffset(): number {
   return (minutes / 60) * HOUR_ROW;
 }
 
-const dayGridRef = ref<HTMLElement | null>(null);
+const dayViewRef = ref<HTMLElement | null>(null);
+const dayTimedRef = ref<HTMLElement | null>(null);
 const weekGridRef = ref<HTMLElement | null>(null);
 
-function scrollMobileToNow(el: HTMLElement | null) {
-  if (!el) return;
-  const target = nowTopOffset() - el.clientHeight / 2;
-  el.scrollTop = Math.max(0, target);
+// The scroll container can be larger than the timed grid (e.g. day view has
+// an optional all-day strip above .day-grid). Use the timed element's
+// offsetTop inside the scroll container so the now-line lands at visual
+// center, not the grid's 0-coordinate.
+function scrollMobileToNow(scrollEl: HTMLElement | null, timedEl?: HTMLElement | null) {
+  if (!scrollEl) return;
+  const innerOffset = timedEl ? timedEl.offsetTop : 0;
+  const target = innerOffset + nowTopOffset() - scrollEl.clientHeight / 2;
+  scrollEl.scrollTop = Math.max(0, target);
 }
 
-watch(
-  () => calendarStore.viewMode,
-  async (mode) => {
-    if (mode !== "day" && mode !== "week") return;
-    await nextTick();
-    scrollMobileToNow(mode === "day" ? dayGridRef.value : weekGridRef.value);
-  },
-  { immediate: true },
-);
+async function recenterMobileGrid() {
+  const mode = calendarStore.viewMode;
+  if (mode !== "day" && mode !== "week") return;
+  await nextTick();
+  if (mode === "day") {
+    scrollMobileToNow(dayViewRef.value, dayTimedRef.value);
+  } else {
+    scrollMobileToNow(weekGridRef.value);
+  }
+}
+
+watch(() => calendarStore.viewMode, recenterMobileGrid, { immediate: true });
+
+// CalendarView is wrapped in <KeepAlive>, so leaving and returning to the
+// calendar tab does not change viewMode and would otherwise leave the
+// cached scroll position stale.
+onActivated(recenterMobileGrid);
 
 function setMobileViewMode(mode: CalendarViewMode) {
   calendarStore.setViewMode(mode);
@@ -413,7 +427,7 @@ onMounted(() => {
     </div>
 
     <!-- DAY VIEW -->
-    <div v-if="calendarStore.viewMode === 'day'" ref="dayGridRef" class="day-view">
+    <div v-if="calendarStore.viewMode === 'day'" ref="dayViewRef" class="day-view">
       <div
         v-if="allDayEventsForDay(new Date(calendarStore.currentDate)).length"
         class="all-day-strip"
@@ -427,7 +441,7 @@ onMounted(() => {
         >{{ ev.title }}</button>
       </div>
 
-      <div class="day-grid">
+      <div ref="dayTimedRef" class="day-grid">
         <div class="hour-column">
           <div v-for="h in DAY_HOURS" :key="h" class="hour-slot">
             <span class="hour-label">{{ h.toString().padStart(2, "0") }}:00</span>
@@ -1010,9 +1024,13 @@ onMounted(() => {
   position: relative;
   display: flex;
   flex: 1;
-  min-height: 1056px;
+  min-height: 0;
   overflow-y: auto;
 }
+
+/* The hour-column carries the in-flow 1056px height (24 × 44px hour-slots);
+   the flex row stretches the absolute-positioned .week-day-columns to match,
+   so .week-grid's scrollHeight is 1056px regardless of clientHeight. */
 
 .week-day-column {
   position: relative;


### PR DESCRIPTION
## Summary
- Desktop week/day view used to scroll to `currentHour - 2`, which fell short on short viewports.
- Mobile day/week had no scroll-to-now at all and always opened at 00:00.
- Both now compute `scrollTop = nowPx - clientHeight / 2` so the red current-time line sits in the middle of the visible grid regardless of window size.
- On mobile the scroll runs via a `watch` on `viewMode` (`immediate: true` + `nextTick`), so flipping between Day, Week, and Month re-centers each time the timed grid becomes visible.

## Test plan
- [x] Build passes (`pnpm run build`)
- [x] Manual: open desktop calendar on a short window, current time is centered in the visible grid
- [x] Manual: open mobile Day view, current time is centered
- [x] Manual: open mobile Week view, current time is centered
- [x] Manual: switch Day -> Month -> Day on mobile, re-centers each time
- [x] Manual: red "now" indicator stays in sync with the centered scroll position