### PR TITLE
fix(mail): refetch when switching to same-named folder of another account

### DIFF
--- a/src/components/mail/FolderTree.vue
+++ b/src/components/mail/FolderTree.vue
@@ -112,9 +112,20 @@ function toggleAccountCollapse(accountId: string) {
 function selectFolder(accountId: string, folderPath: string) {
   // Set the folder path BEFORE switching accounts so the watcher
   // in the folders store doesn't reset it to Inbox.
+  const accountChanged = accountsStore.activeAccountId !== accountId;
+  const folderChanged = foldersStore.activeFolderPath !== folderPath;
   foldersStore.setActiveFolder(folderPath);
-  if (accountsStore.activeAccountId !== accountId) {
+  if (accountChanged) {
     accountsStore.setActiveAccount(accountId);
+  }
+  // When both accounts share a folder name (the typical IMAP case where
+  // both have "INBOX"), neither ref changes by value if the user clicks
+  // the other account's same-named folder, so the messages-store watcher
+  // doesn't always fire reliably. Dispatch the refetch explicitly when
+  // the account changes to make this case work without relying on the
+  // exact ordering of folder/account reactivity.
+  if (accountChanged && !folderChanged) {
+    messagesStore.fetchMessages();
   }
 }
 


### PR DESCRIPTION
## Summary
Follow-up to #164. The messages-store watcher on \`[activeAccountId, activeFolderPath]\` should fire on either edge, but when both accounts share an IMAP \`INBOX\` path the watcher's behavior turned out to be unreliable for the same-folder-name cross-account case: clicking account B's INBOX while on A's INBOX still occasionally kept A's messages in the list.

\`FolderTree.selectFolder\` now detects when the account changed but the folder path string did not, and dispatches \`messagesStore.fetchMessages()\` explicitly. The watcher remains in place as the general-case trigger; this is a deterministic fallback for the cross-account same-path edge.

## Test plan
- [x] Build passes (\`pnpm run build\`)
- [x] Account A INBOX → click account B INBOX in sidebar directly: list refreshes to B's messages
- [x] Account B INBOX → click account A INBOX: list refreshes back to A
- [x] Same-account folder switches still work (Inbox ↔ Sent ↔ Drafts)
- [x] Cross-account switch to a non-matching folder still works (no double-fetch regression)