### PR TITLE
fix: spin the Sync button during calendar sync

### DIFF
--- a/src-tauri/src/commands/calendar.rs
+++ b/src-tauri/src/commands/calendar.rs
@@ -1284,9 +1284,8 @@ pub async fn sync_calendars(
     }
 
     // Tell the frontend a calendar sync has started so the activity panel
-    // and the StatusBar Sync button show the spinning indicator — the same
-    // contract as the mail "sync-started" event. Completed by the
-    // "calendar-changed" event emitted below.
+    // and the StatusBar Sync button show the spinning indicator — same
+    // contract as the mail "sync-started" event.
     use tauri::Emitter;
     app.emit("calendar-sync-started", account_id.as_str()).ok();
 
@@ -1322,10 +1321,31 @@ pub async fn sync_calendars(
     }
     .await;
 
-    // Notify the frontend that calendar data has changed. Emitted on success
-    // *and* failure so the activity indicator started above always completes
-    // and the spinner never gets stuck.
-    app.emit("calendar-changed", account_id.as_str()).ok();
+    // Spinner-state events are kept separate from "calendar-changed" so
+    // unrelated subscribers (invite tracking, calendar list refresh) don't
+    // refetch on every sync tick, and so the spinner doesn't get prematurely
+    // completed by an invite-response or push-processing emission of
+    // "calendar-changed".
+    match &sync_result {
+        Ok(()) => {
+            // Sync succeeded — the DB may have changed; let refetchers run.
+            app.emit("calendar-changed", account_id.as_str()).ok();
+            app.emit("calendar-sync-complete", account_id.as_str()).ok();
+        }
+        Err(e) => {
+            // Sync failed — do NOT emit "calendar-changed" (it would trigger
+            // unnecessary refetches by the invites and calendar stores).
+            // Only signal failure to the activity indicator.
+            app.emit(
+                "calendar-sync-error",
+                serde_json::json!({
+                    "account_id": account_id.as_str(),
+                    "error": e.to_string(),
+                }),
+            )
+            .ok();
+        }
+    }
 
     sync_result?;
 

--- a/src-tauri/src/commands/calendar.rs
+++ b/src-tauri/src/commands/calendar.rs
@@ -1283,37 +1283,51 @@ pub async fn sync_calendars(
         );
     }
 
-    if account.calendar_protocol_str() == "jmap" {
-        sync_calendars_jmap(&state, &account_id, &account).await?;
-    } else if account.calendar_protocol_str() == "google" {
-        // Gmail: use Google CalDAV with OAuth2 bearer token
-        match sync_calendars_google(&state, &account_id, &account).await {
-            Ok(()) => {}
-            Err(e) => {
-                log::warn!(
-                    "sync_calendars: Gmail CalDAV sync failed (OAuth may not be configured): {}",
-                    e
-                );
-                // Fall back to configured CalDAV URL if available
-                if !account.caldav_url.is_empty() {
-                    sync_calendars_caldav(&state, &account_id, &account).await?;
+    // Tell the frontend a calendar sync has started so the activity panel
+    // and the StatusBar Sync button show the spinning indicator — the same
+    // contract as the mail "sync-started" event. Completed by the
+    // "calendar-changed" event emitted below.
+    use tauri::Emitter;
+    app.emit("calendar-sync-started", account_id.as_str()).ok();
+
+    let sync_result: Result<()> = async {
+        if account.calendar_protocol_str() == "jmap" {
+            sync_calendars_jmap(&state, &account_id, &account).await?;
+        } else if account.calendar_protocol_str() == "google" {
+            // Gmail: use Google CalDAV with OAuth2 bearer token
+            match sync_calendars_google(&state, &account_id, &account).await {
+                Ok(()) => {}
+                Err(e) => {
+                    log::warn!(
+                        "sync_calendars: Gmail CalDAV sync failed (OAuth may not be configured): {}",
+                        e
+                    );
+                    // Fall back to configured CalDAV URL if available
+                    if !account.caldav_url.is_empty() {
+                        sync_calendars_caldav(&state, &account_id, &account).await?;
+                    }
                 }
             }
+        } else if account.calendar_protocol_str() == "graph" {
+            sync_calendars_graph(&state, &account_id).await?;
+        } else if !account.caldav_url.is_empty() {
+            sync_calendars_caldav(&state, &account_id, &account).await?;
+        } else {
+            log::debug!(
+                "sync_calendars: skipping account {} (no JMAP or CalDAV configured)",
+                account_id
+            );
         }
-    } else if account.calendar_protocol_str() == "graph" {
-        sync_calendars_graph(&state, &account_id).await?;
-    } else if !account.caldav_url.is_empty() {
-        sync_calendars_caldav(&state, &account_id, &account).await?;
-    } else {
-        log::debug!(
-            "sync_calendars: skipping account {} (no JMAP or CalDAV configured)",
-            account_id
-        );
+        Ok(())
     }
+    .await;
 
-    // Notify frontend that calendar data has changed
-    use tauri::Emitter;
+    // Notify the frontend that calendar data has changed. Emitted on success
+    // *and* failure so the activity indicator started above always completes
+    // and the spinner never gets stuck.
     app.emit("calendar-changed", account_id.as_str()).ok();
+
+    sync_result?;
 
     log::info!("sync_calendars: completed for account {}", account_id);
     Ok(())

--- a/src-tauri/src/commands/calendar.rs
+++ b/src-tauri/src/commands/calendar.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 use tauri::State;
 
 use crate::calendar::ical::{self, ParsedInvite};
+use crate::commands::sync_cmd::try_acquire_sync_guard;
 use crate::db;
 use crate::db::calendar::{Attendee, Calendar, CalendarEvent, Invite, NewCalendar};
 use crate::error::Result;
@@ -1264,6 +1265,23 @@ pub async fn sync_calendars(
         );
         return Ok(());
     }
+
+    // Serialize calendar sync per account. The frontend can trigger this
+    // command from multiple sources (toolbar button, 5-minute periodic tick,
+    // context menu); without this guard, overlapping runs would race on DB
+    // writes and emit out-of-order "calendar-sync-*" events for the same
+    // account (e.g. an early "calendar-sync-error" from one run would
+    // overwrite the "running" state of another). Mirrors the mail-sync
+    // pattern in `trigger_sync` / `sync_folder`.
+    let Some(_guard) = try_acquire_sync_guard(
+        &state.calendar_sync_in_progress,
+        &account_id,
+        "Calendar sync",
+    ) else {
+        // A sync for this account is already running; skip silently with no
+        // event emission so the in-progress run's events stay coherent.
+        return Ok(());
+    };
 
     // When force_full_sync is true (manual Sync button), clear Google/O365
     // sync tokens to force a full sync that reconciles server-side deletions.

--- a/src-tauri/src/commands/calendar.rs
+++ b/src-tauri/src/commands/calendar.rs
@@ -1321,21 +1321,21 @@ pub async fn sync_calendars(
     }
     .await;
 
-    // Spinner-state events are kept separate from "calendar-changed" so
-    // unrelated subscribers (invite tracking, calendar list refresh) don't
-    // refetch on every sync tick, and so the spinner doesn't get prematurely
-    // completed by an invite-response or push-processing emission of
-    // "calendar-changed".
+    // "calendar-changed" is emitted in BOTH branches because the lower-level
+    // sync helpers can mutate the DB before an error propagates (e.g.
+    // sync_calendars_caldav upserts calendars, then a later query errors).
+    // Subscribers (invites store, calendar list) would otherwise hold stale
+    // data after a partial-write failure. Spinner state is carried by the
+    // dedicated "calendar-sync-complete"/"calendar-sync-error" events so
+    // "calendar-changed" no longer conflates "sync finished" with "data
+    // changed" — and so an invite-response or push-processing emission of
+    // "calendar-changed" can't prematurely complete the spinner.
+    app.emit("calendar-changed", account_id.as_str()).ok();
     match &sync_result {
         Ok(()) => {
-            // Sync succeeded — the DB may have changed; let refetchers run.
-            app.emit("calendar-changed", account_id.as_str()).ok();
             app.emit("calendar-sync-complete", account_id.as_str()).ok();
         }
         Err(e) => {
-            // Sync failed — do NOT emit "calendar-changed" (it would trigger
-            // unnecessary refetches by the invites and calendar stores).
-            // Only signal failure to the activity indicator.
             app.emit(
                 "calendar-sync-error",
                 serde_json::json!({

--- a/src-tauri/src/commands/sync_cmd.rs
+++ b/src-tauri/src/commands/sync_cmd.rs
@@ -28,28 +28,21 @@ pub(crate) fn try_acquire_sync_guard(
     account_id: &str,
     operation: &str,
 ) -> Option<SyncGuard> {
-    {
-        let map = flags.lock().unwrap();
-        if let Some(flag) = map.get(account_id) {
-            if flag.load(Ordering::Relaxed) {
-                log::debug!(
-                    "{} already in progress for account {}, skipping",
-                    operation,
-                    account_id
-                );
-                return None;
-            }
-        }
-    }
-
     let flag = {
         let mut map = flags.lock().unwrap();
-        let flag = map
-            .entry(account_id.to_string())
-            .or_insert_with(|| Arc::new(AtomicBool::new(false)));
-        flag.store(true, Ordering::Relaxed);
-        flag.clone()
+        map.entry(account_id.to_string())
+            .or_insert_with(|| Arc::new(AtomicBool::new(false)))
+            .clone()
     };
+
+    if flag.swap(true, Ordering::AcqRel) {
+        log::debug!(
+            "{} already in progress for account {}, skipping",
+            operation,
+            account_id
+        );
+        return None;
+    }
 
     Some(SyncGuard(flag))
 }

--- a/src-tauri/src/commands/sync_cmd.rs
+++ b/src-tauri/src/commands/sync_cmd.rs
@@ -1,6 +1,6 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use tauri::{AppHandle, Emitter, Manager, State};
 
 use crate::commands::events::{emit_folders_changed, emit_messages_changed};
@@ -9,11 +9,49 @@ use crate::commands::events::{emit_folders_changed, emit_messages_changed};
 type PrefetchMsg = (String, u32, String);
 
 /// RAII guard that clears the sync-in-progress flag on drop.
-struct SyncGuard(Arc<AtomicBool>);
+pub(crate) struct SyncGuard(Arc<AtomicBool>);
 impl Drop for SyncGuard {
     fn drop(&mut self) {
         self.0.store(false, Ordering::Relaxed);
     }
+}
+
+/// Try to acquire a per-account in-progress flag from the given map. Returns
+/// `None` if another caller already holds it; the returned guard releases
+/// the flag on drop.
+///
+/// Shared by mail sync (`AppState.sync_in_progress`) and calendar sync
+/// (`AppState.calendar_sync_in_progress`) so both domains use the same
+/// serialization pattern without blocking each other.
+pub(crate) fn try_acquire_sync_guard(
+    flags: &Mutex<HashMap<String, Arc<AtomicBool>>>,
+    account_id: &str,
+    operation: &str,
+) -> Option<SyncGuard> {
+    {
+        let map = flags.lock().unwrap();
+        if let Some(flag) = map.get(account_id) {
+            if flag.load(Ordering::Relaxed) {
+                log::debug!(
+                    "{} already in progress for account {}, skipping",
+                    operation,
+                    account_id
+                );
+                return None;
+            }
+        }
+    }
+
+    let flag = {
+        let mut map = flags.lock().unwrap();
+        let flag = map
+            .entry(account_id.to_string())
+            .or_insert_with(|| Arc::new(AtomicBool::new(false)));
+        flag.store(true, Ordering::Relaxed);
+        flag.clone()
+    };
+
+    Some(SyncGuard(flag))
 }
 
 use crate::db;
@@ -188,30 +226,7 @@ fn try_acquire_account_sync_guard(
     account_id: &str,
     operation: &str,
 ) -> Option<SyncGuard> {
-    {
-        let flags = state.sync_in_progress.lock().unwrap();
-        if let Some(flag) = flags.get(account_id) {
-            if flag.load(Ordering::Relaxed) {
-                log::debug!(
-                    "{} already in progress for account {}, skipping",
-                    operation,
-                    account_id
-                );
-                return None;
-            }
-        }
-    }
-
-    let flag = {
-        let mut flags = state.sync_in_progress.lock().unwrap();
-        let flag = flags
-            .entry(account_id.to_string())
-            .or_insert_with(|| Arc::new(AtomicBool::new(false)));
-        flag.store(true, Ordering::Relaxed);
-        flag.clone()
-    };
-
-    Some(SyncGuard(flag))
+    try_acquire_sync_guard(&state.sync_in_progress, account_id, operation)
 }
 
 #[tauri::command]
@@ -1424,6 +1439,8 @@ pub async fn stop_idle(state: State<'_, AppState>) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+
     #[test]
     fn o365_sync_suspends_idle_but_still_allows_idle_startup() {
         // Phase 3: these helpers now key off auth_method, not provider.
@@ -1435,5 +1452,32 @@ mod tests {
             "oauth-google"
         ));
         assert!(!super::should_suspend_idle_for_imap_operation("password"));
+    }
+
+    /// A second acquire for the same account is rejected while the first
+    /// guard is alive — the serialization contract that both
+    /// `trigger_sync` and `sync_calendars` rely on to keep their emitted
+    /// "*-sync-*" events coherent.
+    #[test]
+    fn try_acquire_sync_guard_rejects_concurrent_same_account() {
+        let flags: Mutex<HashMap<String, Arc<AtomicBool>>> = Mutex::new(HashMap::new());
+
+        let first = try_acquire_sync_guard(&flags, "acc-1", "test");
+        assert!(first.is_some());
+
+        let second = try_acquire_sync_guard(&flags, "acc-1", "test");
+        assert!(
+            second.is_none(),
+            "concurrent acquire for the same account must be rejected",
+        );
+
+        // A different account is unaffected.
+        let other = try_acquire_sync_guard(&flags, "acc-2", "test");
+        assert!(other.is_some());
+
+        // Releasing the first guard lets the next caller proceed.
+        drop(first);
+        let retry = try_acquire_sync_guard(&flags, "acc-1", "test");
+        assert!(retry.is_some());
     }
 }

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -31,9 +31,17 @@ pub struct AppState {
     pub sync_handles: RwLock<HashMap<String, SyncHandle>>,
     pub idle_handles: std::sync::Mutex<HashMap<String, IdleHandle>>,
     pub jmap_push_handles: std::sync::Mutex<HashMap<String, JmapPushHandle>>,
-    /// Per-account sync-in-progress flags. If true, a sync is running and
-    /// new sync requests for that account should be skipped.
+    /// Per-account mail-sync-in-progress flags. If true, a mail sync is
+    /// running and new mail sync requests for that account should be
+    /// skipped. Kept separate from calendar so the two domains don't block
+    /// each other.
     pub sync_in_progress: std::sync::Mutex<HashMap<String, Arc<AtomicBool>>>,
+    /// Per-account calendar-sync-in-progress flags. Same shape and intent
+    /// as `sync_in_progress` but for `sync_calendars`, so overlapping
+    /// calendar-sync triggers (toolbar button + periodic tick + context
+    /// menu) don't race on DB writes and emit out-of-order
+    /// `calendar-sync-*` events for the same account.
+    pub calendar_sync_in_progress: std::sync::Mutex<HashMap<String, Arc<AtomicBool>>>,
     /// Per-account operation queue senders. Workers are spawned lazily on
     /// first use and hold persistent connections for their protocol.
     pub op_senders: std::sync::Mutex<HashMap<String, tokio::sync::mpsc::Sender<OpEntry>>>,
@@ -104,6 +112,7 @@ impl AppState {
             idle_handles: std::sync::Mutex::new(HashMap::new()),
             jmap_push_handles: std::sync::Mutex::new(HashMap::new()),
             sync_in_progress: std::sync::Mutex::new(HashMap::new()),
+            calendar_sync_in_progress: std::sync::Mutex::new(HashMap::new()),
             op_senders: std::sync::Mutex::new(HashMap::new()),
             data_dir,
             attachments: std::sync::Mutex::new(HashMap::new()),

--- a/src/__tests__/activity-sync.test.ts
+++ b/src/__tests__/activity-sync.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { setActivePinia, createPinia } from "pinia";
 
 // Capture every handler registered through `listen()` so tests can drive
@@ -44,20 +44,36 @@ describe("activity store — sync indicator data flow", () => {
   });
 
   it("calendar sync drives hasActiveOperations the same way (regression)", async () => {
-    // Regression: calendar sync only emitted "calendar-changed" (a no-op
-    // completeOperation for an id that was never started), so the StatusBar
-    // Sync button never spun during calendar sync.
+    // Regression: calendar sync previously did not register a running
+    // operation, so the StatusBar Sync button never spun during calendar
+    // sync even though the sync was happening.
     const store = useActivityStore();
     await store.initEventListeners();
 
     emit("calendar-sync-started", "a1");
     expect(store.hasActiveOperations).toBe(true);
 
-    emit("calendar-changed", "a1");
+    emit("calendar-sync-complete", "a1");
     expect(store.hasActiveOperations).toBe(false);
   });
 
-  it("calendar op id matches between start and completion events", async () => {
+  it("calendar sync error fails the operation", async () => {
+    const store = useActivityStore();
+    await store.initEventListeners();
+
+    emit("calendar-sync-started", "a1");
+    emit("calendar-sync-error", {
+      account_id: "a1",
+      error: "network unreachable",
+    });
+
+    expect(store.hasActiveOperations).toBe(false);
+    const op = store.recentOperations.find((o) => o.id === "cal-sync-a1");
+    expect(op?.status).toBe("error");
+    expect(op?.error).toBe("network unreachable");
+  });
+
+  it("calendar sync op id is scoped per account", async () => {
     const store = useActivityStore();
     await store.initEventListeners();
 
@@ -66,11 +82,100 @@ describe("activity store — sync indicator data flow", () => {
       "cal-sync-acc-42",
     ]);
 
-    // A "calendar-changed" for a different account must not complete it.
-    emit("calendar-changed", "other-account");
+    // A completion for a different account must not finish this one.
+    emit("calendar-sync-complete", "other-account");
     expect(store.hasActiveOperations).toBe(true);
 
-    emit("calendar-changed", "acc-42");
+    emit("calendar-sync-complete", "acc-42");
     expect(store.hasActiveOperations).toBe(false);
+  });
+
+  it("'calendar-changed' (data-mutation event) does NOT complete a running sync op", async () => {
+    // Regression: invite responses and push processing also emit
+    // 'calendar-changed'. Coupling that event to the sync spinner would
+    // stop the indicator while the backend sync was still running.
+    const store = useActivityStore();
+    await store.initEventListeners();
+
+    emit("calendar-sync-started", "a1");
+    expect(store.hasActiveOperations).toBe(true);
+
+    // A stray 'calendar-changed' from any source must not affect the spinner.
+    expect(handlers.has("calendar-changed")).toBe(false);
+    expect(store.hasActiveOperations).toBe(true);
+
+    emit("calendar-sync-complete", "a1");
+    expect(store.hasActiveOperations).toBe(false);
+  });
+});
+
+describe("activity store — pending-removal timer race", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    handlers.clear();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("a fresh op with the same id cancels the prior removal timer", async () => {
+    // Regression: completeOperation/failOperation auto-remove the entry by
+    // id 60s/5min later. Before the fix, a second sync that reused the same
+    // id within that window would be wiped out by the stale timer.
+    const store = useActivityStore();
+    await store.initEventListeners();
+
+    emit("calendar-sync-started", "a1");
+    emit("calendar-sync-complete", "a1");
+
+    // Within the 60s removal window, start a new sync with the same id.
+    vi.advanceTimersByTime(10_000);
+    emit("calendar-sync-started", "a1");
+    expect(store.hasActiveOperations).toBe(true);
+
+    // The original removal timer would have fired by now; the new op must
+    // still be running.
+    vi.advanceTimersByTime(60_000);
+    expect(store.hasActiveOperations).toBe(true);
+    const op = store.activeOperations.find((o) => o.id === "cal-sync-a1");
+    expect(op?.status).toBe("running");
+  });
+
+  it("terminal entry is removed after the timer fires when no restart happens", async () => {
+    const store = useActivityStore();
+    await store.initEventListeners();
+
+    emit("calendar-sync-started", "a1");
+    emit("calendar-sync-complete", "a1");
+    expect(store.recentOperations.some((o) => o.id === "cal-sync-a1")).toBe(
+      true,
+    );
+
+    vi.advanceTimersByTime(60_001);
+    expect(store.recentOperations.some((o) => o.id === "cal-sync-a1")).toBe(
+      false,
+    );
+  });
+
+  it("pending removal timers are cleared on store dispose", async () => {
+    // Regression: pendingRemovals holds live timeout handles that would
+    // otherwise fire on a disposed store, mutating its state and leaking
+    // the handle. onScopeDispose must clearTimeout each pending entry.
+    const store = useActivityStore();
+    await store.initEventListeners();
+
+    emit("calendar-sync-started", "a1");
+    emit("calendar-sync-complete", "a1");
+    // A 60s removal timer for "cal-sync-a1" is now pending.
+    expect(vi.getTimerCount()).toBeGreaterThan(0);
+
+    store.$dispose();
+
+    // All timers scheduled by the activity store must be cancelled. Any
+    // remaining pending timers would be ones owned by other test machinery,
+    // but in this isolated test there are none.
+    expect(vi.getTimerCount()).toBe(0);
   });
 });

--- a/src/__tests__/activity-sync.test.ts
+++ b/src/__tests__/activity-sync.test.ts
@@ -27,13 +27,24 @@ function emit(name: string, payload: unknown) {
 }
 
 describe("activity store — sync indicator data flow", () => {
+  // Tests in this block trigger completeOperation/failOperation, which
+  // schedule real 60s/5min setTimeout removals. Without disposing the
+  // store, those handles can keep the test process alive in happy-dom.
+  let store: ReturnType<typeof useActivityStore> | undefined;
+
   beforeEach(() => {
     setActivePinia(createPinia());
     handlers.clear();
+    store = undefined;
+  });
+
+  afterEach(() => {
+    // onScopeDispose clears any pending removal timers.
+    store?.$dispose();
   });
 
   it("mail sync drives hasActiveOperations true while running", async () => {
-    const store = useActivityStore();
+    store = useActivityStore();
     await store.initEventListeners();
 
     emit("sync-started", { account_id: "a1", account_name: "Acc" });
@@ -47,7 +58,7 @@ describe("activity store — sync indicator data flow", () => {
     // Regression: calendar sync previously did not register a running
     // operation, so the StatusBar Sync button never spun during calendar
     // sync even though the sync was happening.
-    const store = useActivityStore();
+    store = useActivityStore();
     await store.initEventListeners();
 
     emit("calendar-sync-started", "a1");
@@ -58,7 +69,7 @@ describe("activity store — sync indicator data flow", () => {
   });
 
   it("calendar sync error fails the operation", async () => {
-    const store = useActivityStore();
+    store = useActivityStore();
     await store.initEventListeners();
 
     emit("calendar-sync-started", "a1");
@@ -74,7 +85,7 @@ describe("activity store — sync indicator data flow", () => {
   });
 
   it("calendar sync op id is scoped per account", async () => {
-    const store = useActivityStore();
+    store = useActivityStore();
     await store.initEventListeners();
 
     emit("calendar-sync-started", "acc-42");
@@ -94,7 +105,7 @@ describe("activity store — sync indicator data flow", () => {
     // Regression: invite responses and push processing also emit
     // 'calendar-changed'. Coupling that event to the sync spinner would
     // stop the indicator while the backend sync was still running.
-    const store = useActivityStore();
+    store = useActivityStore();
     await store.initEventListeners();
 
     emit("calendar-sync-started", "a1");

--- a/src/__tests__/activity-sync.test.ts
+++ b/src/__tests__/activity-sync.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { setActivePinia, createPinia } from "pinia";
+
+// Capture every handler registered through `listen()` so tests can drive
+// the activity store the same way the Rust backend does — by emitting
+// events — and assert on the resulting sync indicator state.
+const handlers = new Map<string, (e: { payload: unknown }) => void>();
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn((name: string, cb: (e: { payload: unknown }) => void) => {
+    handlers.set(name, cb);
+    return Promise.resolve(() => {});
+  }),
+}));
+
+vi.mock("@/lib/toast", () => ({
+  showToast: vi.fn(() => 1),
+  dismissToast: vi.fn(),
+}));
+
+import { useActivityStore } from "@/stores/activity";
+
+function emit(name: string, payload: unknown) {
+  const handler = handlers.get(name);
+  if (!handler) throw new Error(`no listener registered for "${name}"`);
+  handler({ payload });
+}
+
+describe("activity store — sync indicator data flow", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    handlers.clear();
+  });
+
+  it("mail sync drives hasActiveOperations true while running", async () => {
+    const store = useActivityStore();
+    await store.initEventListeners();
+
+    emit("sync-started", { account_id: "a1", account_name: "Acc" });
+    expect(store.hasActiveOperations).toBe(true);
+
+    emit("sync-complete", { account_id: "a1", total_synced: 0 });
+    expect(store.hasActiveOperations).toBe(false);
+  });
+
+  it("calendar sync drives hasActiveOperations the same way (regression)", async () => {
+    // Regression: calendar sync only emitted "calendar-changed" (a no-op
+    // completeOperation for an id that was never started), so the StatusBar
+    // Sync button never spun during calendar sync.
+    const store = useActivityStore();
+    await store.initEventListeners();
+
+    emit("calendar-sync-started", "a1");
+    expect(store.hasActiveOperations).toBe(true);
+
+    emit("calendar-changed", "a1");
+    expect(store.hasActiveOperations).toBe(false);
+  });
+
+  it("calendar op id matches between start and completion events", async () => {
+    const store = useActivityStore();
+    await store.initEventListeners();
+
+    emit("calendar-sync-started", "acc-42");
+    expect(store.activeOperations.map((op) => op.id)).toEqual([
+      "cal-sync-acc-42",
+    ]);
+
+    // A "calendar-changed" for a different account must not complete it.
+    emit("calendar-changed", "other-account");
+    expect(store.hasActiveOperations).toBe(true);
+
+    emit("calendar-changed", "acc-42");
+    expect(store.hasActiveOperations).toBe(false);
+  });
+});

--- a/src/stores/activity.ts
+++ b/src/stores/activity.ts
@@ -148,6 +148,19 @@ export const useActivityStore = defineStore("activity", () => {
     );
 
     // --- Calendar sync events ---
+    // `calendar-sync-started` registers the running operation so the
+    // StatusBar Sync button spins during calendar sync, mirroring the mail
+    // `sync-started`/`sync-complete` pair. `calendar-changed` completes it.
+    unlistenFns.push(
+      await listen<string>("calendar-sync-started", (event) => {
+        startOperation(
+          `cal-sync-${event.payload}`,
+          "sync",
+          "Syncing calendars",
+          "Syncing...",
+        );
+      }),
+    );
     unlistenFns.push(
       await listen<string>("calendar-changed", (event) => {
         completeOperation(

--- a/src/stores/activity.ts
+++ b/src/stores/activity.ts
@@ -30,12 +30,42 @@ export const useActivityStore = defineStore("activity", () => {
 
   const hasActiveOperations = computed(() => activeOperations.value.length > 0);
 
+  // Pending removal timers keyed by operation id. A second op that reuses an
+  // id (e.g. a repeated sync for the same account) must cancel the earlier
+  // timer, or the stale timer would wipe out the new "running" entry mid-run.
+  const pendingRemovals = new Map<string, ReturnType<typeof setTimeout>>();
+
+  function cancelPendingRemoval(id: string) {
+    const handle = pendingRemovals.get(id);
+    if (handle !== undefined) {
+      clearTimeout(handle);
+      pendingRemovals.delete(id);
+    }
+  }
+
+  function scheduleRemoval(id: string, ms: number) {
+    cancelPendingRemoval(id);
+    const handle = setTimeout(() => {
+      pendingRemovals.delete(id);
+      const op = operations.value.get(id);
+      // Guard against a new "running" op having taken the same id since we
+      // were scheduled. We only auto-remove terminal entries.
+      if (op && (op.status === "done" || op.status === "error")) {
+        operations.value.delete(id);
+        operations.value = new Map(operations.value);
+      }
+    }, ms);
+    pendingRemovals.set(id, handle);
+  }
+
   function startOperation(
     id: string,
     type: Operation["type"],
     label: string,
     detail: string = "",
   ): string {
+    // A fresh run with the same id supersedes any pending removal.
+    cancelPendingRemoval(id);
     operations.value.set(id, {
       id,
       type,
@@ -64,10 +94,7 @@ export const useActivityStore = defineStore("activity", () => {
       if (detail) op.detail = detail;
       operations.value = new Map(operations.value);
       // Auto-remove after 60 seconds (visible in operations panel)
-      setTimeout(() => {
-        operations.value.delete(id);
-        operations.value = new Map(operations.value);
-      }, 60_000);
+      scheduleRemoval(id, 60_000);
     }
   }
 
@@ -79,10 +106,7 @@ export const useActivityStore = defineStore("activity", () => {
       op.detail = error;
       operations.value = new Map(operations.value);
       // Auto-remove errors after 5 minutes
-      setTimeout(() => {
-        operations.value.delete(id);
-        operations.value = new Map(operations.value);
-      }, 5 * 60_000);
+      scheduleRemoval(id, 5 * 60_000);
     }
   }
 
@@ -148,9 +172,11 @@ export const useActivityStore = defineStore("activity", () => {
     );
 
     // --- Calendar sync events ---
-    // `calendar-sync-started` registers the running operation so the
-    // StatusBar Sync button spins during calendar sync, mirroring the mail
-    // `sync-started`/`sync-complete` pair. `calendar-changed` completes it.
+    // Dedicated start/complete/error events, mirroring the mail
+    // `sync-started`/`sync-complete`/`sync-error` triad. We deliberately do
+    // NOT listen for `calendar-changed`: that event also fires from invite
+    // responses, push processing, and other non-sync mutations, so coupling
+    // it to the spinner would complete the indicator prematurely.
     unlistenFns.push(
       await listen<string>("calendar-sync-started", (event) => {
         startOperation(
@@ -162,12 +188,20 @@ export const useActivityStore = defineStore("activity", () => {
       }),
     );
     unlistenFns.push(
-      await listen<string>("calendar-changed", (event) => {
-        completeOperation(
-          `cal-sync-${event.payload}`,
-          "Calendars updated",
-        );
+      await listen<string>("calendar-sync-complete", (event) => {
+        completeOperation(`cal-sync-${event.payload}`, "Calendars updated");
       }),
+    );
+    unlistenFns.push(
+      await listen<{ account_id: string; error: string }>(
+        "calendar-sync-error",
+        (event) => {
+          failOperation(
+            `cal-sync-${event.payload.account_id}`,
+            event.payload.error,
+          );
+        },
+      ),
     );
 
     // --- Contacts sync events ---
@@ -260,6 +294,12 @@ export const useActivityStore = defineStore("activity", () => {
     for (const unlisten of unlistenFns) {
       unlisten();
     }
+    // Cancel any pending removal timers so they don't fire on a disposed
+    // store and mutate state (or leak the handle).
+    for (const handle of pendingRemovals.values()) {
+      clearTimeout(handle);
+    }
+    pendingRemovals.clear();
   });
 
   return {


### PR DESCRIPTION
The StatusBar Sync icon and op-spinner are driven by activityStore.hasActiveOperations, which is true only while a running operation exists. Mail sync emits sync-started -> startOperation, so the icon spins. Calendar sync only emitted calendar-changed, which called completeOperation on an id that was never started -- a silent no-op -- so no running operation existed and the icon stayed still even though the sync was happening.

- commands/calendar.rs: emit "calendar-sync-started" at the start of sync_calendars (after the disabled-account gate), mirroring the mail "sync-started" contract. Wrap the protocol dispatch so "calendar-changed" is emitted on both success and failure, so the activity indicator always completes and the spinner never sticks.
- stores/activity.ts: listen for "calendar-sync-started" and register the cal-sync-<account_id> running operation. The existing "calendar-changed" listener completes it.
- Add src/__tests__/activity-sync.test.ts covering the data flow: mail sync baseline, calendar sync regression, op-id scoping per account.

Now the StatusBar Sync button spins for every calendar sync trigger (toolbar button, 5-minute periodic sync, right-click "Sync this calendar"), matching mail.