### PR TITLE
add:  O365 room availability status to event form

### DIFF
--- a/src-tauri/src/commands/calendar.rs
+++ b/src-tauri/src/commands/calendar.rs
@@ -797,7 +797,7 @@ pub async fn list_room_suggestions(
         return Ok(Vec::new());
     }
 
-    let token = crate::mail::graph::get_graph_token(&account.id).await?;
+    let token = crate::mail::graph::get_graph_token_for_rooms(&account.id).await?;
     let client = crate::mail::graph::GraphClient::new(&token);
     let rooms = client.list_rooms().await?;
     Ok(rooms
@@ -830,7 +830,7 @@ pub async fn check_room_availability(
         });
     }
 
-    let token = crate::mail::graph::get_graph_token(&account.id).await?;
+    let token = crate::mail::graph::get_graph_token_for_rooms(&account.id).await?;
     let client = crate::mail::graph::GraphClient::new(&token);
     let availability = client
         .get_room_availability(&room_address, &start_time, &end_time)

--- a/src-tauri/src/commands/calendar.rs
+++ b/src-tauri/src/commands/calendar.rs
@@ -1,4 +1,4 @@
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use tauri::State;
 
 use crate::calendar::ical::{self, ParsedInvite};
@@ -83,6 +83,19 @@ pub struct MeetBindingInput {
     pub protocol: String,
     pub meeting_id: String,
     pub join_url: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RoomSuggestion {
+    pub name: String,
+    pub address: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RoomAvailability {
+    pub state: String,
+    pub busy_start: Option<String>,
+    pub busy_end: Option<String>,
 }
 
 /// Defence-in-depth check on a client-supplied meet binding before
@@ -763,6 +776,71 @@ pub async fn create_event(state: State<'_, AppState>, event: NewEventInput) -> R
 
     log::info!("create_event: created event id={}", id);
     Ok(id)
+}
+
+#[tauri::command]
+pub async fn list_room_suggestions(
+    state: State<'_, AppState>,
+    account_id: String,
+) -> Result<Vec<RoomSuggestion>> {
+    let account = {
+        let conn = state.db.reader();
+        db::accounts::get_account_full(&conn, &account_id)?
+    };
+
+    if account.calendar_protocol_str() != "graph" {
+        log::debug!(
+            "list_room_suggestions: skipping non-graph account {} ({})",
+            account.id,
+            account.calendar_protocol_str()
+        );
+        return Ok(Vec::new());
+    }
+
+    let token = crate::mail::graph::get_graph_token(&account.id).await?;
+    let client = crate::mail::graph::GraphClient::new(&token);
+    let rooms = client.list_rooms().await?;
+    Ok(rooms
+        .into_iter()
+        .map(|room| RoomSuggestion {
+            name: room.name,
+            address: room.address,
+        })
+        .collect())
+}
+
+#[tauri::command]
+pub async fn check_room_availability(
+    state: State<'_, AppState>,
+    account_id: String,
+    room_address: String,
+    start_time: String,
+    end_time: String,
+) -> Result<RoomAvailability> {
+    let account = {
+        let conn = state.db.reader();
+        db::accounts::get_account_full(&conn, &account_id)?
+    };
+
+    if account.calendar_protocol_str() != "graph" {
+        return Ok(RoomAvailability {
+            state: "unknown".into(),
+            busy_start: None,
+            busy_end: None,
+        });
+    }
+
+    let token = crate::mail::graph::get_graph_token(&account.id).await?;
+    let client = crate::mail::graph::GraphClient::new(&token);
+    let availability = client
+        .get_room_availability(&room_address, &start_time, &end_time)
+        .await?;
+
+    Ok(RoomAvailability {
+        state: availability.state,
+        busy_start: availability.busy_start,
+        busy_end: availability.busy_end,
+    })
 }
 
 /// Push the event title back to the meet provider as the meeting's

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -116,6 +116,8 @@ pub fn run() {
             commands::calendar::update_calendar,
             commands::calendar::delete_calendar,
             commands::calendar::get_events,
+            commands::calendar::list_room_suggestions,
+            commands::calendar::check_room_availability,
             commands::calendar::create_event,
             commands::calendar::update_event,
             commands::calendar::delete_event,

--- a/src-tauri/src/mail/graph.rs
+++ b/src-tauri/src/mail/graph.rs
@@ -9,6 +9,7 @@ use crate::mail::search::{build_graph_kql, SearchHit, SearchQuery};
 use serde::{Deserialize, Serialize};
 
 const GRAPH_BASE: &str = "https://graph.microsoft.com/v1.0";
+const GRAPH_BETA_BASE: &str = "https://graph.microsoft.com/beta";
 
 // ---------------------------------------------------------------------------
 // Graph client
@@ -17,6 +18,19 @@ const GRAPH_BASE: &str = "https://graph.microsoft.com/v1.0";
 pub struct GraphClient {
     http: reqwest::Client,
     access_token: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct GraphRoom {
+    pub name: String,
+    pub address: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct GraphRoomAvailability {
+    pub state: String,
+    pub busy_start: Option<String>,
+    pub busy_end: Option<String>,
 }
 
 impl GraphClient {
@@ -51,6 +65,32 @@ impl GraphClient {
 
         serde_json::from_str(&body)
             .map_err(|e| Error::Other(format!("Graph JSON parse failed: {}", e)))
+    }
+
+    async fn get_beta(&self, path: &str, params: &[(&str, &str)]) -> Result<serde_json::Value> {
+        let url = format!("{}{}", GRAPH_BETA_BASE, path);
+        let resp = self
+            .http
+            .get(&url)
+            .bearer_auth(&self.access_token)
+            .query(params)
+            .send()
+            .await
+            .map_err(|e| Error::Other(format!("Graph beta GET {} failed: {}", path, e)))?;
+
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        if !status.is_success() {
+            return Err(Error::Other(format!(
+                "Graph beta GET {} returned {}: {}",
+                path,
+                status,
+                truncate(&body, 500)
+            )));
+        }
+
+        serde_json::from_str(&body)
+            .map_err(|e| Error::Other(format!("Graph beta JSON parse failed: {}", e)))
     }
 
     /// Stream a Graph API response directly to a file on disk.
@@ -637,6 +677,201 @@ impl GraphClient {
             .collect())
     }
 
+    /// List meeting rooms for O365 event creation via the beta room-list API.
+    pub async fn list_rooms(&self) -> Result<Vec<GraphRoom>> {
+        let mut rooms = Vec::new();
+
+        log::info!("Graph rooms: listing room lists via v1.0 /places/microsoft.graph.roomlist");
+        let room_lists = match self
+            .get(
+                "/places/microsoft.graph.roomlist",
+                &[("$top", "200"), ("$select", "displayName,emailAddress")],
+            )
+            .await
+        {
+            Ok(value) => Some(value),
+            Err(e) => {
+                log::warn!(
+                    "Graph rooms: v1.0 /places/microsoft.graph.roomlist failed, falling back to beta room-list lookup: {}",
+                    e
+                );
+                None
+            }
+        };
+
+        if let Some(room_lists) = room_lists {
+            let lists = parse_graph_named_addresses(&room_lists["value"]);
+            log::info!("Graph rooms: found {} room lists", lists.len());
+            for (name, address) in lists {
+                log::info!("Graph rooms: using room list '{}' <{}>", name, address);
+
+                let path = format!(
+                    "/places/{}/microsoft.graph.roomlist/rooms",
+                    urlencoding::encode(&address)
+                );
+                log::debug!(
+                    "Graph rooms: fetching rooms for list '{}' <{}> via Places",
+                    name,
+                    address
+                );
+
+                match self
+                    .get(
+                        &path,
+                        &[("$top", "200"), ("$select", "displayName,emailAddress")],
+                    )
+                    .await
+                {
+                    Ok(resp) => {
+                        let mut list_rooms = parse_graph_rooms(&resp["value"]);
+                        log::info!(
+                            "Graph rooms: list '{}' returned {} rooms",
+                            if name.is_empty() { address } else { name },
+                            list_rooms.len()
+                        );
+                        rooms.append(&mut list_rooms);
+                    }
+                    Err(e) => {
+                        log::warn!(
+                            "Graph rooms: Places rooms failed for list '{}' <{}>: {}",
+                            name,
+                            address,
+                            e
+                        );
+                    }
+                }
+            }
+        }
+
+        if rooms.is_empty() {
+            log::info!("Graph rooms: falling back to v1.0 /places/microsoft.graph.room");
+            match self
+                .get(
+                    "/places/microsoft.graph.room",
+                    &[("$top", "200"), ("$select", "displayName,emailAddress")],
+                )
+                .await
+            {
+                Ok(resp) => {
+                    let mut place_rooms = parse_graph_rooms(&resp["value"]);
+                    log::info!(
+                        "Graph rooms: places direct rooms returned {} rooms",
+                        place_rooms.len()
+                    );
+                    rooms.append(&mut place_rooms);
+                }
+                Err(e) => {
+                    log::warn!(
+                        "Graph rooms: v1.0 /places/microsoft.graph.room failed, falling back to beta /me/findRoomLists: {}",
+                        e
+                    );
+                }
+            }
+        }
+
+        if rooms.is_empty() {
+            log::info!("Graph rooms: listing room lists via beta /me/findRoomLists");
+            let room_lists = match self.get_beta("/me/findRoomLists", &[]).await {
+                Ok(value) => Some(value),
+                Err(e) => {
+                    log::warn!(
+                        "Graph rooms: beta /me/findRoomLists failed, falling back to direct rooms lookup: {}",
+                        e
+                    );
+                    None
+                }
+            };
+
+            if let Some(room_lists) = room_lists {
+                let lists = parse_graph_named_addresses(&room_lists["value"]);
+                log::info!("Graph rooms: found {} beta room lists", lists.len());
+                for (name, address) in lists {
+                    let path = format!("/me/findRooms(RoomList='{}')", address.replace('\'', "''"));
+                    log::debug!(
+                        "Graph rooms: fetching beta rooms for list '{}' <{}>",
+                        name,
+                        address
+                    );
+
+                    match self.get_beta(&path, &[]).await {
+                        Ok(resp) => {
+                            let mut list_rooms = parse_graph_rooms(&resp["value"]);
+                            log::info!(
+                                "Graph rooms: beta list '{}' returned {} rooms",
+                                if name.is_empty() { address } else { name },
+                                list_rooms.len()
+                            );
+                            rooms.append(&mut list_rooms);
+                        }
+                        Err(e) => {
+                            log::warn!(
+                                "Graph rooms: beta findRooms failed for list '{}' <{}>: {}",
+                                name,
+                                address,
+                                e
+                            );
+                        }
+                    }
+                }
+            }
+        }
+
+        if rooms.is_empty() {
+            log::info!("Graph rooms: falling back to beta /me/findRooms");
+            match self.get_beta("/me/findRooms", &[]).await {
+                Ok(resp) => {
+                    let mut direct_rooms = parse_graph_rooms(&resp["value"]);
+                    log::info!(
+                        "Graph rooms: direct findRooms returned {} rooms",
+                        direct_rooms.len()
+                    );
+                    rooms.append(&mut direct_rooms);
+                }
+                Err(e) => {
+                    log::warn!("Graph rooms: beta /me/findRooms failed: {}", e);
+                }
+            }
+        }
+
+        let unique = dedupe_graph_rooms(rooms);
+        log::info!("Graph rooms: returning {} normalized rooms", unique.len());
+        Ok(unique)
+    }
+
+    /// Check whether a room resource is free for a specific time range.
+    pub async fn get_room_availability(
+        &self,
+        room_address: &str,
+        start: &str,
+        end: &str,
+    ) -> Result<GraphRoomAvailability> {
+        let start_utc = normalize_schedule_datetime(start)?;
+        let end_utc = normalize_schedule_datetime(end)?;
+
+        log::debug!(
+            "Graph rooms: getSchedule for {} from {} to {}",
+            room_address,
+            start_utc,
+            end_utc
+        );
+
+        let body = serde_json::json!({
+            "schedules": [room_address],
+            "startTime": {
+                "dateTime": start_utc,
+                "timeZone": "UTC",
+            },
+            "endTime": {
+                "dateTime": end_utc,
+                "timeZone": "UTC",
+            },
+            "availabilityViewInterval": 30,
+        });
+
+        let resp = self.post_json("/me/calendar/getSchedule", &body).await?;
+        Ok(parse_graph_room_availability(&resp))
+    }
+
     /// Rename a calendar via PATCH /me/calendars/{id}.
     pub async fn rename_calendar(&self, calendar_id: &str, new_name: &str) -> Result<()> {
         log::info!("Graph rename calendar: id={} -> {}", calendar_id, new_name);
@@ -1058,6 +1293,114 @@ pub struct GraphCalendarEvent {
     pub is_recurring: bool,
 }
 
+fn parse_graph_rooms(value: &serde_json::Value) -> Vec<GraphRoom> {
+    parse_graph_named_addresses(value)
+        .into_iter()
+        .map(|(name, address)| GraphRoom { name, address })
+        .collect()
+}
+
+fn normalize_schedule_datetime(datetime: &str) -> Result<String> {
+    chrono::DateTime::parse_from_rfc3339(datetime)
+        .map(|dt| {
+            dt.with_timezone(&chrono::Utc)
+                .format("%Y-%m-%dT%H:%M:%S")
+                .to_string()
+        })
+        .map_err(|e| Error::Other(format!("Invalid schedule datetime '{}': {}", datetime, e)))
+}
+
+fn parse_graph_room_availability(value: &serde_json::Value) -> GraphRoomAvailability {
+    let Some(schedule) = value["value"]
+        .as_array()
+        .and_then(|entries| entries.first())
+    else {
+        return GraphRoomAvailability {
+            state: "unknown".into(),
+            busy_start: None,
+            busy_end: None,
+        };
+    };
+
+    if let Some(item) = schedule["scheduleItems"]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .find(|item| {
+            matches!(
+                item["status"]
+                    .as_str()
+                    .unwrap_or("")
+                    .to_ascii_lowercase()
+                    .as_str(),
+                "busy" | "tentative" | "oof" | "workingelsewhere"
+            )
+        })
+    {
+        return GraphRoomAvailability {
+            state: "busy".into(),
+            busy_start: item["start"]["dateTime"].as_str().map(|s| s.to_string()),
+            busy_end: item["end"]["dateTime"].as_str().map(|s| s.to_string()),
+        };
+    }
+
+    GraphRoomAvailability {
+        state: "available".into(),
+        busy_start: None,
+        busy_end: None,
+    }
+}
+
+fn parse_graph_named_addresses(value: &serde_json::Value) -> Vec<(String, String)> {
+    value
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter_map(|entry| {
+            let address = entry["address"]
+                .as_str()
+                .or_else(|| entry["emailAddress"].as_str())?
+                .trim();
+            if address.is_empty() {
+                return None;
+            }
+
+            let name = entry["name"]
+                .as_str()
+                .or_else(|| entry["displayName"].as_str())
+                .unwrap_or(address)
+                .trim();
+            Some((
+                if name.is_empty() {
+                    address.to_string()
+                } else {
+                    name.to_string()
+                },
+                address.to_string(),
+            ))
+        })
+        .collect()
+}
+
+fn dedupe_graph_rooms(rooms: Vec<GraphRoom>) -> Vec<GraphRoom> {
+    let mut seen = std::collections::HashSet::new();
+    let mut unique = Vec::new();
+
+    for room in rooms {
+        let key = room.address.to_ascii_lowercase();
+        if seen.insert(key) {
+            unique.push(room);
+        }
+    }
+
+    unique.sort_by(|a, b| {
+        a.name
+            .to_ascii_lowercase()
+            .cmp(&b.name.to_ascii_lowercase())
+    });
+    unique
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -1466,7 +1809,10 @@ pub async fn get_graph_token(account_id: &str) -> Result<String> {
 
 #[cfg(test)]
 mod color_tests {
-    use super::{graph_color_to_hex, nearest_outlook_color};
+    use super::{
+        dedupe_graph_rooms, graph_color_to_hex, nearest_outlook_color, normalize_schedule_datetime,
+        parse_graph_named_addresses, parse_graph_room_availability, parse_graph_rooms, GraphRoom,
+    };
 
     #[test]
     fn anchor_round_trip() {
@@ -1518,5 +1864,159 @@ mod color_tests {
         assert_ne!(nearest_outlook_color("#000000"), "maxColor");
         assert_ne!(nearest_outlook_color("#ffffff"), "maxColor");
         assert_ne!(nearest_outlook_color("#8b5cf6"), "maxColor");
+    }
+
+    #[test]
+    fn parse_graph_rooms_normalizes_name_and_address() {
+        let value = serde_json::json!([
+            {"name": "Board Room", "address": "board@example.com"},
+            {"name": "", "address": "fallback@example.com"},
+            {"name": "Ignored", "address": ""}
+        ]);
+
+        let rooms = parse_graph_rooms(&value);
+        assert_eq!(rooms.len(), 2);
+        assert_eq!(rooms[0].name, "Board Room");
+        assert_eq!(rooms[0].address, "board@example.com");
+        assert_eq!(rooms[1].name, "fallback@example.com");
+        assert_eq!(rooms[1].address, "fallback@example.com");
+    }
+
+    #[test]
+    fn parse_graph_named_addresses_filters_blank_addresses() {
+        let value = serde_json::json!([
+            {"name": "Building 1 Rooms", "address": "building1@example.com"},
+            {"name": "", "address": "fallback@example.com"},
+            {"name": "Ignored", "address": ""}
+        ]);
+
+        let items = parse_graph_named_addresses(&value);
+        assert_eq!(items.len(), 2);
+        assert_eq!(
+            items[0],
+            (
+                "Building 1 Rooms".to_string(),
+                "building1@example.com".to_string()
+            )
+        );
+        assert_eq!(
+            items[1],
+            (
+                "fallback@example.com".to_string(),
+                "fallback@example.com".to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn parse_graph_named_addresses_supports_places_payload() {
+        let value = serde_json::json!([
+            {"displayName": "Building 1 Rooms", "emailAddress": "building1@example.com"},
+            {"displayName": "", "emailAddress": "fallback@example.com"},
+            {"displayName": "Ignored", "emailAddress": ""}
+        ]);
+
+        let items = parse_graph_named_addresses(&value);
+        assert_eq!(items.len(), 2);
+        assert_eq!(
+            items[0],
+            (
+                "Building 1 Rooms".to_string(),
+                "building1@example.com".to_string()
+            )
+        );
+        assert_eq!(
+            items[1],
+            (
+                "fallback@example.com".to_string(),
+                "fallback@example.com".to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn dedupe_graph_rooms_keeps_unique_addresses() {
+        let rooms = vec![
+            GraphRoom {
+                name: "Zebra".into(),
+                address: "room@example.com".into(),
+            },
+            GraphRoom {
+                name: "Alpha".into(),
+                address: "ROOM@example.com".into(),
+            },
+            GraphRoom {
+                name: "Beta".into(),
+                address: "beta@example.com".into(),
+            },
+        ];
+
+        let unique = dedupe_graph_rooms(rooms);
+        assert_eq!(unique.len(), 2);
+        assert_eq!(unique[0].name, "Beta");
+        assert_eq!(unique[1].address, "room@example.com");
+    }
+
+    #[test]
+    fn normalize_schedule_datetime_converts_to_utc_naive_format() {
+        assert_eq!(
+            normalize_schedule_datetime("2026-05-19T10:00:00+02:00").unwrap(),
+            "2026-05-19T08:00:00"
+        );
+    }
+
+    #[test]
+    fn parse_graph_room_availability_detects_busy_slots() {
+        let value = serde_json::json!({
+            "value": [
+                {
+                    "scheduleItems": [
+                        {
+                            "status": "free",
+                            "start": { "dateTime": "2026-05-19T09:00:00.0000000" },
+                            "end": { "dateTime": "2026-05-19T10:00:00.0000000" }
+                        },
+                        {
+                            "status": "busy",
+                            "start": { "dateTime": "2026-05-19T10:30:00.0000000" },
+                            "end": { "dateTime": "2026-05-19T11:00:00.0000000" }
+                        }
+                    ]
+                }
+            ]
+        });
+
+        let availability = parse_graph_room_availability(&value);
+        assert_eq!(availability.state, "busy");
+        assert_eq!(
+            availability.busy_start.as_deref(),
+            Some("2026-05-19T10:30:00.0000000")
+        );
+        assert_eq!(
+            availability.busy_end.as_deref(),
+            Some("2026-05-19T11:00:00.0000000")
+        );
+    }
+
+    #[test]
+    fn parse_graph_room_availability_defaults_to_available_without_blocks() {
+        let value = serde_json::json!({
+            "value": [
+                {
+                    "scheduleItems": [
+                        {
+                            "status": "free",
+                            "start": { "dateTime": "2026-05-19T09:00:00.0000000" },
+                            "end": { "dateTime": "2026-05-19T10:00:00.0000000" }
+                        }
+                    ]
+                }
+            ]
+        });
+
+        let availability = parse_graph_room_availability(&value);
+        assert_eq!(availability.state, "available");
+        assert!(availability.busy_start.is_none());
+        assert!(availability.busy_end.is_none());
     }
 }

--- a/src-tauri/src/mail/graph.rs
+++ b/src-tauri/src/mail/graph.rs
@@ -93,6 +93,52 @@ impl GraphClient {
             .map_err(|e| Error::Other(format!("Graph beta JSON parse failed: {}", e)))
     }
 
+    /// GET an absolute Graph URL (used to follow `@odata.nextLink`,
+    /// which Graph returns as a fully-qualified URL rather than a path).
+    async fn get_absolute(&self, url: &str) -> Result<serde_json::Value> {
+        let resp = self
+            .http
+            .get(url)
+            .bearer_auth(&self.access_token)
+            .send()
+            .await
+            .map_err(|e| Error::Other(format!("Graph GET {} failed: {}", url, e)))?;
+
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        if !status.is_success() {
+            return Err(Error::Other(format!(
+                "Graph GET {} returned {}: {}",
+                url,
+                status,
+                truncate(&body, 500)
+            )));
+        }
+
+        serde_json::from_str(&body)
+            .map_err(|e| Error::Other(format!("Graph JSON parse failed: {}", e)))
+    }
+
+    /// GET a Graph collection endpoint and return every item across all
+    /// pages, following `@odata.nextLink` until exhausted. Graph caps a
+    /// single page at `$top` items, so endpoints like the room/room-list
+    /// places APIs silently drop everything past the first page on large
+    /// tenants unless pagination is followed (PR #173 review).
+    async fn get_all(&self, path: &str, params: &[(&str, &str)]) -> Result<Vec<serde_json::Value>> {
+        let mut items = Vec::new();
+        let mut page = self.get(path, params).await?;
+        loop {
+            if let Some(values) = page["value"].as_array() {
+                items.extend(values.iter().cloned());
+            }
+            match page["@odata.nextLink"].as_str() {
+                Some(next) => page = self.get_absolute(next).await?,
+                None => break,
+            }
+        }
+        Ok(items)
+    }
+
     /// Stream a Graph API response directly to a file on disk.
     /// Returns the number of bytes written. Avoids buffering the entire
     /// response in memory — critical for large emails with attachments.
@@ -683,7 +729,7 @@ impl GraphClient {
 
         log::info!("Graph rooms: listing room lists via v1.0 /places/microsoft.graph.roomlist");
         let room_lists = match self
-            .get(
+            .get_all(
                 "/places/microsoft.graph.roomlist",
                 &[("$top", "200"), ("$select", "displayName,emailAddress")],
             )
@@ -700,7 +746,7 @@ impl GraphClient {
         };
 
         if let Some(room_lists) = room_lists {
-            let lists = parse_graph_named_addresses(&room_lists["value"]);
+            let lists = parse_graph_named_addresses(&serde_json::Value::Array(room_lists));
             log::info!("Graph rooms: found {} room lists", lists.len());
             for (name, address) in lists {
                 log::info!("Graph rooms: using room list '{}' <{}>", name, address);
@@ -716,14 +762,14 @@ impl GraphClient {
                 );
 
                 match self
-                    .get(
+                    .get_all(
                         &path,
                         &[("$top", "200"), ("$select", "displayName,emailAddress")],
                     )
                     .await
                 {
                     Ok(resp) => {
-                        let mut list_rooms = parse_graph_rooms(&resp["value"]);
+                        let mut list_rooms = parse_graph_rooms(&serde_json::Value::Array(resp));
                         log::info!(
                             "Graph rooms: list '{}' returned {} rooms",
                             if name.is_empty() { address } else { name },
@@ -746,14 +792,14 @@ impl GraphClient {
         if rooms.is_empty() {
             log::info!("Graph rooms: falling back to v1.0 /places/microsoft.graph.room");
             match self
-                .get(
+                .get_all(
                     "/places/microsoft.graph.room",
                     &[("$top", "200"), ("$select", "displayName,emailAddress")],
                 )
                 .await
             {
                 Ok(resp) => {
-                    let mut place_rooms = parse_graph_rooms(&resp["value"]);
+                    let mut place_rooms = parse_graph_rooms(&serde_json::Value::Array(resp));
                     log::info!(
                         "Graph rooms: places direct rooms returned {} rooms",
                         place_rooms.len()
@@ -1322,6 +1368,21 @@ fn parse_graph_room_availability(value: &serde_json::Value) -> GraphRoomAvailabi
         };
     };
 
+    // Graph getSchedule reports per-recipient failures (unresolvable
+    // mailbox, free/busy not published, throttling) via an `error`
+    // object on the schedule entry. Without `scheduleItems`/
+    // `availabilityView` we genuinely don't know — never report "free".
+    if !schedule["error"].is_null()
+        || (schedule["scheduleItems"].as_array().is_none()
+            && schedule["availabilityView"].as_str().is_none())
+    {
+        return GraphRoomAvailability {
+            state: "unknown".into(),
+            busy_start: None,
+            busy_end: None,
+        };
+    }
+
     if let Some(item) = schedule["scheduleItems"]
         .as_array()
         .into_iter()
@@ -1776,6 +1837,21 @@ fn nearest_outlook_color(hex: &str) -> &'static str {
 /// Always refreshes with Graph-specific scopes because the stored token
 /// may be IMAP-scoped (both share the same keyring entry and refresh token).
 pub async fn get_graph_token(account_id: &str) -> Result<String> {
+    get_graph_token_with_scopes(account_id, crate::oauth::MICROSOFT_GRAPH_SCOPES).await
+}
+
+/// Like [`get_graph_token`] but requests the room scopes (`Place.Read.All`).
+///
+/// Accounts that signed in before room support existed never consented to
+/// `Place.Read.All`, so this refresh fails them with consent_required. That
+/// is expected: callers (room suggestion/availability commands) treat the
+/// error as "rooms unavailable" and never let it disrupt baseline Graph
+/// operations, which keep using the consent-safe [`get_graph_token`].
+pub async fn get_graph_token_for_rooms(account_id: &str) -> Result<String> {
+    get_graph_token_with_scopes(account_id, crate::oauth::MICROSOFT_GRAPH_ROOM_SCOPES).await
+}
+
+async fn get_graph_token_with_scopes(account_id: &str, scopes: &str) -> Result<String> {
     let tokens = crate::oauth::load_tokens(account_id)?.ok_or_else(|| {
         Error::Other("No O365 OAuth tokens. Please sign in with Microsoft.".into())
     })?;
@@ -1785,12 +1861,8 @@ pub async fn get_graph_token(account_id: &str) -> Result<String> {
         .ok_or_else(|| Error::Other("No refresh token for O365. Please sign in again.".into()))?;
 
     // Always refresh with Graph scopes — the cached token is likely IMAP-scoped
-    let new_tokens = crate::oauth::refresh_with_scopes(
-        &crate::oauth::MICROSOFT,
-        &refresh_token,
-        crate::oauth::MICROSOFT_GRAPH_SCOPES,
-    )
-    .await?;
+    let new_tokens =
+        crate::oauth::refresh_with_scopes(&crate::oauth::MICROSOFT, &refresh_token, scopes).await?;
     // Don't overwrite the stored tokens — IMAP sync needs the IMAP-scoped token.
     // The refresh_token may rotate, so save that part only.
     if new_tokens.refresh_token.is_some() {
@@ -2018,5 +2090,42 @@ mod color_tests {
         assert_eq!(availability.state, "available");
         assert!(availability.busy_start.is_none());
         assert!(availability.busy_end.is_none());
+    }
+
+    #[test]
+    fn parse_graph_room_availability_reports_unknown_on_schedule_error() {
+        // A per-recipient `error` (e.g. mailbox not found, free/busy
+        // not published) must surface as "unknown" — never "available",
+        // which would tell the user a room is free when Graph failed.
+        let value = serde_json::json!({
+            "value": [
+                {
+                    "scheduleId": "board@example.com",
+                    "error": {
+                        "message": "ErrorMailRecipientNotFound",
+                        "responseCode": "MailRecipientNotFound"
+                    }
+                }
+            ]
+        });
+
+        let availability = parse_graph_room_availability(&value);
+        assert_eq!(availability.state, "unknown");
+        assert!(availability.busy_start.is_none());
+        assert!(availability.busy_end.is_none());
+    }
+
+    #[test]
+    fn parse_graph_room_availability_reports_unknown_without_free_busy_data() {
+        // A schedule entry carrying neither scheduleItems nor an
+        // availabilityView gives us nothing to judge on — "unknown".
+        let value = serde_json::json!({
+            "value": [
+                { "scheduleId": "board@example.com" }
+            ]
+        });
+
+        let availability = parse_graph_room_availability(&value);
+        assert_eq!(availability.state, "unknown");
     }
 }

--- a/src-tauri/src/oauth.rs
+++ b/src-tauri/src/oauth.rs
@@ -73,8 +73,10 @@ pub const MICROSOFT: OAuthProvider = OAuthProvider {
     // Request all scopes during authorization for consent.
     // IMAP/SMTP use outlook.office.com (not office365.com) for personal accounts.
     // Graph scopes use short form (resolved to graph.microsoft.com automatically).
-    // All Graph scopes here must also appear in MICROSOFT_GRAPH_SCOPES or token
-    // refresh will fail with AADSTS65001 (consent_required).
+    // Every Graph scope here must appear in MICROSOFT_GRAPH_SCOPES *or*
+    // MICROSOFT_GRAPH_ROOM_SCOPES, or the corresponding token refresh fails
+    // with AADSTS65001 (consent_required). `Place.Read.All` is deliberately
+    // kept out of the baseline MICROSOFT_GRAPH_SCOPES — see that constant.
     scopes: &[
         "https://outlook.office.com/IMAP.AccessAsUser.All",
         "https://outlook.office.com/SMTP.Send",
@@ -95,7 +97,23 @@ pub const MICROSOFT: OAuthProvider = OAuthProvider {
 };
 
 /// Microsoft Graph scopes — used for a separate token refresh for calendar/contacts.
+///
+/// Deliberately excludes `Place.Read.All`: accounts that signed in before
+/// room support was added never consented to it, so requesting it on every
+/// `get_graph_token()` refresh would fail those accounts with consent_required
+/// (AADSTS65001) and break mail/calendar/contacts sync even when the user
+/// never touches room suggestions. Room features use
+/// [`MICROSOFT_GRAPH_ROOM_SCOPES`] via a separate, room-specific token
+/// request that is allowed to fail gracefully.
 pub const MICROSOFT_GRAPH_SCOPES: &str =
+    "User.Read Mail.ReadWrite Calendars.ReadWrite Contacts.ReadWrite offline_access";
+
+/// Graph scopes for room discovery/availability — the baseline scopes plus
+/// `Place.Read.All`. Requested only by the room-specific token path; a
+/// refresh failure here means rooms are unavailable for that account (an
+/// account that predates room support and never consented), and callers
+/// must treat that as a soft failure rather than propagating it.
+pub const MICROSOFT_GRAPH_ROOM_SCOPES: &str =
     "User.Read Mail.ReadWrite Calendars.ReadWrite Contacts.ReadWrite Place.Read.All offline_access";
 
 /// Zoom OAuth (#148, video conferencing). Native app with PKCE —

--- a/src-tauri/src/oauth.rs
+++ b/src-tauri/src/oauth.rs
@@ -82,6 +82,7 @@ pub const MICROSOFT: OAuthProvider = OAuthProvider {
         "Mail.ReadWrite",
         "Calendars.ReadWrite",
         "Contacts.ReadWrite",
+        "Place.Read.All",
         "offline_access",
         "openid",
         "profile",
@@ -95,7 +96,7 @@ pub const MICROSOFT: OAuthProvider = OAuthProvider {
 
 /// Microsoft Graph scopes — used for a separate token refresh for calendar/contacts.
 pub const MICROSOFT_GRAPH_SCOPES: &str =
-    "User.Read Mail.ReadWrite Calendars.ReadWrite Contacts.ReadWrite offline_access";
+    "User.Read Mail.ReadWrite Calendars.ReadWrite Contacts.ReadWrite Place.Read.All offline_access";
 
 /// Zoom OAuth (#148, video conferencing). Native app with PKCE —
 /// no client_secret ships in the binary. Registered on Zoom

--- a/src/__tests__/calendar.test.ts
+++ b/src/__tests__/calendar.test.ts
@@ -4,6 +4,7 @@ import { setActivePinia, createPinia } from "pinia";
 vi.mock("@/lib/tauri", () => ({
   listAccounts: vi.fn().mockResolvedValue([]),
   listCalendars: vi.fn().mockResolvedValue([]),
+  listRoomSuggestions: vi.fn().mockResolvedValue([]),
   getEvents: vi.fn().mockResolvedValue([]),
   createEvent: vi.fn().mockResolvedValue("evt-1"),
   updateEvent: vi.fn().mockResolvedValue(undefined),

--- a/src/__tests__/event-form-room-suggestions.test.ts
+++ b/src/__tests__/event-form-room-suggestions.test.ts
@@ -122,4 +122,42 @@ describe("EventForm room suggestions", () => {
     );
     expect(wrapper.get('[data-testid="event-form-room-availability"]').text()).toContain("Busy");
   });
+
+  it("checks all-day room availability in the display timezone, not UTC midnight", async () => {
+    const uiStore = useUiStore();
+    uiStore.displayTimezone = "Europe/Stockholm";
+
+    vi.mocked(api.listRoomSuggestions).mockResolvedValueOnce([
+      { name: "Board Room", address: "board@example.com" },
+    ]);
+
+    const wrapper = mount(EventForm, {
+      props: {
+        initialStart: "2026-05-19T10:00:00Z",
+      },
+      global: {
+        stubs: {
+          RecurrenceEditor: { template: "<div />" },
+          AttendeeEditor: { template: "<div />" },
+          TimeInput: { template: "<input />" },
+          DateInput: { template: "<input />" },
+          Select: { template: "<div />" },
+        },
+      },
+    });
+
+    await flushPromises();
+    await wrapper.get('[data-testid="event-form-location"]').setValue("Board Room");
+    await wrapper.get('[data-testid="event-form-allday"]').setValue(true);
+    await flushPromises();
+
+    // May 19 (all-day) in Stockholm (CEST, UTC+2) runs from the
+    // previous day 22:00Z, not 2026-05-19T00:00:00Z.
+    const calls = vi.mocked(api.checkRoomAvailability).mock.calls;
+    const lastCall = calls[calls.length - 1];
+    expect(lastCall?.[0]).toBe("acc-o365");
+    expect(lastCall?.[1]).toBe("board@example.com");
+    expect(lastCall?.[2]).toBe("2026-05-18T22:00:00.000Z");
+    expect(lastCall?.[3]).toBe("2026-05-19T21:59:00.000Z");
+  });
 });

--- a/src/__tests__/event-form-room-suggestions.test.ts
+++ b/src/__tests__/event-form-room-suggestions.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { flushPromises, mount } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+
+vi.mock("@/lib/tauri", () => ({
+  listRoomSuggestions: vi.fn().mockResolvedValue([]),
+  checkRoomAvailability: vi.fn().mockResolvedValue({ state: "unknown", busy_start: null, busy_end: null }),
+  meetCreateUrl: vi.fn(),
+  sendInvites: vi.fn(),
+}));
+
+import EventForm from "@/components/calendar/EventForm.vue";
+import * as api from "@/lib/tauri";
+import { useAccountsStore } from "@/stores/accounts";
+import { useCalendarStore } from "@/stores/calendar";
+import { useUiStore } from "@/stores/ui";
+
+describe("EventForm room suggestions", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+
+    const accountsStore = useAccountsStore();
+    accountsStore.accounts = [
+      {
+        id: "acc-o365",
+        display_name: "Work",
+        email: "me@work.example",
+        username: "me@work.example",
+        provider: "o365",
+        mail_protocol: "graph",
+        enabled: true,
+        mail_sync_interval_seconds: null,
+        calendar_sync_interval_seconds: null,
+        contacts_sync_interval_seconds: null,
+        has_calendar_binding: true,
+        has_contacts_binding: false,
+        meet_protocol: "",
+      },
+    ];
+    accountsStore.activeAccountId = "acc-o365";
+
+    const calendarStore = useCalendarStore();
+    calendarStore.calendars = [
+      {
+        id: "cal-1",
+        account_id: "acc-o365",
+        name: "Calendar",
+        color: "#4285f4",
+        is_default: true,
+        remote_id: null,
+        is_subscribed: true,
+      },
+    ];
+
+    const uiStore = useUiStore();
+    uiStore.displayTimezone = "UTC";
+  });
+
+  it("loads O365 room suggestions into the location datalist", async () => {
+    vi.mocked(api.listRoomSuggestions).mockResolvedValueOnce([
+      { name: "Board Room", address: "board@example.com" },
+      { name: "Focus Room", address: "focus@example.com" },
+    ]);
+
+    const wrapper = mount(EventForm, {
+      global: {
+        stubs: {
+          RecurrenceEditor: { template: "<div />" },
+          AttendeeEditor: { template: "<div />" },
+          TimeInput: { template: "<input />" },
+          DateInput: { template: "<input />" },
+          Select: { template: "<div />" },
+        },
+      },
+    });
+
+    await flushPromises();
+
+    expect(api.listRoomSuggestions).toHaveBeenCalledWith("acc-o365");
+    const datalist = wrapper.get('[data-testid="event-form-room-suggestions"]');
+    const options = datalist.findAll("option");
+    expect(options).toHaveLength(2);
+    expect(options[0].attributes("value")).toBe("Board Room");
+    expect(options[0].text()).toContain("board@example.com");
+  });
+
+  it("shows room availability for the selected time", async () => {
+    vi.mocked(api.listRoomSuggestions).mockResolvedValueOnce([
+      { name: "Board Room", address: "board@example.com" },
+    ]);
+    vi.mocked(api.checkRoomAvailability).mockResolvedValueOnce({
+      state: "busy",
+      busy_start: "2026-05-19T10:30:00.0000000",
+      busy_end: "2026-05-19T11:00:00.0000000",
+    });
+
+    const wrapper = mount(EventForm, {
+      props: {
+        initialStart: "2026-05-19T10:00:00Z",
+      },
+      global: {
+        stubs: {
+          RecurrenceEditor: { template: "<div />" },
+          AttendeeEditor: { template: "<div />" },
+          TimeInput: { template: "<input />" },
+          DateInput: { template: "<input />" },
+          Select: { template: "<div />" },
+        },
+      },
+    });
+
+    await flushPromises();
+    await wrapper.get('[data-testid="event-form-location"]').setValue("Board Room");
+    await flushPromises();
+
+    expect(api.checkRoomAvailability).toHaveBeenCalledWith(
+      "acc-o365",
+      "board@example.com",
+      "2026-05-19T10:00:00.000Z",
+      "2026-05-19T11:00:00.000Z",
+    );
+    expect(wrapper.get('[data-testid="event-form-room-availability"]').text()).toContain("Busy");
+  });
+});

--- a/src/components/calendar/EventForm.vue
+++ b/src/components/calendar/EventForm.vue
@@ -175,6 +175,7 @@ const loadingRoomSuggestions = ref(false);
 const roomAvailability = ref<import("@/lib/types").RoomAvailability | null>(null);
 const checkingRoomAvailability = ref(false);
 let roomAvailabilityRequestId = 0;
+let roomSuggestionsRequestId = 0;
 
 function selectedRoom() {
   const query = location.value.trim().toLowerCase();
@@ -187,13 +188,18 @@ function selectedRoom() {
 }
 
 function currentScheduleRange() {
+  // All-day events still need a concrete UTC window for the Graph
+  // getSchedule query, and that window is the day boundaries in the
+  // user's display timezone — not UTC midnight. A Stockholm all-day
+  // event on May 19 actually runs 2026-05-18T22:00Z..2026-05-19T22:00Z.
+  const tz = uiStore.displayTimezone;
   return {
     start: allDay.value
-      ? `${startDate.value}T00:00:00Z`
-      : localInputToUTC(startDate.value, startTime.value, uiStore.displayTimezone),
+      ? localInputToUTC(startDate.value, "00:00", tz)
+      : localInputToUTC(startDate.value, startTime.value, tz),
     end: allDay.value
-      ? `${endDate.value}T23:59:59Z`
-      : localInputToUTC(endDate.value, endTime.value, uiStore.displayTimezone),
+      ? localInputToUTC(endDate.value, "23:59", tz)
+      : localInputToUTC(endDate.value, endTime.value, tz),
   };
 }
 
@@ -231,6 +237,12 @@ const roomAvailabilityMessage = computed(() => {
 });
 
 async function refreshRoomAvailability() {
+  // Claim a request id up front so any in-flight check is invalidated
+  // immediately — including when we bail out below. Otherwise a slower
+  // earlier response could still match its id and repopulate a stale
+  // message for a room/time that is no longer selected.
+  const requestId = ++roomAvailabilityRequestId;
+
   const room = selectedRoom();
   const accountId = selectedCalendarAccountId.value;
   const account = accountsStore.accounts.find((entry) => entry.id === accountId);
@@ -247,7 +259,6 @@ async function refreshRoomAvailability() {
     return;
   }
 
-  const requestId = ++roomAvailabilityRequestId;
   checkingRoomAvailability.value = true;
   try {
     const availability = await api.checkRoomAvailability(accountId, room.address, start, end);
@@ -267,6 +278,11 @@ async function refreshRoomAvailability() {
 }
 
 async function refreshRoomSuggestions() {
+  // Claim a request id so a slower load for a previously selected
+  // account can't overwrite the current account's suggestions when
+  // the user switches calendars/accounts mid-flight.
+  const requestId = ++roomSuggestionsRequestId;
+
   const accountId = selectedCalendarAccountId.value;
   const account = accountsStore.accounts.find((entry) => entry.id === accountId);
   if (!accountId || !account || (account.provider !== "o365" && account.provider !== "microsoft365")) {
@@ -277,13 +293,22 @@ async function refreshRoomSuggestions() {
 
   loadingRoomSuggestions.value = true;
   try {
-    roomSuggestions.value = await api.listRoomSuggestions(accountId);
+    const suggestions = await api.listRoomSuggestions(accountId);
+    if (requestId !== roomSuggestionsRequestId) {
+      return;
+    }
+    roomSuggestions.value = suggestions;
   } catch (e) {
+    if (requestId !== roomSuggestionsRequestId) {
+      return;
+    }
     console.error("Failed to load room suggestions:", e);
     roomSuggestions.value = [];
     roomAvailability.value = null;
   } finally {
-    loadingRoomSuggestions.value = false;
+    if (requestId === roomSuggestionsRequestId) {
+      loadingRoomSuggestions.value = false;
+    }
   }
 
   await refreshRoomAvailability();

--- a/src/components/calendar/EventForm.vue
+++ b/src/components/calendar/EventForm.vue
@@ -170,6 +170,132 @@ const recurrenceRule = ref<string | null>(null);
 const attendeeEmails = ref<string[]>([]);
 const saving = ref(false);
 const error = ref<string | null>(null);
+const roomSuggestions = ref<import("@/lib/types").RoomSuggestion[]>([]);
+const loadingRoomSuggestions = ref(false);
+const roomAvailability = ref<import("@/lib/types").RoomAvailability | null>(null);
+const checkingRoomAvailability = ref(false);
+let roomAvailabilityRequestId = 0;
+
+function selectedRoom() {
+  const query = location.value.trim().toLowerCase();
+  if (!query) {
+    return null;
+  }
+  return roomSuggestions.value.find((room) =>
+    room.name.toLowerCase() === query || room.address.toLowerCase() === query,
+  ) ?? null;
+}
+
+function currentScheduleRange() {
+  return {
+    start: allDay.value
+      ? `${startDate.value}T00:00:00Z`
+      : localInputToUTC(startDate.value, startTime.value, uiStore.displayTimezone),
+    end: allDay.value
+      ? `${endDate.value}T23:59:59Z`
+      : localInputToUTC(endDate.value, endTime.value, uiStore.displayTimezone),
+  };
+}
+
+function formatAvailabilityTime(value: string | null) {
+  if (!value) {
+    return "";
+  }
+  const date = new Date(`${value}Z`);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  return new Intl.DateTimeFormat(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+    month: "short",
+    day: "numeric",
+    timeZone: uiStore.displayTimezone,
+  }).format(date);
+}
+
+const roomAvailabilityMessage = computed(() => {
+  if (checkingRoomAvailability.value) {
+    return "Checking room availability...";
+  }
+  if (!roomAvailability.value) {
+    return null;
+  }
+  if (roomAvailability.value.state === "available") {
+    return "Available for the selected time";
+  }
+  if (roomAvailability.value.state === "busy") {
+    return `Busy ${formatAvailabilityTime(roomAvailability.value.busy_start)} - ${formatAvailabilityTime(roomAvailability.value.busy_end)}`;
+  }
+  return "Availability unknown";
+});
+
+async function refreshRoomAvailability() {
+  const room = selectedRoom();
+  const accountId = selectedCalendarAccountId.value;
+  const account = accountsStore.accounts.find((entry) => entry.id === accountId);
+  if (!room || !accountId || !account || (account.provider !== "o365" && account.provider !== "microsoft365")) {
+    roomAvailability.value = null;
+    checkingRoomAvailability.value = false;
+    return;
+  }
+
+  const { start, end } = currentScheduleRange();
+  if (new Date(end) <= new Date(start)) {
+    roomAvailability.value = null;
+    checkingRoomAvailability.value = false;
+    return;
+  }
+
+  const requestId = ++roomAvailabilityRequestId;
+  checkingRoomAvailability.value = true;
+  try {
+    const availability = await api.checkRoomAvailability(accountId, room.address, start, end);
+    if (requestId === roomAvailabilityRequestId) {
+      roomAvailability.value = availability;
+    }
+  } catch (e) {
+    if (requestId === roomAvailabilityRequestId) {
+      console.error("Failed to check room availability:", e);
+      roomAvailability.value = { state: "unknown", busy_start: null, busy_end: null };
+    }
+  } finally {
+    if (requestId === roomAvailabilityRequestId) {
+      checkingRoomAvailability.value = false;
+    }
+  }
+}
+
+async function refreshRoomSuggestions() {
+  const accountId = selectedCalendarAccountId.value;
+  const account = accountsStore.accounts.find((entry) => entry.id === accountId);
+  if (!accountId || !account || (account.provider !== "o365" && account.provider !== "microsoft365")) {
+    roomSuggestions.value = [];
+    roomAvailability.value = null;
+    return;
+  }
+
+  loadingRoomSuggestions.value = true;
+  try {
+    roomSuggestions.value = await api.listRoomSuggestions(accountId);
+  } catch (e) {
+    console.error("Failed to load room suggestions:", e);
+    roomSuggestions.value = [];
+    roomAvailability.value = null;
+  } finally {
+    loadingRoomSuggestions.value = false;
+  }
+
+  await refreshRoomAvailability();
+}
+
+watch(selectedCalendarAccountId, () => {
+  void refreshRoomSuggestions();
+}, { immediate: true });
+
+watch([location, startDate, startTime, endDate, endTime, allDay], () => {
+  void refreshRoomAvailability();
+});
 
 async function save() {
   if (!title.value.trim()) {
@@ -296,7 +422,41 @@ async function save() {
 
         <div class="form-group">
           <label>Location</label>
-          <input v-model="location" type="text" placeholder="Add location" data-testid="event-form-location" />
+          <input
+            v-model="location"
+            type="text"
+            placeholder="Add location"
+            :list="roomSuggestions.length > 0 ? 'event-form-room-suggestions' : undefined"
+            data-testid="event-form-location"
+          />
+          <datalist
+            v-if="roomSuggestions.length > 0"
+            id="event-form-room-suggestions"
+            data-testid="event-form-room-suggestions"
+          >
+            <option
+              v-for="room in roomSuggestions"
+              :key="room.address"
+              :value="room.name"
+            >
+              {{ room.address }}
+            </option>
+          </datalist>
+          <span
+            v-if="loadingRoomSuggestions"
+            class="room-suggestions-loading"
+            data-testid="event-form-room-suggestions-loading"
+          >
+            Loading rooms...
+          </span>
+          <span
+            v-if="roomAvailabilityMessage"
+            class="room-availability"
+            :class="roomAvailability ? `room-availability--${roomAvailability.state}` : undefined"
+            data-testid="event-form-room-availability"
+          >
+            {{ roomAvailabilityMessage }}
+          </span>
           <!-- #148: one-click video conference. Only renders when
                at least one account has a meet binding configured
                in Settings. Picking an entry creates the room /
@@ -392,6 +552,31 @@ async function save() {
   margin-top: 6px;
   font-size: 11px;
   color: var(--color-danger, #c0392b);
+}
+
+.room-suggestions-loading {
+  display: block;
+  margin-top: 6px;
+  font-size: 11px;
+  color: var(--color-text-secondary, #666);
+}
+
+.room-availability {
+  display: block;
+  margin-top: 6px;
+  font-size: 11px;
+}
+
+.room-availability--available {
+  color: var(--color-success, #2f7a3e);
+}
+
+.room-availability--busy {
+  color: var(--color-warning, #a65a00);
+}
+
+.room-availability--unknown {
+  color: var(--color-text-secondary, #666);
 }
 
 .event-form-overlay {

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -315,6 +315,26 @@ export async function getEvents(
   return invoke("get_events", { accountId, start, end, calendarId: calendarId ?? null });
 }
 
+export async function listRoomSuggestions(
+  accountId: string,
+): Promise<import("./types").RoomSuggestion[]> {
+  return invoke("list_room_suggestions", { accountId });
+}
+
+export async function checkRoomAvailability(
+  accountId: string,
+  roomAddress: string,
+  startTime: string,
+  endTime: string,
+): Promise<import("./types").RoomAvailability> {
+  return invoke("check_room_availability", {
+    accountId,
+    roomAddress,
+    startTime,
+    endTime,
+  });
+}
+
 export async function createEvent(
   event: import("./types").NewEventInput,
 ): Promise<string> {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -83,6 +83,17 @@ export interface Address {
   email: string;
 }
 
+export interface RoomSuggestion {
+  name: string;
+  address: string;
+}
+
+export interface RoomAvailability {
+  state: "available" | "busy" | "unknown";
+  busy_start: string | null;
+  busy_end: string | null;
+}
+
 export interface MessageSummary {
   id: string;
   subject: string | null;


### PR DESCRIPTION
Use Microsoft Graph getSchedule to check selected room availability and surface the result in the calendar event form.

add backend room availability lookup and parsing
expose a new Tauri command and frontend API wrapper show available/busy/unknown room status under Location add focused Rust and Vue tests for availability behavior