### PR TITLE
fix: quote IMAP mailbox names in COPY (#185)

### DIFF
--- a/src-tauri/src/mail/imap.rs
+++ b/src-tauri/src/mail/imap.rs
@@ -484,8 +484,9 @@ impl ImapConnection {
         );
 
         // 1. Copy messages to destination
+        let quoted_dest = quote_mailbox_for_imap(dest_folder)?;
         self.session
-            .uid_copy(&uid_set, quote_mailbox_for_imap(dest_folder))
+            .uid_copy(&uid_set, &quoted_dest)
             .map_err(|e| {
                 log::error!("IMAP UID COPY to '{}' failed: {}", dest_folder, e);
                 Error::Imap(format!("COPY to '{}' failed: {}", dest_folder, e))
@@ -646,8 +647,9 @@ impl ImapConnection {
             dest_folder
         );
 
+        let quoted_dest = quote_mailbox_for_imap(dest_folder)?;
         self.session
-            .uid_copy(&uid_set, quote_mailbox_for_imap(dest_folder))
+            .uid_copy(&uid_set, &quoted_dest)
             .map_err(|e| {
                 log::error!("IMAP UID COPY to '{}' failed: {}", dest_folder, e);
                 Error::Imap(format!("COPY to '{}' failed: {}", dest_folder, e))
@@ -852,7 +854,20 @@ fn uid_set_string(uids: &[u32]) -> String {
 /// parsed by the server as two atoms and the COPY fails with
 /// `Mailbox doesn't exist: Infra/SUNET`. Quote it ourselves: wrap in
 /// `"` and backslash-escape `"` and `\` per the `quoted` grammar.
-fn quote_mailbox_for_imap(name: &str) -> String {
+///
+/// The `quoted` grammar (RFC 3501 §4.3) excludes CR, LF, and NUL —
+/// these would break command framing on the wire. Since `dest_folder`
+/// reaches us from a Tauri command argument we fail loudly on any
+/// control character rather than silently stripping it (silent
+/// stripping would change the destination folder, which is worse than
+/// a clear error).
+fn quote_mailbox_for_imap(name: &str) -> Result<String> {
+    if let Some(c) = name.chars().find(|c| c.is_control()) {
+        return Err(Error::Imap(format!(
+            "invalid mailbox name: contains control character U+{:04X}",
+            c as u32
+        )));
+    }
     let mut out = String::with_capacity(name.len() + 2);
     out.push('"');
     for c in name.chars() {
@@ -862,7 +877,7 @@ fn quote_mailbox_for_imap(name: &str) -> String {
         out.push(c);
     }
     out.push('"');
-    out
+    Ok(out)
 }
 
 fn flag_to_string(flag: &imap::types::Flag<'_>) -> String {
@@ -912,7 +927,7 @@ mod quote_mailbox_tests {
 
     #[test]
     fn simple_name_is_quoted() {
-        assert_eq!(quote_mailbox_for_imap("INBOX"), "\"INBOX\"");
+        assert_eq!(quote_mailbox_for_imap("INBOX").unwrap(), "\"INBOX\"");
     }
 
     #[test]
@@ -920,24 +935,43 @@ mod quote_mailbox_tests {
         // The regression from #185: a space in the name caused the server
         // to parse `Infra/SUNET Drive` as two atoms.
         assert_eq!(
-            quote_mailbox_for_imap("Infra/SUNET Drive"),
+            quote_mailbox_for_imap("Infra/SUNET Drive").unwrap(),
             "\"Infra/SUNET Drive\""
         );
     }
 
     #[test]
     fn embedded_double_quote_is_backslash_escaped() {
-        assert_eq!(quote_mailbox_for_imap("weird\"name"), "\"weird\\\"name\"");
+        assert_eq!(
+            quote_mailbox_for_imap("weird\"name").unwrap(),
+            "\"weird\\\"name\""
+        );
     }
 
     #[test]
     fn embedded_backslash_is_backslash_escaped() {
-        assert_eq!(quote_mailbox_for_imap("a\\b"), "\"a\\\\b\"");
+        assert_eq!(quote_mailbox_for_imap("a\\b").unwrap(), "\"a\\\\b\"");
     }
 
     #[test]
     fn empty_name_round_trips_to_empty_quoted_string() {
-        assert_eq!(quote_mailbox_for_imap(""), "\"\"");
+        assert_eq!(quote_mailbox_for_imap("").unwrap(), "\"\"");
+    }
+
+    #[test]
+    fn control_characters_are_rejected() {
+        // RFC 3501 §4.3 excludes CR/LF/NUL from the quoted grammar. We
+        // reject loudly rather than silently strip — silent stripping
+        // would change the destination folder, which is worse than a
+        // clear error and could mask injection attempts via the Tauri
+        // command argument.
+        for bad in ["a\rb", "a\nb", "a\0b", "\x07bell"] {
+            assert!(
+                quote_mailbox_for_imap(bad).is_err(),
+                "expected rejection for {:?}",
+                bad
+            );
+        }
     }
 }
 

--- a/src-tauri/src/mail/imap.rs
+++ b/src-tauri/src/mail/imap.rs
@@ -484,10 +484,12 @@ impl ImapConnection {
         );
 
         // 1. Copy messages to destination
-        self.session.uid_copy(&uid_set, dest_folder).map_err(|e| {
-            log::error!("IMAP UID COPY to '{}' failed: {}", dest_folder, e);
-            Error::Imap(format!("COPY to '{}' failed: {}", dest_folder, e))
-        })?;
+        self.session
+            .uid_copy(&uid_set, quote_mailbox_for_imap(dest_folder))
+            .map_err(|e| {
+                log::error!("IMAP UID COPY to '{}' failed: {}", dest_folder, e);
+                Error::Imap(format!("COPY to '{}' failed: {}", dest_folder, e))
+            })?;
         log::debug!("IMAP COPY to '{}' succeeded", dest_folder);
 
         // 2. Mark originals as deleted
@@ -644,10 +646,12 @@ impl ImapConnection {
             dest_folder
         );
 
-        self.session.uid_copy(&uid_set, dest_folder).map_err(|e| {
-            log::error!("IMAP UID COPY to '{}' failed: {}", dest_folder, e);
-            Error::Imap(format!("COPY to '{}' failed: {}", dest_folder, e))
-        })?;
+        self.session
+            .uid_copy(&uid_set, quote_mailbox_for_imap(dest_folder))
+            .map_err(|e| {
+                log::error!("IMAP UID COPY to '{}' failed: {}", dest_folder, e);
+                Error::Imap(format!("COPY to '{}' failed: {}", dest_folder, e))
+            })?;
 
         log::info!(
             "IMAP copy complete: {} messages copied to '{}'",
@@ -840,6 +844,27 @@ fn uid_set_string(uids: &[u32]) -> String {
         .join(",")
 }
 
+/// Quote a mailbox name as an IMAP RFC 3501 quoted-string.
+///
+/// `imap` 2.4.1's `Session::uid_copy` / `Session::copy` interpolate the
+/// destination mailbox name into `UID COPY <set> <name>` without any
+/// quoting, so a name containing a space (e.g. `Infra/SUNET Drive`) is
+/// parsed by the server as two atoms and the COPY fails with
+/// `Mailbox doesn't exist: Infra/SUNET`. Quote it ourselves: wrap in
+/// `"` and backslash-escape `"` and `\` per the `quoted` grammar.
+fn quote_mailbox_for_imap(name: &str) -> String {
+    let mut out = String::with_capacity(name.len() + 2);
+    out.push('"');
+    for c in name.chars() {
+        if c == '"' || c == '\\' {
+            out.push('\\');
+        }
+        out.push(c);
+    }
+    out.push('"');
+    out
+}
+
 fn flag_to_string(flag: &imap::types::Flag<'_>) -> String {
     match flag {
         imap::types::Flag::Seen => "seen".to_string(),
@@ -879,6 +904,41 @@ fn flag_to_wire(flag: &str) -> String {
 /// which RFC 3501 §2.3.2 forbids modifying via STORE.
 fn is_recent_flag(flag: &str) -> bool {
     flag.trim_start_matches('\\').eq_ignore_ascii_case("recent")
+}
+
+#[cfg(test)]
+mod quote_mailbox_tests {
+    use super::quote_mailbox_for_imap;
+
+    #[test]
+    fn simple_name_is_quoted() {
+        assert_eq!(quote_mailbox_for_imap("INBOX"), "\"INBOX\"");
+    }
+
+    #[test]
+    fn name_with_space_is_quoted_unchanged() {
+        // The regression from #185: a space in the name caused the server
+        // to parse `Infra/SUNET Drive` as two atoms.
+        assert_eq!(
+            quote_mailbox_for_imap("Infra/SUNET Drive"),
+            "\"Infra/SUNET Drive\""
+        );
+    }
+
+    #[test]
+    fn embedded_double_quote_is_backslash_escaped() {
+        assert_eq!(quote_mailbox_for_imap("weird\"name"), "\"weird\\\"name\"");
+    }
+
+    #[test]
+    fn embedded_backslash_is_backslash_escaped() {
+        assert_eq!(quote_mailbox_for_imap("a\\b"), "\"a\\\\b\"");
+    }
+
+    #[test]
+    fn empty_name_round_trips_to_empty_quoted_string() {
+        assert_eq!(quote_mailbox_for_imap(""), "\"\"");
+    }
 }
 
 #[cfg(test)]

--- a/src-tauri/src/mail/imap.rs
+++ b/src-tauri/src/mail/imap.rs
@@ -485,12 +485,10 @@ impl ImapConnection {
 
         // 1. Copy messages to destination
         let quoted_dest = quote_mailbox_for_imap(dest_folder)?;
-        self.session
-            .uid_copy(&uid_set, &quoted_dest)
-            .map_err(|e| {
-                log::error!("IMAP UID COPY to '{}' failed: {}", dest_folder, e);
-                Error::Imap(format!("COPY to '{}' failed: {}", dest_folder, e))
-            })?;
+        self.session.uid_copy(&uid_set, &quoted_dest).map_err(|e| {
+            log::error!("IMAP UID COPY to '{}' failed: {}", dest_folder, e);
+            Error::Imap(format!("COPY to '{}' failed: {}", dest_folder, e))
+        })?;
         log::debug!("IMAP COPY to '{}' succeeded", dest_folder);
 
         // 2. Mark originals as deleted
@@ -648,12 +646,10 @@ impl ImapConnection {
         );
 
         let quoted_dest = quote_mailbox_for_imap(dest_folder)?;
-        self.session
-            .uid_copy(&uid_set, &quoted_dest)
-            .map_err(|e| {
-                log::error!("IMAP UID COPY to '{}' failed: {}", dest_folder, e);
-                Error::Imap(format!("COPY to '{}' failed: {}", dest_folder, e))
-            })?;
+        self.session.uid_copy(&uid_set, &quoted_dest).map_err(|e| {
+            log::error!("IMAP UID COPY to '{}' failed: {}", dest_folder, e);
+            Error::Imap(format!("COPY to '{}' failed: {}", dest_folder, e))
+        })?;
 
         log::info!(
             "IMAP copy complete: {} messages copied to '{}'",


### PR DESCRIPTION
## Summary

- The `imap` 2.4.1 crate's `Session::uid_copy` / `Session::copy` interpolate the destination mailbox name into `UID COPY <set> <name>` **without quoting** (unlike `SELECT` / `CREATE` / `DELETE`, which all go through the crate's internal `validate_str`).
- For a folder name containing a space (e.g. `Infra/SUNET Drive`) the server parses two atoms and the COPY fails:
  ```
  COPY to 'Infra/SUNET Drive' failed: No Response: Mailbox doesn't exist: Infra/SUNET
  ```
- Fix: add `quote_mailbox_for_imap`, a tiny RFC 3501 `quoted`-grammar formatter (wrap in `"…"`, backslash-escape `"` and `\`), and use it at both `move_messages` and `copy_messages` call sites. Always-quoting is safe — a mailbox may be a quoted string even when an atom would do.
- Added 5 unit tests covering the regression case, plain names, embedded `"`, embedded `\`, and the empty string.

Fixes #185.

## Test plan

- [x] `cargo check --lib`
- [x] `cargo test --lib mail::imap` (19 passed, including the 5 new `quote_mailbox_tests`)
- [x] Manual: move a message to `Infra/SUNET Drive` on a real IMAP account and confirm the move succeeds without the retry loop.