### PR TITLE
fix(mail): refetch messages when switching accounts to a same-named folder

### DIFF
--- a/src/stores/messages.ts
+++ b/src/stores/messages.ts
@@ -728,8 +728,13 @@ export const useMessagesStore = defineStore("messages", () => {
     fetchMessages();
   }
 
+  // Key on both account and folder path. Two accounts can share a folder
+  // name (e.g. "INBOX"), so watching the path alone never fires when the
+  // user clicks INBOX in account B while INBOX in account A is active,
+  // and the list keeps showing A's messages until a different folder is
+  // clicked first.
   watch(
-    () => foldersStore.activeFolderPath,
+    () => [accountsStore.activeAccountId, foldersStore.activeFolderPath] as const,
     () => {
       activeMessage.value = null;
       activeMessageId.value = null;


### PR DESCRIPTION
## Summary
- The messages-store watcher in \`src/stores/messages.ts\` keyed only on \`foldersStore.activeFolderPath\`.
- \`FolderTree.selectFolder\` writes the folder path first and the account id second. When both accounts have a folder with the same path (\"INBOX\"), the path ref never changes on the account switch, the watcher never fires, and the list keeps the previous account's messages.
- Workaround was to click any other folder of the new account first, which forced a path change.
- Fix: key the watcher on \`[activeAccountId, activeFolderPath]\` so either edge triggers \`fetchMessages\` (plus the existing selection/server-search reset).

## Test plan
- [x] Build passes (\`pnpm run build\`)
- [x] Account A → Inbox shows A's messages; click account B → Inbox in the sidebar directly, list refreshes to B's messages
- [x] Back to A → Inbox, A's messages reappear
- [x] Within a single account, switching between Inbox and any other folder still works
- [x] Same-name custom folders across accounts (e.g. both have \"Archive\") also switch correctly