### PR TITLE
fix: make first email in expanded thread clickable

### DIFF
--- a/src-tauri/src/db/messages.rs
+++ b/src-tauri/src/db/messages.rs
@@ -926,7 +926,7 @@ fn get_threaded_messages_inner(
             MAX(has_attachments) AS has_attach,
             MAX(flags) AS latest_flags,
             MAX(snippet) AS latest_snippet,
-            GROUP_CONCAT(id, '||') AS all_ids
+            GROUP_CONCAT(id, '||' ORDER BY date ASC) AS all_ids
          FROM messages
          WHERE account_id = ?1 AND folder_path = ?2{filter}
          GROUP BY tid
@@ -1180,6 +1180,53 @@ mod tests {
         let conn = setup_db();
         let paths = get_maildir_paths(&conn, "acc1", &[]).unwrap();
         assert!(paths.is_empty());
+    }
+
+    /// Regression: in an expanded thread the first (oldest) email must stay
+    /// reachable. The ThreadRow header opens `message_ids[0]` and the frontend
+    /// renders only `threadMessages[1..]` as separate rows, so `message_ids[0]`
+    /// has to be the chronologically-first message. `GROUP_CONCAT` without an
+    /// explicit `ORDER BY` echoes rowid (insertion) order, which is not
+    /// chronological after delta syncs — leaving the first email unclickable.
+    #[test]
+    fn threaded_message_ids_are_ordered_by_date_ascending() {
+        let conn = setup_db();
+        // Insertion order is deliberately NOT chronological.
+        let insert = |id: &str, date: &str| {
+            conn.execute(
+                "INSERT INTO messages
+                 (id, account_id, folder_path, uid, message_id, thread_id, date, from_email, maildir_path)
+                 VALUES (?1, 'acc1', 'INBOX', 1, ?1, '<root@t>', ?2, 'x@y', '')",
+                params![id, date],
+            )
+            .unwrap();
+        };
+        insert("newest", "2026-05-03T00:00:00Z");
+        insert("oldest", "2026-05-01T00:00:00Z");
+        insert("middle", "2026-05-02T00:00:00Z");
+
+        let page = get_threaded_messages_inner(
+            &conn,
+            "acc1",
+            "INBOX",
+            0,
+            50,
+            "date",
+            false,
+            &QuickFilter::default(),
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(page.threads.len(), 1);
+        assert_eq!(
+            page.threads[0].message_ids,
+            vec![
+                "oldest".to_string(),
+                "middle".to_string(),
+                "newest".to_string(),
+            ],
+        );
     }
 
     fn insert_threaded_row(

--- a/src-tauri/src/db/messages.rs
+++ b/src-tauri/src/db/messages.rs
@@ -926,7 +926,11 @@ fn get_threaded_messages_inner(
             MAX(has_attachments) AS has_attach,
             MAX(flags) AS latest_flags,
             MAX(snippet) AS latest_snippet,
-            GROUP_CONCAT(id, '||' ORDER BY date ASC) AS all_ids
+            GROUP_CONCAT(
+                id,
+                '||'
+                ORDER BY date ASC, COALESCE(uid, 9223372036854775807) ASC, id ASC
+            ) AS all_ids
          FROM messages
          WHERE account_id = ?1 AND folder_path = ?2{filter}
          GROUP BY tid
@@ -991,7 +995,8 @@ fn get_threaded_messages_inner(
 /// Only returns messages from the given folder — Gmail stores the same email
 /// in multiple folders (INBOX, All Mail, Sent Mail, Important) as "labels",
 /// so without folder filtering a thread would show duplicates.
-/// Messages are sorted by date ASC to show the conversation chronologically.
+/// Messages are sorted chronologically with deterministic tie-breakers so the
+/// expanded-thread rows and thread summary agree on the root message.
 pub fn get_thread_messages(
     conn: &Connection,
     account_id: &str,
@@ -1012,7 +1017,7 @@ pub fn get_thread_messages(
          FROM messages
          WHERE account_id = ?1 AND folder_path = ?2
            AND (thread_id = ?3 OR (thread_id IS NULL AND id = ?3))
-         ORDER BY date ASC",
+         ORDER BY date ASC, COALESCE(uid, 9223372036854775807) ASC, id ASC",
     )?;
 
     let messages = stmt
@@ -1226,6 +1231,58 @@ mod tests {
                 "middle".to_string(),
                 "newest".to_string(),
             ],
+        );
+    }
+
+    #[test]
+    fn threaded_message_ids_use_deterministic_tiebreakers_for_equal_dates() {
+        let conn = setup_db();
+        let insert = |id: &str, uid: Option<i64>| {
+            conn.execute(
+                "INSERT INTO messages
+                 (id, account_id, folder_path, uid, message_id, thread_id, date, from_email, maildir_path)
+                 VALUES (?1, 'acc1', 'INBOX', ?2, ?1, '<root@t>', '2026-05-01T00:00:00Z', 'x@y', '')",
+                params![id, uid],
+            )
+            .unwrap();
+        };
+        // Insertion order is deliberately different from the expected
+        // deterministic order.
+        insert("uid-30", Some(30));
+        insert("uid-10", Some(10));
+        insert("uid-20", Some(20));
+        insert("null-b", None);
+        insert("null-a", None);
+
+        let page = get_threaded_messages_inner(
+            &conn,
+            "acc1",
+            "INBOX",
+            0,
+            50,
+            "date",
+            false,
+            &QuickFilter::default(),
+            false,
+        )
+        .unwrap();
+        let thread_messages = get_thread_messages(&conn, "acc1", "INBOX", "<root@t>").unwrap();
+        let expected = vec![
+            "uid-10".to_string(),
+            "uid-20".to_string(),
+            "uid-30".to_string(),
+            "null-a".to_string(),
+            "null-b".to_string(),
+        ];
+
+        assert_eq!(page.threads.len(), 1);
+        assert_eq!(page.threads[0].message_ids, expected);
+        assert_eq!(
+            thread_messages
+                .into_iter()
+                .map(|msg| msg.id)
+                .collect::<Vec<_>>(),
+            expected
         );
     }
 

--- a/src/__tests__/messages-selection.test.ts
+++ b/src/__tests__/messages-selection.test.ts
@@ -277,3 +277,63 @@ describe("Mark as read", () => {
     expect(store.subjectForMessage("missing")).toBeNull();
   });
 });
+
+describe("Threaded Shift+click range selection", () => {
+  beforeEach(() => setActivePinia(createPinia()));
+
+  it("range across an expanded thread has no duplicate IDs", () => {
+    const store = setup(true);
+    // message_ids[0] is the thread root, rendered by the ThreadRow header.
+    // threadMessages[0] is that same root; childrenWithDepth() renders only
+    // threadMessages[1..] as reply rows, so getVisibleIds() must skip the
+    // root in threadMessages to avoid listing it twice.
+    store.threads = [makeThread("t1", ["msg1", "msg2", "msg3"])];
+    store.threadMessages = {
+      t1: [makeSummary("msg1"), makeSummary("msg2"), makeSummary("msg3")],
+    };
+    store.collapsedThreads = []; // expanded
+
+    store.selectMessage("msg1", noMod); // ThreadRow header
+    store.selectMessage("msg3", shift); // last reply row
+
+    expect(store.selectedIds).toEqual(["msg1", "msg2", "msg3"]);
+    expect(new Set(store.selectedIds).size).toBe(store.selectedIds.length);
+  });
+
+  it("range spans the header id and reply rows across threads in order", () => {
+    const store = setup(true);
+    store.threads = [
+      makeThread("t1", ["msg1", "msg2"]),
+      makeThread("t2", ["msg3"]),
+    ];
+    store.threadMessages = {
+      t1: [makeSummary("msg1"), makeSummary("msg2")],
+    };
+    store.collapsedThreads = [];
+
+    store.selectMessage("msg1", noMod);
+    store.selectMessage("msg3", shift);
+
+    expect(store.selectedIds).toEqual(["msg1", "msg2", "msg3"]);
+  });
+
+  it("collapsed thread contributes only its header id to the range", () => {
+    const store = setup(true);
+    store.threads = [
+      makeThread("t1", ["msg1", "msg2"]),
+      makeThread("t2", ["msg3", "msg4"]),
+    ];
+    store.threadMessages = {
+      t1: [makeSummary("msg1"), makeSummary("msg2")],
+      t2: [makeSummary("msg3"), makeSummary("msg4")],
+    };
+    store.collapsedThreads = ["t1"]; // t1 collapsed, t2 expanded
+
+    store.selectMessage("msg1", noMod);
+    store.selectMessage("msg4", shift);
+
+    // t1 is collapsed so only its header (msg1) is visible; t2 expanded
+    // contributes its header (msg3) plus reply rows (msg4).
+    expect(store.selectedIds).toEqual(["msg1", "msg3", "msg4"]);
+  });
+});

--- a/src/stores/messages.ts
+++ b/src/stores/messages.ts
@@ -585,8 +585,8 @@ export const useMessagesStore = defineStore("messages", () => {
           // ThreadRow header (message_ids[0]). Only the replies are rendered
           // as separate rows, so skip the root to avoid a duplicate entry.
           const children = threadMessages.value[thread.thread_id] ?? [];
-          for (const msg of children.slice(1)) {
-            ids.push(msg.id);
+          for (let i = 1; i < children.length; i += 1) {
+            ids.push(children[i].id);
           }
         }
       }

--- a/src/stores/messages.ts
+++ b/src/stores/messages.ts
@@ -581,8 +581,11 @@ export const useMessagesStore = defineStore("messages", () => {
       for (const thread of threads.value) {
         ids.push(thread.message_ids[0]);
         if (isThreadExpanded(thread.thread_id)) {
+          // threadMessages[0] is the thread root, already represented by the
+          // ThreadRow header (message_ids[0]). Only the replies are rendered
+          // as separate rows, so skip the root to avoid a duplicate entry.
           const children = threadMessages.value[thread.thread_id] ?? [];
-          for (const msg of children) {
+          for (const msg of children.slice(1)) {
             ids.push(msg.id);
           }
         }


### PR DESCRIPTION
The ThreadRow header opens message_ids[0], while the frontend renders only threadMessages[1..] as separate rows -- so message_ids[0] must be the chronologically-first email. SQLite GROUP_CONCAT(id) echoed rowid (insertion) order, which is not chronological after delta syncs, leaving the thread's first email represented by the header but never selectable.

- db/messages.rs: GROUP_CONCAT(id, '||' ORDER BY date ASC) so message_ids[0] is deterministically the thread root.
- stores/messages.ts: getVisibleIds() skips threadMessages[0] (the root, already counted via message_ids[0]) to avoid a duplicate range entry.
- Add regression test threaded_message_ids_are_ordered_by_date_ascending.