### PR TITLE
fix(folder-tree): clamp right-click context menu to viewport

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3354,9 +3354,9 @@ dependencies = [
 
 [[package]]
 name = "libtumpa"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "021c60c784ce25d3977755fb4ea2fc43d59a12c903e9241d396ff2f149c66748"
+checksum = "b51648abd1a3f530771428544b7a8612c86a560935ca10d93ab3c2357f02dcba"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7425,9 +7425,9 @@ dependencies = [
 
 [[package]]
 name = "wecanencrypt"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75f3922162bbe25f4ba50ed561c49b48c9b5172991348c8eed1cee852f3ac228"
+checksum = "0d31ef55c4c35762827bc7e90452e6871e0428e58fa7fd91c1a36b5ce7f037be"
 dependencies = [
  "aes",
  "aes-kw",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -60,7 +60,7 @@ clearurls = "0.0.4"
 # OpenPGP keystore + smartcard + WKD operations. Shares the on-disk
 # keystore at ~/.tumpa/keys.db with tumpa-cli and the tumpa desktop app
 # (honors $TUMPA_DIR / $TUMPA_KEYSTORE).
-libtumpa = { version = "0.4.0", default-features = false, features = ["card", "network"] }
+libtumpa = { version = "0.4.1", default-features = false, features = ["card", "network"] }
 zeroize = { version = "1", features = ["derive"] }
 
 [target.'cfg(unix)'.dependencies]

--- a/src/components/mail/FolderTree.vue
+++ b/src/components/mail/FolderTree.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted, watch } from "vue";
+import { ref, onMounted, watch, nextTick } from "vue";
 import { useFoldersStore } from "@/stores/folders";
 import { useAccountsStore } from "@/stores/accounts";
 import { useMessagesStore } from "@/stores/messages";
@@ -141,9 +141,24 @@ watch(
   },
 );
 
+const folderMenuEl = ref<HTMLElement | null>(null);
+const accountMenuEl = ref<HTMLElement | null>(null);
+
+function clampMenuPosition(el: HTMLElement, x: number, y: number) {
+  const rect = el.getBoundingClientRect();
+  const margin = 4;
+  const maxX = window.innerWidth - rect.width - margin;
+  const maxY = window.innerHeight - rect.height - margin;
+  el.style.left = `${Math.max(margin, Math.min(x, maxX))}px`;
+  el.style.top = `${Math.max(margin, Math.min(y, maxY))}px`;
+}
+
 function onFolderContextMenu(event: MouseEvent, folder: Folder, accountId: string) {
   event.preventDefault();
   contextMenu.value = { x: event.clientX, y: event.clientY, folder, accountId };
+  void nextTick(() => {
+    if (folderMenuEl.value) clampMenuPosition(folderMenuEl.value, event.clientX, event.clientY);
+  });
 }
 
 function closeContextMenu() {
@@ -155,6 +170,9 @@ function onAccountContextMenu(event: MouseEvent, accountId: string) {
   event.preventDefault();
   contextMenu.value = null;
   accountMenu.value = { x: event.clientX, y: event.clientY, accountId };
+  void nextTick(() => {
+    if (accountMenuEl.value) clampMenuPosition(accountMenuEl.value, event.clientX, event.clientY);
+  });
 }
 
 function openNewFolderFromAccount() {
@@ -526,6 +544,7 @@ async function doDeleteFolder() {
       <div v-if="contextMenu" class="folder-menu-overlay" @click="closeContextMenu"></div>
       <div
         v-if="contextMenu"
+        ref="folderMenuEl"
         class="folder-context-menu"
         data-testid="folder-context-menu"
         :style="{ left: contextMenu.x + 'px', top: contextMenu.y + 'px' }"
@@ -551,6 +570,7 @@ async function doDeleteFolder() {
       <div v-if="accountMenu" class="folder-menu-overlay" @click="closeContextMenu"></div>
       <div
         v-if="accountMenu"
+        ref="accountMenuEl"
         class="folder-context-menu"
         :style="{ left: accountMenu.x + 'px', top: accountMenu.y + 'px' }"
       >


### PR DESCRIPTION
The folder and account context menus were positioned with raw click coordinates, so right-clicking near the bottom or right edge of the window caused the lower menu items to be cut off by the viewport.

Measure each menu's bounding rect after render and shift left/top so the menu stays fully visible with a small margin.

Also updated libtumpa verison.