### PR TITLE
fix: O365 calendar invite RSVP - SMTP error, keyring, deadlock, status

### DIFF
--- a/src-tauri/src/commands/calendar.rs
+++ b/src-tauri/src/commands/calendar.rs
@@ -2177,6 +2177,29 @@ pub async fn get_invite_status(
     Ok(event.and_then(|e| e.my_status))
 }
 
+/// How an iTIP REPLY to a meeting invite should be delivered, by calendar
+/// protocol. Graph/O365 accounts have no SMTP host configured — Microsoft
+/// delivers the reply to the organizer itself via the Graph RSVP call
+/// (`sendResponse: true`). Routing them through SMTP fails with an empty
+/// hostname.
+#[derive(Debug, PartialEq, Eq)]
+enum InviteReplyTransport {
+    /// Send the reply email over JMAP submission.
+    Jmap,
+    /// No client-side send — the Graph RSVP call delivers the reply.
+    GraphRsvp,
+    /// Send the reply email over SMTP (IMAP/Gmail accounts).
+    Smtp,
+}
+
+fn invite_reply_transport(calendar_protocol: &str) -> InviteReplyTransport {
+    match calendar_protocol {
+        "jmap" => InviteReplyTransport::Jmap,
+        "graph" => InviteReplyTransport::GraphRsvp,
+        _ => InviteReplyTransport::Smtp,
+    }
+}
+
 #[tauri::command]
 pub async fn respond_to_invite(
     app: tauri::AppHandle,
@@ -2247,49 +2270,90 @@ pub async fn respond_to_invite(
             invite.summary.as_deref().unwrap_or("Calendar Invite")
         );
 
-        if account.calendar_protocol_str() == "jmap" {
-            log::info!("respond_to_invite: sending reply via JMAP");
-            let jmap_config = crate::commands::sync_cmd::build_jmap_config(&account).await?;
+        match invite_reply_transport(account.calendar_protocol_str()) {
+            InviteReplyTransport::Jmap => {
+                log::info!("respond_to_invite: sending reply via JMAP");
+                let jmap_config = crate::commands::sync_cmd::build_jmap_config(&account).await?;
 
-            let raw_message = build_calendar_reply_message(
-                &account.email,
-                organizer_email,
-                &subject,
-                &body_text,
-                &reply_ical,
-            )?;
+                let raw_message = build_calendar_reply_message(
+                    &account.email,
+                    organizer_email,
+                    &subject,
+                    &body_text,
+                    &reply_ical,
+                )?;
 
-            let jmap_conn = crate::mail::jmap::JmapConnection::connect(&jmap_config).await?;
-            jmap_conn.send_email(&jmap_config, &raw_message).await?;
-        } else {
-            log::info!("respond_to_invite: sending reply via SMTP");
-            let raw_message = build_calendar_reply_message(
-                &account.email,
-                organizer_email,
-                &subject,
-                &body_text,
-                &reply_ical,
-            )?;
+                let jmap_conn = crate::mail::jmap::JmapConnection::connect(&jmap_config).await?;
+                jmap_conn.send_email(&jmap_config, &raw_message).await?;
+            }
+            InviteReplyTransport::GraphRsvp => {
+                // O365/Graph accounts have no SMTP host configured. The reply
+                // email to the organizer is sent by Microsoft itself via the
+                // Graph API RSVP call (`sendResponse: true`) in Step 3b below.
+                log::info!(
+                    "respond_to_invite: O365 account — reply delivered via Graph API RSVP (Step 3b)"
+                );
+            }
+            InviteReplyTransport::Smtp => {
+                log::info!("respond_to_invite: sending reply via SMTP");
+                let raw_message = build_calendar_reply_message(
+                    &account.email,
+                    organizer_email,
+                    &subject,
+                    &body_text,
+                    &reply_ical,
+                )?;
 
-            // For O365: refresh SMTP-scoped OAuth token
-            let (smtp_password, use_xoauth2) = get_smtp_credentials(&account).await?;
+                // For O365: refresh SMTP-scoped OAuth token
+                let (smtp_password, use_xoauth2) = get_smtp_credentials(&account).await?;
 
-            send_raw_smtp(
-                &account.smtp_host,
-                account.smtp_port,
-                &account.username,
-                &smtp_password,
-                account.use_tls,
-                use_xoauth2,
-                &account.email,
-                organizer_email,
-                &raw_message,
-            )
-            .await?;
+                send_raw_smtp(
+                    &account.smtp_host,
+                    account.smtp_port,
+                    &account.username,
+                    &smtp_password,
+                    account.use_tls,
+                    use_xoauth2,
+                    &account.email,
+                    organizer_email,
+                    &raw_message,
+                )
+                .await?;
+            }
         }
     } else {
         log::info!("respond_to_invite: no organizer email, skipping send");
     }
+
+    // Step 3b: For O365/Graph accounts, deliver the RSVP to the organizer
+    // *before* the local DB write below. The Graph RSVP (`sendResponse:
+    // true`) is the only delivery path for these accounts, and Graph locates
+    // the event by UID itself (no organizer address needed). Doing it here
+    // keeps the operation atomic: a delivery failure returns an error
+    // without having marked the invite answered locally — Step 4 (and the
+    // remote_id store in Step 6) only run once delivery has succeeded.
+    let graph_event_id: Option<String> = if account.calendar_protocol_str() == "graph" {
+        let token = crate::mail::graph::get_graph_token(&account_id).await?;
+        let client = crate::mail::graph::GraphClient::new(&token);
+        let event_id = client
+            .find_event_by_ical_uid(&invite_uid)
+            .await?
+            .ok_or_else(|| {
+                crate::error::Error::Other(
+                    "This invitation isn't on your Outlook calendar yet. \
+                     Sync the calendar and try again."
+                        .into(),
+                )
+            })?;
+        client.rsvp_event(&event_id, &response, "").await?;
+        log::info!(
+            "respond_to_invite: updated O365 Calendar response to {}",
+            response
+        );
+        Some(event_id)
+    } else {
+        None
+    };
 
     // Step 4: Create/update event in local calendar
     let my_status = response.to_lowercase();
@@ -2323,10 +2387,20 @@ pub async fn respond_to_invite(
         cal_id
     };
 
+    // Reflect the user's own RSVP in the attendee list. The invite email
+    // carries the original "needs-action" PARTSTAT for every attendee, so
+    // without this patch the event popup shows "needs-action" next to the
+    // user's own name even though they just responded.
     let attendees_json = if invite.attendees.is_empty() {
         None
     } else {
-        Some(serde_json::to_string(&invite.attendees).unwrap_or_else(|_| "[]".to_string()))
+        let mut attendees = invite.attendees.clone();
+        for att in attendees.iter_mut() {
+            if att.email.eq_ignore_ascii_case(&account.email) {
+                att.status = my_status.clone();
+            }
+        }
+        Some(serde_json::to_string(&attendees).unwrap_or_else(|_| "[]".to_string()))
     };
 
     // Check if we already have this event
@@ -2373,9 +2447,13 @@ pub async fn respond_to_invite(
         );
     }
 
+    // The DB write lock covers only the local update above. Release it before
+    // any network I/O below, so calendar reads aren't blocked and so the
+    // Google/Graph steps can re-acquire the writer without deadlocking.
+    drop(conn);
+
     // Step 5: Update Google Calendar if this is a Gmail account with OAuth
     if account.calendar_protocol_str() == "google" {
-        drop(conn); // Release DB lock before async
         if let Ok(token) = get_google_token(&account_id).await {
             let google_status = match response.to_lowercase().as_str() {
                 "accepted" => "accepted",
@@ -2502,41 +2580,17 @@ pub async fn respond_to_invite(
         }
     }
 
-    // Step 6: Update O365 calendar via Graph API RSVP
-    if account.calendar_protocol_str() == "graph" {
-        match crate::mail::graph::get_graph_token(&account_id).await {
-            Ok(token) => {
-                let client = crate::mail::graph::GraphClient::new(&token);
-                match client.find_event_by_ical_uid(&invite_uid).await {
-                    Ok(Some(graph_event_id)) => {
-                        match client.rsvp_event(&graph_event_id, &response, "").await {
-                            Ok(()) => {
-                                log::info!(
-                                    "respond_to_invite: updated O365 Calendar response to {}",
-                                    response
-                                );
-                                // Store remote_id so process_invite_reply can find the event later
-                                let conn = state.db.writer().await;
-                                conn.execute(
-                                    "UPDATE calendar_events SET remote_id = ?1 WHERE uid = ?2 AND account_id = ?3",
-                                    rusqlite::params![graph_event_id, invite_uid, account_id],
-                                ).ok();
-                            }
-                            Err(e) => {
-                                log::warn!("respond_to_invite: O365 Graph RSVP failed: {}", e)
-                            }
-                        }
-                    }
-                    Ok(None) => log::debug!(
-                        "respond_to_invite: event not found on O365 Calendar by iCalUId"
-                    ),
-                    Err(e) => {
-                        log::warn!("respond_to_invite: O365 Graph event lookup failed: {}", e)
-                    }
-                }
-            }
-            Err(e) => log::warn!("respond_to_invite: failed to get O365 token: {}", e),
-        }
+    // Step 6: Persist the Graph event id. The RSVP itself was already
+    // delivered in Step 3b; this only records remote_id on the now-existing
+    // local row so process_invite_reply can locate the event later. It is
+    // best-effort (`.ok()`) — a failure here doesn't lose the RSVP.
+    if let Some(graph_event_id) = graph_event_id {
+        let conn = state.db.writer().await;
+        conn.execute(
+            "UPDATE calendar_events SET remote_id = ?1 WHERE uid = ?2 AND account_id = ?3",
+            rusqlite::params![graph_event_id, invite_uid, account_id],
+        )
+        .ok();
     }
 
     // Notify frontend that calendar data changed so the UI refreshes
@@ -3492,7 +3546,8 @@ async fn sync_calendars_graph(state: &State<'_, AppState>, account_id: &str) -> 
                     conn.execute(
                         "UPDATE calendar_events SET title = ?1, start_time = ?2, end_time = ?3,
                          all_day = ?4, location = ?5, organizer_email = ?6, attendees_json = ?7,
-                         description = ?8, timezone = ?9, calendar_id = ?10 WHERE id = ?11",
+                         description = ?8, timezone = ?9, my_status = ?10, calendar_id = ?11
+                         WHERE id = ?12",
                         rusqlite::params![
                             ge.subject,
                             ge.start,
@@ -3503,6 +3558,7 @@ async fn sync_calendars_graph(state: &State<'_, AppState>, account_id: &str) -> 
                             ge.attendees_json,
                             ge.body_preview,
                             ge.timezone,
+                            ge.my_status,
                             local_cal_id,
                             local_id,
                         ],
@@ -3525,7 +3581,7 @@ async fn sync_calendars_graph(state: &State<'_, AppState>, account_id: &str) -> 
                         recurrence_rule: None,
                         organizer_email: ge.organizer_email.clone(),
                         attendees_json: ge.attendees_json.clone(),
-                        my_status: None,
+                        my_status: ge.my_status.clone(),
                         source_message_id: None,
                         ical_data: None,
                         remote_id: Some(ge.id.clone()),
@@ -3587,4 +3643,35 @@ pub fn list_timezones() -> Vec<String> {
 #[tauri::command]
 pub fn get_default_timezone() -> String {
     iana_time_zone::get_timezone().unwrap_or_else(|_| "UTC".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Regression: replying to a meeting invite on an O365/Graph account must
+    // NOT route through SMTP. Graph accounts have no SMTP host configured
+    // (empty string), so SMTP delivery fails. Microsoft delivers the reply
+    // itself via the Graph RSVP call.
+    #[test]
+    fn graph_invite_reply_does_not_use_smtp() {
+        assert_eq!(
+            invite_reply_transport("graph"),
+            InviteReplyTransport::GraphRsvp
+        );
+    }
+
+    #[test]
+    fn jmap_invite_reply_uses_jmap() {
+        assert_eq!(invite_reply_transport("jmap"), InviteReplyTransport::Jmap);
+    }
+
+    #[test]
+    fn imap_and_gmail_invite_reply_use_smtp() {
+        // IMAP/CalDAV and Gmail accounts send the iTIP REPLY over SMTP.
+        assert_eq!(invite_reply_transport("caldav"), InviteReplyTransport::Smtp);
+        assert_eq!(invite_reply_transport("google"), InviteReplyTransport::Smtp);
+        // An account with no calendar binding still falls back to SMTP.
+        assert_eq!(invite_reply_transport(""), InviteReplyTransport::Smtp);
+    }
 }

--- a/src-tauri/src/mail/graph.rs
+++ b/src-tauri/src/mail/graph.rs
@@ -1000,7 +1000,7 @@ impl GraphClient {
                         .query(&[
                             ("startDateTime", start),
                             ("endDateTime", end),
-                            ("$select", "id,subject,bodyPreview,start,end,location,isAllDay,organizer,attendees,iCalUId,recurrence"),
+                            ("$select", "id,subject,bodyPreview,start,end,location,isAllDay,organizer,attendees,iCalUId,recurrence,responseStatus"),
                             ("$top", "100"),
                             ("$orderby", "start/dateTime"),
                         ])
@@ -1073,7 +1073,7 @@ impl GraphClient {
                         .query(&[
                             ("startDateTime", start),
                             ("endDateTime", end),
-                            ("$select", "id,subject,bodyPreview,start,end,location,isAllDay,organizer,attendees,iCalUId,recurrence"),
+                            ("$select", "id,subject,bodyPreview,start,end,location,isAllDay,organizer,attendees,iCalUId,recurrence,responseStatus"),
                             ("$top", "100"),
                             ("$orderby", "start/dateTime"),
                         ])
@@ -1335,6 +1335,10 @@ pub struct GraphCalendarEvent {
     pub location: Option<String>,
     pub organizer_email: Option<String>,
     pub attendees_json: Option<String>,
+    /// The signed-in user's own RSVP to this event, in iCal PARTSTAT
+    /// vocabulary. `None` for events with no RSVP concept (events the user
+    /// organized, or invites not yet responded to).
+    pub my_status: Option<String>,
     pub ical_uid: Option<String>,
     pub is_recurring: bool,
 }
@@ -1622,6 +1626,36 @@ pub fn guess_folder_type(display_name: &str) -> Option<&'static str> {
     }
 }
 
+/// Translate a Microsoft Graph attendee `status.response` value into the
+/// iCal PARTSTAT vocabulary the rest of the app (and the UI) uses. Graph
+/// emits its own `responseType` enum (`none`, `organizer`, `accepted`,
+/// `tentativelyAccepted`, `declined`, `notResponded`); storing those verbatim
+/// makes the event popup show e.g. "tentativelyAccepted" instead of "Maybe".
+fn graph_response_to_partstat(response: &str) -> &'static str {
+    match response {
+        "accepted" => "accepted",
+        "tentativelyAccepted" => "tentative",
+        "declined" => "declined",
+        // The organizer implicitly accepts their own event.
+        "organizer" => "accepted",
+        // "none", "notResponded", and anything unrecognised.
+        _ => "needs-action",
+    }
+}
+
+/// Translate the event-level Graph `responseStatus.response` (the signed-in
+/// user's own RSVP) into an `Option` of iCal PARTSTAT. Only a genuine RSVP
+/// produces a value: `organizer`, `none`, and `notResponded` map to `None`
+/// so the UI doesn't show a stray status badge on the user's own events.
+fn graph_response_to_my_status(response: &str) -> Option<String> {
+    match response {
+        "accepted" => Some("accepted".to_string()),
+        "tentativelyAccepted" => Some("tentative".to_string()),
+        "declined" => Some("declined".to_string()),
+        _ => None,
+    }
+}
+
 fn parse_graph_event(e: &serde_json::Value) -> GraphCalendarEvent {
     let start_obj = &e["start"];
     let end_obj = &e["end"];
@@ -1679,7 +1713,9 @@ fn parse_graph_event(e: &serde_json::Value) -> GraphCalendarEvent {
                 serde_json::json!({
                     "name": a["emailAddress"]["name"].as_str().unwrap_or(""),
                     "email": a["emailAddress"]["address"].as_str().unwrap_or(""),
-                    "status": a["status"]["response"].as_str().unwrap_or("none"),
+                    "status": graph_response_to_partstat(
+                        a["status"]["response"].as_str().unwrap_or("none"),
+                    ),
                 })
             })
             .collect();
@@ -1697,6 +1733,9 @@ fn parse_graph_event(e: &serde_json::Value) -> GraphCalendarEvent {
         location,
         organizer_email,
         attendees_json,
+        my_status: graph_response_to_my_status(
+            e["responseStatus"]["response"].as_str().unwrap_or("none"),
+        ),
         ical_uid: e["iCalUId"].as_str().map(|s| s.to_string()),
         is_recurring: e["recurrence"].is_object(),
     }
@@ -1882,9 +1921,102 @@ async fn get_graph_token_with_scopes(account_id: &str, scopes: &str) -> Result<S
 #[cfg(test)]
 mod color_tests {
     use super::{
-        dedupe_graph_rooms, graph_color_to_hex, nearest_outlook_color, normalize_schedule_datetime,
-        parse_graph_named_addresses, parse_graph_room_availability, parse_graph_rooms, GraphRoom,
+        dedupe_graph_rooms, graph_color_to_hex, graph_response_to_my_status,
+        graph_response_to_partstat, nearest_outlook_color, normalize_schedule_datetime,
+        parse_graph_event, parse_graph_named_addresses, parse_graph_room_availability,
+        parse_graph_rooms, GraphRoom,
     };
+
+    // Graph emits its own responseType enum; the UI only understands iCal
+    // PARTSTAT values. Storing Graph's vocabulary verbatim made the event
+    // popup show "tentativelyAccepted" / "notResponded" next to attendees.
+    #[test]
+    fn graph_response_types_map_to_partstat() {
+        assert_eq!(graph_response_to_partstat("accepted"), "accepted");
+        assert_eq!(
+            graph_response_to_partstat("tentativelyAccepted"),
+            "tentative"
+        );
+        assert_eq!(graph_response_to_partstat("declined"), "declined");
+        assert_eq!(graph_response_to_partstat("organizer"), "accepted");
+        assert_eq!(graph_response_to_partstat("none"), "needs-action");
+        assert_eq!(graph_response_to_partstat("notResponded"), "needs-action");
+        // Unknown / future values fall back safely.
+        assert_eq!(graph_response_to_partstat("somethingNew"), "needs-action");
+    }
+
+    // A synced Graph event's attendee list must carry translated statuses.
+    #[test]
+    fn parse_graph_event_translates_attendee_status() {
+        let raw = serde_json::json!({
+            "id": "evt1",
+            "subject": "Linux docs",
+            "start": { "dateTime": "2026-05-19T11:00:00.0000000", "timeZone": "UTC" },
+            "end": { "dateTime": "2026-05-19T11:30:00.0000000", "timeZone": "UTC" },
+            "isAllDay": false,
+            "organizer": { "emailAddress": { "address": "chithiapp@outlook.com" } },
+            "attendees": [
+                {
+                    "emailAddress": { "name": "Kushal", "address": "kushal@sunet.se" },
+                    "status": { "response": "tentativelyAccepted" }
+                }
+            ]
+        });
+        let parsed = parse_graph_event(&raw);
+        let atts: serde_json::Value =
+            serde_json::from_str(&parsed.attendees_json.unwrap()).unwrap();
+        assert_eq!(atts[0]["status"], "tentative");
+    }
+
+    // The signed-in user's own RSVP comes from the event-level
+    // responseStatus; only a genuine RSVP yields a my_status badge.
+    #[test]
+    fn graph_response_maps_to_my_status() {
+        assert_eq!(
+            graph_response_to_my_status("tentativelyAccepted").as_deref(),
+            Some("tentative")
+        );
+        assert_eq!(
+            graph_response_to_my_status("accepted").as_deref(),
+            Some("accepted")
+        );
+        assert_eq!(
+            graph_response_to_my_status("declined").as_deref(),
+            Some("declined")
+        );
+        // No RSVP concept — the user's own events / unanswered invites.
+        assert_eq!(graph_response_to_my_status("organizer"), None);
+        assert_eq!(graph_response_to_my_status("none"), None);
+        assert_eq!(graph_response_to_my_status("notResponded"), None);
+    }
+
+    // A synced Graph event carries the user's RSVP from responseStatus.
+    #[test]
+    fn parse_graph_event_extracts_my_status() {
+        let raw = serde_json::json!({
+            "id": "evt2",
+            "subject": "Linux docs",
+            "start": { "dateTime": "2026-05-19T11:00:00.0000000", "timeZone": "UTC" },
+            "end": { "dateTime": "2026-05-19T11:30:00.0000000", "timeZone": "UTC" },
+            "isAllDay": false,
+            "responseStatus": { "response": "tentativelyAccepted" }
+        });
+        assert_eq!(
+            parse_graph_event(&raw).my_status.as_deref(),
+            Some("tentative")
+        );
+
+        // An event the user organized has no RSVP badge.
+        let own = serde_json::json!({
+            "id": "evt3",
+            "subject": "My own event",
+            "start": { "dateTime": "2026-05-19T11:00:00.0000000", "timeZone": "UTC" },
+            "end": { "dateTime": "2026-05-19T11:30:00.0000000", "timeZone": "UTC" },
+            "isAllDay": false,
+            "responseStatus": { "response": "organizer" }
+        });
+        assert_eq!(parse_graph_event(&own).my_status, None);
+    }
 
     #[test]
     fn anchor_round_trip() {

--- a/src-tauri/src/oauth.rs
+++ b/src-tauri/src/oauth.rs
@@ -1145,6 +1145,30 @@ fn store_tokens_keyring(account_id: &str, tokens: &OAuthTokens) -> Result<()> {
     Ok(())
 }
 
+/// Read tokens from the keyring exactly once.
+///
+/// Distinguishes three outcomes so the caller can react correctly:
+/// - `Ok(Some(_))` — tokens found.
+/// - `Ok(None)` — keyring reachable, but no entry exists (`NoEntry`). The
+///   account genuinely has no stored tokens; the user must sign in.
+/// - `Err(Error::Keyring(_))` — the keyring could not be reached (e.g. the
+///   Secret Service DBus connection dropped). This is *not* the same as
+///   "no tokens" and must never be reported as such.
+#[cfg(not(target_os = "android"))]
+fn load_tokens_keyring_once(account_id: &str) -> Result<Option<OAuthTokens>> {
+    let entry = keyring::Entry::new(KEYRING_SERVICE, account_id)
+        .map_err(|e| Error::Keyring(format!("Failed to create keyring entry: {}", e)))?;
+    match entry.get_password() {
+        Ok(json) => {
+            let tokens: OAuthTokens = serde_json::from_str(&json)
+                .map_err(|e| Error::Other(format!("Token deserialize failed: {}", e)))?;
+            Ok(Some(tokens))
+        }
+        Err(keyring::Error::NoEntry) => Ok(None),
+        Err(e) => Err(Error::Keyring(format!("keyring read failed: {}", e))),
+    }
+}
+
 pub fn load_tokens(account_id: &str) -> Result<Option<OAuthTokens>> {
     #[cfg(target_os = "android")]
     {
@@ -1152,19 +1176,29 @@ pub fn load_tokens(account_id: &str) -> Result<Option<OAuthTokens>> {
     }
     #[cfg(not(target_os = "android"))]
     {
-        let entry = keyring::Entry::new(KEYRING_SERVICE, account_id)
-            .map_err(|e| Error::Keyring(format!("Failed to create keyring entry: {}", e)))?;
-        match entry.get_password() {
-            Ok(json) => {
-                let tokens: OAuthTokens = serde_json::from_str(&json)
-                    .map_err(|e| Error::Other(format!("Token deserialize failed: {}", e)))?;
-                Ok(Some(tokens))
+        // The Secret Service DBus connection can drop transiently
+        // ("Remote peer disconnected") — e.g. when the gnome-keyring daemon
+        // or session bus restarts. Retry once with a fresh connection before
+        // surfacing the failure. Crucially, a keyring error is propagated as
+        // an error (not Ok(None)): treating it as "no tokens" would wrongly
+        // tell the user to sign in again when their tokens are still stored.
+        match load_tokens_keyring_once(account_id) {
+            Err(Error::Keyring(first)) => {
+                log::warn!(
+                    "OAuth2: keyring read failed for {} ({}); retrying once",
+                    account_id,
+                    first,
+                );
+                load_tokens_keyring_once(account_id).map_err(|e| {
+                    log::error!(
+                        "OAuth2: keyring read retry failed for {}: {}",
+                        account_id,
+                        e
+                    );
+                    e
+                })
             }
-            Err(keyring::Error::NoEntry) => Ok(None),
-            Err(e) => {
-                log::warn!("OAuth2: keyring read failed for {}: {}", account_id, e);
-                Ok(None)
-            }
+            other => other,
         }
     }
 }


### PR DESCRIPTION
  Replying to a meeting invite (Accept/Maybe/Decline) on a Microsoft 365
  account failed and showed wrong attendee status. Five related defects:

  1. SMTP routing - respond_to_invite() only special-cased "jmap" and let every other protocol fall through to SMTP. O365/Graph accounts have no SMTP host configured (empty string), so lettre's starttls_relay("") failed. Graph accounts now skip client-side send entirely; Microsoft delivers the reply via the Graph RSVP call (sendResponse: true). Routing is extracted into invite_reply_transport() for testability.

  2. Keyring transient failure - load_tokens() swallowed Secret Service DBus errors ("Remote peer disconnected") and returned Ok(None), which callers reported as "No O365 OAuth tokens. Please sign in." It now retries once with a fresh connection and propagates a real error instead of pretending the user is signed out. NoEntry still maps to Ok(None) so a genuinely absent entry is distinguished from an unreachable keyring.

  3. Latent deadlock - the Step 4 DB writer MutexGuard was released only on the "google" branch, so a successful Graph RSVP re-acquired writer() while still holding it and hung forever. The lock is now dropped unconditionally before any network I/O.

  4. Attendee status - respond_to_invite() serialized the attendee list straight from the invite email, so the user's own entry kept the original "needs-action" PARTSTAT even after they responded. The matching attendee is now patched to the chosen status.

  5. Graph status vocabulary - Graph emits its own responseType enum (notResponded, tentativelyAccepted, organizer, ...) which was stored verbatim. Added graph_response_to_partstat() for attendee statuses and graph_response_to_my_status() for the event-level RSVP, both translating to iCal PARTSTAT. responseStatus is now requested in the calendar $select and my_status is synced from Graph.

  Step 6 of respond_to_invite() now surfaces Graph RSVP failures to the
  user instead of swallowing them, so a failed "Maybe" no longer silently
  flips only the local status.