### PR TITLE
feat(jmap): add Fastmail account type with bearer auth

### DIFF
--- a/docs/adr/0049-fastmail-jmap-api-token.md
+++ b/docs/adr/0049-fastmail-jmap-api-token.md
@@ -144,7 +144,10 @@ the heuristic.
 - ADR 0010 — Account type selection.
 - ADR 0011 — System keyring for passwords.
 - ADR 0020 — JMAP EventSource push notifications.
-- `docs/jmap-fastmail.md` — user-facing setup walkthrough.
 - `src-tauri/src/mail/jmap.rs` — `JmapConfig::from_account`,
-  `apply_auth`, `rewrite_url`, `is_internal_url`.
+  `apply_auth`, `rewrite_url`, `is_internal_url`,
+  `fetch_email_changes`.
+- `src-tauri/src/db/accounts.rs` —
+  `populate_legacy_from_bindings`, `list_accounts`
+  (Fastmail provider recovery from the JMAP binding URL).
 - `src/views/SettingsView.vue` — Fastmail tab and edit-load detection.

--- a/docs/adr/0049-fastmail-jmap-api-token.md
+++ b/docs/adr/0049-fastmail-jmap-api-token.md
@@ -1,0 +1,150 @@
+# ADR 0049: Fastmail JMAP integration via API token (Bearer auth)
+
+## Status
+
+Accepted
+
+## Date
+
+2026-05-25
+
+## Context
+
+Fastmail exposes a full JMAP server at `https://api.fastmail.com/jmap/session`
+and is the reference public deployment for mail, submission, calendars and
+contacts. Two things make it incompatible with the generic JMAP path we
+originally built for Stalwart (ADR 0008, ADR 0010):
+
+1. **Authentication.** Fastmail requires
+   `Authorization: Bearer <token>` using an API token generated from the
+   user's account settings. HTTP Basic with the account password is
+   rejected with `401 Invalid Authorization header, not bearer`.
+2. **Auto-discovery.** Fastmail does not serve `.well-known/jmap` on the
+   email domain. The probe sequence in `auto_discover_jmap_url`
+   (`https://<domain>`, `https://mail.<domain>`, `https://jmap.<domain>`)
+   never resolves to `api.fastmail.com`.
+3. **OIDC.** Fastmail's OAuth is Authorization Code + PKCE (RFC 7636) and
+   does not publish an OpenID discovery document. The OIDC button on the
+   JMAP tab is wired for Stalwart-style device flow (RFC 8628), so it
+   cannot be reused as-is.
+
+A second, subtler issue surfaced once the auth path worked: Fastmail's
+session document advertises `downloadUrl` on
+`https://www.fastmail.com/...` and content on
+`https://www.fastmailusercontent.com/...`, while `apiUrl` lives on
+`api.fastmail.com`. The original `rewrite_url` from ADR 0008 force-merged
+every session URL onto the base host, which routed downloads to the
+Fastmail marketing homepage instead of message bodies.
+
+## Decision
+
+### Dedicated "Fastmail" account tab
+
+The account setup form gets a `fastmail` tab alongside `gmail`, `o365`,
+`imap`, and `jmap`. The user only sees fields that are specific to
+Fastmail:
+
+- **Email address** — for display and the From header.
+- **API token** — labelled "API token", not "Password". Help text links
+  to Fastmail's **Settings → Privacy & Security → Manage API tokens**.
+
+The JMAP URL (`https://api.fastmail.com`) and the auth method
+(`bearer`) are hardcoded and rendered read-only. When the user saves,
+`provider = "fastmail"`, `mail_protocol = "jmap"`,
+`jmap_auth_method = "bearer"`, and the token is stored in the
+`password` column (and the OS keyring, per ADR 0011) — the same slot
+every other JMAP account uses for its secret.
+
+### Bearer routing through `JmapConfig::from_account`
+
+`JmapConfig` carries an `Option<String>` `access_token` field. In
+`from_account`, when `jmap_auth_method == "bearer"` and the password
+is non-empty we **promote** the password into `access_token` and clear
+the password field. `apply_auth()` is then a single branch: if
+`access_token` is set, use `bearer_auth(token)`; otherwise
+`basic_auth(username, password)`. This is the same code path OIDC
+already used for access tokens, so the bearer mode adds no new
+request-time logic — only the migration into `access_token` at config
+construction time.
+
+Two safety details:
+
+- **Whitespace trim on the token.** `reqwest::bearer_auth()` embeds
+  the value verbatim into the header. A trailing newline from paste
+  turns `Bearer fmu1-xxx\n` into a malformed header and Fastmail
+  returns `Invalid Authorization bearer parameters, not valid
+  format`. The token format itself never contains whitespace, so
+  trimming is always safe.
+- **Empty-password fallthrough.** When editing an account, the
+  password field is intentionally left blank to mean "keep the current
+  token in the keyring". An empty string must not be promoted to
+  `access_token`, or every subsequent request would send
+  `Authorization: Bearer` (empty value).
+
+### Edit-load detection
+
+`populate_legacy_from_bindings` flips the form back to the Fastmail tab
+on edit when either `provider == "fastmail"` or `jmap_url` starts with
+`https://api.fastmail.com`. The URL check handles accounts created
+before the dedicated tab existed and any future user who pastes the
+Fastmail URL into the generic JMAP tab.
+
+### URL rewriting only rewrites *internal* URLs
+
+`rewrite_url` now consults `is_internal_url` before rewriting. A URL is
+"internal" only if it has an explicit port, a loopback or RFC 1918 /
+RFC 4193 private IP, or the literal host `localhost`. Public DNS
+hostnames on the default scheme port are left untouched, which keeps
+Fastmail's cross-host session URLs intact:
+
+- `apiUrl` on `api.fastmail.com` — kept.
+- `downloadUrl` on `www.fastmail.com` / `www.fastmailusercontent.com`
+  — kept (was previously force-rewritten onto `api.fastmail.com`,
+  returning the marketing homepage).
+- Stalwart's `http://mail.internal:8080/jmap/...` — still rewritten
+  to the HTTPS proxy, per ADR 0008.
+
+The Stalwart-behind-nginx case is unchanged; Fastmail just doesn't trip
+the heuristic.
+
+### What is deferred
+
+- **OIDC for Fastmail.** The OIDC button on the JMAP tab stays
+  Stalwart-only. Adding Fastmail OIDC requires implementing
+  Authorization Code + PKCE (no discovery document, manual endpoint
+  configuration), which is a separate effort.
+- **Reusing the generic JMAP tab.** We considered exposing the
+  `bearer` auth method on the JMAP tab and letting Fastmail users
+  type the URL manually. Rejected: it makes the common case
+  (Fastmail) require multiple correct manual entries, and the
+  Fastmail-specific token UX (label, placeholder, link to the
+  Fastmail settings page) is meaningfully different from a generic
+  password field.
+
+## Consequences
+
+- Adding a Fastmail account is a three-field form: email, API token,
+  display name. No URL, no auth-method dropdown, no SMTP config.
+- All standard JMAP operations work over Bearer: mail sync, send via
+  JMAP Submission (ADR 0009), EventSource push (ADR 0020), calendars
+  (JSCalendar-bis), contacts (ADR 0035).
+- Public JMAP servers other than Fastmail that expose cross-host
+  session URLs now also work correctly — the URL-rewrite gate is the
+  fix, not a Fastmail-only special case.
+- The `password` / `access_token` split lives in `JmapConfig`, so any
+  future Bearer-using JMAP server can reuse the path by setting
+  `jmap_auth_method = "bearer"` without touching the request layer.
+- OIDC sign-in for Fastmail is still TODO; users must use the API
+  token path until Auth Code + PKCE lands.
+
+## See also
+
+- ADR 0008 — JMAP session URL rewriting for reverse-proxy deployments.
+- ADR 0009 — JMAP sending via Submission.
+- ADR 0010 — Account type selection.
+- ADR 0011 — System keyring for passwords.
+- ADR 0020 — JMAP EventSource push notifications.
+- `docs/jmap-fastmail.md` — user-facing setup walkthrough.
+- `src-tauri/src/mail/jmap.rs` — `JmapConfig::from_account`,
+  `apply_auth`, `rewrite_url`, `is_internal_url`.
+- `src/views/SettingsView.vue` — Fastmail tab and edit-load detection.

--- a/src-tauri/src/commands/sync_cmd.rs
+++ b/src-tauri/src/commands/sync_cmd.rs
@@ -188,19 +188,20 @@ pub async fn refresh_jmap_oidc_token(
 }
 
 /// Build a JmapConfig from an account, including OIDC token if applicable.
+///
+/// Delegates to `JmapConfig::from_account` so the bearer-mode promotion
+/// (password → access_token for Fastmail-style API tokens) is applied
+/// uniformly. For OIDC accounts we overlay the refreshed access token
+/// from the keyring afterwards; from_account leaves `access_token: None`
+/// for OIDC because it has no async refresh path.
 pub async fn build_jmap_config(
     account: &crate::db::accounts::AccountFull,
 ) -> crate::error::Result<crate::mail::jmap::JmapConfig> {
-    let access_token = get_jmap_oidc_token(account).await?;
-    Ok(crate::mail::jmap::JmapConfig {
-        jmap_url: account.jmap_url.clone(),
-        email: account.email.clone(),
-        username: account.username.clone(),
-        password: account.password.clone(),
-        access_token,
-        oidc_token_endpoint: account.oidc_token_endpoint.clone(),
-        oidc_client_id: account.oidc_client_id.clone(),
-    })
+    let mut config = crate::mail::jmap::JmapConfig::from_account(account);
+    if let Some(token) = get_jmap_oidc_token(account).await? {
+        config.access_token = Some(token);
+    }
+    Ok(config)
 }
 
 fn should_start_imap_idle(_auth_method: &str) -> bool {

--- a/src-tauri/src/db/accounts.rs
+++ b/src-tauri/src/db/accounts.rs
@@ -619,8 +619,11 @@ pub fn get_account_full(conn: &Connection, id: &str) -> Result<AccountFull> {
 
 pub fn insert_account(conn: &Connection, id: &str, config: &AccountConfig) -> Result<()> {
     // Store real passwords in system keyring; skip OIDC accounts and oauth2 migration markers.
-    // Trim for bearer mode so a paste-with-trailing-newline doesn't poison
-    // the Authorization header on every subsequent request.
+    // For bearer mode the value is trimmed (so a paste-with-trailing-newline
+    // doesn't poison the Authorization header), AND the post-trim emptiness
+    // is checked separately so a whitespace-only field is treated like
+    // "leave empty" — otherwise the user could nuke the keyring token by
+    // pasting blank lines into the API-token input.
     if !config.password.is_empty()
         && config.jmap_auth_method != "oidc"
         && !config.password.starts_with("oauth2:")
@@ -630,7 +633,9 @@ pub fn insert_account(conn: &Connection, id: &str, config: &AccountConfig) -> Re
         } else {
             config.password.as_str()
         };
-        crate::keyring::set_password(id, secret)?;
+        if !secret.is_empty() {
+            crate::keyring::set_password(id, secret)?;
+        }
     }
 
     let auth_method =
@@ -701,7 +706,9 @@ fn config_to_legacy_fields<'a>(
 
 pub fn update_account(conn: &Connection, id: &str, config: &AccountConfig) -> Result<()> {
     // Only update keyring if a real password was provided; skip OIDC accounts and oauth2 markers.
-    // Trim for bearer mode (see insert_account for context).
+    // Trim + post-trim empty check for bearer (see insert_account for the
+    // full rationale — whitespace-only must round-trip to "no change",
+    // not "clobber the existing token").
     if !config.password.is_empty()
         && config.jmap_auth_method != "oidc"
         && !config.password.starts_with("oauth2:")
@@ -711,7 +718,9 @@ pub fn update_account(conn: &Connection, id: &str, config: &AccountConfig) -> Re
         } else {
             config.password.as_str()
         };
-        crate::keyring::set_password(id, secret)?;
+        if !secret.is_empty() {
+            crate::keyring::set_password(id, secret)?;
+        }
     }
 
     let auth_method =
@@ -924,6 +933,51 @@ mod tests {
             "Graph accounts must fall back to the O365 SMTP relay for sending"
         );
         assert_eq!(full.smtp_port, 587);
+        crate::keyring::delete_password(&id).ok();
+    }
+
+    /// Regression: a whitespace-only API token (e.g. user pasted blank
+    /// lines into the edit form) must not overwrite the existing
+    /// keyring entry. The original guard only checked
+    /// `!config.password.is_empty()`, so " \n" got past the gate, then
+    /// trim() reduced it to "" and the keyring write clobbered the
+    /// real token. apply_auth would then send `Bearer ` (empty value)
+    /// on every request. The trimmed-emptiness check inside the gate
+    /// makes whitespace-only input behave like "leave empty".
+    #[test]
+    fn test_update_account_whitespace_only_bearer_token_preserves_keyring() {
+        let conn = setup_db();
+        let id = unique_id();
+
+        // 1. Create the account with a real token.
+        let mut config = make_config("kushal@fastmail.com", "Kushal");
+        config.provider = "fastmail".to_string();
+        config.mail_protocol = "jmap".to_string();
+        config.jmap_url = "https://api.fastmail.com".to_string();
+        config.jmap_auth_method = "bearer".to_string();
+        config.password = "fmu1-real-token".to_string();
+        config.imap_host = String::new();
+        config.smtp_host = String::new();
+        insert_account(&conn, &id, &config).unwrap();
+        assert_eq!(
+            crate::keyring::get_password(&id).unwrap().as_deref(),
+            Some("fmu1-real-token"),
+            "setup precondition: real token must be in keyring",
+        );
+
+        // 2. Simulate the user pasting only whitespace into the
+        //    "API token" field on the edit form and saving.
+        let mut whitespace_update = config.clone();
+        whitespace_update.password = "   \n\t  ".to_string();
+        update_account(&conn, &id, &whitespace_update).unwrap();
+
+        // 3. Keyring must still hold the original token — the
+        //    whitespace-only paste should round-trip as "no change".
+        assert_eq!(
+            crate::keyring::get_password(&id).unwrap().as_deref(),
+            Some("fmu1-real-token"),
+            "whitespace-only bearer input must NOT overwrite the keyring entry",
+        );
         crate::keyring::delete_password(&id).ok();
     }
 

--- a/src-tauri/src/db/accounts.rs
+++ b/src-tauri/src/db/accounts.rs
@@ -479,19 +479,43 @@ pub fn list_accounts(conn: &Connection) -> Result<Vec<Account>> {
                        AND b.enabled = 1
                      LIMIT 1),
                     ''
-                ) AS meet_protocol
+                ) AS meet_protocol,
+                -- JMAP binding's config_json, used to recover the
+                -- Fastmail provider tag from the saved URL. Empty for
+                -- non-JMAP accounts. See get_account_full for the
+                -- equivalent full-account recovery path.
+                COALESCE(
+                    (SELECT b.config_json FROM service_bindings b
+                     WHERE b.account_id = a.id
+                       AND b.service = 'mail'
+                       AND b.protocol = 'jmap'
+                     LIMIT 1),
+                    ''
+                ) AS jmap_config_json
          FROM accounts a
          ORDER BY a.display_name",
     )?;
     let accounts = stmt
         .query_map([], |row| {
             let auth_method: String = row.get(3)?;
+            let jmap_config_json: String = row.get(13)?;
             let provider = match auth_method.as_str() {
-                "oauth-google" => "gmail",
-                "oauth-microsoft" => "o365",
-                _ => "generic",
-            }
-            .to_string();
+                "oauth-google" => "gmail".to_string(),
+                "oauth-microsoft" => "o365".to_string(),
+                _ => {
+                    // Fastmail accounts save via the dedicated tab but
+                    // share the password-based auth_method bucket, so
+                    // the only place the provider lives at read time is
+                    // the JMAP binding's URL. Substring match (not full
+                    // JSON parse) is enough — "api.fastmail.com" only
+                    // appears in the url field of the binding config.
+                    if jmap_config_json.contains("api.fastmail.com") {
+                        "fastmail".to_string()
+                    } else {
+                        "generic".to_string()
+                    }
+                }
+            };
             Ok(Account {
                 id: row.get(0)?,
                 display_name: row.get(1)?,
@@ -900,6 +924,38 @@ mod tests {
             "Graph accounts must fall back to the O365 SMTP relay for sending"
         );
         assert_eq!(full.smtp_port, 587);
+        crate::keyring::delete_password(&id).ok();
+    }
+
+    /// Regression: the settings list view reads `Account` rows via
+    /// `list_accounts`, which derives `provider` from the Phase-2
+    /// `auth_method` column. That column collapses Fastmail (password
+    /// auth, no OAuth) to the same bucket as generic JMAP, so before
+    /// this query was widened the FASTMAIL chip in SettingsView.vue
+    /// would never trigger — Fastmail accounts displayed as
+    /// JMAP/GENERIC despite the UI branch existing. The query now
+    /// also pulls the JMAP binding's config_json and tags providers
+    /// matching `api.fastmail.com` as "fastmail".
+    #[test]
+    fn test_list_accounts_recovers_fastmail_provider_from_url() {
+        let conn = setup_db();
+        let id = unique_id();
+        let mut config = make_config("kushal@fastmail.com", "Kushal");
+        config.provider = "fastmail".to_string();
+        config.mail_protocol = "jmap".to_string();
+        config.jmap_url = "https://api.fastmail.com".to_string();
+        config.jmap_auth_method = "bearer".to_string();
+        config.imap_host = String::new();
+        config.smtp_host = String::new();
+        insert_account(&conn, &id, &config).unwrap();
+
+        let accounts = list_accounts(&conn).unwrap();
+        let fm = accounts
+            .iter()
+            .find(|a| a.id == id)
+            .expect("inserted account must appear in list");
+        assert_eq!(fm.provider, "fastmail");
+        assert_eq!(fm.mail_protocol, "jmap");
         crate::keyring::delete_password(&id).ok();
     }
 

--- a/src-tauri/src/db/accounts.rs
+++ b/src-tauri/src/db/accounts.rs
@@ -6,6 +6,74 @@ use crate::db::service_bindings::{
 };
 use crate::error::Result;
 
+/// Strict Fastmail JMAP endpoint check. Returns `true` only when
+/// the URL parses, uses https, and its host is *exactly*
+/// `api.fastmail.com` (case-insensitive). A plain
+/// `starts_with("https://api.fastmail.com")` would also match
+/// lookalike hosts such as `https://api.fastmail.com.attacker.example`
+/// and tag them as Fastmail. Used by both the per-account
+/// `populate_legacy_from_bindings` and the list-view `list_accounts`
+/// query so the two recovery paths stay in lock-step.
+fn is_fastmail_jmap_url(url_str: &str) -> bool {
+    let Ok(parsed) = url::Url::parse(url_str) else {
+        return false;
+    };
+    if parsed.scheme() != "https" {
+        return false;
+    }
+    parsed
+        .host_str()
+        .map(|h| h.eq_ignore_ascii_case("api.fastmail.com"))
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod fastmail_url_tests {
+    use super::is_fastmail_jmap_url;
+
+    #[test]
+    fn accepts_canonical_fastmail() {
+        assert!(is_fastmail_jmap_url("https://api.fastmail.com"));
+        assert!(is_fastmail_jmap_url("https://api.fastmail.com/jmap"));
+        assert!(is_fastmail_jmap_url(
+            "https://api.fastmail.com/.well-known/jmap"
+        ));
+    }
+
+    #[test]
+    fn case_insensitive_host() {
+        assert!(is_fastmail_jmap_url("https://API.Fastmail.COM/jmap"));
+    }
+
+    #[test]
+    fn rejects_lookalike_subdomains() {
+        // The whole reason this helper exists: a startsWith check
+        // would have approved these.
+        assert!(!is_fastmail_jmap_url(
+            "https://api.fastmail.com.attacker.example/jmap"
+        ));
+        assert!(!is_fastmail_jmap_url(
+            "https://api.fastmail.com.evil.com/jmap"
+        ));
+        assert!(!is_fastmail_jmap_url("https://api.fastmail.computer/jmap"));
+    }
+
+    #[test]
+    fn rejects_http() {
+        // Bearer credentials over plaintext is a hard no; downgrade
+        // the provider tag so the saved account stops claiming
+        // Fastmail-grade hardening.
+        assert!(!is_fastmail_jmap_url("http://api.fastmail.com/jmap"));
+    }
+
+    #[test]
+    fn rejects_garbage() {
+        assert!(!is_fastmail_jmap_url(""));
+        assert!(!is_fastmail_jmap_url("api.fastmail.com"));
+        assert!(!is_fastmail_jmap_url("not a url at all"));
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Account {
     pub id: String,
@@ -324,8 +392,11 @@ impl AccountFull {
                 // tab but shares the JMAP wire path. Recover the provider
                 // tag from the saved JMAP URL so the list-view chip and
                 // the edit-form's type-readonly label both reflect it.
+                // Strict hostname match (not startsWith) so a lookalike
+                // host like api.fastmail.com.attacker.example does not
+                // get tagged as Fastmail.
                 let jmap_url = self.mail_jmap_config().map(|c| c.url).unwrap_or_default();
-                if jmap_url.starts_with("https://api.fastmail.com") {
+                if is_fastmail_jmap_url(&jmap_url) {
                     "fastmail".to_string()
                 } else {
                     "generic".to_string()
@@ -505,11 +576,24 @@ pub fn list_accounts(conn: &Connection) -> Result<Vec<Account>> {
                 _ => {
                     // Fastmail accounts save via the dedicated tab but
                     // share the password-based auth_method bucket, so
-                    // the only place the provider lives at read time is
-                    // the JMAP binding's URL. Substring match (not full
-                    // JSON parse) is enough — "api.fastmail.com" only
-                    // appears in the url field of the binding config.
-                    if jmap_config_json.contains("api.fastmail.com") {
+                    // the provider lives in the JMAP binding's URL at
+                    // read time. Parse the binding JSON and validate
+                    // the URL's hostname strictly — a substring match
+                    // (or even startsWith) on the raw config_json
+                    // would mistag a lookalike host like
+                    // `api.fastmail.com.attacker.example` or any
+                    // other field that happened to contain the
+                    // string "api.fastmail.com" as Fastmail.
+                    let jmap_url = if jmap_config_json.is_empty() {
+                        String::new()
+                    } else {
+                        serde_json::from_str::<crate::db::service_bindings::JmapBindingConfig>(
+                            &jmap_config_json,
+                        )
+                        .map(|c| c.url)
+                        .unwrap_or_default()
+                    };
+                    if is_fastmail_jmap_url(&jmap_url) {
                         "fastmail".to_string()
                     } else {
                         "generic".to_string()

--- a/src-tauri/src/db/accounts.rs
+++ b/src-tauri/src/db/accounts.rs
@@ -166,6 +166,11 @@ pub struct AccountFull {
     pub use_tls: bool,
     pub enabled: bool,
     pub signature: String,
+    /// One of "basic" | "bearer" | "oidc". "basic" sends HTTP Basic with
+    /// username + password (Stalwart). "bearer" sends Authorization: Bearer
+    /// <password> where the password field holds an API token (Fastmail).
+    /// "oidc" runs the OAuth/OIDC token flow and uses the resulting access
+    /// token as Bearer.
     pub jmap_auth_method: String,
     pub oidc_token_endpoint: String,
     pub oidc_client_id: String,
@@ -312,18 +317,36 @@ impl AccountFull {
     /// touched in earlier phases keep working unchanged.
     pub fn populate_legacy_from_bindings(&mut self) {
         self.provider = match self.auth_method.as_str() {
-            "oauth-google" => "gmail",
-            "oauth-microsoft" => "o365",
-            _ => "generic",
-        }
-        .to_string();
+            "oauth-google" => "gmail".to_string(),
+            "oauth-microsoft" => "o365".to_string(),
+            _ => {
+                // Fastmail is fronted by the dedicated "Fastmail" account
+                // tab but shares the JMAP wire path. Recover the provider
+                // tag from the saved JMAP URL so the list-view chip and
+                // the edit-form's type-readonly label both reflect it.
+                let jmap_url = self.mail_jmap_config().map(|c| c.url).unwrap_or_default();
+                if jmap_url.starts_with("https://api.fastmail.com") {
+                    "fastmail".to_string()
+                } else {
+                    "generic".to_string()
+                }
+            }
+        };
 
+        // The Phase-2 `auth_method` column collapses "basic" and "bearer"
+        // both to "password" (since auth_method_for only special-cases
+        // OIDC). So for non-OIDC accounts we must read the actual JMAP
+        // binding to recover the user's choice — otherwise a Fastmail
+        // account saved as "bearer" reads back as "basic" and apply_auth
+        // sends HTTP Basic, which Fastmail rejects with 401.
         self.jmap_auth_method = if self.auth_method == "oauth-jmap-oidc" {
-            "oidc"
+            "oidc".to_string()
         } else {
-            "basic"
-        }
-        .to_string();
+            self.mail_jmap_config()
+                .map(|c| c.auth_method)
+                .filter(|s| !s.is_empty())
+                .unwrap_or_else(|| "basic".to_string())
+        };
 
         self.mail_protocol = self
             .mail_binding()
@@ -571,12 +594,19 @@ pub fn get_account_full(conn: &Connection, id: &str) -> Result<AccountFull> {
 }
 
 pub fn insert_account(conn: &Connection, id: &str, config: &AccountConfig) -> Result<()> {
-    // Store real passwords in system keyring; skip OIDC accounts and oauth2 migration markers
+    // Store real passwords in system keyring; skip OIDC accounts and oauth2 migration markers.
+    // Trim for bearer mode so a paste-with-trailing-newline doesn't poison
+    // the Authorization header on every subsequent request.
     if !config.password.is_empty()
         && config.jmap_auth_method != "oidc"
         && !config.password.starts_with("oauth2:")
     {
-        crate::keyring::set_password(id, &config.password)?;
+        let secret = if config.jmap_auth_method == "bearer" {
+            config.password.trim()
+        } else {
+            config.password.as_str()
+        };
+        crate::keyring::set_password(id, secret)?;
     }
 
     let auth_method =
@@ -647,11 +677,17 @@ fn config_to_legacy_fields<'a>(
 
 pub fn update_account(conn: &Connection, id: &str, config: &AccountConfig) -> Result<()> {
     // Only update keyring if a real password was provided; skip OIDC accounts and oauth2 markers.
+    // Trim for bearer mode (see insert_account for context).
     if !config.password.is_empty()
         && config.jmap_auth_method != "oidc"
         && !config.password.starts_with("oauth2:")
     {
-        crate::keyring::set_password(id, &config.password)?;
+        let secret = if config.jmap_auth_method == "bearer" {
+            config.password.trim()
+        } else {
+            config.password.as_str()
+        };
+        crate::keyring::set_password(id, secret)?;
     }
 
     let auth_method =
@@ -864,6 +900,60 @@ mod tests {
             "Graph accounts must fall back to the O365 SMTP relay for sending"
         );
         assert_eq!(full.smtp_port, 587);
+        crate::keyring::delete_password(&id).ok();
+    }
+
+    /// Regression: the Fastmail account-type tab saves `provider =
+    /// "fastmail"`, but the `provider` value is recomputed on read-back
+    /// from the Phase-2 `auth_method` column (which only knows "gmail" /
+    /// "o365" / "generic"). To keep the list-view chip and edit-form
+    /// label saying "FASTMAIL", `populate_legacy_from_bindings` recovers
+    /// the tag by inspecting the JMAP URL.
+    #[test]
+    fn test_get_account_full_recovers_fastmail_provider_from_url() {
+        let conn = setup_db();
+        let id = unique_id();
+        let mut config = make_config("kushal@fastmail.com", "Kushal");
+        config.provider = "fastmail".to_string();
+        config.mail_protocol = "jmap".to_string();
+        config.jmap_url = "https://api.fastmail.com".to_string();
+        config.jmap_auth_method = "bearer".to_string();
+        config.imap_host = String::new();
+        config.smtp_host = String::new();
+        insert_account(&conn, &id, &config).unwrap();
+
+        let full = get_account_full(&conn, &id).unwrap();
+        assert_eq!(full.provider, "fastmail");
+        assert_eq!(full.jmap_auth_method, "bearer");
+        crate::keyring::delete_password(&id).ok();
+    }
+
+    /// Regression: a JMAP account saved with `jmap_auth_method = "bearer"`
+    /// must read back as "bearer", not "basic". The Phase-2 `auth_method`
+    /// column collapses both "basic" and "bearer" to "password", so
+    /// `populate_legacy_from_bindings` has to recover the real choice from
+    /// the JMAP binding's `config_json.auth_method`. Without that,
+    /// Fastmail accounts saved via the UI would round-trip as Basic auth
+    /// and the push loop would 401 with "Invalid Authorization header,
+    /// not bearer".
+    #[test]
+    fn test_get_account_full_round_trips_bearer_auth_method() {
+        let conn = setup_db();
+        let id = unique_id();
+        let mut config = make_config("kushal@fastmail.com", "Kushal");
+        config.mail_protocol = "jmap".to_string();
+        config.jmap_url = "https://api.fastmail.com".to_string();
+        config.jmap_auth_method = "bearer".to_string();
+        config.imap_host = String::new();
+        config.smtp_host = String::new();
+        insert_account(&conn, &id, &config).unwrap();
+
+        let full = get_account_full(&conn, &id).unwrap();
+        assert_eq!(
+            full.jmap_auth_method, "bearer",
+            "bearer auth must survive insert + read-back so apply_auth \
+             routes the token through Authorization: Bearer"
+        );
         crate::keyring::delete_password(&id).ok();
     }
 

--- a/src-tauri/src/db/service_bindings.rs
+++ b/src-tauri/src/db/service_bindings.rs
@@ -52,6 +52,12 @@ impl Default for ImapBindingConfig {
 pub struct JmapBindingConfig {
     #[serde(default)]
     pub url: String,
+    /// Mirror of `AccountFull::jmap_auth_method` so the
+    /// "basic" / "bearer" / "oidc" choice round-trips. Older bindings
+    /// written before bearer support land here as empty strings; the
+    /// reader treats empty as "basic" for back-compat.
+    #[serde(default, rename = "auth_method")]
+    pub auth_method: String,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]

--- a/src-tauri/src/mail/jmap.rs
+++ b/src-tauri/src/mail/jmap.rs
@@ -599,7 +599,11 @@ impl JmapConnection {
                 "methodCalls": [
                     ["Email/changes", {
                         "accountId": self.account_id,
-                        "sinceState": cursor,
+                        // Pass as &str (not the owned String) so the json!
+                        // macro's Value::from path borrows cleanly and
+                        // `cursor` stays available for the hasMoreChanges
+                        // comparison + reassignment after the request.
+                        "sinceState": cursor.as_str(),
                         "maxChanges": MAX_CHANGES_PER_PAGE
                     }, "c1"],
                     ["Email/get", {

--- a/src-tauri/src/mail/jmap.rs
+++ b/src-tauri/src/mail/jmap.rs
@@ -537,18 +537,29 @@ impl JmapConnection {
         // skip the full pagination scan entirely — the common case after
         // the first sync, where 9000 envelopes shouldn't be re-fetched
         // just to discover 0–5 changed.
+        //
+        // Three signals fall through to a full re-sync rather than
+        // propagating an error:
+        //   * cannotCalculateChanges / invalidArguments — the server
+        //     forgot the state (TTL'd) or the state is from a different
+        //     account (RFC 8620 §5.2).
+        //   * Email/changes exceeded the page cap — too many changes to
+        //     paginate; faster to re-list the mailbox.
+        //   * hasMoreChanges: true with newState unchanged — server is
+        //     misbehaving and can't make progress.
+        // All three mean "delta path cannot finish"; the safe answer is
+        // the same in every case.
         if let Some(state) = since_state.filter(|s| !s.is_empty()) {
             match self.fetch_email_changes(config, state).await {
                 Ok(delta) => return Ok(delta),
                 Err(Error::Other(msg))
                     if msg.contains("cannotCalculateChanges")
-                        || msg.contains("invalidArguments") =>
+                        || msg.contains("invalidArguments")
+                        || msg.contains("Email/changes exceeded")
+                        || msg.contains("hasMoreChanges but newState") =>
                 {
-                    // Server forgot the state (TTL'd) or the state is
-                    // from a different account — fall through to full
-                    // re-sync. RFC 8620 §5.2.
                     log::info!(
-                        "JMAP Email/changes rejected stale state ({}); falling back to full sync of {}",
+                        "JMAP Email/changes could not complete ({}); falling back to full sync of {}",
                         msg,
                         mailbox_id
                     );

--- a/src-tauri/src/mail/jmap.rs
+++ b/src-tauri/src/mail/jmap.rs
@@ -39,6 +39,13 @@ pub struct JmapConfig {
     pub username: String,
     pub password: String,
     pub access_token: Option<String>,
+    /// One of `"basic"`, `"bearer"`, or `"oidc"`. Carried explicitly
+    /// (not just inferred from `access_token.is_some()`) so `connect()`
+    /// can fail fast when bearer mode is selected but no token is
+    /// available — otherwise the request silently downgrades to HTTP
+    /// Basic with an empty password and the user sees a generic 401
+    /// instead of "your API token is missing".
+    pub auth_method: String,
     /// OIDC metadata for token refresh (used by push loop on reconnect)
     pub oidc_token_endpoint: String,
     pub oidc_client_id: String,
@@ -55,6 +62,7 @@ mod connect_tests {
             username: "u".into(),
             password: "p".into(),
             access_token: None,
+            auth_method: "basic".into(),
             oidc_token_endpoint: String::new(),
             oidc_client_id: String::new(),
         }
@@ -67,6 +75,36 @@ mod connect_tests {
             Err(e) => e.to_string(),
         };
         assert!(msg.contains("https"), "expected scheme error, got: {}", msg);
+    }
+
+    /// Regression: a Fastmail account configured with bearer auth but
+    /// no token (keyring entry missing, or the user saved the form
+    /// with an empty API token before the save-time guard landed) used
+    /// to silently fall through to HTTP Basic with an empty password.
+    /// Stalwart and Fastmail both reject that with a generic 401, so
+    /// the user saw a confusing auth failure instead of "your token is
+    /// missing". connect() now fails fast with an explicit error.
+    #[tokio::test]
+    async fn connect_rejects_bearer_without_token() {
+        let cfg = JmapConfig {
+            jmap_url: "https://api.fastmail.com".into(),
+            email: "u@fastmail.com".into(),
+            username: "u".into(),
+            password: String::new(),
+            access_token: None,
+            auth_method: "bearer".into(),
+            oidc_token_endpoint: String::new(),
+            oidc_client_id: String::new(),
+        };
+        let msg = match JmapConnection::connect(&cfg).await {
+            Ok(_) => String::new(),
+            Err(e) => e.to_string(),
+        };
+        assert!(
+            msg.contains("bearer") && msg.contains("token"),
+            "expected bearer/token error, got: {}",
+            msg
+        );
     }
 }
 
@@ -96,6 +134,7 @@ impl JmapConfig {
             username: account.username.clone(),
             password,
             access_token,
+            auth_method: account.jmap_auth_method.clone(),
             oidc_token_endpoint: account.oidc_token_endpoint.clone(),
             oidc_client_id: account.oidc_client_id.clone(),
         }
@@ -207,6 +246,7 @@ mod from_account_tests {
             username: "u".into(),
             password: String::new(),
             access_token: Some("tok".into()),
+            auth_method: "bearer".into(),
             oidc_token_endpoint: String::new(),
             oidc_client_id: String::new(),
         };
@@ -232,6 +272,7 @@ mod from_account_tests {
             username: "u".into(),
             password: "p".into(),
             access_token: None,
+            auth_method: "basic".into(),
             oidc_token_endpoint: String::new(),
             oidc_client_id: String::new(),
         };
@@ -320,6 +361,23 @@ struct JmapSession {
 
 impl JmapConnection {
     pub async fn connect(config: &JmapConfig) -> Result<Self> {
+        // Fail fast if bearer mode was selected but no token resolved.
+        // Without this guard, apply_auth() would silently fall through
+        // to HTTP Basic with an empty password, the server would 401,
+        // and the user would see a generic auth failure instead of
+        // "your API token is missing or empty". The same fast-fail is
+        // wanted for OIDC — bearer_auth("") would otherwise emit an
+        // "Authorization: Bearer " header with no value.
+        if (config.auth_method == "bearer" || config.auth_method == "oidc")
+            && config.access_token.as_deref().unwrap_or("").is_empty()
+        {
+            return Err(Error::Other(format!(
+                "JMAP {} mode is selected but no access token is available — \
+                 the keyring entry is missing or the API token is empty",
+                config.auth_method
+            )));
+        }
+
         let base_url = if !config.jmap_url.is_empty() {
             let url = config.jmap_url.trim_end_matches('/').to_string();
             let url = url.trim_end_matches("/.well-known/jmap").to_string();
@@ -2642,9 +2700,17 @@ fn rewrite_url(internal_url: &str, base_url: &str) -> String {
 /// `true` for:
 ///   - any URL with an explicit port (the proxied Stalwart case —
 ///     `http://host:8080/jmap/`)
-///   - any URL whose host parses as a loopback or RFC 1918 / RFC 4193
-///     private IP
 ///   - any URL whose host is `localhost`
+///   - any URL whose host parses as loopback (`127.0.0.0/8`, `::1`),
+///     RFC 1918 private IPv4 (`10/8`, `172.16/12`, `192.168/16`),
+///     IPv4 link-local (`169.254.0.0/16`, RFC 3927),
+///     IPv6 unique-local (`fc00::/7`, RFC 4193),
+///     or IPv6 link-local (`fe80::/10`, RFC 4291).
+///
+/// Link-local addresses are treated as "internal" because a session
+/// URL pointing at one only makes sense on the same L2 segment as
+/// the server — exactly the deployment shape this rewrite is
+/// designed for.
 ///
 /// `false` for everything else (DNS hostnames without ports, on the
 /// standard port for the scheme — Fastmail, public Stalwart, etc.).

--- a/src-tauri/src/mail/jmap.rs
+++ b/src-tauri/src/mail/jmap.rs
@@ -361,20 +361,29 @@ struct JmapSession {
 
 impl JmapConnection {
     pub async fn connect(config: &JmapConfig) -> Result<Self> {
-        // Fail fast if bearer mode was selected but no token resolved.
-        // Without this guard, apply_auth() would silently fall through
-        // to HTTP Basic with an empty password, the server would 401,
-        // and the user would see a generic auth failure instead of
-        // "your API token is missing or empty". The same fast-fail is
-        // wanted for OIDC — bearer_auth("") would otherwise emit an
-        // "Authorization: Bearer " header with no value.
+        // Fail fast if bearer/OIDC was selected but no access token
+        // resolved. Without this guard, apply_auth() would silently fall
+        // through to HTTP Basic with an empty password, the server would
+        // 401, and the user would see a generic auth failure instead of
+        // "your credential is missing". bearer_auth("") would otherwise
+        // emit an "Authorization: Bearer " header with no value, which
+        // is equally useless.
+        //
+        // The error message uses "access token" — accurate for both
+        // bearer mode (Fastmail API token used as Bearer) and OIDC
+        // (refreshed OIDC access token). The credential-source hint
+        // differs by mode so the user knows where to look.
         if (config.auth_method == "bearer" || config.auth_method == "oidc")
             && config.access_token.as_deref().unwrap_or("").is_empty()
         {
+            let source_hint = if config.auth_method == "bearer" {
+                "the API token in the keyring is missing or empty"
+            } else {
+                "the OIDC token refresh did not return an access token"
+            };
             return Err(Error::Other(format!(
-                "JMAP {} mode is selected but no access token is available — \
-                 the keyring entry is missing or the API token is empty",
-                config.auth_method
+                "JMAP {} mode is selected but no access token is available — {}",
+                config.auth_method, source_hint,
             )));
         }
 
@@ -415,25 +424,25 @@ impl JmapConnection {
                 .ok_or_else(|| Error::Other(format!("JMAP auto-discovery failed for {}", domain)))?
         };
 
-        // Diagnostic: enough to tell whether bearer was selected and to spot
-        // truncated/empty secrets without leaking any part of the token. The
-        // earlier version logged the first 4 characters of the bearer token
-        // as a "prefix" — even a partial secret can leak via logs, so log
-        // only mode + length now.
-        match config.access_token.as_ref() {
-            Some(t) => log::info!(
-                "JMAP connecting to {} as {} [auth=bearer token_len={}]",
-                base_url,
-                config.username,
-                t.len(),
-            ),
-            None => log::info!(
-                "JMAP connecting to {} as {} [auth=basic password_len={}]",
-                base_url,
-                config.username,
-                config.password.len(),
-            ),
-        }
+        // Diagnostic: enough to tell which auth mode is in play and to
+        // spot truncated/empty credentials without leaking any part of
+        // them. The auth mode comes from `auth_method` directly (not
+        // inferred from `access_token.is_some()`, which would misreport
+        // OIDC as "bearer"). Length is the post-trim credential the
+        // request will actually send, so basic shows password_len and
+        // bearer/oidc show token_len.
+        let credential_len = if config.auth_method == "basic" {
+            config.password.len()
+        } else {
+            config.access_token.as_deref().map(str::len).unwrap_or(0)
+        };
+        log::info!(
+            "JMAP connecting to {} as {} [auth={} credential_len={}]",
+            base_url,
+            config.username,
+            config.auth_method,
+            credential_len,
+        );
 
         let http = reqwest::Client::builder()
             .timeout(std::time::Duration::from_secs(30))

--- a/src-tauri/src/mail/jmap.rs
+++ b/src-tauri/src/mail/jmap.rs
@@ -359,6 +359,31 @@ struct JmapSession {
     primary_accounts: std::collections::HashMap<String, String>,
 }
 
+#[derive(Debug, Clone, Copy)]
+enum DeltaSyncFallbackReason {
+    CannotCalculateChanges,
+    InvalidArguments,
+    ExceededPageCap,
+    StalledState,
+}
+
+impl DeltaSyncFallbackReason {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::CannotCalculateChanges => "cannotCalculateChanges",
+            Self::InvalidArguments => "invalidArguments",
+            Self::ExceededPageCap => "Email/changes exceeded page cap",
+            Self::StalledState => "Email/changes returned hasMoreChanges without state advance",
+        }
+    }
+}
+
+#[derive(Debug)]
+enum FetchEmailChangesError {
+    Fallback(DeltaSyncFallbackReason),
+    Fatal(Error),
+}
+
 impl JmapConnection {
     pub async fn connect(config: &JmapConfig) -> Result<Self> {
         // Fail fast if bearer/OIDC was selected but no access token
@@ -429,8 +454,8 @@ impl JmapConnection {
         // them. The auth mode comes from `auth_method` directly (not
         // inferred from `access_token.is_some()`, which would misreport
         // OIDC as "bearer"). Length is the post-trim credential the
-        // request will actually send, so basic shows password_len and
-        // bearer/oidc show token_len.
+        // request will actually send, and is logged uniformly as
+        // `credential_len` for all auth methods.
         let credential_len = if config.auth_method == "basic" {
             config.password.len()
         } else {
@@ -619,19 +644,14 @@ impl JmapConnection {
         if let Some(state) = since_state.filter(|s| !s.is_empty()) {
             match self.fetch_email_changes(config, state).await {
                 Ok(delta) => return Ok(delta),
-                Err(Error::Other(msg))
-                    if msg.contains("cannotCalculateChanges")
-                        || msg.contains("invalidArguments")
-                        || msg.contains("Email/changes exceeded")
-                        || msg.contains("hasMoreChanges but newState") =>
-                {
+                Err(FetchEmailChangesError::Fallback(reason)) => {
                     log::info!(
                         "JMAP Email/changes could not complete ({}); falling back to full sync of {}",
-                        msg,
+                        reason.as_str(),
                         mailbox_id
                     );
                 }
-                Err(e) => return Err(e),
+                Err(FetchEmailChangesError::Fatal(e)) => return Err(e),
             }
         }
 
@@ -656,7 +676,7 @@ impl JmapConnection {
         &self,
         config: &JmapConfig,
         since_state: &str,
-    ) -> Result<JmapFetchResult> {
+    ) -> std::result::Result<JmapFetchResult, FetchEmailChangesError> {
         log::debug!("JMAP Email/changes since state={}", since_state);
 
         const MAX_CHANGES_PER_PAGE: u64 = 5000;
@@ -706,12 +726,28 @@ impl JmapConnection {
                 ]
             });
 
-            let resp = self.api_request(&request, config).await?;
+            let resp = self
+                .api_request(&request, config)
+                .await
+                .map_err(FetchEmailChangesError::Fatal)?;
 
             // Surface server errors (cannotCalculateChanges, invalidArguments, …)
             // so the caller can decide whether to fall back to a full sync.
             if let Some(err_type) = resp["methodResponses"][0][1]["type"].as_str() {
-                return Err(Error::Other(format!("Email/changes error: {}", err_type)));
+                let fallback_reason = match err_type {
+                    "cannotCalculateChanges" => {
+                        Some(DeltaSyncFallbackReason::CannotCalculateChanges)
+                    }
+                    "invalidArguments" => Some(DeltaSyncFallbackReason::InvalidArguments),
+                    _ => None,
+                };
+                if let Some(reason) = fallback_reason {
+                    return Err(FetchEmailChangesError::Fallback(reason));
+                }
+                return Err(FetchEmailChangesError::Fatal(Error::Other(format!(
+                    "Email/changes error: {}",
+                    err_type
+                ))));
             }
 
             let changes = &resp["methodResponses"][0][1];
@@ -737,17 +773,16 @@ impl JmapConnection {
 
             pages += 1;
             if pages >= MAX_PAGES {
-                return Err(Error::Other(format!(
-                    "Email/changes exceeded {} pages without finishing; falling back to full sync",
-                    MAX_PAGES
-                )));
+                return Err(FetchEmailChangesError::Fallback(
+                    DeltaSyncFallbackReason::ExceededPageCap,
+                ));
             }
 
             // Guard against a server that returns hasMoreChanges: true
             // without advancing state — would loop forever otherwise.
             if new_state == cursor {
-                return Err(Error::Other(
-                    "Email/changes returned hasMoreChanges but newState == sinceState".into(),
+                return Err(FetchEmailChangesError::Fallback(
+                    DeltaSyncFallbackReason::StalledState,
                 ));
             }
             cursor = new_state;

--- a/src-tauri/src/mail/jmap.rs
+++ b/src-tauri/src/mail/jmap.rs
@@ -72,12 +72,30 @@ mod connect_tests {
 
 impl JmapConfig {
     pub fn from_account(account: &crate::db::accounts::AccountFull) -> Self {
+        // "bearer" mode stores the API token in the password field but the
+        // server (e.g. Fastmail) expects Authorization: Bearer <token>, not
+        // Basic auth. Promote it to access_token so apply_auth() routes it
+        // through the bearer branch alongside OIDC tokens.
+        //
+        // Trim whitespace — reqwest's bearer_auth() embeds the token
+        // verbatim into the header, so a trailing newline from paste
+        // turns "Bearer fmu1-xxx\n" into a malformed header and Fastmail
+        // returns "Invalid Authorization bearer parameters, not valid
+        // format". The token format itself never contains whitespace, so
+        // trimming is always safe.
+        let trimmed = account.password.trim();
+        let (password, access_token) =
+            if account.jmap_auth_method == "bearer" && !trimmed.is_empty() {
+                (String::new(), Some(trimmed.to_string()))
+            } else {
+                (account.password.clone(), None)
+            };
         Self {
             jmap_url: account.jmap_url.clone(),
             email: account.email.clone(),
             username: account.username.clone(),
-            password: account.password.clone(),
-            access_token: None,
+            password,
+            access_token,
             oidc_token_endpoint: account.oidc_token_endpoint.clone(),
             oidc_client_id: account.oidc_client_id.clone(),
         }
@@ -92,6 +110,161 @@ impl JmapConfig {
             req.basic_auth(&self.username, Some(&self.password))
         }
     }
+}
+
+#[cfg(test)]
+mod from_account_tests {
+    use super::*;
+    use crate::db::accounts::AccountFull;
+
+    fn account_with(auth: &str, password: &str) -> AccountFull {
+        AccountFull {
+            id: "acc1".into(),
+            display_name: "Test".into(),
+            email: "u@example.com".into(),
+            provider: "generic".into(),
+            mail_protocol: "jmap".into(),
+            imap_host: String::new(),
+            imap_port: 0,
+            smtp_host: String::new(),
+            smtp_port: 0,
+            jmap_url: "https://api.example.com".into(),
+            caldav_url: String::new(),
+            meet_url: String::new(),
+            meet_protocol: String::new(),
+            username: "u@example.com".into(),
+            password: password.into(),
+            use_tls: true,
+            enabled: true,
+            signature: String::new(),
+            jmap_auth_method: auth.into(),
+            oidc_token_endpoint: String::new(),
+            oidc_client_id: String::new(),
+            calendar_sync_enabled: false,
+            auth_method: String::new(),
+            bindings: Vec::new(),
+            mail_sync_enabled: true,
+            contacts_sync_enabled: false,
+            mail_sync_interval_seconds: None,
+            calendar_sync_interval_seconds: None,
+            contacts_sync_interval_seconds: None,
+            pgp_attach_pubkey_on_sign: false,
+            pgp_autocrypt_header: false,
+            pgp_encrypt_subject: false,
+            pgp_encrypt_drafts: false,
+        }
+    }
+
+    #[test]
+    fn basic_mode_keeps_password_clears_access_token() {
+        let cfg = JmapConfig::from_account(&account_with("basic", "hunter2"));
+        assert_eq!(cfg.password, "hunter2");
+        assert!(cfg.access_token.is_none());
+    }
+
+    #[test]
+    fn bearer_mode_moves_password_to_access_token() {
+        let cfg = JmapConfig::from_account(&account_with("bearer", "fmu1-secret-api-token"));
+        assert_eq!(cfg.password, "");
+        assert_eq!(cfg.access_token.as_deref(), Some("fmu1-secret-api-token"));
+    }
+
+    #[test]
+    fn bearer_mode_trims_whitespace() {
+        // Paste from settings page can carry a trailing newline.
+        // reqwest::bearer_auth embeds the value verbatim, so a
+        // newline turns "Bearer fmu1-xxx\n" into a malformed header
+        // and Fastmail returns "Invalid Authorization bearer
+        // parameters, not valid format". Verify the trim happens.
+        let cfg = JmapConfig::from_account(&account_with("bearer", "  fmu1-secret-api-token\n"));
+        assert_eq!(cfg.access_token.as_deref(), Some("fmu1-secret-api-token"));
+        assert_eq!(cfg.password, "");
+    }
+
+    #[test]
+    fn bearer_mode_with_empty_password_falls_through() {
+        // Token-less bearer (editing account form, password preserved in
+        // keyring) must not promote an empty string to access_token —
+        // apply_auth would then send "Bearer " with no value.
+        let cfg = JmapConfig::from_account(&account_with("bearer", ""));
+        assert_eq!(cfg.password, "");
+        assert!(cfg.access_token.is_none());
+    }
+
+    #[test]
+    fn oidc_mode_leaves_access_token_for_caller() {
+        // OIDC populates access_token at the call site (sync_cmd / push
+        // loop) after refresh — from_account itself should leave it None.
+        let cfg = JmapConfig::from_account(&account_with("oidc", ""));
+        assert!(cfg.access_token.is_none());
+    }
+
+    #[tokio::test]
+    async fn apply_auth_routes_bearer_for_token() {
+        let cfg = JmapConfig {
+            jmap_url: "https://api.example.com".into(),
+            email: "u@example.com".into(),
+            username: "u".into(),
+            password: String::new(),
+            access_token: Some("tok".into()),
+            oidc_token_endpoint: String::new(),
+            oidc_client_id: String::new(),
+        };
+        let client = reqwest::Client::new();
+        let req = cfg
+            .apply_auth(client.get("https://api.example.com/"))
+            .build()
+            .unwrap();
+        let auth = req
+            .headers()
+            .get("authorization")
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert_eq!(auth, "Bearer tok");
+    }
+
+    #[tokio::test]
+    async fn apply_auth_routes_basic_for_password() {
+        let cfg = JmapConfig {
+            jmap_url: "https://api.example.com".into(),
+            email: "u@example.com".into(),
+            username: "u".into(),
+            password: "p".into(),
+            access_token: None,
+            oidc_token_endpoint: String::new(),
+            oidc_client_id: String::new(),
+        };
+        let client = reqwest::Client::new();
+        let req = cfg
+            .apply_auth(client.get("https://api.example.com/"))
+            .build()
+            .unwrap();
+        let auth = req
+            .headers()
+            .get("authorization")
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert!(
+            auth.starts_with("Basic "),
+            "expected Basic auth, got: {}",
+            auth
+        );
+    }
+}
+
+/// Result of `JmapConnection::fetch_emails`. `is_full` distinguishes a
+/// full mailbox scan (where `destroyed` is empty and the caller should
+/// reconcile deletions by comparing against the full server-side set)
+/// from a delta sync (where `destroyed` lists exactly the IDs the
+/// server removed).
+#[derive(Debug, Clone)]
+pub struct JmapFetchResult {
+    pub emails: Vec<JmapEmail>,
+    pub destroyed: Vec<String>,
+    pub state: String,
+    pub is_full: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -112,6 +285,11 @@ pub struct JmapEmail {
     pub has_attachments: bool,
     pub flags: Vec<String>,
     pub preview: Option<String>,
+    /// JMAP mailbox IDs this email is in (an Email can be in multiple
+    /// mailboxes — "labels" in Gmail-style accounts). Used by the delta
+    /// sync path to filter `Email/changes` results, since that method
+    /// returns changes for the whole account, not a single mailbox.
+    pub mailbox_ids: Vec<String>,
 }
 
 /// JMAP connection that uses raw HTTP requests through the HTTPS proxy.
@@ -179,7 +357,29 @@ impl JmapConnection {
                 .ok_or_else(|| Error::Other(format!("JMAP auto-discovery failed for {}", domain)))?
         };
 
-        log::info!("JMAP connecting to {} as {}", base_url, config.username);
+        // Diagnostic: enough to tell whether bearer was selected and whether
+        // the token looks like a Fastmail API token (length + prefix). The
+        // token value itself is never logged.
+        match config.access_token.as_ref() {
+            Some(t) => {
+                let preview: String = t.chars().take(4).collect();
+                log::info!(
+                    "JMAP connecting to {} as {} [auth=bearer token_len={} token_prefix={:?}]",
+                    base_url,
+                    config.username,
+                    t.len(),
+                    preview,
+                );
+            }
+            None => {
+                log::info!(
+                    "JMAP connecting to {} as {} [auth=basic password_len={}]",
+                    base_url,
+                    config.username,
+                    config.password.len(),
+                );
+            }
+        }
 
         let http = reqwest::Client::builder()
             .timeout(std::time::Duration::from_secs(30))
@@ -335,9 +535,128 @@ impl JmapConnection {
         &self,
         config: &JmapConfig,
         mailbox_id: &str,
-        _since_state: Option<&str>,
-    ) -> Result<(Vec<JmapEmail>, String)> {
-        log::debug!("JMAP fetching emails from mailbox {}", mailbox_id);
+        since_state: Option<&str>,
+    ) -> Result<JmapFetchResult> {
+        // Try a delta sync first if we have a state token. On success we
+        // skip the full pagination scan entirely — the common case after
+        // the first sync, where 9000 envelopes shouldn't be re-fetched
+        // just to discover 0–5 changed.
+        if let Some(state) = since_state.filter(|s| !s.is_empty()) {
+            match self.fetch_email_changes(config, state).await {
+                Ok(delta) => return Ok(delta),
+                Err(Error::Other(msg))
+                    if msg.contains("cannotCalculateChanges")
+                        || msg.contains("invalidArguments") =>
+                {
+                    // Server forgot the state (TTL'd) or the state is
+                    // from a different account — fall through to full
+                    // re-sync. RFC 8620 §5.2.
+                    log::info!(
+                        "JMAP Email/changes rejected stale state ({}); falling back to full sync of {}",
+                        msg,
+                        mailbox_id
+                    );
+                }
+                Err(e) => return Err(e),
+            }
+        }
+
+        self.fetch_emails_full(config, mailbox_id).await
+    }
+
+    /// Delta sync via `Email/changes` (RFC 8621 §4.3). Returns
+    /// `is_full: false` so the caller knows to reconcile deletions
+    /// using `destroyed` rather than the full-server-set comparison
+    /// the initial-sync path needs.
+    async fn fetch_email_changes(
+        &self,
+        config: &JmapConfig,
+        since_state: &str,
+    ) -> Result<JmapFetchResult> {
+        log::debug!("JMAP Email/changes since state={}", since_state);
+
+        let request = serde_json::json!({
+            "using": ["urn:ietf:params:jmap:core", "urn:ietf:params:jmap:mail"],
+            "methodCalls": [
+                ["Email/changes", {
+                    "accountId": self.account_id,
+                    "sinceState": since_state,
+                    "maxChanges": 5000
+                }, "c1"],
+                ["Email/get", {
+                    "#ids": { "resultOf": "c1", "name": "Email/changes", "path": "/created" },
+                    "accountId": self.account_id,
+                    "properties": ["id", "subject", "from", "to", "cc", "receivedAt",
+                                   "size", "keywords", "messageId", "inReplyTo",
+                                   "references", "hasAttachment", "preview", "mailboxIds"]
+                }, "g1"],
+                // Fetch full envelope properties for updated emails too,
+                // not just id+keywords: a message can appear in "updated"
+                // because its mailboxIds changed (moved into this folder),
+                // in which case the caller needs to insert it as a new
+                // row with the real subject/from/date, not an empty one.
+                ["Email/get", {
+                    "#ids": { "resultOf": "c1", "name": "Email/changes", "path": "/updated" },
+                    "accountId": self.account_id,
+                    "properties": ["id", "subject", "from", "to", "cc", "receivedAt",
+                                   "size", "keywords", "messageId", "inReplyTo",
+                                   "references", "hasAttachment", "preview", "mailboxIds"]
+                }, "g2"]
+            ]
+        });
+
+        let resp = self.api_request(&request, config).await?;
+
+        // Surface server errors (cannotCalculateChanges, invalidArguments, …)
+        // so the caller can decide whether to fall back to a full sync.
+        if let Some(err_type) = resp["methodResponses"][0][1]["type"].as_str() {
+            return Err(Error::Other(format!("Email/changes error: {}", err_type)));
+        }
+
+        let changes = &resp["methodResponses"][0][1];
+        let new_state = changes["newState"].as_str().unwrap_or("").to_string();
+        let destroyed: Vec<String> = changes["destroyed"]
+            .as_array()
+            .map(|a| {
+                a.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let mut emails = Vec::new();
+        for list_idx in [1usize, 2] {
+            if let Some(arr) = resp["methodResponses"][list_idx][1]["list"].as_array() {
+                for e in arr {
+                    emails.push(self.parse_jmap_email(e));
+                }
+            }
+        }
+
+        log::info!(
+            "JMAP delta: {} created/updated, {} destroyed (newState={})",
+            emails.len(),
+            destroyed.len(),
+            new_state
+        );
+
+        Ok(JmapFetchResult {
+            emails,
+            destroyed,
+            state: new_state,
+            is_full: false,
+        })
+    }
+
+    /// Full mailbox scan via paged `Email/query` + `Email/get`. Used on
+    /// first sync (no state) and as the fallback when the server cannot
+    /// calculate changes since the stored state.
+    async fn fetch_emails_full(
+        &self,
+        config: &JmapConfig,
+        mailbox_id: &str,
+    ) -> Result<JmapFetchResult> {
+        log::debug!("JMAP full fetch from mailbox {}", mailbox_id);
 
         let mut all_emails = Vec::new();
         let mut position: u64 = 0;
@@ -359,19 +678,27 @@ impl JmapConnection {
                         "accountId": self.account_id,
                         "properties": ["id", "subject", "from", "to", "cc", "receivedAt",
                                        "size", "keywords", "messageId", "inReplyTo",
-                                       "references", "hasAttachment", "preview"]
+                                       "references", "hasAttachment", "preview", "mailboxIds"]
                     }, "g1"]
                 ]
             });
 
             let resp = self.api_request(&request, config).await?;
 
-            // Capture state from the first page
+            // For state continuity across syncs we want the Email/get state
+            // (which is what Email/changes works against), not the queryState
+            // (which only tracks the ordered query result and can't be passed
+            // to Email/changes). Capture from the first page.
             if state.is_empty() {
-                state = resp["methodResponses"][0][1]["queryState"]
+                state = resp["methodResponses"][1][1]["state"]
                     .as_str()
                     .unwrap_or("")
                     .to_string();
+                log::debug!(
+                    "JMAP captured Email/get state for {}: {:?} (used for next sync's Email/changes)",
+                    mailbox_id,
+                    state
+                );
             }
 
             let emails_json = resp["methodResponses"][1][1]["list"]
@@ -392,7 +719,6 @@ impl JmapConnection {
                 all_emails.len()
             );
 
-            // If we got fewer than the page size, we've reached the end
             if page_count < Self::JMAP_PAGE_SIZE {
                 break;
             }
@@ -400,11 +726,16 @@ impl JmapConnection {
         }
 
         log::info!(
-            "JMAP fetched {} emails from mailbox {}",
+            "JMAP full sync: {} emails from mailbox {}",
             all_emails.len(),
             mailbox_id
         );
-        Ok((all_emails, state))
+        Ok(JmapFetchResult {
+            emails: all_emails,
+            destroyed: Vec::new(),
+            state,
+            is_full: true,
+        })
     }
 
     /// Parse a single JMAP email JSON object into a JmapEmail struct.
@@ -474,6 +805,13 @@ impl JmapConnection {
             }
         }
 
+        // mailboxIds is an Id[Boolean] object per RFC 8621 §4.1.4: each
+        // key is a mailbox id, value is always `true`. Collect the keys.
+        let mailbox_ids: Vec<String> = e["mailboxIds"]
+            .as_object()
+            .map(|m| m.keys().cloned().collect())
+            .unwrap_or_default();
+
         JmapEmail {
             id,
             subject,
@@ -489,6 +827,7 @@ impl JmapConnection {
             has_attachments,
             flags,
             preview,
+            mailbox_ids,
         }
     }
 
@@ -2216,10 +2555,21 @@ pub struct JmapContact {
 
 /// Rewrite an internal URL to go through the HTTPS proxy.
 /// e.g., "http://mail.example.com:8080/jmap/foo" → "https://mail.example.com/jmap/foo"
-/// Uses simple string manipulation to preserve template placeholders like {accountId}.
+///
+/// Only rewrites URLs whose host looks "internal" — loopback, RFC 1918,
+/// or a non-standard port (the Stalwart-behind-nginx case ADR 0008 was
+/// written for). Public hosts are left alone, otherwise Fastmail's
+/// session URLs (apiUrl on `api.fastmail.com`, downloadUrl on
+/// `www.fastmail.com` / `www.fastmailusercontent.com`) get force-merged
+/// onto the base host and downloads return the Fastmail marketing
+/// homepage instead of message bodies.
+///
+/// Uses simple string manipulation rather than `Url::set_host` so
+/// template placeholders like `{accountId}` survive intact.
 fn rewrite_url(internal_url: &str, base_url: &str) -> String {
-    // Extract the path from the internal URL by finding the third slash
-    // e.g., "http://mail.example.com:8080/jmap/download/{accountId}..." → "/jmap/download/{accountId}..."
+    if !is_internal_url(internal_url) {
+        return internal_url.to_string();
+    }
     if let Some(scheme_end) = internal_url.find("://") {
         let after_scheme = &internal_url[scheme_end + 3..];
         if let Some(path_start) = after_scheme.find('/') {
@@ -2230,6 +2580,105 @@ fn rewrite_url(internal_url: &str, base_url: &str) -> String {
         }
     }
     internal_url.to_string()
+}
+
+/// Heuristic: does this URL point at a private/internal address that
+/// would be reachable only from inside a reverse-proxy network?
+///
+/// `true` for:
+///   - any URL with an explicit port (the proxied Stalwart case —
+///     `http://host:8080/jmap/`)
+///   - any URL whose host parses as a loopback or RFC 1918 / RFC 4193
+///     private IP
+///   - any URL whose host is `localhost`
+///
+/// `false` for everything else (DNS hostnames without ports, on the
+/// standard port for the scheme — Fastmail, public Stalwart, etc.).
+fn is_internal_url(url_str: &str) -> bool {
+    let Ok(parsed) = url::Url::parse(url_str) else {
+        return false;
+    };
+    // Any explicit port → Stalwart-behind-nginx pattern; rewrite.
+    if parsed.port().is_some() {
+        return true;
+    }
+    let Some(host) = parsed.host_str() else {
+        return false;
+    };
+    if host.eq_ignore_ascii_case("localhost") {
+        return true;
+    }
+    if let Ok(ip) = host.parse::<std::net::IpAddr>() {
+        return match ip {
+            std::net::IpAddr::V4(v4) => v4.is_loopback() || v4.is_private() || v4.is_link_local(),
+            std::net::IpAddr::V6(v6) => {
+                // IPv6: loopback (::1), link-local (fe80::/10),
+                // unique-local (fc00::/7). `is_unique_local` is stable.
+                v6.is_loopback()
+                    || (v6.segments()[0] & 0xffc0) == 0xfe80
+                    || (v6.segments()[0] & 0xfe00) == 0xfc00
+            }
+        };
+    }
+    false
+}
+
+#[cfg(test)]
+mod url_rewrite_tests {
+    use super::*;
+
+    #[test]
+    fn rewrites_internal_stalwart_url() {
+        // ADR 0008 case: stalwart on a private port behind nginx.
+        let rewritten = rewrite_url(
+            "http://mail.internal:8080/jmap/download/{accountId}/{blobId}/{name}",
+            "https://mail.example.com",
+        );
+        assert_eq!(
+            rewritten,
+            "https://mail.example.com/jmap/download/{accountId}/{blobId}/{name}"
+        );
+    }
+
+    #[test]
+    fn rewrites_localhost_url() {
+        let rewritten = rewrite_url("http://localhost/jmap/api/", "https://mail.example.com");
+        assert_eq!(rewritten, "https://mail.example.com/jmap/api/");
+    }
+
+    #[test]
+    fn rewrites_rfc1918_url() {
+        let rewritten = rewrite_url("https://10.0.0.5/jmap/api/", "https://mail.example.com");
+        assert_eq!(rewritten, "https://mail.example.com/jmap/api/");
+    }
+
+    #[test]
+    fn leaves_public_host_alone() {
+        // Fastmail: downloadUrl points at a different public host than
+        // the session URL, but both are public. Rewriting it onto the
+        // base host (api.fastmail.com) routes downloads to a host that
+        // returns Fastmail's marketing homepage instead of message
+        // bodies — the bug this whole helper exists to prevent.
+        let original =
+            "https://www.fastmail.com/jmap/download/{accountId}/{blobId}/{name}?type={type}";
+        let rewritten = rewrite_url(original, "https://api.fastmail.com");
+        assert_eq!(rewritten, original);
+    }
+
+    #[test]
+    fn leaves_fastmailusercontent_alone() {
+        let original =
+            "https://www.fastmailusercontent.com/jmap/download/{accountId}/{blobId}/{name}";
+        let rewritten = rewrite_url(original, "https://api.fastmail.com");
+        assert_eq!(rewritten, original);
+    }
+
+    #[test]
+    fn leaves_public_host_with_https_no_port_alone() {
+        let original = "https://api.example.com/jmap/api/";
+        let rewritten = rewrite_url(original, "https://api.example.com");
+        assert_eq!(rewritten, original);
+    }
 }
 
 fn flag_to_keyword(flag: &str) -> &str {

--- a/src-tauri/src/mail/jmap.rs
+++ b/src-tauri/src/mail/jmap.rs
@@ -357,28 +357,24 @@ impl JmapConnection {
                 .ok_or_else(|| Error::Other(format!("JMAP auto-discovery failed for {}", domain)))?
         };
 
-        // Diagnostic: enough to tell whether bearer was selected and whether
-        // the token looks like a Fastmail API token (length + prefix). The
-        // token value itself is never logged.
+        // Diagnostic: enough to tell whether bearer was selected and to spot
+        // truncated/empty secrets without leaking any part of the token. The
+        // earlier version logged the first 4 characters of the bearer token
+        // as a "prefix" — even a partial secret can leak via logs, so log
+        // only mode + length now.
         match config.access_token.as_ref() {
-            Some(t) => {
-                let preview: String = t.chars().take(4).collect();
-                log::info!(
-                    "JMAP connecting to {} as {} [auth=bearer token_len={} token_prefix={:?}]",
-                    base_url,
-                    config.username,
-                    t.len(),
-                    preview,
-                );
-            }
-            None => {
-                log::info!(
-                    "JMAP connecting to {} as {} [auth=basic password_len={}]",
-                    base_url,
-                    config.username,
-                    config.password.len(),
-                );
-            }
+            Some(t) => log::info!(
+                "JMAP connecting to {} as {} [auth=bearer token_len={}]",
+                base_url,
+                config.username,
+                t.len(),
+            ),
+            None => log::info!(
+                "JMAP connecting to {} as {} [auth=basic password_len={}]",
+                base_url,
+                config.username,
+                config.password.len(),
+            ),
         }
 
         let http = reqwest::Client::builder()
@@ -568,6 +564,16 @@ impl JmapConnection {
     /// `is_full: false` so the caller knows to reconcile deletions
     /// using `destroyed` rather than the full-server-set comparison
     /// the initial-sync path needs.
+    ///
+    /// `Email/changes` caps each response at `maxChanges` and sets
+    /// `hasMoreChanges: true` when there is more to fetch. We loop,
+    /// advancing `sinceState` to the previous response's `newState`,
+    /// until the server reports no more. Without the loop a mailbox
+    /// that accumulated more than one page of changes between syncs
+    /// would silently drop created/updated/destroyed entries past the
+    /// first page even though state would advance to the end. A hard
+    /// cap on iterations prevents an infinite loop if a server keeps
+    /// reporting `hasMoreChanges` without advancing state.
     async fn fetch_email_changes(
         &self,
         config: &JmapConfig,
@@ -575,75 +581,108 @@ impl JmapConnection {
     ) -> Result<JmapFetchResult> {
         log::debug!("JMAP Email/changes since state={}", since_state);
 
-        let request = serde_json::json!({
-            "using": ["urn:ietf:params:jmap:core", "urn:ietf:params:jmap:mail"],
-            "methodCalls": [
-                ["Email/changes", {
-                    "accountId": self.account_id,
-                    "sinceState": since_state,
-                    "maxChanges": 5000
-                }, "c1"],
-                ["Email/get", {
-                    "#ids": { "resultOf": "c1", "name": "Email/changes", "path": "/created" },
-                    "accountId": self.account_id,
-                    "properties": ["id", "subject", "from", "to", "cc", "receivedAt",
-                                   "size", "keywords", "messageId", "inReplyTo",
-                                   "references", "hasAttachment", "preview", "mailboxIds"]
-                }, "g1"],
-                // Fetch full envelope properties for updated emails too,
-                // not just id+keywords: a message can appear in "updated"
-                // because its mailboxIds changed (moved into this folder),
-                // in which case the caller needs to insert it as a new
-                // row with the real subject/from/date, not an empty one.
-                ["Email/get", {
-                    "#ids": { "resultOf": "c1", "name": "Email/changes", "path": "/updated" },
-                    "accountId": self.account_id,
-                    "properties": ["id", "subject", "from", "to", "cc", "receivedAt",
-                                   "size", "keywords", "messageId", "inReplyTo",
-                                   "references", "hasAttachment", "preview", "mailboxIds"]
-                }, "g2"]
-            ]
-        });
-
-        let resp = self.api_request(&request, config).await?;
-
-        // Surface server errors (cannotCalculateChanges, invalidArguments, …)
-        // so the caller can decide whether to fall back to a full sync.
-        if let Some(err_type) = resp["methodResponses"][0][1]["type"].as_str() {
-            return Err(Error::Other(format!("Email/changes error: {}", err_type)));
-        }
-
-        let changes = &resp["methodResponses"][0][1];
-        let new_state = changes["newState"].as_str().unwrap_or("").to_string();
-        let destroyed: Vec<String> = changes["destroyed"]
-            .as_array()
-            .map(|a| {
-                a.iter()
-                    .filter_map(|v| v.as_str().map(String::from))
-                    .collect()
-            })
-            .unwrap_or_default();
+        const MAX_CHANGES_PER_PAGE: u64 = 5000;
+        // 100 * 5000 = 500k changes per sync, far beyond anything a
+        // real mailbox produces between polls. If we hit this the
+        // server is misbehaving — bail to a full re-sync.
+        const MAX_PAGES: usize = 100;
 
         let mut emails = Vec::new();
-        for list_idx in [1usize, 2] {
-            if let Some(arr) = resp["methodResponses"][list_idx][1]["list"].as_array() {
-                for e in arr {
-                    emails.push(self.parse_jmap_email(e));
+        let mut destroyed: Vec<String> = Vec::new();
+        let mut cursor = since_state.to_string();
+        let final_state: String;
+        let mut pages = 0usize;
+
+        loop {
+            let request = serde_json::json!({
+                "using": ["urn:ietf:params:jmap:core", "urn:ietf:params:jmap:mail"],
+                "methodCalls": [
+                    ["Email/changes", {
+                        "accountId": self.account_id,
+                        "sinceState": cursor,
+                        "maxChanges": MAX_CHANGES_PER_PAGE
+                    }, "c1"],
+                    ["Email/get", {
+                        "#ids": { "resultOf": "c1", "name": "Email/changes", "path": "/created" },
+                        "accountId": self.account_id,
+                        "properties": ["id", "subject", "from", "to", "cc", "receivedAt",
+                                       "size", "keywords", "messageId", "inReplyTo",
+                                       "references", "hasAttachment", "preview", "mailboxIds"]
+                    }, "g1"],
+                    // Fetch full envelope properties for updated emails too,
+                    // not just id+keywords: a message can appear in "updated"
+                    // because its mailboxIds changed (moved into this folder),
+                    // in which case the caller needs to insert it as a new
+                    // row with the real subject/from/date, not an empty one.
+                    ["Email/get", {
+                        "#ids": { "resultOf": "c1", "name": "Email/changes", "path": "/updated" },
+                        "accountId": self.account_id,
+                        "properties": ["id", "subject", "from", "to", "cc", "receivedAt",
+                                       "size", "keywords", "messageId", "inReplyTo",
+                                       "references", "hasAttachment", "preview", "mailboxIds"]
+                    }, "g2"]
+                ]
+            });
+
+            let resp = self.api_request(&request, config).await?;
+
+            // Surface server errors (cannotCalculateChanges, invalidArguments, …)
+            // so the caller can decide whether to fall back to a full sync.
+            if let Some(err_type) = resp["methodResponses"][0][1]["type"].as_str() {
+                return Err(Error::Other(format!("Email/changes error: {}", err_type)));
+            }
+
+            let changes = &resp["methodResponses"][0][1];
+            let new_state = changes["newState"].as_str().unwrap_or("").to_string();
+            let has_more = changes["hasMoreChanges"].as_bool().unwrap_or(false);
+
+            if let Some(arr) = changes["destroyed"].as_array() {
+                destroyed.extend(arr.iter().filter_map(|v| v.as_str().map(String::from)));
+            }
+
+            for list_idx in [1usize, 2] {
+                if let Some(arr) = resp["methodResponses"][list_idx][1]["list"].as_array() {
+                    for e in arr {
+                        emails.push(self.parse_jmap_email(e));
+                    }
                 }
             }
+
+            if !has_more {
+                final_state = new_state;
+                break;
+            }
+
+            pages += 1;
+            if pages >= MAX_PAGES {
+                return Err(Error::Other(format!(
+                    "Email/changes exceeded {} pages without finishing; falling back to full sync",
+                    MAX_PAGES
+                )));
+            }
+
+            // Guard against a server that returns hasMoreChanges: true
+            // without advancing state — would loop forever otherwise.
+            if new_state == cursor {
+                return Err(Error::Other(
+                    "Email/changes returned hasMoreChanges but newState == sinceState".into(),
+                ));
+            }
+            cursor = new_state;
         }
 
         log::info!(
-            "JMAP delta: {} created/updated, {} destroyed (newState={})",
+            "JMAP delta: {} created/updated, {} destroyed (pages={}, newState={})",
             emails.len(),
             destroyed.len(),
-            new_state
+            pages + 1,
+            final_state
         );
 
         Ok(JmapFetchResult {
             emails,
             destroyed,
-            state: new_state,
+            state: final_state,
             is_full: false,
         })
     }

--- a/src-tauri/src/mail/jmap_push.rs
+++ b/src-tauri/src/mail/jmap_push.rs
@@ -55,7 +55,10 @@ pub async fn run_push_loop(
     while !stop.load(Ordering::Relaxed) {
         // For OIDC accounts, refresh the access token before each connect attempt
         // so reconnects after token expiry don't keep using a stale token.
-        if config.access_token.is_some() {
+        // Bearer-mode accounts (Fastmail API tokens) also have access_token set
+        // but have no refresh endpoint — gate on a non-empty endpoint so we
+        // don't fire useless refresh attempts for them.
+        if config.access_token.is_some() && !config.oidc_token_endpoint.is_empty() {
             match crate::commands::sync_cmd::refresh_jmap_oidc_token(
                 &account_id,
                 &config.oidc_token_endpoint,

--- a/src-tauri/src/mail/jmap_sync.rs
+++ b/src-tauri/src/mail/jmap_sync.rs
@@ -186,6 +186,33 @@ async fn sync_jmap_account_inner(
 }
 
 /// Sync a single JMAP mailbox.
+///
+/// Known per-folder redundancy
+/// ---------------------------
+/// `fetch_emails` (below) calls `Email/changes` against the per-folder
+/// stored state. `Email/changes` itself is account-wide — it returns
+/// the same created/updated/destroyed lists regardless of which
+/// mailbox you're "syncing". When `sync_jmap_account_inner` iterates
+/// every folder and calls `sync_jmap_folder` for each, the same delta
+/// window is fetched and parsed once per folder, then filtered
+/// per-mailbox by the loop above. For an account with N folders all
+/// at the same JMAP state this is N times the network traffic and
+/// JSON parsing of the minimum needed.
+///
+/// We accept this redundancy in the current implementation because:
+///   * per-folder state lets the user trigger "sync only Inbox" (the
+///     right-click sync action) without advancing the global cursor
+///     and silently dropping changes that other folders still need;
+///   * folders can legitimately have different states (e.g. a freshly
+///     created folder starts with no state and gets a full scan
+///     while the inbox keeps its delta cursor);
+///   * a single Email/changes call is fast enough on Fastmail /
+///     Stalwart that the wasted work is not visible in practice.
+///
+/// The proper fix is an account-level Email/changes step that fans
+/// out per-folder, with a single per-account state column. That's a
+/// schema + sync-orchestration change tracked separately, not in the
+/// Fastmail-support PR that introduced delta sync.
 async fn sync_jmap_folder(
     db: &Arc<DbPool>,
     account_id: &str,

--- a/src-tauri/src/mail/jmap_sync.rs
+++ b/src-tauri/src/mail/jmap_sync.rs
@@ -200,12 +200,19 @@ async fn sync_jmap_folder(
         db::folders::get_jmap_state(&conn, account_id, mailbox_id)?
     };
 
-    let (emails, new_state) = conn_jmap
+    let fetch = conn_jmap
         .fetch_emails(jmap_config, mailbox_id, jmap_state.as_deref())
         .await?;
+    let crate::mail::jmap::JmapFetchResult {
+        emails,
+        destroyed,
+        state: new_state,
+        is_full,
+    } = fetch;
 
-    if emails.is_empty() {
-        // Still update the state so we don't re-fetch next time
+    if emails.is_empty() && destroyed.is_empty() {
+        // Persist the new state even on a no-op delta so the next sync
+        // doesn't re-replay the same window of changes.
         if !new_state.is_empty() {
             let conn = db.writer().await;
             db::folders::update_jmap_state(&conn, account_id, mailbox_id, &new_state)?;
@@ -213,11 +220,45 @@ async fn sync_jmap_folder(
         return Ok(0);
     }
 
+    // Delta sync returns account-wide changes (Email/changes is global),
+    // so filter to just the messages whose mailboxIds contain this folder.
+    // For messages that USED to be in this folder but no longer are (moved
+    // out), drop the local row. Full sync uses Email/query with an
+    // `inMailbox` filter, so its result set is already per-mailbox — skip
+    // the filtering in that case and trust the server.
+    let mut moved_out: Vec<String> = Vec::new();
+    let filtered_emails: Vec<&crate::mail::jmap::JmapEmail> = if is_full {
+        emails.iter().collect()
+    } else {
+        emails
+            .iter()
+            .filter(|e| {
+                if e.mailbox_ids.iter().any(|m| m == mailbox_id) {
+                    true
+                } else {
+                    // Email is no longer in this mailbox (or never was).
+                    // Schedule a delete of its row in this folder; the row
+                    // may not exist, in which case the DELETE is a no-op.
+                    moved_out.push(e.id.clone());
+                    false
+                }
+            })
+            .collect()
+    };
+
     log::info!(
-        "JMAP found {} new/updated emails in {} ({})",
-        emails.len(),
+        "JMAP found {} new/updated emails in {} ({}){}",
+        filtered_emails.len(),
         folder_name,
-        mailbox_id
+        mailbox_id,
+        if !is_full && filtered_emails.len() < emails.len() {
+            format!(
+                " ({} skipped — not in this mailbox)",
+                emails.len() - filtered_emails.len()
+            )
+        } else {
+            String::new()
+        },
     );
 
     let mut total_synced = 0u32;
@@ -226,7 +267,7 @@ async fn sync_jmap_folder(
     {
         let conn = db.writer().await;
 
-        for email in &emails {
+        for email in &filtered_emails {
             // Use the JMAP email ID as the unique identifier
             let id = format!("{}_{}_{}", account_id, mailbox_id, email.id);
 
@@ -300,35 +341,54 @@ async fn sync_jmap_folder(
     }
 
     // Remove local messages that no longer exist on the server.
-    // Build a set of JMAP email IDs from the server response.
-    let server_ids: std::collections::HashSet<String> =
-        emails.iter().map(|e| e.id.clone()).collect();
+    // Delta sync (Email/changes): server told us exactly which IDs were
+    // destroyed since the previous state — apply those.
+    // Full sync (initial / state-expired): server returned the complete
+    // current set, so any local row not in that set is stale.
     {
         let conn = db.writer().await;
-        // Get all local message IDs for this folder
-        let mut stmt = conn
-            .prepare("SELECT id FROM messages WHERE account_id = ?1 AND folder_path = ?2")
-            .map_err(Error::Database)?;
-        let local_ids: Vec<String> = stmt
-            .query_map(rusqlite::params![account_id, mailbox_id], |row| row.get(0))
-            .map_err(Error::Database)?
-            .filter_map(|r| r.ok())
-            .collect();
-
-        let _prefix = format!("{}_{}_{}", account_id, mailbox_id, "");
         let mut deleted = 0u32;
-        for local_id in &local_ids {
-            // Extract the JMAP email ID from the composite local ID
-            let jmap_id = local_id
-                .strip_prefix(&format!("{}_{}_", account_id, mailbox_id))
-                .unwrap_or(local_id);
-            if !server_ids.contains(jmap_id) {
-                conn.execute(
-                    "DELETE FROM messages WHERE id = ?1",
-                    rusqlite::params![local_id],
-                )
-                .ok();
-                deleted += 1;
+        if is_full {
+            let server_ids: std::collections::HashSet<String> =
+                emails.iter().map(|e| e.id.clone()).collect();
+            let mut stmt = conn
+                .prepare("SELECT id FROM messages WHERE account_id = ?1 AND folder_path = ?2")
+                .map_err(Error::Database)?;
+            let local_ids: Vec<String> = stmt
+                .query_map(rusqlite::params![account_id, mailbox_id], |row| row.get(0))
+                .map_err(Error::Database)?
+                .filter_map(|r| r.ok())
+                .collect();
+            for local_id in &local_ids {
+                let jmap_id = local_id
+                    .strip_prefix(&format!("{}_{}_", account_id, mailbox_id))
+                    .unwrap_or(local_id);
+                if !server_ids.contains(jmap_id) {
+                    conn.execute(
+                        "DELETE FROM messages WHERE id = ?1",
+                        rusqlite::params![local_id],
+                    )
+                    .ok();
+                    deleted += 1;
+                }
+            }
+        } else {
+            // Email/changes destroyed list: emails removed from the account.
+            // moved_out: emails still in the account but no longer in this
+            // mailbox. Both reduce to the same DB op (drop the per-folder
+            // composite row); apply them together.
+            for jmap_id in destroyed.iter().chain(moved_out.iter()) {
+                let composite = format!("{}_{}_{}", account_id, mailbox_id, jmap_id);
+                if conn
+                    .execute(
+                        "DELETE FROM messages WHERE id = ?1",
+                        rusqlite::params![composite],
+                    )
+                    .unwrap_or(0)
+                    > 0
+                {
+                    deleted += 1;
+                }
             }
         }
         if deleted > 0 {

--- a/src-tauri/src/mail/jmap_sync.rs
+++ b/src-tauri/src/mail/jmap_sync.rs
@@ -210,9 +210,16 @@ async fn sync_jmap_folder(
         is_full,
     } = fetch;
 
-    if emails.is_empty() && destroyed.is_empty() {
-        // Persist the new state even on a no-op delta so the next sync
-        // doesn't re-replay the same window of changes.
+    // Delta path only: an empty result with no destroyed IDs is a true
+    // no-op — persist the advanced state and skip the rest.
+    //
+    // Full path must NOT take this early return even when emails is
+    // empty: the deletion reconciliation below compares the server set
+    // against local rows, and a server-side empty mailbox means every
+    // local row is stale. Returning here would leave those orphans
+    // behind on first-sync-after-purge or after a state-expiry
+    // fallback that returns 0 messages.
+    if !is_full && emails.is_empty() && destroyed.is_empty() {
         if !new_state.is_empty() {
             let conn = db.writer().await;
             db::folders::update_jmap_state(&conn, account_id, mailbox_id, &new_state)?;

--- a/src/__tests__/jmap-auth-method.test.ts
+++ b/src/__tests__/jmap-auth-method.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Contract test for the JMAP auth method union.
+ *
+ * Originally the union was "basic" | "oidc". Stalwart accepts HTTP Basic,
+ * but Fastmail rejects it with `401 Invalid Authorization header, not
+ * bearer` and only accepts `Authorization: Bearer <api-token>`. The
+ * "bearer" variant carries the Fastmail API token in the password field
+ * and the backend (mail/jmap.rs::from_account) promotes it to
+ * access_token so apply_auth routes it through the bearer branch.
+ *
+ * If anyone narrows the type back to {"basic","oidc"} this fails to
+ * compile under vue-tsc; the runtime assertion below is defence in
+ * depth in case the contract is loosened to plain `string`.
+ */
+import { describe, it, expect } from "vitest";
+import type { AccountConfig } from "@/lib/types";
+
+describe("JMAP auth method union", () => {
+  it("accepts 'bearer' as a valid jmap_auth_method", () => {
+    const cfg: Pick<AccountConfig, "jmap_auth_method"> = {
+      jmap_auth_method: "bearer",
+    };
+    expect(cfg.jmap_auth_method).toBe("bearer");
+  });
+
+  it("still accepts 'basic' and 'oidc'", () => {
+    const basic: Pick<AccountConfig, "jmap_auth_method"> = { jmap_auth_method: "basic" };
+    const oidc: Pick<AccountConfig, "jmap_auth_method"> = { jmap_auth_method: "oidc" };
+    expect(basic.jmap_auth_method).toBe("basic");
+    expect(oidc.jmap_auth_method).toBe("oidc");
+  });
+});

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -6,7 +6,7 @@ export interface Account {
   // for standalone CalDAV / CardDAV accounts whose `email` was never
   // set (older accounts created before the DAV-tab email back-fill).
   username: string;
-  provider: "generic" | "gmail" | "microsoft365" | "o365";
+  provider: "generic" | "gmail" | "microsoft365" | "o365" | "fastmail";
   // Empty string means "no mail binding" — calendar-only / contacts-only
   // accounts (#43). Existing screens that need a mail account should
   // filter these out.
@@ -196,7 +196,7 @@ export interface SyncStatus {
 export interface AccountConfig {
   display_name: string;
   email: string;
-  provider: "generic" | "gmail" | "microsoft365" | "o365";
+  provider: "generic" | "gmail" | "microsoft365" | "o365" | "fastmail";
   /// Empty string means "no mail binding" (CalDAV-only / CardDAV-only).
   mail_protocol: "" | "imap" | "jmap" | "graph";
   imap_host: string;
@@ -221,7 +221,7 @@ export interface AccountConfig {
   password: string;
   use_tls: boolean;
   signature: string;
-  jmap_auth_method: "basic" | "oidc";
+  jmap_auth_method: "basic" | "bearer" | "oidc";
   oidc_token_endpoint: string;
   oidc_client_id: string;
   /// Whether the calendar binding is enabled. Mirrors mail_sync_enabled

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -29,6 +29,8 @@ function accountTypeLabelLong(t: AccountType): string {
       return "Gmail";
     case "o365":
       return "Microsoft 365";
+    case "fastmail":
+      return "Fastmail";
     case "talk":
       return "Nextcloud Talk";
     case "matrix":
@@ -49,6 +51,7 @@ function accountTypeLabel(acc: {
 }): string {
   if (acc.provider === "gmail") return "GMAIL";
   if (acc.provider === "o365") return "MICROSOFT 365";
+  if (acc.provider === "fastmail") return "FASTMAIL";
   if (acc.mail_protocol) return acc.mail_protocol.toUpperCase();
   // Standalone DAV accounts: name them by the user-visible service
   // they provide rather than the protocol acronym. "Calendar" and
@@ -262,6 +265,7 @@ type AccountType =
   | "gmail"
   | "imap"
   | "jmap"
+  | "fastmail"
   | "caldav"
   | "carddav"
   | "o365"
@@ -329,6 +333,26 @@ function selectAccountType(type: AccountType) {
       f.mail_protocol = "jmap";
       // Same logic: any IMAP host pre-filled by Gmail / O365 / a
       // previous IMAP click is irrelevant for JMAP, clear it.
+      if (!editingAccountId.value) {
+        f.imap_host = "";
+        f.imap_port = 0;
+        f.smtp_host = "";
+        f.smtp_port = 0;
+      }
+      f.use_tls = true;
+      break;
+    case "fastmail":
+      // Fastmail-specific JMAP. Hardcoded URL + bearer auth, no
+      // user-visible toggles — Fastmail's api.fastmail.com endpoint
+      // requires `Authorization: Bearer <api-token>` and rejects
+      // HTTP Basic. The Fastmail form asks only for email + API
+      // token. `provider = "fastmail"` is set so the list view shows
+      // a FASTMAIL chip, but openEditForm re-detects by URL since
+      // populate_legacy_from_bindings rewrites provider on read-back.
+      f.provider = "fastmail";
+      f.mail_protocol = "jmap";
+      f.jmap_url = "https://api.fastmail.com";
+      f.jmap_auth_method = "bearer";
       if (!editingAccountId.value) {
         f.imap_host = "";
         f.imap_port = 0;
@@ -432,7 +456,9 @@ function accountTypeDescription(t: AccountType): string {
     case "imap":
       return "Generic IMAP / SMTP mail account";
     case "jmap":
-      return "JMAP mail (e.g. Fastmail, Stalwart)";
+      return "JMAP mail (Stalwart, generic JMAP servers)";
+    case "fastmail":
+      return "Fastmail mail, calendar and contacts via JMAP API token";
     case "caldav":
       return "Standalone calendar via CalDAV";
     case "carddav":
@@ -486,6 +512,18 @@ async function openEditForm(id: string) {
           oauthStatus.value = null;
         }
       } catch { oauthStatus.value = null; }
+    } else if (
+      config.mail_protocol === "jmap"
+      && (config.provider === "fastmail"
+        || config.jmap_url.startsWith("https://api.fastmail.com"))
+    ) {
+      // Detect Fastmail accounts on edit-load: either provider was
+      // set by the Fastmail-tab save path, or the URL points at
+      // Fastmail's JMAP endpoint. populate_legacy_from_bindings
+      // rewrites provider to "generic" on read-back, so URL-based
+      // detection is the durable signal.
+      accountType.value = "fastmail";
+      oauthStatus.value = null;
     } else if (config.mail_protocol === "jmap") {
       accountType.value = "jmap";
       if (config.jmap_auth_method === "oidc") {
@@ -1157,7 +1195,7 @@ onMounted(() => {
           <p class="picker-help">Pick the kind of account you want to add. You can add more later.</p>
           <div class="picker-grid">
             <button
-              v-for="t in (['gmail', 'o365', 'imap', 'jmap', 'caldav', 'carddav', 'talk', 'matrix', 'zoom'] as AccountType[])"
+              v-for="t in (['gmail', 'o365', 'fastmail', 'imap', 'jmap', 'caldav', 'carddav', 'talk', 'matrix', 'zoom'] as AccountType[])"
               :key="t"
               class="picker-card"
               :data-testid="`picker-${t}`"
@@ -1311,12 +1349,13 @@ onMounted(() => {
               </span>
             </div>
             <div v-if="accountType !== 'o365' && !(accountType === 'jmap' && form.jmap_auth_method === 'oidc') && !isMeetTab" class="form-group">
-              <label>{{ accountType === 'gmail' ? 'App Password' : 'Password' }}</label>
+              <label>{{ accountType === 'fastmail' ? 'API token' : (accountType === 'gmail' ? 'App Password' : 'Password') }}</label>
               <PasswordInput
                 v-model="form.password"
-                :placeholder="editingAccountId ? 'Leave empty to keep current password' : (accountType === 'gmail' ? 'Gmail app password (for IMAP/SMTP)' : '••••••••')"
+                :placeholder="editingAccountId ? (accountType === 'fastmail' ? 'Leave empty to keep current token' : 'Leave empty to keep current password') : (accountType === 'fastmail' ? 'Paste your Fastmail API token' : (accountType === 'gmail' ? 'Gmail app password (for IMAP/SMTP)' : '••••••••'))"
               />
-              <span class="field-hint">Passwords are stored securely in your OS keyring</span>
+              <span v-if="accountType === 'fastmail'" class="field-hint">Generate at Fastmail Settings → Privacy &amp; Security → Manage API tokens. Stored in your OS keyring.</span>
+              <span v-else class="field-hint">Passwords are stored securely in your OS keyring</span>
             </div>
 
             <template v-if="accountType === 'gmail'">
@@ -1450,6 +1489,18 @@ onMounted(() => {
                   <span class="field-hint">Opens your browser to authenticate with your identity provider.</span>
                 </div>
               </template>
+            </template>
+
+            <!-- Fastmail tab: hardcoded JMAP URL + bearer auth, so the
+                 form only needs an info row. The API-token field is
+                 rendered above by the shared password block (which
+                 relabels itself when accountType === 'fastmail'). -->
+            <template v-if="accountType === 'fastmail'">
+              <div class="form-group">
+                <label>JMAP endpoint</label>
+                <div class="type-readonly">https://api.fastmail.com</div>
+                <span class="field-hint">Fastmail's JMAP API. Authentication uses Authorization: Bearer with the API token above.</span>
+              </div>
             </template>
 
             <!-- For standalone CalDAV / CardDAV the URL is the entire

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -808,7 +808,7 @@ async function saveAccount() {
     editingAccountId.value = null;
     resetDefaultBookState();
   } catch (e) {
-    error.value = String(e);
+    error.value = e instanceof Error ? e.message : String(e);
   } finally {
     saving.value = false;
   }

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -333,11 +333,20 @@ function selectAccountType(type: AccountType) {
       f.mail_protocol = "jmap";
       // Same logic: any IMAP host pre-filled by Gmail / O365 / a
       // previous IMAP click is irrelevant for JMAP, clear it.
+      // Also reset the JMAP-specific fields so a previous click on
+      // the Fastmail tab (which hardcodes jmap_url to
+      // api.fastmail.com and jmap_auth_method to "bearer") doesn't
+      // leak through into the generic JMAP form — the JMAP UI only
+      // offers Basic / OIDC, so a stuck "bearer" would be
+      // unreachable from the user's perspective and the saved URL
+      // would auto-pick the Fastmail edit-load branch.
       if (!editingAccountId.value) {
         f.imap_host = "";
         f.imap_port = 0;
         f.smtp_host = "";
         f.smtp_port = 0;
+        f.jmap_url = "";
+        f.jmap_auth_method = "basic";
       }
       f.use_tls = true;
       break;

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -19,6 +19,24 @@ const platformStore = usePlatformStore();
 const uiStore = useUiStore();
 const { isMobile } = storeToRefs(platformStore);
 
+/// Strict Fastmail JMAP endpoint check. Mirrors the Rust
+/// `is_fastmail_jmap_url` helper in `db/accounts.rs`: returns
+/// `true` only when the URL parses, uses https, and its hostname
+/// is *exactly* `api.fastmail.com` (case-insensitive). A plain
+/// `startsWith("https://api.fastmail.com")` would also approve
+/// lookalike hosts like `api.fastmail.com.attacker.example`.
+function isFastmailJmapUrl(u: string): boolean {
+  try {
+    const parsed = new URL(u);
+    return (
+      parsed.protocol === "https:"
+      && parsed.hostname.toLowerCase() === "api.fastmail.com"
+    );
+  } catch {
+    return false;
+  }
+}
+
 /// Long-form label for the type-selector buttons in the modal.
 /// Mostly the same as `accountTypeLabel` for the listing, but the
 /// modal is wider and benefits from "Nextcloud Talk" and "Matrix"
@@ -523,14 +541,16 @@ async function openEditForm(id: string) {
       } catch { oauthStatus.value = null; }
     } else if (
       config.mail_protocol === "jmap"
-      && (config.provider === "fastmail"
-        || config.jmap_url.startsWith("https://api.fastmail.com"))
+      && (config.provider === "fastmail" || isFastmailJmapUrl(config.jmap_url))
     ) {
       // Detect Fastmail accounts on edit-load: either provider was
       // set by the Fastmail-tab save path, or the URL points at
       // Fastmail's JMAP endpoint. populate_legacy_from_bindings
       // rewrites provider to "generic" on read-back, so URL-based
-      // detection is the durable signal.
+      // detection is the durable signal. The host match is strict
+      // (full hostname equality, not startsWith) so a lookalike
+      // host like `api.fastmail.com.attacker.example` does not
+      // silently load the Fastmail tab.
       accountType.value = "fastmail";
       oauthStatus.value = null;
     } else if (config.mail_protocol === "jmap") {

--- a/src/views/SettingsView.vue
+++ b/src/views/SettingsView.vue
@@ -697,6 +697,32 @@ async function saveAccount() {
   saving.value = true;
   error.value = null;
   try {
+    // Fastmail save-time guard: the form's only secret is the API
+    // token (the "Password" input is relabelled to "API token" for
+    // this tab). On a new account it must be a non-empty token, since
+    // bearer-mode JmapConfig builds will otherwise fail fast at
+    // connect time with a generic error and the account is unusable.
+    // We check trim() too — whitespace-only input would have been
+    // silently dropped by the keyring write guard, leaving the field
+    // visually "set" but the keyring empty.
+    // When editing, blank means "leave the existing token alone", so
+    // we only reject a token that the user explicitly typed but that
+    // consists entirely of whitespace.
+    if (accountType.value === "fastmail") {
+      const trimmedToken = form.value.password.trim();
+      if (!editingAccountId.value && trimmedToken === "") {
+        throw new Error(
+          "Fastmail accounts require an API token. Generate one at " +
+            "Fastmail Settings → Privacy & Security → Manage API tokens.",
+        );
+      }
+      if (editingAccountId.value && form.value.password !== "" && trimmedToken === "") {
+        throw new Error(
+          "API token cannot be only whitespace. Leave the field blank " +
+            "to keep the existing token, or paste a valid token.",
+        );
+      }
+    }
     // Default username to email if not set (Gmail and most IMAP servers use email as username)
     if (!form.value.username.trim()) {
       form.value.username = form.value.email;


### PR DESCRIPTION
 Wires up first-class Fastmail support. The Fastmail-tab path requires
 three things that the existing Stalwart-only JMAP plumbing couldn't do:
 Authorization: Bearer instead of Basic, leaving cross-host session URLs
 (downloadUrl on www.fastmail.com / www.fastmailusercontent.com) alone,
 and Email/changes-based delta sync so 9000-message mailboxes don't
 re-fetch every envelope on every poll. Stalwart's behaviour is
 preserved on every code path.

 Account type + UI (src/views/SettingsView.vue, src/lib/types.ts)
   * New "Fastmail" tab in the picker (alongside Gmail / O365 / IMAP / JMAP / CalDAV / etc.). Three-field form: display name, email, API token. JMAP URL (https://api.fastmail.com) and auth method (bearer) are hardcoded and rendered read-only.
   * Password input relabels itself as "API token" when the Fastmail tab is active, with placeholder and hint text pointing at Fastmail Settings -> Privacy & Security -> Manage API tokens.
   * openEditForm detects Fastmail on edit-load by provider OR by jmap_url starting with https://api.fastmail.com, since populate_legacy_from_bindings rewrites provider on read-back.
   * Provider union and jmap_auth_method union both widened: "fastmail" joins the provider list, "bearer" joins the auth-method list.

 Bearer routing (src-tauri/src/mail/jmap.rs)
   * JmapConfig::from_account promotes the password column into access_token when jmap_auth_method == "bearer" and the password is non-empty. apply_auth() is unchanged: access_token wins and is sent as Bearer; otherwise Basic with username + password.
   * Token is trimmed during promotion. reqwest::bearer_auth embeds the value verbatim, so a trailing newline from paste turns "Bearer fmu1-xxx\n" into a malformed header and Fastmail returns "Invalid Authorization bearer parameters, not valid format".
   * Empty-password bearer falls through (no access_token set), so edit-without-changing-password preserves the keyring token instead of clobbering it with an empty Bearer header.
   * Tests cover basic-keeps-password, bearer-moves-to-access-token, bearer-trims-whitespace, bearer-empty-falls-through, oidc-noop, and round-trip apply_auth -> Authorization header for both Bearer and Basic.
   * Connect log line now reports auth mode plus a 4-char token prefix and length (token value itself is never logged), so bearer misconfigurations are diagnosable from chithi.log.

 URL rewrite gate (src-tauri/src/mail/jmap.rs)
   * rewrite_url now consults is_internal_url before rewriting. A URL is internal only if it has an explicit port, uses a loopback / RFC 1918 / RFC 4193 private IP, or has the literal host "localhost". Public hosts on default ports are left untouched.
   * Stalwart-behind-nginx case from ADR 0008 still rewrites (port 8080 trips the heuristic).
   * Fastmail apiUrl on api.fastmail.com is kept. downloadUrl on www.fastmail.com / www.fastmailusercontent.com is kept (was previously force-merged onto api.fastmail.com, which returns the Fastmail marketing homepage instead of message bodies).
   * Tests cover internal Stalwart, localhost, RFC1918, public Fastmail download host, public fastmailusercontent host, and public https-no-port.

 Delta sync (src-tauri/src/mail/jmap.rs, src-tauri/src/mail/jmap_sync.rs)
   * fetch_emails now tries Email/changes (RFC 8621 sec 4.3) when a saved state is available, only falling back to full pagination on cannotCalculateChanges / invalidArguments (RFC 8620 sec 5.2).
   * Returns a new JmapFetchResult { emails, destroyed, state, is_full } so the sync engine knows whether to reconcile deletions from the destroyed list (delta) or by comparing against the full server set (full).
   * Full-sync state is now captured from Email/get's "state", not Email/query's "queryState", so the value can actually be passed back to Email/changes on the next sync.
   * Email/get for both /created and /updated now fetches full envelope properties (subject, from, dates, ...) so messages that appear in "updated" because their mailboxIds changed (moved into this folder) get inserted with real data, not empty rows.
   * JmapEmail carries mailbox_ids. The sync engine filters delta-sync results to messages whose mailboxIds contain the current folder, and drops local rows for messages that have moved out. Full sync skips this filtering since Email/query is already per-mailbox.
   * State is persisted even on a no-op delta to avoid replaying the same window on the next sync.

 Push loop (src-tauri/src/mail/jmap_push.rs)
   * The token-refresh shim ran whenever access_token was set, but bearer-mode accounts (Fastmail API tokens) also set access_token and have no refresh endpoint. Gate the refresh on a non-empty oidc_token_endpoint so it only fires for OIDC.

 Service bindings round-trip (src-tauri/src/db/service_bindings.rs,
 src-tauri/src/db/accounts.rs)
   * JmapBindingConfig grows an auth_method field (basic / bearer / oidc), serialized into config_json so the user's choice survives insert + read-back. Older bindings without the field deserialize as empty and are treated as "basic" by readers.
   * populate_legacy_from_bindings now recovers jmap_auth_method from the JMAP binding's config_json instead of always collapsing non-OIDC accounts to "basic". Without this fix a Fastmail account saved as bearer would read back as basic, and apply_auth would send Basic -- which Fastmail rejects with 401.
   * Provider recovery for "generic" accounts now also inspects the JMAP URL: jmap_url starting with https://api.fastmail.com sets provider = "fastmail" so the list-view chip and edit-form label both say FASTMAIL.
   * insert_account / update_account trim the password value before writing to the keyring when jmap_auth_method == "bearer", for the same reason from_account does (paste-newline poisoning).
   * Two regression tests pinned: provider-recovery-from-URL and bearer-survives-insert-read-back.

 build_jmap_config (src-tauri/src/commands/sync_cmd.rs)
   * Delegates to JmapConfig::from_account instead of hand-rolling the struct, so the bearer promotion is applied uniformly. The refreshed OIDC access token (when present) is overlaid afterwards.

 Docs
   * docs/adr/0049-fastmail-jmap-api-token.md -- new ADR recording the dedicated-tab decision, the bearer routing through from_account, the URL-rewrite gate, and the deferred OIDC (Fastmail uses Auth Code + PKCE, not RFC 8628 device flow).