### PR TITLE
feat(links): hover preview, click popup, tracking-strip on open; sticky HTML/plain reader

### DIFF
--- a/docs/adr/0001-copy-link-on-click.md
+++ b/docs/adr/0001-copy-link-on-click.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted
+Superseded by [ADR 0045: Link click opens a popup; tracking parameters stripped before opening](0045-link-popup-with-tracking-strip.md)
 
 ## Date
 

--- a/docs/adr/0045-link-popup-with-tracking-strip.md
+++ b/docs/adr/0045-link-popup-with-tracking-strip.md
@@ -1,0 +1,88 @@
+# ADR 0045: Link click opens a popup; tracking parameters stripped before opening
+
+## Status
+
+Accepted
+
+## Date
+
+2026-05-14
+
+## Supersedes
+
+[ADR 0001: Copy link to clipboard on click instead of opening browser](0001-copy-link-on-click.md)
+
+## Context
+
+ADR 0001 settled on copying a clicked URL to the clipboard, because every
+attempt to spawn a browser from a Tauri webview on Linux ran into
+`GDK_BACKEND` / `MOZ_LAUNCHED_CHILD` leakage that broke Firefox's profile
+lock detection. The user then had to paste into a browser themselves.
+
+Two things have changed since:
+
+1. **`tauri-plugin-opener` works**, and we already rely on it from the
+   `open_oauth_url` command (ADR 0014 / 0030) without the breakage seen
+   when calling Rust's `opener` crate or `xdg-open` directly. The plugin
+   sanitizes its own child environment before exec.
+2. **Tracking parameters are a privacy concern.** `utm_*`, `fbclid`,
+   `gclid`, `mc_eid`, and per-provider rules can identify the user to
+   the destination site even when the rest of the URL is legitimate. The
+   ClearURLs project maintains a crowd-sourced ruleset for exactly this.
+
+The clipboard-only flow also hid useful information: users could not see
+where a link pointed before committing to it, and a misclick on a long
+link copied something they had to inspect by pasting.
+
+## Decision
+
+A click on a link in mail, calendar, or contact content opens a small
+modal popup that shows:
+
+- The original URL.
+- The URL that would actually be opened, after stripping tracking
+  parameters via the embedded ClearURLs ruleset (or "No tracking
+  parameters detected" when the two are identical).
+- Three actions: **Copy** (original to clipboard), **Open** (sanitized,
+  via `tauri-plugin-opener`), **Cancel**.
+
+Two Tauri commands back the flow:
+
+- `clean_url(url)` returns the sanitized form for the popup preview.
+- `open_link(url)` re-sanitizes and opens. It refuses any scheme that is
+  not `http://` or `https://`, so a crafted href smuggled through the
+  iframe `postMessage` bridge or a hand-edited calendar field cannot
+  shell out to `mailto:`, `file:`, `javascript:`, etc.
+
+The hovered URL is mirrored into the status bar (left-aligned, ellipsis,
+full URL on tooltip) for both mail-iframe links and the linkified
+plain-text fields, so the user can preview the destination without
+opening the popup at all.
+
+For plain-text fields (calendar `location`, calendar `description`,
+contact `notes`), a `LinkifiedText` component detects `https?://...`
+matches client-side and renders them as `<a>` wired into the same popup
+and hover flow. Trailing punctuation is trimmed off the matched URL.
+Exchange/Outlook calendar descriptions that arrive as a full HTML
+document are decoded via `DOMParser` first, so the visible text is
+readable and any embedded anchor `href` values are exposed for
+linkification.
+
+## Consequences
+
+- The "one extra paste step" cost from ADR 0001 is gone; the popup turns
+  it into a one-click confirmation while keeping the user in control of
+  whether to copy or open.
+- Tracking parameters that previously survived to whichever browser the
+  user pasted into are now stripped before either copy or open. (Copy
+  copies the original because the user may have a reason to keep
+  parameters; Open uses the cleaned form.)
+- The browser-spawning failure modes ADR 0001 was avoiding are now the
+  plugin's responsibility, not ours. If a particular distro/browser
+  combination regresses, that becomes an upstream concern.
+- ClearURLs rules are vendored in the `clearurls` crate (~35 KB
+  minified JSON). Refreshing the rules means bumping the crate version.
+- `mailto:` links are still intercepted by the iframe and currently
+  routed through the popup; opening one will fail the http(s) guard.
+  Wiring `mailto:` to the compose window (the deferred follow-up from
+  ADR 0001) is out of scope here and will be tracked separately.

--- a/docs/adr/0045-link-popup-with-tracking-strip.md
+++ b/docs/adr/0045-link-popup-with-tracking-strip.md
@@ -82,7 +82,11 @@ linkification.
   combination regresses, that becomes an upstream concern.
 - ClearURLs rules are vendored in the `clearurls` crate (~35 KB
   minified JSON). Refreshing the rules means bumping the crate version.
-- `mailto:` links are still intercepted by the iframe and currently
-  routed through the popup; opening one will fail the http(s) guard.
-  Wiring `mailto:` to the compose window (the deferred follow-up from
-  ADR 0001) is out of scope here and will be tracked separately.
+- `mailto:` links are intercepted in the mail iframe and parsed per
+  RFC 6068 (`to`/`cc`/`bcc`/`subject`/`body`, query and path forms),
+  then handed to `openComposeWindow` with the current active account,
+  bypassing the popup. This finally resolves the deferred follow-up
+  from ADR 0001.
+- `tel:` links are passed through `tauri-plugin-opener` so the OS
+  handler picks them up.
+- Other schemes (`javascript:`, `file:`, `data:`, ...) remain refused.

--- a/docs/adr/0045-link-popup-with-tracking-strip.md
+++ b/docs/adr/0045-link-popup-with-tracking-strip.md
@@ -86,7 +86,9 @@ linkification.
   RFC 6068 (`to`/`cc`/`bcc`/`subject`/`body`, query and path forms),
   then handed to `openComposeWindow` with the current active account,
   bypassing the popup. This finally resolves the deferred follow-up
-  from ADR 0001.
+  from ADR 0001. Contact email fields use the same parser + routing
+  so clicking an email in the contact detail composes a new message
+  to that address.
 - `tel:` links are passed through `tauri-plugin-opener` so the OS
   handler picks them up.
 - Other schemes (`javascript:`, `file:`, `data:`, ...) remain refused.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -560,6 +560,7 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "chrono-tz",
+ "clearurls",
  "dirs",
  "fern",
  "futures",
@@ -596,7 +597,6 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
- "untrack",
  "uppsala",
  "url",
  "urlencoding",
@@ -627,6 +627,19 @@ checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
 dependencies = [
  "chrono",
  "phf 0.12.1",
+]
+
+[[package]]
+name = "clearurls"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e291c00af89ac0a5b400d9ba46a682e38015ae3cd8926dbbe85b3b864d550be3"
+dependencies = [
+ "percent-encoding",
+ "regex",
+ "serde",
+ "serde_json",
+ "url",
 ]
 
 [[package]]
@@ -971,12 +984,6 @@ dependencies = [
  "rustc_version",
  "syn 2.0.117",
 ]
-
-[[package]]
-name = "diff"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "digest"
@@ -2743,15 +2750,6 @@ dependencies = [
  "cc",
  "pkg-config",
  "vcpkg",
-]
-
-[[package]]
-name = "linkify"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1dfa36d52c581e9ec783a7ce2a5e0143da6237be5811a0b3153fedfdbe9f780"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -6042,17 +6040,6 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "untrack"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b201b8089505940853ad7dab38b9c8ee6229fe037993fa566381e02abc8871ac"
-dependencies = [
- "diff",
- "linkify",
- "url",
-]
 
 [[package]]
 name = "untrusted"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1013,7 +1013,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1230,7 +1230,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2645,9 +2645,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "lettre"
-version = "0.11.20"
+version = "0.11.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "471816f3e24b85e820dee02cde962379ea1a669e5242f19c61bcbcffedf4c4fb"
+checksum = "0da65617f6cb926332d039cb578aad56178da86e128db6a1b09f4c94fa5b3349"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3012,7 +3012,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4407,7 +4407,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4885,7 +4885,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5520,10 +5520,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5925,7 +5925,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5973,7 +5973,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6491,7 +6491,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -596,6 +596,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "untrack",
  "uppsala",
  "url",
  "urlencoding",
@@ -970,6 +971,12 @@ dependencies = [
  "rustc_version",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "digest"
@@ -2736,6 +2743,15 @@ dependencies = [
  "cc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "linkify"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dfa36d52c581e9ec783a7ce2a5e0143da6237be5811a0b3153fedfdbe9f780"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -6026,6 +6042,17 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "untrack"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b201b8089505940853ad7dab38b9c8ee6229fe037993fa566381e02abc8871ac"
+dependencies = [
+ "diff",
+ "linkify",
+ "url",
+]
 
 [[package]]
 name = "untrusted"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -53,6 +53,9 @@ hickory-resolver = "0.26"
 # CLDR windowsZones table for converting Microsoft display names
 # (e.g. "W. Europe Standard Time") to IANA timezone IDs.
 windows-timezones = "0.5"
+# Strips tracking parameters (utm_*, fbclid, gclid, ...) before opening
+# user-clicked links from mail/calendar/contacts.
+untrack = "0.1"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -53,9 +53,10 @@ hickory-resolver = "0.26"
 # CLDR windowsZones table for converting Microsoft display names
 # (e.g. "W. Europe Standard Time") to IANA timezone IDs.
 windows-timezones = "0.5"
-# Strips tracking parameters (utm_*, fbclid, gclid, ...) before opening
-# user-clicked links from mail/calendar/contacts.
-untrack = "0.1"
+# Strips tracking parameters (utm_*, fbclid, gclid, per-provider rules)
+# before opening user-clicked links from mail/calendar/contacts. Uses the
+# embedded ClearURLs ruleset (~35 KB minified JSON, vendored in the crate).
+clearurls = "0.0.4"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/src-tauri/src/commands/links.rs
+++ b/src-tauri/src/commands/links.rs
@@ -1,9 +1,22 @@
 use crate::error::{Error, Result};
+use clearurls::UrlCleaner;
+use std::sync::OnceLock;
 
-/// Strip tracking parameters (utm_*, fbclid, gclid, ...) from a single URL.
-/// Returns the cleaned URL, or the original if untrack made no changes.
+/// The ClearURLs ruleset is embedded in the crate; building the cleaner
+/// compiles the regex providers once. Kept in a OnceLock so the work
+/// happens at most once per process rather than per command call.
+fn cleaner() -> &'static UrlCleaner {
+    static CLEANER: OnceLock<UrlCleaner> = OnceLock::new();
+    CLEANER.get_or_init(|| {
+        UrlCleaner::from_embedded_rules().expect("embedded ClearURLs ruleset is valid")
+    })
+}
+
 fn sanitize(url: &str) -> String {
-    untrack::clone_and_sanitize_text(url).unwrap_or_else(|| url.to_string())
+    cleaner()
+        .clear_single_url_str(url)
+        .map(|c| c.into_owned())
+        .unwrap_or_else(|_| url.to_string())
 }
 
 /// Preview the cleaned form of a URL without opening it. The frontend uses
@@ -16,9 +29,10 @@ pub fn clean_url(url: String) -> Result<String> {
 }
 
 /// Open a user-clicked link in the OS default handler, stripping tracking
-/// parameters first via the `untrack` crate. Refuses anything that is not
-/// http(s) so the renderer can't shell out to mailto:, file:, javascript:,
-/// etc. by smuggling a crafted href through the iframe postMessage bridge.
+/// parameters first via the ClearURLs ruleset. Refuses anything that is
+/// not http(s) so the renderer can't shell out to mailto:, file:,
+/// javascript:, etc. by smuggling a crafted href through the iframe
+/// postMessage bridge or a hand-edited calendar field.
 #[tauri::command]
 pub fn open_link(url: String) -> Result<()> {
     if !(url.starts_with("https://") || url.starts_with("http://")) {

--- a/src-tauri/src/commands/links.rs
+++ b/src-tauri/src/commands/links.rs
@@ -35,12 +35,19 @@ pub fn clean_url(url: String) -> Result<String> {
 /// bridge or a hand-edited calendar field cannot escape the renderer.
 const ALLOWED_SCHEMES: &[&str] = &["http://", "https://", "mailto:", "tel:"];
 
+// Case-insensitive ASCII prefix check. Works on raw bytes so a URL with
+// multi-byte UTF-8 characters (e.g. an IRI like `héllo://...`) cannot
+// trigger a panic on a non-char-boundary slice — the allowed scheme
+// prefixes are all ASCII, so byte comparison is the right primitive.
+fn starts_with_ci(url: &str, prefix: &str) -> bool {
+    url.as_bytes()
+        .get(..prefix.len())
+        .is_some_and(|head| head.eq_ignore_ascii_case(prefix.as_bytes()))
+}
+
 fn has_allowed_scheme(url: &str) -> bool {
-    // RFC 3986 §3.1 — schemes are case-insensitive. Lowercase just enough
-    // of the head to cover the longest allowed scheme prefix.
-    let head_len = url.len().min(8);
-    let head = url[..head_len].to_ascii_lowercase();
-    ALLOWED_SCHEMES.iter().any(|s| head.starts_with(s))
+    // RFC 3986 §3.1 — schemes are case-insensitive.
+    ALLOWED_SCHEMES.iter().any(|s| starts_with_ci(url, s))
 }
 
 /// Open a user-clicked link in the OS default handler, stripping tracking
@@ -54,9 +61,7 @@ pub fn open_link(url: String) -> Result<()> {
             url
         )));
     }
-    let to_open = if url[..5.min(url.len())].eq_ignore_ascii_case("http:")
-        || url[..6.min(url.len())].eq_ignore_ascii_case("https:")
-    {
+    let to_open = if starts_with_ci(&url, "http://") || starts_with_ci(&url, "https://") {
         sanitize(&url)
     } else {
         url

--- a/src-tauri/src/commands/links.rs
+++ b/src-tauri/src/commands/links.rs
@@ -1,0 +1,33 @@
+use crate::error::{Error, Result};
+
+/// Strip tracking parameters (utm_*, fbclid, gclid, ...) from a single URL.
+/// Returns the cleaned URL, or the original if untrack made no changes.
+fn sanitize(url: &str) -> String {
+    untrack::clone_and_sanitize_text(url).unwrap_or_else(|| url.to_string())
+}
+
+/// Preview the cleaned form of a URL without opening it. The frontend uses
+/// this to show "Open as: <cleaned>" alongside the original in the link
+/// popup so the user knows what tracking will be stripped before they
+/// commit to opening.
+#[tauri::command]
+pub fn clean_url(url: String) -> Result<String> {
+    Ok(sanitize(&url))
+}
+
+/// Open a user-clicked link in the OS default handler, stripping tracking
+/// parameters first via the `untrack` crate. Refuses anything that is not
+/// http(s) so the renderer can't shell out to mailto:, file:, javascript:,
+/// etc. by smuggling a crafted href through the iframe postMessage bridge.
+#[tauri::command]
+pub fn open_link(url: String) -> Result<()> {
+    if !(url.starts_with("https://") || url.starts_with("http://")) {
+        return Err(Error::Other(format!(
+            "Refusing to open non-http(s) URL: {}",
+            url
+        )));
+    }
+    let cleaned = sanitize(&url);
+    tauri_plugin_opener::open_url(&cleaned, None::<&str>)
+        .map_err(|e| Error::Other(format!("open_url failed: {}", e)))
+}

--- a/src-tauri/src/commands/links.rs
+++ b/src-tauri/src/commands/links.rs
@@ -28,20 +28,39 @@ pub fn clean_url(url: String) -> Result<String> {
     Ok(sanitize(&url))
 }
 
+/// Schemes the OS handler may be asked to open. http(s) get tracking
+/// stripped first; mailto/tel are user-facing handoffs the OS already
+/// knows how to route. Everything else (javascript:, file:, data:, ...)
+/// is refused so a crafted href smuggled through the iframe postMessage
+/// bridge or a hand-edited calendar field cannot escape the renderer.
+const ALLOWED_SCHEMES: &[&str] = &["http://", "https://", "mailto:", "tel:"];
+
+fn has_allowed_scheme(url: &str) -> bool {
+    // RFC 3986 §3.1 — schemes are case-insensitive. Lowercase just enough
+    // of the head to cover the longest allowed scheme prefix.
+    let head_len = url.len().min(8);
+    let head = url[..head_len].to_ascii_lowercase();
+    ALLOWED_SCHEMES.iter().any(|s| head.starts_with(s))
+}
+
 /// Open a user-clicked link in the OS default handler, stripping tracking
-/// parameters first via the ClearURLs ruleset. Refuses anything that is
-/// not http(s) so the renderer can't shell out to mailto:, file:,
-/// javascript:, etc. by smuggling a crafted href through the iframe
-/// postMessage bridge or a hand-edited calendar field.
+/// parameters first via the ClearURLs ruleset for http(s) URLs.
+/// mailto/tel are passed through unchanged.
 #[tauri::command]
 pub fn open_link(url: String) -> Result<()> {
-    if !(url.starts_with("https://") || url.starts_with("http://")) {
+    if !has_allowed_scheme(&url) {
         return Err(Error::Other(format!(
-            "Refusing to open non-http(s) URL: {}",
+            "Refusing to open URL with disallowed scheme: {}",
             url
         )));
     }
-    let cleaned = sanitize(&url);
-    tauri_plugin_opener::open_url(&cleaned, None::<&str>)
+    let to_open = if url[..5.min(url.len())].eq_ignore_ascii_case("http:")
+        || url[..6.min(url.len())].eq_ignore_ascii_case("https:")
+    {
+        sanitize(&url)
+    } else {
+        url
+    };
+    tauri_plugin_opener::open_url(&to_open, None::<&str>)
         .map_err(|e| Error::Other(format!("open_url failed: {}", e)))
 }

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -7,6 +7,7 @@ pub mod compose;
 pub mod contacts;
 pub mod events;
 pub mod filters;
+pub mod links;
 pub mod mail;
 pub mod meet;
 pub mod oauth;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -99,6 +99,8 @@ pub fn run() {
             commands::oauth::jmap_oidc_start,
             commands::oauth::jmap_oidc_complete,
             commands::oauth::open_oauth_url,
+            commands::links::clean_url,
+            commands::links::open_link,
             commands::actions::move_messages,
             commands::actions::move_messages_cross_account,
             commands::actions::delete_messages,

--- a/src/components/calendar/EventDetail.vue
+++ b/src/components/calendar/EventDetail.vue
@@ -8,6 +8,7 @@ import { message as tauriMessage } from "@tauri-apps/plugin-dialog";
 import * as api from "@/lib/tauri";
 import TimeInput from "@/components/common/TimeInput.vue";
 import DateInput from "@/components/common/DateInput.vue";
+import LinkifiedText from "@/components/common/LinkifiedText.vue";
 
 const emit = defineEmits<{
   close: [];
@@ -225,7 +226,7 @@ async function handleDelete() {
 
         <div v-if="event.location" class="detail-row">
           <span class="detail-icon">&#x1F4CD;</span>
-          <span>{{ event.location }}</span>
+          <LinkifiedText :text="event.location" data-testid="event-location" />
         </div>
 
         <div v-if="event.my_status" class="detail-row">
@@ -254,7 +255,7 @@ async function handleDelete() {
 
         <div v-if="event.description" class="detail-row">
           <span class="detail-icon">&#x1F4DD;</span>
-          <pre class="description">{{ event.description }}</pre>
+          <LinkifiedText :text="event.description" class="description" data-testid="event-description" />
         </div>
 
         <div v-if="event.recurrence_rule" class="detail-row">

--- a/src/components/common/LinkPopup.vue
+++ b/src/components/common/LinkPopup.vue
@@ -8,6 +8,7 @@ const uiStore = useUiStore();
 
 const cleaned = ref<string | null>(null);
 const cleaning = ref(false);
+const cleanError = ref(false);
 
 const original = computed(() => uiStore.linkPopupUrl);
 const wasModified = computed(
@@ -28,12 +29,17 @@ watch(
   () => uiStore.linkPopupUrl,
   async (url) => {
     cleaned.value = null;
+    cleanError.value = false;
     if (!url) return;
     cleaning.value = true;
     try {
       cleaned.value = await api.cleanUrl(url);
     } catch {
+      // Preserve the original so Open still has a sensible argument, but
+      // surface the failure to the user instead of silently claiming the
+      // URL is clean.
       cleaned.value = url;
+      cleanError.value = true;
     } finally {
       cleaning.value = false;
     }
@@ -102,6 +108,11 @@ onUnmounted(() => window.removeEventListener("keydown", onKeydown));
       </div>
       <div v-else-if="cleaning" class="link-popup-row hint">
         <span class="link-popup-hint">Checking for tracking parameters...</span>
+      </div>
+      <div v-else-if="cleanError" class="link-popup-row hint">
+        <span class="link-popup-hint error" data-testid="link-popup-clean-error">
+          Could not check for tracking parameters.
+        </span>
       </div>
       <div v-else class="link-popup-row hint">
         <span class="link-popup-hint">No tracking parameters detected.</span>
@@ -194,6 +205,10 @@ onUnmounted(() => window.removeEventListener("keydown", onKeydown));
 .link-popup-hint {
   font-size: 11px;
   color: var(--color-text-muted);
+}
+
+.link-popup-hint.error {
+  color: var(--color-danger-text, var(--color-danger));
 }
 
 .link-popup-actions {

--- a/src/components/common/LinkPopup.vue
+++ b/src/components/common/LinkPopup.vue
@@ -1,0 +1,231 @@
+<script setup lang="ts">
+import { ref, computed, watch, onMounted, onUnmounted } from "vue";
+import { useUiStore } from "@/stores/ui";
+import * as api from "@/lib/tauri";
+import { showToast } from "@/lib/toast";
+
+const uiStore = useUiStore();
+
+const cleaned = ref<string | null>(null);
+const cleaning = ref(false);
+
+const original = computed(() => uiStore.linkPopupUrl);
+const wasModified = computed(
+  () => cleaned.value !== null && original.value !== null && cleaned.value !== original.value,
+);
+const openableScheme = computed(() => {
+  const u = original.value ?? "";
+  return u.startsWith("https://") || u.startsWith("http://");
+});
+
+// Fetch the cleaned form whenever a new URL is shown. The Tauri command
+// returns the original string unchanged if no tracking was found, so
+// `wasModified` reliably tells us whether to surface the diff in the UI.
+watch(
+  () => uiStore.linkPopupUrl,
+  async (url) => {
+    cleaned.value = null;
+    if (!url) return;
+    cleaning.value = true;
+    try {
+      cleaned.value = await api.cleanUrl(url);
+    } catch {
+      cleaned.value = url;
+    } finally {
+      cleaning.value = false;
+    }
+  },
+  { immediate: true },
+);
+
+async function onCopy() {
+  if (!original.value) return;
+  try {
+    await navigator.clipboard.writeText(original.value);
+    showToast("Link copied to clipboard", "success");
+  } catch (e) {
+    showToast("Copy failed: " + String(e), "error");
+  }
+  uiStore.closeLinkPopup();
+}
+
+async function onOpen() {
+  if (!original.value) return;
+  try {
+    // The Rust side re-sanitizes, so we pass the original and let the
+    // backend strip again. Avoids any drift between the preview and the
+    // URL actually opened.
+    await api.openLink(original.value);
+  } catch (e) {
+    showToast("Open failed: " + String(e), "error");
+  }
+  uiStore.closeLinkPopup();
+}
+
+function onCancel() {
+  uiStore.closeLinkPopup();
+}
+
+function onKeydown(e: KeyboardEvent) {
+  if (!uiStore.linkPopupUrl) return;
+  if (e.key === "Escape") {
+    e.preventDefault();
+    onCancel();
+  }
+}
+
+onMounted(() => window.addEventListener("keydown", onKeydown));
+onUnmounted(() => window.removeEventListener("keydown", onKeydown));
+</script>
+
+<template>
+  <div
+    v-if="uiStore.linkPopupUrl"
+    class="link-popup-backdrop"
+    data-testid="link-popup"
+    @click.self="onCancel"
+  >
+    <div class="link-popup" role="dialog" aria-labelledby="link-popup-title">
+      <div id="link-popup-title" class="link-popup-title">Open link</div>
+
+      <div class="link-popup-row">
+        <span class="link-popup-label">URL</span>
+        <span class="link-popup-url" data-testid="link-popup-original">{{ original }}</span>
+      </div>
+
+      <div v-if="wasModified" class="link-popup-row clean">
+        <span class="link-popup-label">Open as</span>
+        <span class="link-popup-url clean" data-testid="link-popup-cleaned">{{ cleaned }}</span>
+      </div>
+      <div v-else-if="cleaning" class="link-popup-row hint">
+        <span class="link-popup-hint">Checking for tracking parameters...</span>
+      </div>
+      <div v-else class="link-popup-row hint">
+        <span class="link-popup-hint">No tracking parameters detected.</span>
+      </div>
+
+      <div class="link-popup-actions">
+        <button
+          type="button"
+          class="link-popup-btn"
+          data-testid="link-popup-cancel"
+          @click="onCancel"
+        >Cancel</button>
+        <button
+          type="button"
+          class="link-popup-btn"
+          data-testid="link-popup-copy"
+          @click="onCopy"
+        >Copy</button>
+        <button
+          type="button"
+          class="link-popup-btn primary"
+          :disabled="!openableScheme"
+          :title="openableScheme ? '' : 'Only http(s) URLs can be opened from chithi'"
+          data-testid="link-popup-open"
+          @click="onOpen"
+        >Open</button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.link-popup-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 16px;
+}
+
+.link-popup {
+  background: var(--color-bg);
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
+  width: 100%;
+  max-width: 520px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.link-popup-title {
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.link-popup-row {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.link-popup-label {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--color-text-muted);
+}
+
+.link-popup-url {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+  word-break: break-all;
+  background: var(--color-bg-secondary, var(--color-bg-hover));
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  padding: 6px 8px;
+}
+
+.link-popup-url.clean {
+  border-color: var(--color-accent);
+}
+
+.link-popup-hint {
+  font-size: 11px;
+  color: var(--color-text-muted);
+}
+
+.link-popup-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 4px;
+}
+
+.link-popup-btn {
+  font-size: 12px;
+  padding: 6px 12px;
+  border-radius: 4px;
+  border: 1px solid var(--color-border);
+  background: var(--color-bg);
+  color: var(--color-text);
+  cursor: pointer;
+}
+
+.link-popup-btn:hover {
+  background: var(--color-bg-hover);
+}
+
+.link-popup-btn.primary {
+  background: var(--color-accent);
+  color: #fff;
+  border-color: var(--color-accent);
+}
+
+.link-popup-btn.primary:hover {
+  filter: brightness(1.05);
+}
+
+.link-popup-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+</style>

--- a/src/components/common/LinkPopup.vue
+++ b/src/components/common/LinkPopup.vue
@@ -118,6 +118,12 @@ onUnmounted(() => window.removeEventListener("keydown", onKeydown));
         <span class="link-popup-hint">No tracking parameters detected.</span>
       </div>
 
+      <div v-if="!openableScheme" class="link-popup-row hint">
+        <span class="link-popup-hint warn" data-testid="link-popup-unopenable">
+          chithi can only open http(s), mailto:, and tel: links. Copy this one and paste it where you need it.
+        </span>
+      </div>
+
       <div class="link-popup-actions">
         <button
           type="button"
@@ -209,6 +215,10 @@ onUnmounted(() => window.removeEventListener("keydown", onKeydown));
 
 .link-popup-hint.error {
   color: var(--color-danger-text, var(--color-danger));
+}
+
+.link-popup-hint.warn {
+  color: var(--color-warning, var(--color-text));
 }
 
 .link-popup-actions {

--- a/src/components/common/LinkPopup.vue
+++ b/src/components/common/LinkPopup.vue
@@ -13,9 +13,12 @@ const original = computed(() => uiStore.linkPopupUrl);
 const wasModified = computed(
   () => cleaned.value !== null && original.value !== null && cleaned.value !== original.value,
 );
+// Mirror src-tauri/src/commands/links.rs::ALLOWED_SCHEMES. Schemes are
+// case-insensitive per RFC 3986 §3.1, so compare lowercased.
+const OPENABLE_SCHEMES = ["http://", "https://", "mailto:", "tel:"];
 const openableScheme = computed(() => {
-  const u = original.value ?? "";
-  return u.startsWith("https://") || u.startsWith("http://");
+  const u = (original.value ?? "").slice(0, 8).toLowerCase();
+  return OPENABLE_SCHEMES.some((s) => u.startsWith(s));
 });
 
 // Fetch the cleaned form whenever a new URL is shown. The Tauri command

--- a/src/components/common/LinkifiedText.vue
+++ b/src/components/common/LinkifiedText.vue
@@ -49,12 +49,16 @@ function trimTrailingPunct(url: string): { url: string; trailing: string } {
 // so links that only existed as anchors (no visible URL) still get
 // linkified by the regex pass below.
 //
-// The trigger requires a doctype, <html>, or any explicit closing tag.
-// Plain prose containing comparisons like "a < b" or "span > 0" therefore
-// does not get fed to DOMParser (which would silently rewrite whitespace
-// and drop anything outside <body>).
+// The trigger requires a doctype/<html>/<body> root marker, or both an
+// opening and matching closing tag of the same element. Notes that just
+// mention a stray close-tag in prose do not qualify, so they go through
+// the regex pass without DOMParser's whitespace rewriting.
 function looksLikeHtml(input: string): boolean {
-  return /<!doctype html|<html\b|<\/[a-z][a-z0-9]*\s*>/i.test(input);
+  if (/<!doctype html\b|<html\b|<body\b/i.test(input)) return true;
+  const m = input.match(/<([a-z][a-z0-9]*)\b[^>]*>/i);
+  if (!m) return false;
+  const tag = m[1].toLowerCase();
+  return new RegExp(`</${tag}\\s*>`, "i").test(input);
 }
 
 function htmlToPlain(input: string): string {

--- a/src/components/common/LinkifiedText.vue
+++ b/src/components/common/LinkifiedText.vue
@@ -1,0 +1,120 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { useUiStore } from "@/stores/ui";
+
+const props = defineProps<{
+  text: string | null | undefined;
+}>();
+
+const uiStore = useUiStore();
+
+// Trailing punctuation that a user almost never means as part of a URL but
+// which the regex would otherwise capture. Stripped at split-time and
+// returned as plain text so it stays visible in the rendered output.
+const TRAILING_PUNCT = /[.,!?;:)\]}>'"]+$/;
+const URL_RE = /https?:\/\/[^\s<>"']+/g;
+
+// Exchange/Outlook calendar descriptions sometimes arrive as a full HTML
+// document instead of plain text. Decode them to text so the user sees the
+// content rather than raw markup, preserving line breaks from <br> and
+// common block elements. <a href> values are appended to the text output
+// so links that only existed as anchors (no visible URL) still get
+// linkified by the regex pass below.
+function htmlToPlain(input: string): string {
+  if (!/<\s*(html|body|head|div|p|br|a|span)\b/i.test(input)) return input;
+  const doc = new DOMParser().parseFromString(input, "text/html");
+  doc.querySelectorAll("br").forEach((br) => br.replaceWith("\n"));
+  doc
+    .querySelectorAll("p, div, li, h1, h2, h3, h4, h5, h6, tr")
+    .forEach((el) => el.append("\n"));
+  doc.querySelectorAll("a[href]").forEach((a) => {
+    const href = (a as HTMLAnchorElement).getAttribute("href") ?? "";
+    if (!href.startsWith("http://") && !href.startsWith("https://")) return;
+    const text = (a.textContent ?? "").trim();
+    if (!text || !text.includes(href)) a.append(` (${href})`);
+  });
+  const out = (doc.body?.textContent ?? input)
+    .replace(/[ \t]+\n/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+  return out;
+}
+
+interface Segment {
+  kind: "text" | "link";
+  value: string;
+}
+
+const segments = computed<Segment[]>(() => {
+  const input = htmlToPlain(props.text ?? "");
+  if (!input) return [];
+  const out: Segment[] = [];
+  let lastIndex = 0;
+  for (const match of input.matchAll(URL_RE)) {
+    const start = match.index ?? 0;
+    let url = match[0];
+    let trailing = "";
+    const m = url.match(TRAILING_PUNCT);
+    if (m) {
+      trailing = m[0];
+      url = url.slice(0, url.length - trailing.length);
+    }
+    if (start > lastIndex) {
+      out.push({ kind: "text", value: input.slice(lastIndex, start) });
+    }
+    out.push({ kind: "link", value: url });
+    if (trailing) out.push({ kind: "text", value: trailing });
+    lastIndex = start + match[0].length;
+  }
+  if (lastIndex < input.length) {
+    out.push({ kind: "text", value: input.slice(lastIndex) });
+  }
+  return out;
+});
+
+function onLinkClick(url: string, e: MouseEvent) {
+  e.preventDefault();
+  uiStore.setHoverUrl(null);
+  uiStore.openLinkPopup(url);
+}
+function onLinkEnter(url: string) {
+  uiStore.setHoverUrl(url);
+}
+function onLinkLeave() {
+  uiStore.setHoverUrl(null);
+}
+</script>
+
+<template>
+  <span class="linkified">
+    <template v-for="(seg, i) in segments" :key="i">
+      <a
+        v-if="seg.kind === 'link'"
+        :href="seg.value"
+        class="linkified-link"
+        @click="onLinkClick(seg.value, $event)"
+        @mouseenter="onLinkEnter(seg.value)"
+        @mouseleave="onLinkLeave"
+      >{{ seg.value }}</a>
+      <template v-else>{{ seg.value }}</template>
+    </template>
+  </span>
+</template>
+
+<style scoped>
+.linkified {
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+}
+
+.linkified-link {
+  color: var(--color-accent);
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.linkified-link:hover {
+  filter: brightness(1.1);
+}
+</style>

--- a/src/components/common/LinkifiedText.vue
+++ b/src/components/common/LinkifiedText.vue
@@ -11,8 +11,36 @@ const uiStore = useUiStore();
 // Trailing punctuation that a user almost never means as part of a URL but
 // which the regex would otherwise capture. Stripped at split-time and
 // returned as plain text so it stays visible in the rendered output.
-const TRAILING_PUNCT = /[.,!?;:)\]}>'"]+$/;
+// Closing brackets get a balanced-pair check below (Wikipedia URLs like
+// .../Foo_(disambiguation) keep the trailing ')').
+const TRAILING_PUNCT_ALWAYS = /[.,!?;:>'"]+$/;
 const URL_RE = /https?:\/\/[^\s<>"']+/g;
+const BRACKET_PAIRS: Record<string, string> = { ")": "(", "]": "[", "}": "{" };
+
+// Walk trailing punctuation off the end of a matched URL. Symmetric
+// brackets are only stripped when the URL has more of them at the end
+// than openers inside it; otherwise we leave them so URLs containing
+// balanced parens (Wikipedia, MDN, ...) survive unscathed.
+function trimTrailingPunct(url: string): { url: string; trailing: string } {
+  let trailing = "";
+  while (url.length > 0) {
+    const last = url[url.length - 1];
+    if (last in BRACKET_PAIRS) {
+      const opener = BRACKET_PAIRS[last];
+      const opens = (url.match(new RegExp("\\" + opener, "g")) ?? []).length;
+      const closes = (url.match(new RegExp("\\" + last, "g")) ?? []).length;
+      if (closes <= opens) break;
+      trailing = last + trailing;
+      url = url.slice(0, -1);
+      continue;
+    }
+    const m = url.match(TRAILING_PUNCT_ALWAYS);
+    if (!m) break;
+    trailing = m[0] + trailing;
+    url = url.slice(0, url.length - m[0].length);
+  }
+  return { url, trailing };
+}
 
 // Exchange/Outlook calendar descriptions sometimes arrive as a full HTML
 // document instead of plain text. Decode them to text so the user sees the
@@ -20,9 +48,22 @@ const URL_RE = /https?:\/\/[^\s<>"']+/g;
 // common block elements. <a href> values are appended to the text output
 // so links that only existed as anchors (no visible URL) still get
 // linkified by the regex pass below.
+//
+// The trigger requires a doctype, <html>, or any explicit closing tag.
+// Plain prose containing comparisons like "a < b" or "span > 0" therefore
+// does not get fed to DOMParser (which would silently rewrite whitespace
+// and drop anything outside <body>).
+function looksLikeHtml(input: string): boolean {
+  return /<!doctype html|<html\b|<\/[a-z][a-z0-9]*\s*>/i.test(input);
+}
+
 function htmlToPlain(input: string): string {
-  if (!/<\s*(html|body|head|div|p|br|a|span)\b/i.test(input)) return input;
+  if (!looksLikeHtml(input)) return input;
   const doc = new DOMParser().parseFromString(input, "text/html");
+  // Outlook/Word HTML exports embed large <style> blocks ("p.MsoNormal {...}")
+  // and the occasional <script>. textContent would otherwise dump that
+  // CSS/JS into the user-visible description.
+  doc.querySelectorAll("style, script, head, noscript").forEach((el) => el.remove());
   doc.querySelectorAll("br").forEach((br) => br.replaceWith("\n"));
   doc
     .querySelectorAll("p, div, li, h1, h2, h3, h4, h5, h6, tr")
@@ -52,13 +93,7 @@ const segments = computed<Segment[]>(() => {
   let lastIndex = 0;
   for (const match of input.matchAll(URL_RE)) {
     const start = match.index ?? 0;
-    let url = match[0];
-    let trailing = "";
-    const m = url.match(TRAILING_PUNCT);
-    if (m) {
-      trailing = m[0];
-      url = url.slice(0, url.length - trailing.length);
-    }
+    const { url, trailing } = trimTrailingPunct(match[0]);
     if (start > lastIndex) {
       out.push({ kind: "text", value: input.slice(lastIndex, start) });
     }

--- a/src/components/common/StatusBar.vue
+++ b/src/components/common/StatusBar.vue
@@ -110,9 +110,15 @@ async function syncAll() {
       </button>
       <span v-if="activityStore.hasActiveOperations" class="op-spinner"></span>
       <span class="status-dot" :class="connectionStatus" data-testid="sync-status"></span>
-      <span v-if="syncError" class="sync-error-msg" data-testid="sync-error">{{ syncError }}</span>
+      <span
+        v-if="uiStore.hoverUrl"
+        class="hover-url"
+        data-testid="status-hover-url"
+        :title="uiStore.hoverUrl"
+      >{{ uiStore.hoverUrl }}</span>
+      <span v-else-if="syncError" class="sync-error-msg" data-testid="sync-error">{{ syncError }}</span>
       <button v-else-if="opsStore.hasFailures" class="sync-error-msg" data-testid="op-failure" @click="opsStore.clearFailures()" title="Click to dismiss">{{ opsStore.recentFailures[0]?.error }}</button>
-      <span v-else-if="connectionStatus === 'disconnected'" class="disconnect-msg">Offline — reconnecting...</span>
+      <span v-else-if="connectionStatus === 'disconnected'" class="disconnect-msg">Offline, reconnecting...</span>
       <span v-else class="account-info">{{ accountsStore.accounts.length }} account{{ accountsStore.accounts.length !== 1 ? 's' : '' }} connected</span>
     </div>
     <div class="status-right">
@@ -242,6 +248,17 @@ async function syncAll() {
 
 .account-info {
   white-space: nowrap;
+}
+
+.hover-url {
+  color: var(--color-text);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+  max-width: 70vw;
 }
 
 .last-sync {

--- a/src/components/mail/MessageReader.vue
+++ b/src/components/mail/MessageReader.vue
@@ -35,8 +35,13 @@ const accountsStore = useAccountsStore();
 const foldersStore = useFoldersStore();
 const uiStore = useUiStore();
 
-// View mode: plain text by default
-const showHtml = ref(false);
+// View mode: sticky across messages via uiStore so a user who flips to
+// HTML once doesn't have to re-flip on every subsequent message. Falls
+// back to plain text if the current message has no HTML part.
+const showHtml = computed({
+  get: () => uiStore.preferHtmlBody && hasHtml(),
+  set: (v: boolean) => uiStore.setPreferHtmlBody(v),
+});
 const invites = ref<ParsedInvite[]>([]);
 
 // Remote images: per-message, not persisted
@@ -49,11 +54,11 @@ const hasRemoteImages = computed(() => {
   return messagesStore.activeMessage?.has_remote_images ?? false;
 });
 
-// Reset view state when switching messages
+// Reset per-message state when switching messages. The HTML/plain choice
+// is preserved in uiStore.preferHtmlBody and intentionally not touched.
 watch(
   () => messagesStore.activeMessageId,
   () => {
-    showHtml.value = false;
     invites.value = [];
     imagesHtml.value = null;
     loadingImages.value = false;

--- a/src/components/mail/MessageReader.vue
+++ b/src/components/mail/MessageReader.vue
@@ -158,9 +158,14 @@ function iframeSrcdoc(): string {
   });
   document.addEventListener('mouseout', function(e) {
     var a = e.target.closest ? e.target.closest('a') : null;
-    if (a && a.href) {
-      parent.postMessage({ type: 'link-leave' }, '*');
-    }
+    if (!a || !a.href) return;
+    // mouseout also fires when the pointer moves between an anchor's own
+    // child nodes; relatedTarget is where the pointer went next. Only
+    // emit link-leave when the cursor actually left this <a>.
+    var rel = e.relatedTarget;
+    var relAnchor = rel && rel.closest ? rel.closest('a') : null;
+    if (relAnchor === a) return;
+    parent.postMessage({ type: 'link-leave' }, '*');
   });
   // Intercept right-click and forward to parent
   document.addEventListener('contextmenu', function(e) {

--- a/src/components/mail/MessageReader.vue
+++ b/src/components/mail/MessageReader.vue
@@ -8,6 +8,7 @@ import type { ParsedInvite, Contact, ContactBook } from "@/lib/types";
 import InviteCard from "@/components/calendar/InviteCard.vue";
 import Select from "@/components/common/Select.vue";
 import { openComposeWindow } from "@/lib/compose-window";
+import { parseMailto } from "@/lib/mailto";
 import * as api from "@/lib/tauri";
 
 const EMAIL_LABEL_OPTIONS = [
@@ -196,11 +197,20 @@ function handleIframeMessage(event: MessageEvent) {
   if (!fromOurIframe) return;
 
   if (event.data.type === 'link-click' && typeof event.data.href === 'string') {
-    // The popup gives the user the choice between copy and open-untracked.
-    // Clear the hover state first so the status bar doesn't keep showing
-    // the URL underneath the modal.
     uiStore.setHoverUrl(null);
-    uiStore.openLinkPopup(event.data.href);
+    // mailto: goes straight to compose, matching the expected behavior of
+    // an email client; users almost never want a confirmation step on
+    // their own send action. Everything else routes through the popup so
+    // the user can choose copy / open / cancel and preview the cleaned URL.
+    const mailto = parseMailto(event.data.href);
+    if (mailto) {
+      openComposeWindow({
+        accountId: accountsStore.activeAccountId ?? undefined,
+        ...mailto,
+      });
+    } else {
+      uiStore.openLinkPopup(event.data.href);
+    }
   } else if (event.data.type === 'link-hover' && typeof event.data.href === 'string') {
     uiStore.setHoverUrl(event.data.href);
   } else if (event.data.type === 'link-leave') {

--- a/src/components/mail/MessageReader.vue
+++ b/src/components/mail/MessageReader.vue
@@ -186,9 +186,11 @@ function handleIframeMessage(event: MessageEvent) {
   if (!fromOurIframe) return;
 
   if (event.data.type === 'link-click' && typeof event.data.href === 'string') {
-    navigator.clipboard.writeText(event.data.href).then(() => {
-      showToast("Link copied to clipboard");
-    });
+    // The popup gives the user the choice between copy and open-untracked.
+    // Clear the hover state first so the status bar doesn't keep showing
+    // the URL underneath the modal.
+    uiStore.setHoverUrl(null);
+    uiStore.openLinkPopup(event.data.href);
   } else if (event.data.type === 'link-hover' && typeof event.data.href === 'string') {
     uiStore.setHoverUrl(event.data.href);
   } else if (event.data.type === 'link-leave') {

--- a/src/components/mail/MessageReader.vue
+++ b/src/components/mail/MessageReader.vue
@@ -139,13 +139,24 @@ function iframeSrcdoc(): string {
 </style>
 </head>
 <body>${html}<script nonce="${nonce}">
+  // Anchor's raw href attribute; null/empty for fragment-only or hrefless
+  // anchors. Use getAttribute (not .href, which auto-resolves relatives
+  // against the iframe location and would surface "about:srcdoc#foo").
+  function anchorHref(a) {
+    var h = a ? a.getAttribute('href') : '';
+    if (!h) return '';
+    h = h.trim();
+    if (!h || h.charAt(0) === '#') return '';
+    return h;
+  }
   // Intercept all link clicks and forward to parent via postMessage
   document.addEventListener('click', function(e) {
     var a = e.target.closest ? e.target.closest('a') : null;
-    if (a && a.href) {
+    var href = anchorHref(a);
+    if (href) {
       e.preventDefault();
       e.stopPropagation();
-      parent.postMessage({ type: 'link-click', href: a.getAttribute('href') }, '*');
+      parent.postMessage({ type: 'link-click', href: href }, '*');
     }
   });
   // Forward hover state on links so the parent can preview the URL in the
@@ -153,13 +164,14 @@ function iframeSrcdoc(): string {
   // single document-level listener is enough.
   document.addEventListener('mouseover', function(e) {
     var a = e.target.closest ? e.target.closest('a') : null;
-    if (a && a.href) {
-      parent.postMessage({ type: 'link-hover', href: a.getAttribute('href') }, '*');
+    var href = anchorHref(a);
+    if (href) {
+      parent.postMessage({ type: 'link-hover', href: href }, '*');
     }
   });
   document.addEventListener('mouseout', function(e) {
     var a = e.target.closest ? e.target.closest('a') : null;
-    if (!a || !a.href) return;
+    if (!anchorHref(a)) return;
     // mouseout also fires when the pointer moves between an anchor's own
     // child nodes; relatedTarget is where the pointer went next. Only
     // emit link-leave when the cursor actually left this <a>.

--- a/src/components/mail/MessageReader.vue
+++ b/src/components/mail/MessageReader.vue
@@ -142,6 +142,21 @@ function iframeSrcdoc(): string {
       parent.postMessage({ type: 'link-click', href: a.getAttribute('href') }, '*');
     }
   });
+  // Forward hover state on links so the parent can preview the URL in the
+  // status bar. mouseover/mouseout bubble (mouseenter/leave do not), so a
+  // single document-level listener is enough.
+  document.addEventListener('mouseover', function(e) {
+    var a = e.target.closest ? e.target.closest('a') : null;
+    if (a && a.href) {
+      parent.postMessage({ type: 'link-hover', href: a.getAttribute('href') }, '*');
+    }
+  });
+  document.addEventListener('mouseout', function(e) {
+    var a = e.target.closest ? e.target.closest('a') : null;
+    if (a && a.href) {
+      parent.postMessage({ type: 'link-leave' }, '*');
+    }
+  });
   // Intercept right-click and forward to parent
   document.addEventListener('contextmenu', function(e) {
     e.preventDefault();
@@ -174,6 +189,10 @@ function handleIframeMessage(event: MessageEvent) {
     navigator.clipboard.writeText(event.data.href).then(() => {
       showToast("Link copied to clipboard");
     });
+  } else if (event.data.type === 'link-hover' && typeof event.data.href === 'string') {
+    uiStore.setHoverUrl(event.data.href);
+  } else if (event.data.type === 'link-leave') {
+    uiStore.setHoverUrl(null);
   } else if (event.data.type === 'resize' && typeof event.data.height === 'number') {
     // Auto-resize the specific iframe that sent the message
     for (const iframe of iframes) {
@@ -191,7 +210,12 @@ watch(() => messagesStore.activeMessageId, () => {
 
 // Set up / tear down message listener
 onMounted(() => window.addEventListener('message', handleIframeMessage));
-onUnmounted(() => window.removeEventListener('message', handleIframeMessage));
+onUnmounted(() => {
+  window.removeEventListener('message', handleIframeMessage);
+  // The iframe's last hover state can otherwise outlive the component (e.g.
+  // the user navigates away mid-hover and no mouseout ever fires).
+  uiStore.setHoverUrl(null);
+});
 
 // Toast
 const toast = ref<string | null>(null);

--- a/src/components/shell/DesktopShell.vue
+++ b/src/components/shell/DesktopShell.vue
@@ -5,6 +5,7 @@ import Sidebar from "@/components/common/Sidebar.vue";
 import MenuBar from "@/components/common/MenuBar.vue";
 import StatusBar from "@/components/common/StatusBar.vue";
 import OperationsPanel from "@/components/common/OperationsPanel.vue";
+import LinkPopup from "@/components/common/LinkPopup.vue";
 
 const route = useRoute();
 
@@ -17,6 +18,7 @@ const isStandaloneWindow = computed(
 <template>
   <div v-if="isStandaloneWindow" class="standalone-shell">
     <router-view />
+    <LinkPopup />
   </div>
 
   <div v-else class="app-shell">
@@ -38,6 +40,7 @@ const isStandaloneWindow = computed(
       <OperationsPanel />
       <StatusBar />
     </div>
+    <LinkPopup />
   </div>
 </template>
 

--- a/src/components/shell/MobileShell.vue
+++ b/src/components/shell/MobileShell.vue
@@ -5,6 +5,7 @@ import { storeToRefs } from "pinia";
 import MobileTabBar from "@/components/mobile/MobileTabBar.vue";
 import FolderDrawer from "@/components/mobile/FolderDrawer.vue";
 import ComposeSheet from "@/components/mobile/ComposeSheet.vue";
+import LinkPopup from "@/components/common/LinkPopup.vue";
 import { useUiStore } from "@/stores/ui";
 
 const route = useRoute();
@@ -37,6 +38,7 @@ const showTabBar = computed(() => {
     <MobileTabBar v-if="showTabBar" />
     <FolderDrawer />
     <ComposeSheet v-if="composeOpen" />
+    <LinkPopup />
   </div>
 </template>
 

--- a/src/lib/compose-window.ts
+++ b/src/lib/compose-window.ts
@@ -7,6 +7,7 @@ export interface ComposeParams {
   replyTo?: string;
   to?: string;
   cc?: string;
+  bcc?: string;
   subject?: string;
   body?: string;
 }
@@ -20,6 +21,7 @@ export function openComposeWindow(params: ComposeParams = {}) {
   if (params.replyTo) query.set("replyTo", params.replyTo);
   if (params.to) query.set("to", params.to);
   if (params.cc) query.set("cc", params.cc);
+  if (params.bcc) query.set("bcc", params.bcc);
   if (params.subject) query.set("subject", params.subject);
   if (params.body) query.set("body", params.body);
 

--- a/src/lib/mailto.ts
+++ b/src/lib/mailto.ts
@@ -1,0 +1,65 @@
+import type { ComposeParams } from "./compose-window";
+
+/// Parse a `mailto:` URI into the compose-window's parameter shape per
+/// RFC 6068. Returns null when the input doesn't look like mailto: so
+/// callers can fall back to their generic link handling.
+///
+/// Supported:
+///   mailto:foo@example.com
+///   mailto:foo,bar@example.com
+///   mailto:?to=foo&cc=bar&bcc=baz&subject=Hi&body=Hello
+///   mailto:foo?subject=Hi%20there&body=Line%201%0ALine%202
+///
+/// `to` addresses from the path and from the query are merged. Newlines
+/// in the body arrive as %0A and survive decodeURIComponent intact.
+export function parseMailto(href: string): ComposeParams | null {
+  if (!href.slice(0, 7).toLowerCase().startsWith("mailto:")) return null;
+
+  const afterScheme = href.slice(7);
+  const qIndex = afterScheme.indexOf("?");
+  const path = qIndex === -1 ? afterScheme : afterScheme.slice(0, qIndex);
+  const queryStr = qIndex === -1 ? "" : afterScheme.slice(qIndex + 1);
+
+  const toFromPath = path
+    .split(",")
+    .map((s) => safeDecode(s.trim()))
+    .filter(Boolean);
+
+  const params = new URLSearchParams(queryStr);
+  const merged = mergeCommaList(toFromPath, params.getAll("to"));
+
+  const result: ComposeParams = {};
+  if (merged) result.to = merged;
+  const cc = mergeCommaList([], params.getAll("cc"));
+  if (cc) result.cc = cc;
+  const bcc = mergeCommaList([], params.getAll("bcc"));
+  if (bcc) result.bcc = bcc;
+  const subject = params.get("subject");
+  if (subject) result.subject = subject;
+  const body = params.get("body");
+  if (body) result.body = body;
+  return result;
+}
+
+function safeDecode(s: string): string {
+  try {
+    return decodeURIComponent(s);
+  } catch {
+    return s;
+  }
+}
+
+// Multiple ?to= / ?cc= / ?bcc= parameters are allowed, and each may itself
+// contain a comma-separated list. Flatten into a single comma-separated
+// string with no duplicates so the compose form gets a clean prefill.
+function mergeCommaList(initial: string[], extra: string[]): string {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const piece of [...initial, ...extra.flatMap((e) => e.split(","))]) {
+    const v = piece.trim();
+    if (!v || seen.has(v)) continue;
+    seen.add(v);
+    out.push(v);
+  }
+  return out.join(", ");
+}

--- a/src/lib/mailto.ts
+++ b/src/lib/mailto.ts
@@ -26,13 +26,16 @@ export function parseMailto(href: string): ComposeParams | null {
     .filter(Boolean);
 
   const params = new URLSearchParams(queryStr);
-  const merged = mergeCommaList(toFromPath, params.getAll("to"));
+  // Per RFC 6068 the path is a comma-separated list of full addr-specs;
+  // drop anything that doesn't at least contain "@" so a malformed
+  // mailto: doesn't push "foo" into the compose To field.
+  const merged = mergeCommaList(toFromPath, params.getAll("to"), true);
 
   const result: ComposeParams = {};
   if (merged) result.to = merged;
-  const cc = mergeCommaList([], params.getAll("cc"));
+  const cc = mergeCommaList([], params.getAll("cc"), true);
   if (cc) result.cc = cc;
-  const bcc = mergeCommaList([], params.getAll("bcc"));
+  const bcc = mergeCommaList([], params.getAll("bcc"), true);
   if (bcc) result.bcc = bcc;
   const subject = params.get("subject");
   if (subject) result.subject = subject;
@@ -52,12 +55,15 @@ function safeDecode(s: string): string {
 // Multiple ?to= / ?cc= / ?bcc= parameters are allowed, and each may itself
 // contain a comma-separated list. Flatten into a single comma-separated
 // string with no duplicates so the compose form gets a clean prefill.
-function mergeCommaList(initial: string[], extra: string[]): string {
+// When requireAt is set, entries missing "@" are discarded so a partial
+// addr-spec doesn't end up in the recipient field.
+function mergeCommaList(initial: string[], extra: string[], requireAt = false): string {
   const seen = new Set<string>();
   const out: string[] = [];
   for (const piece of [...initial, ...extra.flatMap((e) => e.split(","))]) {
     const v = piece.trim();
     if (!v || seen.has(v)) continue;
+    if (requireAt && !v.includes("@")) continue;
     seen.add(v);
     out.push(v);
   }

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -698,6 +698,14 @@ export async function openOauthUrl(url: string): Promise<void> {
   return invoke("open_oauth_url", { url });
 }
 
+export async function cleanUrl(url: string): Promise<string> {
+  return invoke("clean_url", { url });
+}
+
+export async function openLink(url: string): Promise<void> {
+  return invoke("open_link", { url });
+}
+
 export async function listTimezones(): Promise<string[]> {
   return invoke("list_timezones");
 }

--- a/src/stores/ui.ts
+++ b/src/stores/ui.ts
@@ -246,6 +246,13 @@ export const useUiStore = defineStore("ui", () => {
     drawerOpen.value = false;
   }
 
+  // URL currently hovered in a mail/calendar/contact view; rendered in the
+  // status bar so the user can preview where a link will lead before clicking.
+  const hoverUrl = ref<string | null>(null);
+  function setHoverUrl(url: string | null) {
+    hoverUrl.value = url;
+  }
+
   return {
     threadingEnabled,
     folderPaneWidth,
@@ -284,5 +291,7 @@ export const useUiStore = defineStore("ui", () => {
     closeCompose,
     openDrawer,
     closeDrawer,
+    hoverUrl,
+    setHoverUrl,
   };
 });

--- a/src/stores/ui.ts
+++ b/src/stores/ui.ts
@@ -63,6 +63,17 @@ export const useUiStore = defineStore("ui", () => {
     localStorage.getItem("chithi-decorations") !== "false",
   );
 
+  // Sticky HTML/plain-text preference for the message reader. Default is
+  // plain text (safer, no remote content surprises); flips to whatever the
+  // user last picked so they don't have to re-toggle on every message.
+  const preferHtmlBody = ref(
+    localStorage.getItem("chithi-prefer-html-body") === "true",
+  );
+  function setPreferHtmlBody(prefer: boolean) {
+    preferHtmlBody.value = prefer;
+    localStorage.setItem("chithi-prefer-html-body", String(prefer));
+  }
+
   // Week start day: 0 = Sunday, 1 = Monday, 6 = Saturday
   const VALID_WEEK_STARTS = [0, 1, 6];
   const weekStartDay = ref<number>(
@@ -308,5 +319,7 @@ export const useUiStore = defineStore("ui", () => {
     linkPopupUrl,
     openLinkPopup,
     closeLinkPopup,
+    preferHtmlBody,
+    setPreferHtmlBody,
   };
 });

--- a/src/stores/ui.ts
+++ b/src/stores/ui.ts
@@ -253,6 +253,18 @@ export const useUiStore = defineStore("ui", () => {
     hoverUrl.value = url;
   }
 
+  // URL the user activated; when non-null, the global LinkPopup component
+  // shows a chooser (copy / open-untracked / cancel) and clears this back
+  // to null when dismissed. Centralized here so any view can trigger the
+  // popup without each owning its own copy of the modal.
+  const linkPopupUrl = ref<string | null>(null);
+  function openLinkPopup(url: string) {
+    linkPopupUrl.value = url;
+  }
+  function closeLinkPopup() {
+    linkPopupUrl.value = null;
+  }
+
   return {
     threadingEnabled,
     folderPaneWidth,
@@ -293,5 +305,8 @@ export const useUiStore = defineStore("ui", () => {
     closeDrawer,
     hoverUrl,
     setHoverUrl,
+    linkPopupUrl,
+    openLinkPopup,
+    closeLinkPopup,
   };
 });

--- a/src/views/ComposeView.vue
+++ b/src/views/ComposeView.vue
@@ -104,7 +104,7 @@ const replyToMessageId = (route.query.replyTo as string) || "";
 const selectedAccountId = ref("");
 const to = ref((route.query.to as string) || "");
 const cc = ref((route.query.cc as string) || "");
-const bcc = ref("");
+const bcc = ref((route.query.bcc as string) || "");
 const subject = ref((route.query.subject as string) || "");
 const bodyText = ref((route.query.body as string) || "");
 const sending = ref(false);
@@ -288,10 +288,11 @@ watch(selectedAccountId, (newId) => {
 // a new message with only a signature is not considered dirty.
 const initialTo = (route.query.to as string) || "";
 const initialCc = (route.query.cc as string) || "";
+const initialBcc = (route.query.bcc as string) || "";
 const initialSubject = (route.query.subject as string) || "";
 const baselineTo = ref(initialTo);
 const baselineCc = ref(initialCc);
-const baselineBcc = ref("");
+const baselineBcc = ref(initialBcc);
 const baselineSubject = ref(initialSubject);
 const baselineBody = ref((route.query.body as string) || "");
 

--- a/src/views/ContactsView.vue
+++ b/src/views/ContactsView.vue
@@ -9,6 +9,7 @@ import { useUiStore } from "@/stores/ui";
 import type { ContactBook, Contact } from "@/lib/types";
 import * as api from "@/lib/tauri";
 import { acctColor } from "@/lib/account-colors";
+import LinkifiedText from "@/components/common/LinkifiedText.vue";
 import {
   applyMergeChoices,
   defaultChoices,
@@ -990,7 +991,11 @@ async function applyMerge() {
             </div>
             <div v-if="selectedContact.notes" class="field-row">
               <span class="field-label">Notes</span>
-              <span class="field-value notes">{{ selectedContact.notes }}</span>
+              <LinkifiedText
+                :text="selectedContact.notes"
+                class="field-value notes"
+                data-testid="contact-detail-notes"
+              />
             </div>
           </div>
         </template>

--- a/src/views/ContactsView.vue
+++ b/src/views/ContactsView.vue
@@ -398,11 +398,30 @@ function parsePhones(json: string): { number: string; label: string }[] {
   try { return JSON.parse(json); } catch { return []; }
 }
 
+// RFC 6068 requires URI-encoding of reserved characters in the mailto:
+// path. encodeURIComponent over-encodes "@", "/" and other addr-spec
+// chars; selectively re-decode the ones that are safe inside an
+// addr-spec so the resulting URI looks natural in the status bar
+// preview while remaining well-formed.
+function encodeMailtoAddress(email: string): string {
+  return encodeURIComponent(email.trim())
+    .replace(/%40/g, "@")
+    .replace(/%2E/gi, ".")
+    .replace(/%2B/gi, "+");
+}
+
+// RFC 3966 visual-separator chars are kept verbatim; everything else
+// (spaces, parens, letters, "ext." suffix, ...) is stripped, since
+// the OS dialer interprets only digits and "+".
+function sanitizeTel(number: string): string {
+  return number.replace(/[^0-9+*#\-.]/g, "");
+}
+
 // Clicking a contact's email opens compose with `to` prefilled, matching
 // how a mailto: link inside a mail body behaves. The address is built
 // via mailto: so it goes through the same parser and routing.
 function onEmailClick(email: string) {
-  const params = parseMailto(`mailto:${email}`);
+  const params = parseMailto(`mailto:${encodeMailtoAddress(email)}`);
   if (!params) return;
   openComposeWindow({
     accountId: accountsStore.activeAccountId ?? undefined,
@@ -413,7 +432,9 @@ function onEmailClick(email: string) {
 // Phone numbers hand off to the OS via the same backend command that
 // powers the LinkPopup's Open button; tel: is in its allow-list.
 function onPhoneClick(number: string) {
-  api.openLink(`tel:${number}`).catch((e) => console.error("openLink tel: failed:", e));
+  const tel = sanitizeTel(number);
+  if (!tel) return;
+  api.openLink(`tel:${tel}`).catch((e) => console.error("openLink tel: failed:", e));
 }
 
 function onLinkEnter(url: string) {
@@ -1013,9 +1034,9 @@ async function applyMerge() {
               <a
                 class="field-value field-link"
                 data-testid="contact-detail-email"
-                :href="`mailto:${em.email}`"
+                :href="`mailto:${encodeMailtoAddress(em.email)}`"
                 @click.prevent="onEmailClick(em.email)"
-                @mouseenter="onLinkEnter(`mailto:${em.email}`)"
+                @mouseenter="onLinkEnter(`mailto:${encodeMailtoAddress(em.email)}`)"
                 @mouseleave="onLinkLeave"
               >{{ em.email }}</a>
             </div>
@@ -1024,9 +1045,9 @@ async function applyMerge() {
               <a
                 class="field-value field-link"
                 data-testid="contact-detail-phone"
-                :href="`tel:${ph.number}`"
+                :href="`tel:${sanitizeTel(ph.number)}`"
                 @click.prevent="onPhoneClick(ph.number)"
-                @mouseenter="onLinkEnter(`tel:${ph.number}`)"
+                @mouseenter="onLinkEnter(`tel:${sanitizeTel(ph.number)}`)"
                 @mouseleave="onLinkLeave"
               >{{ ph.number }}</a>
             </div>

--- a/src/views/ContactsView.vue
+++ b/src/views/ContactsView.vue
@@ -10,6 +10,8 @@ import type { ContactBook, Contact } from "@/lib/types";
 import * as api from "@/lib/tauri";
 import { acctColor } from "@/lib/account-colors";
 import LinkifiedText from "@/components/common/LinkifiedText.vue";
+import { openComposeWindow } from "@/lib/compose-window";
+import { parseMailto } from "@/lib/mailto";
 import {
   applyMergeChoices,
   defaultChoices,
@@ -394,6 +396,31 @@ function parseEmails(json: string): { email: string; label: string }[] {
 
 function parsePhones(json: string): { number: string; label: string }[] {
   try { return JSON.parse(json); } catch { return []; }
+}
+
+// Clicking a contact's email opens compose with `to` prefilled, matching
+// how a mailto: link inside a mail body behaves. The address is built
+// via mailto: so it goes through the same parser and routing.
+function onEmailClick(email: string) {
+  const params = parseMailto(`mailto:${email}`);
+  if (!params) return;
+  openComposeWindow({
+    accountId: accountsStore.activeAccountId ?? undefined,
+    ...params,
+  });
+}
+
+// Phone numbers hand off to the OS via the same backend command that
+// powers the LinkPopup's Open button; tel: is in its allow-list.
+function onPhoneClick(number: string) {
+  api.openLink(`tel:${number}`).catch((e) => console.error("openLink tel: failed:", e));
+}
+
+function onLinkEnter(url: string) {
+  uiStore.setHoverUrl(url);
+}
+function onLinkLeave() {
+  uiStore.setHoverUrl(null);
 }
 
 function selectContact(contact: Contact, event?: MouseEvent) {
@@ -983,11 +1010,25 @@ async function applyMerge() {
           <div class="detail-fields">
             <div v-for="em in parseEmails(selectedContact.emails_json)" :key="em.email" class="field-row">
               <span class="field-label">{{ em.label }}</span>
-              <span class="field-value" data-testid="contact-detail-email">{{ em.email }}</span>
+              <a
+                class="field-value field-link"
+                data-testid="contact-detail-email"
+                :href="`mailto:${em.email}`"
+                @click.prevent="onEmailClick(em.email)"
+                @mouseenter="onLinkEnter(`mailto:${em.email}`)"
+                @mouseleave="onLinkLeave"
+              >{{ em.email }}</a>
             </div>
             <div v-for="ph in parsePhones(selectedContact.phones_json)" :key="ph.number" class="field-row">
               <span class="field-label">{{ ph.label }}</span>
-              <span class="field-value" data-testid="contact-detail-phone">{{ ph.number }}</span>
+              <a
+                class="field-value field-link"
+                data-testid="contact-detail-phone"
+                :href="`tel:${ph.number}`"
+                @click.prevent="onPhoneClick(ph.number)"
+                @mouseenter="onLinkEnter(`tel:${ph.number}`)"
+                @mouseleave="onLinkLeave"
+              >{{ ph.number }}</a>
             </div>
             <div v-if="selectedContact.notes" class="field-row">
               <span class="field-label">Notes</span>
@@ -1616,6 +1657,12 @@ async function applyMerge() {
 
 .field-value { font-size: 14px; color: var(--color-text); }
 .field-value.notes { white-space: pre-wrap; color: var(--color-text-secondary); }
+.field-link {
+  color: var(--color-accent);
+  text-decoration: underline;
+  cursor: pointer;
+}
+.field-link:hover { filter: brightness(1.1); }
 
 .empty-text { padding: 32px 20px; text-align: center; color: var(--color-text-muted); font-size: 14px; }
 


### PR DESCRIPTION
## Summary

Reworks how URLs from mail, calendar, and contacts are surfaced and opened; routes `mailto:` to chithi's compose window; and makes the mail reader remember the HTML/plain choice across messages.

Previously, clicking a link in a mail body silently copied the URL to the clipboard with no preview or sanitization; `mailto:` was a dead-end (clipboard only); calendar location/description and contact notes were plain text with no link affordance; contact email/phone fields were not interactive; and the HTML/plain toggle reset on every message.

Supersedes [ADR 0001](docs/adr/0001-copy-link-on-click.md) with the new [ADR 0045](docs/adr/0045-link-popup-with-tracking-strip.md).

### Hover preview in the status bar
- New `uiStore.hoverUrl` ref, rendered left-aligned in `StatusBar` with ellipsis truncation and a full-URL tooltip.
- Mail body iframe forwards `mouseover`/`mouseout` for `<a href>` via `postMessage`; `mouseout` checks `relatedTarget`'s closest `<a>` to avoid flicker when the pointer moves between an anchor's own child elements. Hover state is cleared on `MessageReader` unmount so it doesn't survive navigation.
- Linkified calendar / contact text uses native `@mouseenter`/`@mouseleave` (no iframe).

### Click popup (`LinkPopup.vue`)
- Mounted once in `DesktopShell` and `MobileShell`; triggered via `uiStore.openLinkPopup(url)`.
- Shows the original URL, the cleaned form when different (else "No tracking parameters detected"), and Copy / Open / Cancel.
- Esc, backdrop click, or Cancel dismiss. Open is disabled for schemes outside the allowlist.

### Tracking-strip on open
- Two Tauri commands: `clean_url` (preview) and `open_link` (sanitize + open via `tauri-plugin-opener`).
- Uses the embedded ClearURLs ruleset (~35 KB, LGPL-3.0, compatible with chithi's GPL-3.0) via the `clearurls` crate. `untrack` was tried first but only covers a narrow allowlist of hosts; ClearURLs strips `utm_*`, `fbclid`, `gclid`, `mc_eid`, and per-provider params across any host. Cleaner built once via `OnceLock`.
- Scheme allowlist: `http://`, `https://`, `mailto:`, `tel:` (case-insensitive per RFC 3986). http(s) get sanitized; mailto/tel pass through. `javascript:`, `file:`, `data:`, etc. are refused so a crafted href smuggled through the iframe `postMessage` bridge or a hand-edited calendar field cannot escape the renderer.

### `mailto:` → compose window (resolves ADR 0001 follow-up)
- `src/lib/mailto.ts` parses RFC 6068 mailto: into `ComposeParams` (path + `?to=&cc=&bcc=&subject=&body=`, comma-merged and dedup'd).
- `ComposeParams` / `compose-window.ts` / `ComposeView.vue` gain a `bcc` field plumbed through the query string.
- `MessageReader` iframe handler detects `mailto:` and goes straight to `openComposeWindow` with the active account, bypassing the popup.

### Plain-text linkification (`LinkifiedText.vue`)
- Splits a string on `https?://...` and renders each URL as a clickable anchor wired into the same hover / popup flow.
- Trailing-punctuation stripper counts brackets and only strips an unmatched closer, so `https://en.wikipedia.org/wiki/Foo_(bar)` survives intact.
- HTML-detection trigger requires `<!doctype>`, `<html>`, or any explicit closing tag, so prose like `"a < b and span > 0"` is not fed through `DOMParser`.
- For Exchange/Outlook descriptions that arrive as a full HTML document, the parser strips `<style>` / `<script>` / `<head>` / `<noscript>` first (so MsoNormal CSS doesn't leak), turns `<br>` and block elements into newlines, exposes anchor `href` values for the regex pass, and collapses 3+ blank lines.
- Used in `EventDetail.vue` for `location` and `description`, and in `ContactsView.vue` for `notes`.

### Clickable contact fields
- Each email in the contact detail is now `<a href="mailto:…">` that routes through `parseMailto` + `openComposeWindow`.
- Each phone is `<a href="tel:…">` that calls `openLink` (OS handler picks it up).
- Both publish their URL to `uiStore.hoverUrl` on hover.

### Sticky HTML/plain reader preference
- New `uiStore.preferHtmlBody`, persisted to `localStorage` under `chithi-prefer-html-body`. Default plain text.
- `MessageReader`'s `showHtml` is a `computed` get/set on the store, so switching to HTML on message A keeps it for message B; switching back to plain on B applies to C; survives app restart.
- Falls back to plain when the current message has no HTML part.

## Test plan
- [x] `pnpm run build` and `cargo build` both clean
- [x] Hover a link in a mail body → URL in status bar; pointer over a `<span>` inside the link doesn't flicker
- [x] Click an `https://...` link → popup; Copy + Open both work; cleaned URL shown for `?utm_*`/`fbclid`/`gclid`; non-tracking params preserved
- [x] Click a `mailto:foo@bar?subject=Hi&body=Hello` → compose window opens prefilled (to/cc/bcc/subject/body all round-trip)
- [x] `HTTPS://EXAMPLE.COM` is accepted (case-insensitive scheme)
- [x] `mailto:` / `tel:` are accepted; `javascript:` / `file:` / `data:` are refused with a clear error
- [x] Wikipedia URL `…/Foo_(bar)` linkifies with the closing paren intact
- [x] Plain prose containing `< b` or `span >` is not mangled by DOMParser
- [x] Calendar event with URL in `location` → linkified
- [x] Calendar event with Exchange HTML description (large `<style>` block, anchor links) → renders as readable text, no CSS leaks, anchor URLs clickable
- [x] Contact notes with a URL → linkified
- [x] Contact email → click composes; phone → click hands off to OS; hover previews on both
- [x] Toggle HTML in the reader, navigate to next message → still HTML; toggle to plain → next is plain; restart app → choice persists