### PR TITLE
fix: APPEND sent messages to the IMAP Sent folder (#189)

### DIFF
--- a/src-tauri/src/commands/compose.rs
+++ b/src-tauri/src/commands/compose.rs
@@ -231,6 +231,54 @@ pub async fn send_message(
                     &references,
                 )
                 .await?;
+
+                // Best-effort: APPEND the sent message to the IMAP Sent
+                // folder (#189). SMTP submission alone never writes to
+                // Sent for plain IMAP+SMTP or Exchange-via-SMTP-AUTH;
+                // JMAP / Graph send APIs are unaffected because they
+                // populate Sent server-side. Failures here MUST NOT
+                // propagate — the message has been delivered, and a
+                // retried send would duplicate it for the recipient.
+                let sent_folder_path = {
+                    let conn = db_bg.writer().await;
+                    crate::db::folders::folder_path_by_type(&conn, &account_id_bg, "sent")
+                        .ok()
+                        .flatten()
+                };
+                let imap_config = crate::mail::imap::ImapConfig {
+                    host: account.imap_host.clone(),
+                    port: account.imap_port,
+                    username: smtp_username.clone(),
+                    password: smtp_password.clone(),
+                    use_tls: account.use_tls,
+                    use_xoauth2,
+                };
+                let raw_for_append = raw_message.clone();
+                let account_id_append = account_id_bg.clone();
+                let append_result = tokio::task::spawn_blocking(move || {
+                    crate::mail::imap::append_message_to_sent(
+                        &imap_config,
+                        sent_folder_path.as_deref(),
+                        &raw_for_append,
+                    )
+                })
+                .await;
+                match append_result {
+                    Ok(Ok(())) => log::info!(
+                        "Sent message APPENDed to Sent folder for account {}",
+                        account_id_append
+                    ),
+                    Ok(Err(e)) => log::warn!(
+                        "Sent delivered but APPEND to Sent failed for account {}: {}",
+                        account_id_append,
+                        e
+                    ),
+                    Err(e) => log::warn!(
+                        "APPEND-to-Sent task panicked for account {}: {}",
+                        account_id_append,
+                        e
+                    ),
+                }
             }
             Ok(())
         }

--- a/src-tauri/src/commands/compose.rs
+++ b/src-tauri/src/commands/compose.rs
@@ -88,7 +88,10 @@ pub async fn send_message(
     let (in_reply_to, references) =
         resolve_reply_headers(&state, &account_id, message.reply_to_message_id.as_deref());
 
-    let raw_message = smtp::build_raw_message(
+    // `raw_message` carries the inlined attachment bytes — wrap in `Arc`
+    // so the background spawn can share the buffer with the IMAP APPEND
+    // path without deep-cloning megabytes of MIME each send.
+    let raw_message: std::sync::Arc<[u8]> = smtp::build_raw_message(
         &account.email,
         &message.to,
         &message.cc,
@@ -99,7 +102,8 @@ pub async fn send_message(
         &attachment_data,
         in_reply_to.as_deref(),
         &references,
-    )?;
+    )?
+    .into();
 
     // For O365 SMTP: refresh OAuth token now (needs keyring access)
     let smtp_creds =
@@ -243,8 +247,10 @@ pub async fn send_message(
                 // populate Sent server-side. Failures here MUST NOT
                 // propagate — the message has been delivered, and a
                 // retried send would duplicate it for the recipient.
+                // Read-only lookup — use the pool's reader so we don't
+                // serialize on the single-writer mutex.
                 let sent_folder_path = {
-                    let conn = db_bg.writer().await;
+                    let conn = db_bg.reader();
                     crate::db::folders::folder_path_by_type(&conn, &account_id_bg, "sent")
                         .ok()
                         .flatten()
@@ -257,7 +263,10 @@ pub async fn send_message(
                     use_tls: account.use_tls,
                     use_xoauth2,
                 };
-                let raw_for_append = raw_message.clone();
+                // `Arc::clone` of `Arc<[u8]>` is a refcount bump — does
+                // not duplicate the inlined-attachment bytes (which can
+                // be many MB on a send with large attachments).
+                let raw_for_append = std::sync::Arc::clone(&raw_message);
                 let account_id_append = account_id_bg.clone();
                 let append_result = tokio::task::spawn_blocking(move || {
                     crate::mail::imap::append_message_to_sent(
@@ -298,11 +307,21 @@ pub async fn send_message(
                         account_id_append,
                         e
                     ),
-                    Err(e) => log::warn!(
-                        "APPEND-to-Sent task panicked for account {}: {}",
-                        account_id_append,
-                        e
-                    ),
+                    Err(e) => {
+                        let kind = if e.is_panic() {
+                            "panicked"
+                        } else if e.is_cancelled() {
+                            "cancelled"
+                        } else {
+                            "failed"
+                        };
+                        log::warn!(
+                            "APPEND-to-Sent task {} for account {}: {}",
+                            kind,
+                            account_id_append,
+                            e
+                        );
+                    }
                 }
             }
             Ok(())

--- a/src-tauri/src/commands/compose.rs
+++ b/src-tauri/src/commands/compose.rs
@@ -188,6 +188,10 @@ pub async fn send_message(
     let account_id_bg = account_id.clone();
     let subject_bg = subject_display.clone();
     let db_bg = state.db.clone();
+    // Capture the worker's op-sender now so the spawn can enqueue a
+    // Sent-folder sync after a successful APPEND (#189). `state` is
+    // not `'static`, so the sender must be cloned out before the move.
+    let op_sender_bg = state.get_op_sender(&account_id, &app);
     let recipients: Vec<String> = message
         .to
         .iter()
@@ -264,10 +268,31 @@ pub async fn send_message(
                 })
                 .await;
                 match append_result {
-                    Ok(Ok(())) => log::info!(
-                        "Sent message APPENDed to Sent folder for account {}",
-                        account_id_append
-                    ),
+                    Ok(Ok(sent_folder)) => {
+                        log::info!(
+                            "APPENDed sent message to '{}' for account {}",
+                            sent_folder,
+                            account_id_append
+                        );
+                        // Nudge a targeted sync so the freshly-APPENDed
+                        // message shows up in the UI immediately instead
+                        // of waiting for the next scheduled sync.
+                        let send_res = op_sender_bg
+                            .send(crate::ops::queue::OpEntry {
+                                op: crate::ops::queue::MailOp::SyncFolder {
+                                    folder_path: sent_folder,
+                                },
+                                priority: crate::ops::queue::OpPriority::User,
+                            })
+                            .await;
+                        if let Err(e) = send_res {
+                            log::warn!(
+                                "Failed to queue Sent-folder sync for account {}: {}",
+                                account_id_append,
+                                e
+                            );
+                        }
+                    }
                     Ok(Err(e)) => log::warn!(
                         "Sent delivered but APPEND to Sent failed for account {}: {}",
                         account_id_append,

--- a/src-tauri/src/db/folders.rs
+++ b/src-tauri/src/db/folders.rs
@@ -328,6 +328,28 @@ pub fn recalculate_folder_counts(conn: &Connection, account_id: &str) -> Result<
     Ok(())
 }
 
+/// Look up the IMAP path of the first folder belonging to `account_id`
+/// whose `folder_type` matches (e.g. `"sent"`, `"drafts"`, `"trash"`).
+///
+/// Returns `Ok(None)` when no folder is tagged with that type yet — the
+/// cache is populated by `guess_folder_type` during folder sync, so a
+/// brand-new account may not have it until the first sync completes.
+pub fn folder_path_by_type(
+    conn: &Connection,
+    account_id: &str,
+    folder_type: &str,
+) -> Result<Option<String>> {
+    use rusqlite::OptionalExtension;
+    let path = conn
+        .query_row(
+            "SELECT path FROM folders WHERE account_id = ?1 AND folder_type = ?2 LIMIT 1",
+            params![account_id, folder_type],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?;
+    Ok(path)
+}
+
 /// Guess folder type from name for common IMAP folder names
 pub fn guess_folder_type(name: &str) -> Option<&'static str> {
     let lower = name.to_lowercase();
@@ -488,6 +510,47 @@ mod tests {
             .find(|f| f.path == "INBOX/Infra")
             .unwrap();
         assert_eq!(infra.children.len(), 1);
+    }
+
+    #[test]
+    fn folder_path_by_type_returns_path_for_matching_account_and_type() {
+        let conn = create_delete_test_db();
+        // Sent folder for the target account; Sent for another account too.
+        conn.execute(
+            "INSERT INTO folders (account_id, name, path, folder_type) VALUES (?1, ?2, ?3, ?4)",
+            params!["acc1", "Sent", "INBOX.Sent", "sent"],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO folders (account_id, name, path, folder_type) VALUES (?1, ?2, ?3, ?4)",
+            params!["acc2", "Sent", "Sent Items", "sent"],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO folders (account_id, name, path, folder_type) VALUES (?1, ?2, ?3, ?4)",
+            params!["acc1", "Drafts", "Drafts", "drafts"],
+        )
+        .unwrap();
+
+        assert_eq!(
+            folder_path_by_type(&conn, "acc1", "sent").unwrap(),
+            Some("INBOX.Sent".to_string())
+        );
+        assert_eq!(
+            folder_path_by_type(&conn, "acc2", "sent").unwrap(),
+            Some("Sent Items".to_string())
+        );
+        assert_eq!(
+            folder_path_by_type(&conn, "acc1", "drafts").unwrap(),
+            Some("Drafts".to_string())
+        );
+        // No archive folder anywhere -> None, not an error.
+        assert_eq!(folder_path_by_type(&conn, "acc1", "archive").unwrap(), None);
+        // Unknown account -> None.
+        assert_eq!(
+            folder_path_by_type(&conn, "acc-none", "sent").unwrap(),
+            None
+        );
     }
 
     fn create_delete_test_db() -> Connection {

--- a/src-tauri/src/db/folders.rs
+++ b/src-tauri/src/db/folders.rs
@@ -340,9 +340,14 @@ pub fn folder_path_by_type(
     folder_type: &str,
 ) -> Result<Option<String>> {
     use rusqlite::OptionalExtension;
+    // `ORDER BY id` keeps the choice stable when an account ends up with
+    // more than one folder tagged for the same role (e.g. a server-side
+    // rename leaves both the old and new Sent boxes classified). The
+    // first inserted wins, which lines up with sync's insertion order.
     let path = conn
         .query_row(
-            "SELECT path FROM folders WHERE account_id = ?1 AND folder_type = ?2 LIMIT 1",
+            "SELECT path FROM folders WHERE account_id = ?1 AND folder_type = ?2 \
+             ORDER BY id LIMIT 1",
             params![account_id, folder_type],
             |row| row.get::<_, String>(0),
         )

--- a/src-tauri/src/mail/imap.rs
+++ b/src-tauri/src/mail/imap.rs
@@ -678,6 +678,24 @@ impl ImapConnection {
         Ok(())
     }
 
+    /// Append a raw RFC5322 message to a folder, marking it `\Seen`.
+    ///
+    /// Used by the post-SMTP-send hook (#189) to populate the Sent
+    /// folder. Differs from [`Self::append_message`] in that it does
+    /// **not** set `\Draft` — these are delivered messages, not drafts.
+    pub fn append_sent_message(&mut self, folder: &str, message: &[u8]) -> Result<()> {
+        log::info!(
+            "IMAP appending sent message ({} bytes) to folder '{}'",
+            message.len(),
+            folder
+        );
+        self.session
+            .append_with_flags(folder, message, &[imap::types::Flag::Seen])
+            .map_err(|e| Error::Imap(format!("IMAP APPEND to '{}' failed: {}", folder, e)))?;
+        log::info!("IMAP sent message appended to '{}'", folder);
+        Ok(())
+    }
+
     /// Append a raw RFC5322 message to a folder preserving its original state
     /// (no extra flags). Used for cross-account moves where we want to keep
     /// the message as-is.
@@ -810,6 +828,57 @@ pub fn search_account_blocking(
 
     conn.logout();
     Ok(hits)
+}
+
+/// Open an IMAP session and APPEND `raw_message` to the account's Sent
+/// folder, marking it `\Seen`.
+///
+/// Tries `sent_folder_path` first when supplied (from the local folder
+/// cache), then walks a list of common Sent-folder names — covering
+/// vanilla IMAP servers (`Sent`), Courier-style hierarchies
+/// (`INBOX.Sent`), Exchange / O365 (`Sent Items`), Cyrus
+/// (`Sent Messages`) and Gmail (`[Gmail]/Sent Mail`).
+///
+/// This is the post-SMTP-send hook from #189: SMTP submission alone
+/// never writes to Sent (JMAP/Graph send APIs handle Sent server-side,
+/// but Exchange-via-SMTP and plain IMAP do not). Callers should treat
+/// failures as best-effort — the message has already been delivered,
+/// so a failed APPEND must NOT bubble up and trigger an outbox retry
+/// (that would cause duplicate delivery).
+///
+/// Blocking. Wrap in `tokio::task::spawn_blocking` from async code.
+pub fn append_message_to_sent(
+    config: &ImapConfig,
+    sent_folder_path: Option<&str>,
+    raw_message: &[u8],
+) -> Result<()> {
+    let mut conn = ImapConnection::connect(config)?;
+    let candidates: Vec<&str> = match sent_folder_path {
+        Some(p) => vec![p],
+        None => vec![
+            "Sent",
+            "INBOX.Sent",
+            "Sent Items",
+            "Sent Messages",
+            "[Gmail]/Sent Mail",
+        ],
+    };
+    let mut last_err: Option<Error> = None;
+    for folder in candidates {
+        match conn.append_sent_message(folder, raw_message) {
+            Ok(()) => {
+                conn.logout();
+                return Ok(());
+            }
+            Err(e) => {
+                log::debug!("APPEND to Sent candidate '{}' failed: {}", folder, e);
+                last_err = Some(e);
+            }
+        }
+    }
+    conn.logout();
+    Err(last_err
+        .unwrap_or_else(|| Error::Imap("APPEND to Sent failed: no candidate folders".into())))
 }
 
 fn envelope_to_hit(account_id: &str, folder_path: &str, env: EnvelopeData) -> SearchHit {

--- a/src-tauri/src/mail/imap.rs
+++ b/src-tauri/src/mail/imap.rs
@@ -831,7 +831,8 @@ pub fn search_account_blocking(
 }
 
 /// Open an IMAP session and APPEND `raw_message` to the account's Sent
-/// folder, marking it `\Seen`.
+/// folder, marking it `\Seen`. Returns the folder path that succeeded
+/// so the caller can nudge a targeted sync on it.
 ///
 /// Tries `sent_folder_path` first when supplied (from the local folder
 /// cache), then walks a list of common Sent-folder names — covering
@@ -851,24 +852,24 @@ pub fn append_message_to_sent(
     config: &ImapConfig,
     sent_folder_path: Option<&str>,
     raw_message: &[u8],
-) -> Result<()> {
+) -> Result<String> {
     let mut conn = ImapConnection::connect(config)?;
-    let candidates: Vec<&str> = match sent_folder_path {
-        Some(p) => vec![p],
+    let candidates: Vec<String> = match sent_folder_path {
+        Some(p) => vec![p.to_string()],
         None => vec![
-            "Sent",
-            "INBOX.Sent",
-            "Sent Items",
-            "Sent Messages",
-            "[Gmail]/Sent Mail",
+            "Sent".to_string(),
+            "INBOX.Sent".to_string(),
+            "Sent Items".to_string(),
+            "Sent Messages".to_string(),
+            "[Gmail]/Sent Mail".to_string(),
         ],
     };
     let mut last_err: Option<Error> = None;
     for folder in candidates {
-        match conn.append_sent_message(folder, raw_message) {
+        match conn.append_sent_message(&folder, raw_message) {
             Ok(()) => {
                 conn.logout();
-                return Ok(());
+                return Ok(folder);
             }
             Err(e) => {
                 log::debug!("APPEND to Sent candidate '{}' failed: {}", folder, e);

--- a/src-tauri/src/mail/imap.rs
+++ b/src-tauri/src/mail/imap.rs
@@ -854,16 +854,26 @@ pub fn append_message_to_sent(
     raw_message: &[u8],
 ) -> Result<String> {
     let mut conn = ImapConnection::connect(config)?;
-    let candidates: Vec<String> = match sent_folder_path {
-        Some(p) => vec![p.to_string()],
-        None => vec![
-            "Sent".to_string(),
-            "INBOX.Sent".to_string(),
-            "Sent Items".to_string(),
-            "Sent Messages".to_string(),
-            "[Gmail]/Sent Mail".to_string(),
-        ],
-    };
+    // Cached path first (preferred — picked up by sync from SPECIAL-USE
+    // or name heuristics), then the common fallbacks. The fallback walk
+    // covers the case where the cached path is stale or wrong: an
+    // account that was renamed server-side, or first-sync edge cases
+    // where the cache lists an outdated path.
+    let mut candidates: Vec<String> = Vec::new();
+    if let Some(p) = sent_folder_path {
+        candidates.push(p.to_string());
+    }
+    for fallback in [
+        "Sent",
+        "INBOX.Sent",
+        "Sent Items",
+        "Sent Messages",
+        "[Gmail]/Sent Mail",
+    ] {
+        if !candidates.iter().any(|c| c == fallback) {
+            candidates.push(fallback.to_string());
+        }
+    }
     let mut last_err: Option<Error> = None;
     for folder in candidates {
         match conn.append_sent_message(&folder, raw_message) {

--- a/src-tauri/src/ops/worker.rs
+++ b/src-tauri/src/ops/worker.rs
@@ -710,11 +710,21 @@ impl AccountWorker {
                 account_id_append,
                 e
             ),
-            Err(e) => log::warn!(
-                "Outbox replay: APPEND-to-Sent task panicked for account {}: {}",
-                account_id_append,
-                e
-            ),
+            Err(e) => {
+                let kind = if e.is_panic() {
+                    "panicked"
+                } else if e.is_cancelled() {
+                    "cancelled"
+                } else {
+                    "failed"
+                };
+                log::warn!(
+                    "Outbox replay: APPEND-to-Sent task {} for account {}: {}",
+                    kind,
+                    account_id_append,
+                    e
+                );
+            }
         }
         Ok(())
     }

--- a/src-tauri/src/ops/worker.rs
+++ b/src-tauri/src/ops/worker.rs
@@ -653,7 +653,52 @@ impl AccountWorker {
             &bcc,
             &raw_message,
         )
-        .await
+        .await?;
+
+        // Best-effort APPEND to Sent (#189). Same rule as the live-send
+        // path in `commands::compose`: a failure here MUST NOT propagate,
+        // because the message has been delivered and the outbox would
+        // otherwise retry the send and duplicate it for the recipient.
+        let sent_folder_path = {
+            let conn = self.db.reader();
+            crate::db::folders::folder_path_by_type(&conn, &self.account_id, "sent")
+                .ok()
+                .flatten()
+        };
+        let imap_config = crate::mail::imap::ImapConfig {
+            host: account.imap_host.clone(),
+            port: account.imap_port,
+            username: smtp_username,
+            password: smtp_password,
+            use_tls: account.use_tls,
+            use_xoauth2,
+        };
+        let account_id_append = self.account_id.clone();
+        let append_result = tokio::task::spawn_blocking(move || {
+            crate::mail::imap::append_message_to_sent(
+                &imap_config,
+                sent_folder_path.as_deref(),
+                &raw_message,
+            )
+        })
+        .await;
+        match append_result {
+            Ok(Ok(())) => log::info!(
+                "Outbox replay: APPENDed sent message to Sent for account {}",
+                account_id_append
+            ),
+            Ok(Err(e)) => log::warn!(
+                "Outbox replay: delivered but APPEND to Sent failed for account {}: {}",
+                account_id_append,
+                e
+            ),
+            Err(e) => log::warn!(
+                "Outbox replay: APPEND-to-Sent task panicked for account {}: {}",
+                account_id_append,
+                e
+            ),
+        }
+        Ok(())
     }
 }
 

--- a/src-tauri/src/ops/worker.rs
+++ b/src-tauri/src/ops/worker.rs
@@ -683,10 +683,28 @@ impl AccountWorker {
         })
         .await;
         match append_result {
-            Ok(Ok(())) => log::info!(
-                "Outbox replay: APPENDed sent message to Sent for account {}",
-                account_id_append
-            ),
+            Ok(Ok(sent_folder)) => {
+                log::info!(
+                    "Outbox replay: APPENDed sent message to '{}' for account {}",
+                    sent_folder,
+                    account_id_append
+                );
+                // Nudge a targeted sync of the Sent folder so the
+                // freshly-APPENDed message surfaces in the UI without
+                // waiting for the next scheduled sync.
+                if let Err(e) = self
+                    .execute_sync(MailOp::SyncFolder {
+                        folder_path: sent_folder,
+                    })
+                    .await
+                {
+                    log::warn!(
+                        "Outbox replay: Sent-folder sync nudge failed for account {}: {}",
+                        account_id_append,
+                        e
+                    );
+                }
+            }
             Ok(Err(e)) => log::warn!(
                 "Outbox replay: delivered but APPEND to Sent failed for account {}: {}",
                 account_id_append,


### PR DESCRIPTION
## Summary

For IMAP+SMTP accounts (and Exchange-via-SMTP-AUTH), SMTP submission alone never writes a copy of the outgoing message to the **Sent** folder — the server happily returns `250 queued` and delivers the message, but the client has to `IMAP APPEND` it to Sent itself. Without that, sent messages are delivered to recipients but never appear in the user's Sent folder. JMAP and Microsoft Graph send APIs are unaffected because they populate Sent server-side.

## Changes

- `db::folders::folder_path_by_type` — look up the cached IMAP path of a folder by its sync-time-classified role (`sent`, `drafts`, `trash`, …). Returns `None` when the cache hasn't seen one yet — first-sync edge case.
- `ImapConnection::append_sent_message` — APPEND with `\Seen` only (the pre-existing `append_message` also sets `\Draft`, which is wrong for delivered mail).
- `mail::imap::append_message_to_sent` — top-level orchestrator: opens an IMAP session and tries the cached Sent path first, falling back through common names (`Sent`, `INBOX.Sent`, `Sent Items`, `Sent Messages`, `[Gmail]/Sent Mail`).
- Wired into **both** send paths:
  - `commands::compose::send_message` (live send) — after `smtp::send_message` succeeds.
  - `ops::worker::execute_smtp_send` (outbox replay) — after `smtp::send_raw` succeeds.

## Failure handling

APPEND is **strictly best-effort**. Failures log a warning and do **not** propagate. Propagating would mark the outbox row failed and trigger a retry, which would re-deliver the message and create duplicates for the recipient.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --lib` (293/293 pass, including the new `folder_path_by_type` DB test)
- [x] Manual: send a message from an IMAP+SMTP account and verify the message lands in Sent on the next sync.

Fixes #189.