### PR TITLE
feat(mail): save raw .eml from message list right-click

### DIFF
--- a/src-tauri/src/commands/mail.rs
+++ b/src-tauri/src/commands/mail.rs
@@ -271,6 +271,146 @@ pub async fn import_search_hit(
     Ok(id)
 }
 
+/// Ensure the raw RFC822 body for `message_id` is on disk and return the
+/// relative maildir path that resolves under `state.data_dir`. If the body
+/// hasn't been downloaded yet (empty or legacy `graph:` prefix), fetches it
+/// on-demand from the appropriate backend (Graph / JMAP / IMAP).
+async fn ensure_message_body_on_disk(
+    app: &tauri::AppHandle,
+    state: &State<'_, AppState>,
+    account_id: &str,
+    message_id: &str,
+    maildir_path: &str,
+    flags_json: &str,
+) -> Result<String> {
+    if !maildir_path.is_empty() && !maildir_path.starts_with("graph:") {
+        return Ok(maildir_path.to_string());
+    }
+
+    let (account, folder_path, uid) = {
+        let conn = state.db.reader();
+        let account = db::accounts::get_account_full(&conn, account_id)?;
+        let (fp, u) = db::messages::get_folder_and_uid(&conn, message_id)?;
+        (account, fp, u)
+    };
+
+    let flags: Vec<String> = serde_json::from_str(flags_json).unwrap_or_default();
+    let data_dir = state.data_dir.clone();
+
+    let relative_path = if account.mail_protocol_str() == "graph" {
+        log::info!("Body not on disk for {}, streaming from Graph", message_id);
+
+        let graph_msg_id = if let Some(gid) = maildir_path.strip_prefix("graph:") {
+            gid.to_string()
+        } else {
+            message_id
+                .strip_prefix(&format!("{}_", account_id))
+                .unwrap_or(message_id)
+                .to_string()
+        };
+
+        let token = crate::mail::graph::get_graph_token(account_id).await?;
+        let client = crate::mail::graph::GraphClient::new(&token);
+
+        let folder_dir = crate::mail::sync::sanitize_folder_name(&folder_path);
+        let maildir_base = data_dir.join(account_id).join(&folder_dir);
+        crate::mail::sync::create_maildir_dirs(&maildir_base)?;
+
+        let filename = format!(
+            "{}:2,{}",
+            graph_msg_id,
+            crate::mail::sync::flags_to_maildir_suffix(&flags)
+        );
+        let msg_path = maildir_base.join("cur").join(&filename);
+
+        let bytes_written = client
+            .download_mime_to_file(&graph_msg_id, &msg_path)
+            .await?;
+        let rp = format!("{}/{}/cur/{}", account_id, folder_dir, filename);
+        log::info!("Graph body streamed: {} ({} bytes)", rp, bytes_written);
+        rp
+    } else if account.mail_protocol_str() == "jmap" {
+        log::info!("Body not on disk for {}, fetching from JMAP", message_id);
+
+        let jmap_config = crate::commands::sync_cmd::build_jmap_config(&account).await?;
+
+        let jmap_email_id = message_id
+            .strip_prefix(&format!("{}_{}_", account_id, folder_path))
+            .unwrap_or(message_id);
+
+        jmap_sync::fetch_and_store_jmap_body(
+            &jmap_config,
+            &data_dir,
+            account_id,
+            &folder_path,
+            jmap_email_id,
+            &flags,
+        )
+        .await?
+    } else {
+        log::info!("Body not on disk for {}, fetching from IMAP", message_id);
+
+        let suspended_idle = if should_suspend_idle_for_imap_operation(&account.auth_method) {
+            suspend_imap_idle_for_account(state, account_id).await?
+        } else {
+            false
+        };
+        let resume_account = account.clone();
+
+        let (password, use_xoauth2) = if account.auth_method == "oauth-microsoft" {
+            let tokens = crate::oauth::load_tokens(account_id)?
+                .ok_or_else(|| Error::Other("No O365 tokens".into()))?;
+            let refresh = tokens
+                .refresh_token
+                .ok_or_else(|| Error::Other("No O365 refresh token".into()))?;
+            let new = crate::oauth::refresh_with_scopes(
+                &crate::oauth::MICROSOFT,
+                &refresh,
+                crate::oauth::MICROSOFT_IMAP_SCOPES,
+            )
+            .await?;
+            crate::oauth::store_tokens(account_id, &new)?;
+            (new.access_token, true)
+        } else {
+            (account.password, false)
+        };
+
+        let imap_config = ImapConfig {
+            host: account.imap_host,
+            port: account.imap_port,
+            username: account.username,
+            password,
+            use_tls: account.use_tls,
+            use_xoauth2,
+        };
+
+        let account_id_clone = account_id.to_string();
+        let relative_path = tokio::task::spawn_blocking(move || {
+            mail_sync::fetch_and_store_body(
+                &imap_config,
+                &data_dir,
+                &account_id_clone,
+                &folder_path,
+                uid,
+                &flags,
+            )
+        })
+        .await
+        .map_err(|e| Error::Other(format!("Body fetch panicked: {}", e)))??;
+
+        resume_imap_idle_for_account(app, state, &resume_account, suspended_idle).await?;
+
+        relative_path
+    };
+
+    {
+        let conn = state.db.writer().await;
+        db::messages::update_maildir_path(&conn, message_id, &relative_path)?;
+    }
+
+    Ok(relative_path)
+}
+
 #[tauri::command]
 pub async fn get_message_body(
     app: tauri::AppHandle,
@@ -285,139 +425,15 @@ pub async fn get_message_body(
         db::messages::get_message_metadata(&conn, &account_id, &message_id)?
     };
 
-    // If body hasn't been downloaded yet (empty or legacy `graph:` prefix), fetch on-demand
-    let actual_maildir_path = if maildir_path.is_empty() || maildir_path.starts_with("graph:") {
-        // Get account config and message details
-        let (account, folder_path, uid) = {
-            let conn = state.db.reader();
-            let account = db::accounts::get_account_full(&conn, &account_id)?;
-            let (fp, u) = db::messages::get_folder_and_uid(&conn, &message_id)?;
-            (account, fp, u)
-        };
-
-        let flags: Vec<String> = serde_json::from_str(&flags_json).unwrap_or_default();
-        let data_dir = state.data_dir.clone();
-
-        let relative_path = if account.mail_protocol_str() == "graph" {
-            // Graph: stream raw MIME to disk via GET /me/messages/{id}/$value
-            log::info!("Body not on disk for {}, streaming from Graph", message_id);
-
-            let graph_msg_id = if let Some(gid) = maildir_path.strip_prefix("graph:") {
-                gid.to_string()
-            } else {
-                message_id
-                    .strip_prefix(&format!("{}_", account_id))
-                    .unwrap_or(&message_id)
-                    .to_string()
-            };
-
-            let token = crate::mail::graph::get_graph_token(&account_id).await?;
-            let client = crate::mail::graph::GraphClient::new(&token);
-
-            let folder_dir = crate::mail::sync::sanitize_folder_name(&folder_path);
-            let maildir_base = data_dir.join(&account_id).join(&folder_dir);
-            crate::mail::sync::create_maildir_dirs(&maildir_base)?;
-
-            let filename = format!(
-                "{}:2,{}",
-                graph_msg_id,
-                crate::mail::sync::flags_to_maildir_suffix(&flags)
-            );
-            let msg_path = maildir_base.join("cur").join(&filename);
-
-            let bytes_written = client
-                .download_mime_to_file(&graph_msg_id, &msg_path)
-                .await?;
-            let rp = format!("{}/{}/cur/{}", account_id, folder_dir, filename);
-            log::info!("Graph body streamed: {} ({} bytes)", rp, bytes_written);
-            rp
-        } else if account.mail_protocol_str() == "jmap" {
-            log::info!("Body not on disk for {}, fetching from JMAP", message_id);
-
-            let jmap_config = crate::commands::sync_cmd::build_jmap_config(&account).await?;
-
-            // Extract the JMAP email ID from our composite message ID
-            // Format: {account_id}_{folder_path}_{jmap_email_id}
-            let jmap_email_id = message_id
-                .strip_prefix(&format!("{}_{}_", account_id, folder_path))
-                .unwrap_or(&message_id);
-
-            jmap_sync::fetch_and_store_jmap_body(
-                &jmap_config,
-                &data_dir,
-                &account_id,
-                &folder_path,
-                jmap_email_id,
-                &flags,
-            )
-            .await?
-        } else {
-            log::info!("Body not on disk for {}, fetching from IMAP", message_id);
-
-            let suspended_idle = if should_suspend_idle_for_imap_operation(&account.auth_method) {
-                suspend_imap_idle_for_account(&state, &account_id).await?
-            } else {
-                false
-            };
-            let resume_account = account.clone();
-
-            // For O365, refresh IMAP-scoped token for XOAUTH2
-            let (password, use_xoauth2) = if account.auth_method == "oauth-microsoft" {
-                let tokens = crate::oauth::load_tokens(&account_id)?
-                    .ok_or_else(|| Error::Other("No O365 tokens".into()))?;
-                let refresh = tokens
-                    .refresh_token
-                    .ok_or_else(|| Error::Other("No O365 refresh token".into()))?;
-                let new = crate::oauth::refresh_with_scopes(
-                    &crate::oauth::MICROSOFT,
-                    &refresh,
-                    crate::oauth::MICROSOFT_IMAP_SCOPES,
-                )
-                .await?;
-                crate::oauth::store_tokens(&account_id, &new)?;
-                (new.access_token, true)
-            } else {
-                (account.password, false)
-            };
-
-            let imap_config = ImapConfig {
-                host: account.imap_host,
-                port: account.imap_port,
-                username: account.username,
-                password,
-                use_tls: account.use_tls,
-                use_xoauth2,
-            };
-
-            let account_id_clone = account_id.clone();
-            let relative_path = tokio::task::spawn_blocking(move || {
-                mail_sync::fetch_and_store_body(
-                    &imap_config,
-                    &data_dir,
-                    &account_id_clone,
-                    &folder_path,
-                    uid,
-                    &flags,
-                )
-            })
-            .await
-            .map_err(|e| Error::Other(format!("Body fetch panicked: {}", e)))??;
-
-            resume_imap_idle_for_account(&app, &state, &resume_account, suspended_idle).await?;
-
-            relative_path
-        };
-
-        // Update the maildir_path in the database
-        {
-            let conn = state.db.writer().await;
-            db::messages::update_maildir_path(&conn, &message_id, &relative_path)?;
-        }
-
-        relative_path
-    } else {
-        maildir_path
-    };
+    let actual_maildir_path = ensure_message_body_on_disk(
+        &app,
+        &state,
+        &account_id,
+        &message_id,
+        &maildir_path,
+        &flags_json,
+    )
+    .await?;
 
     // Read and parse the message from disk
     let full_path = crate::path_validation::resolve_under(&state.data_dir, &actual_maildir_path)?;
@@ -931,16 +947,29 @@ pub async fn save_attachment(
 
     let contents = attachment.contents().to_vec();
 
-    // Open the native save dialog from the backend (renderer cannot bypass).
-    // We use the non-blocking callback API and await a oneshot rather than
-    // `blocking_save_file()` because blocking the tokio worker that invoked
-    // this command starves the GTK main thread on Linux, which manifests as
-    // a dialog that opens but never renders its Save button.
+    prompt_save_and_write_bytes(&app, &suggested_filename, &contents, "attachment").await
+}
+
+/// Open the native save-as dialog with `suggested_filename`, then atomically
+/// write `contents` to the user-chosen path (refusing symlinks, temp file +
+/// fsync + rename). Returns `Ok(())` if the user cancelled the dialog, since
+/// cancellation isn't an error from the caller's perspective.
+///
+/// The non-blocking callback API + oneshot is intentional: calling
+/// `blocking_save_file()` on the tokio worker that invoked the command
+/// starves the GTK main thread on Linux, which manifests as a dialog that
+/// opens but never renders its Save button.
+async fn prompt_save_and_write_bytes(
+    app: &tauri::AppHandle,
+    suggested_filename: &str,
+    contents: &[u8],
+    what: &str,
+) -> Result<()> {
     use tauri_plugin_dialog::DialogExt;
     let (tx, rx) = tokio::sync::oneshot::channel();
     app.dialog()
         .file()
-        .set_file_name(&suggested_filename)
+        .set_file_name(suggested_filename)
         .save_file(move |path| {
             let _ = tx.send(path);
         });
@@ -951,14 +980,13 @@ pub async fn save_attachment(
 
     let dest = match dest {
         Some(path) => path,
-        None => return Ok(()), // user cancelled
+        None => return Ok(()),
     };
 
     let dest_path = dest
         .as_path()
         .ok_or_else(|| Error::Other("Invalid save path".to_string()))?;
 
-    // Refuse to follow symlinks
     if let Ok(metadata) = std::fs::symlink_metadata(dest_path) {
         if metadata.file_type().is_symlink() {
             return Err(Error::Other(
@@ -967,7 +995,6 @@ pub async fn save_attachment(
         }
     }
 
-    // Write atomically: temp file + fsync + rename
     let dest_dir = dest_path
         .parent()
         .ok_or_else(|| Error::Other("Save path must have a parent directory".to_string()))?;
@@ -999,13 +1026,13 @@ pub async fn save_attachment(
             .open(&temp_path)
             .map_err(|e| Error::Other(format!("Failed to create temp file: {}", e)))?;
 
-        if let Err(e) = file.write_all(&contents) {
+        if let Err(e) = file.write_all(contents) {
             let _ = std::fs::remove_file(&temp_path);
-            return Err(Error::Other(format!("Failed to write attachment: {}", e)));
+            return Err(Error::Other(format!("Failed to write {}: {}", what, e)));
         }
         if let Err(e) = file.sync_all() {
             let _ = std::fs::remove_file(&temp_path);
-            return Err(Error::Other(format!("Failed to flush attachment: {}", e)));
+            return Err(Error::Other(format!("Failed to flush {}: {}", what, e)));
         }
         drop(file);
 
@@ -1014,7 +1041,6 @@ pub async fn save_attachment(
             return Err(Error::Other(format!("Failed to rename temp file: {}", e)));
         }
 
-        // Fsync parent directory for durability
         if let Ok(dir) = std::fs::File::open(dest_dir) {
             let _ = dir.sync_all();
         }
@@ -1030,17 +1056,16 @@ pub async fn save_attachment(
             .open(&temp_path)
             .map_err(|e| Error::Other(format!("Failed to create temp file: {}", e)))?;
 
-        if let Err(e) = file.write_all(&contents) {
+        if let Err(e) = file.write_all(contents) {
             let _ = std::fs::remove_file(&temp_path);
-            return Err(Error::Other(format!("Failed to write attachment: {}", e)));
+            return Err(Error::Other(format!("Failed to write {}: {}", what, e)));
         }
         if let Err(e) = file.sync_all() {
             let _ = std::fs::remove_file(&temp_path);
-            return Err(Error::Other(format!("Failed to flush attachment: {}", e)));
+            return Err(Error::Other(format!("Failed to flush {}: {}", what, e)));
         }
         drop(file);
 
-        // On Windows, rename fails if dest exists. Remove it first.
         if dest_path.exists() {
             let _ = std::fs::remove_file(dest_path);
         }
@@ -1050,8 +1075,44 @@ pub async fn save_attachment(
         }
     }
 
-    log::info!("Attachment saved to {}", dest_path.display());
+    log::info!("{} saved to {}", what, dest_path.display());
     Ok(())
+}
+
+/// Save a message's raw RFC822 (.eml) bytes to a user-chosen path. Fetches
+/// the body on-demand if it isn't on disk yet, then opens the native save
+/// dialog. `suggested_filename` is provided by the caller (typically derived
+/// from the subject).
+#[tauri::command]
+pub async fn save_message_as_eml(
+    app: tauri::AppHandle,
+    state: State<'_, AppState>,
+    account_id: String,
+    message_id: String,
+    suggested_filename: String,
+) -> Result<()> {
+    log::info!("Saving message {} as .eml", message_id);
+
+    let (maildir_path, _, _, _, flags_json, _, _) = {
+        let conn = state.db.reader();
+        db::messages::get_message_metadata(&conn, &account_id, &message_id)?
+    };
+
+    let actual_maildir_path = ensure_message_body_on_disk(
+        &app,
+        &state,
+        &account_id,
+        &message_id,
+        &maildir_path,
+        &flags_json,
+    )
+    .await?;
+
+    let full_path = crate::path_validation::resolve_under(&state.data_dir, &actual_maildir_path)?;
+    let raw = std::fs::read(&full_path)
+        .map_err(|e| Error::Other(format!("Failed to read message file: {}", e)))?;
+
+    prompt_save_and_write_bytes(&app, &suggested_filename, &raw, "message").await
 }
 
 #[cfg(test)]

--- a/src-tauri/src/commands/mail.rs
+++ b/src-tauri/src/commands/mail.rs
@@ -947,23 +947,31 @@ pub async fn save_attachment(
 
     let contents = attachment.contents().to_vec();
 
-    prompt_save_and_write_bytes(&app, &suggested_filename, &contents, "attachment").await
+    prompt_save_and_stream(
+        &app,
+        &suggested_filename,
+        "attachment",
+        std::io::Cursor::new(contents),
+    )
+    .await
 }
 
 /// Open the native save-as dialog with `suggested_filename`, then atomically
-/// write `contents` to the user-chosen path (refusing symlinks, temp file +
-/// fsync + rename). Returns `Ok(())` if the user cancelled the dialog, since
-/// cancellation isn't an error from the caller's perspective.
+/// stream bytes from `reader` to the user-chosen path (refusing symlinks,
+/// temp file + fsync + rename). `std::io::copy` is used so large payloads
+/// don't have to be buffered in memory. Returns `Ok(())` if the user
+/// cancelled the dialog, since cancellation isn't an error from the
+/// caller's perspective.
 ///
 /// The non-blocking callback API + oneshot is intentional: calling
 /// `blocking_save_file()` on the tokio worker that invoked the command
 /// starves the GTK main thread on Linux, which manifests as a dialog that
 /// opens but never renders its Save button.
-async fn prompt_save_and_write_bytes(
+async fn prompt_save_and_stream<R: std::io::Read>(
     app: &tauri::AppHandle,
     suggested_filename: &str,
-    contents: &[u8],
     what: &str,
+    mut reader: R,
 ) -> Result<()> {
     use tauri_plugin_dialog::DialogExt;
     let (tx, rx) = tokio::sync::oneshot::channel();
@@ -1015,63 +1023,51 @@ async fn prompt_save_and_write_bytes(
     ));
 
     #[cfg(unix)]
-    {
-        use std::io::Write;
+    let mut file = {
         use std::os::unix::fs::OpenOptionsExt;
-
-        let mut file = std::fs::OpenOptions::new()
+        std::fs::OpenOptions::new()
             .write(true)
             .create_new(true)
             .custom_flags(libc::O_NOFOLLOW)
             .open(&temp_path)
-            .map_err(|e| Error::Other(format!("Failed to create temp file: {}", e)))?;
+            .map_err(|e| Error::Other(format!("Failed to create temp file: {}", e)))?
+    };
 
-        if let Err(e) = file.write_all(contents) {
-            let _ = std::fs::remove_file(&temp_path);
-            return Err(Error::Other(format!("Failed to write {}: {}", what, e)));
-        }
-        if let Err(e) = file.sync_all() {
-            let _ = std::fs::remove_file(&temp_path);
-            return Err(Error::Other(format!("Failed to flush {}: {}", what, e)));
-        }
-        drop(file);
+    #[cfg(not(unix))]
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&temp_path)
+        .map_err(|e| Error::Other(format!("Failed to create temp file: {}", e)))?;
 
-        if let Err(e) = std::fs::rename(&temp_path, dest_path) {
-            let _ = std::fs::remove_file(&temp_path);
-            return Err(Error::Other(format!("Failed to rename temp file: {}", e)));
-        }
-
-        if let Ok(dir) = std::fs::File::open(dest_dir) {
-            let _ = dir.sync_all();
-        }
+    if let Err(e) = std::io::copy(&mut reader, &mut file) {
+        let _ = std::fs::remove_file(&temp_path);
+        return Err(Error::Other(format!("Failed to write {}: {}", what, e)));
     }
+    if let Err(e) = file.sync_all() {
+        let _ = std::fs::remove_file(&temp_path);
+        return Err(Error::Other(format!("Failed to flush {}: {}", what, e)));
+    }
+    drop(file);
 
     #[cfg(not(unix))]
     {
-        use std::io::Write;
-
-        let mut file = std::fs::OpenOptions::new()
-            .write(true)
-            .create_new(true)
-            .open(&temp_path)
-            .map_err(|e| Error::Other(format!("Failed to create temp file: {}", e)))?;
-
-        if let Err(e) = file.write_all(contents) {
-            let _ = std::fs::remove_file(&temp_path);
-            return Err(Error::Other(format!("Failed to write {}: {}", what, e)));
-        }
-        if let Err(e) = file.sync_all() {
-            let _ = std::fs::remove_file(&temp_path);
-            return Err(Error::Other(format!("Failed to flush {}: {}", what, e)));
-        }
-        drop(file);
-
+        // On Windows, rename fails if dest exists. Remove it first.
         if dest_path.exists() {
             let _ = std::fs::remove_file(dest_path);
         }
-        if let Err(e) = std::fs::rename(&temp_path, dest_path) {
-            let _ = std::fs::remove_file(&temp_path);
-            return Err(Error::Other(format!("Failed to rename temp file: {}", e)));
+    }
+
+    if let Err(e) = std::fs::rename(&temp_path, dest_path) {
+        let _ = std::fs::remove_file(&temp_path);
+        return Err(Error::Other(format!("Failed to rename temp file: {}", e)));
+    }
+
+    #[cfg(unix)]
+    {
+        // Fsync parent directory for durability.
+        if let Ok(dir) = std::fs::File::open(dest_dir) {
+            let _ = dir.sync_all();
         }
     }
 
@@ -1081,8 +1077,9 @@ async fn prompt_save_and_write_bytes(
 
 /// Save a message's raw RFC822 (.eml) bytes to a user-chosen path. Fetches
 /// the body on-demand if it isn't on disk yet, then opens the native save
-/// dialog. `suggested_filename` is provided by the caller (typically derived
-/// from the subject).
+/// dialog and streams the bytes through to the destination without
+/// buffering the whole message in memory. `suggested_filename` is provided
+/// by the caller (typically derived from the subject).
 #[tauri::command]
 pub async fn save_message_as_eml(
     app: tauri::AppHandle,
@@ -1109,10 +1106,16 @@ pub async fn save_message_as_eml(
     .await?;
 
     let full_path = crate::path_validation::resolve_under(&state.data_dir, &actual_maildir_path)?;
-    let raw = std::fs::read(&full_path)
-        .map_err(|e| Error::Other(format!("Failed to read message file: {}", e)))?;
+    let source = std::fs::File::open(&full_path)
+        .map_err(|e| Error::Other(format!("Failed to open message file: {}", e)))?;
 
-    prompt_save_and_write_bytes(&app, &suggested_filename, &raw, "message").await
+    prompt_save_and_stream(
+        &app,
+        &suggested_filename,
+        "message",
+        std::io::BufReader::new(source),
+    )
+    .await
 }
 
 #[cfg(test)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -59,6 +59,7 @@ pub fn run() {
             commands::mail::create_folder,
             commands::mail::delete_folder,
             commands::mail::save_attachment,
+            commands::mail::save_message_as_eml,
             commands::sync_cmd::trigger_sync,
             commands::sync_cmd::sync_folder,
             commands::sync_cmd::get_sync_status,

--- a/src/__tests__/message-list-clicks.test.ts
+++ b/src/__tests__/message-list-clicks.test.ts
@@ -22,6 +22,7 @@ vi.mock("@/lib/tauri", () => ({
   triggerSync: vi.fn().mockResolvedValue(undefined),
   backfillThreads: vi.fn().mockResolvedValue(0),
   prefetchBodies: vi.fn().mockResolvedValue(0),
+  saveMessageAsEml: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock("@tauri-apps/api/event", () => ({
@@ -161,5 +162,40 @@ describe("MessageList click handling", () => {
     const wrapper = mount(MessageList, { global: { plugins: [router] } });
     const row = wrapper.find(".message-row");
     expect(row.element.tagName).toBe("DIV");
+  });
+
+  it("Save as .eml context-menu item invokes the backend with sanitized filename", async () => {
+    const store = setupStores();
+    // Subject containing characters illegal on Windows ("/", ":") plus a
+    // path separator, to verify the renderer-side sanitizer doesn't leak
+    // them into the suggested filename — and that the ".eml" suffix is
+    // appended exactly once.
+    store.messages[0] = { ...store.messages[0], subject: "Re: Project/Update " };
+    const wrapper = mount(MessageList, {
+      attachTo: document.body,
+      global: { plugins: [router] },
+    });
+
+    // Right-click first row to open the context menu (single-selection).
+    const rows = wrapper.findAll(".message-row");
+    await rows[0].trigger("contextmenu");
+    await wrapper.vm.$nextTick();
+
+    // The menu is rendered via `<Teleport to="body">` so it lives outside the
+    // component's mount root — query the document directly.
+    const api = await import("@/lib/tauri");
+    const saveBtn = document.querySelector<HTMLElement>('[data-testid="ctx-save-eml"]');
+    expect(saveBtn).not.toBeNull();
+    saveBtn!.click();
+    await wrapper.vm.$nextTick();
+
+    expect(api.saveMessageAsEml).toHaveBeenCalledTimes(1);
+    const args = (api.saveMessageAsEml as any).mock.calls[0];
+    expect(args[0]).toBe("acc1");
+    expect(args[1]).toBe("msg1");
+    // "/" and ":" must be replaced; trailing whitespace stripped; one ".eml".
+    expect(args[2]).toBe("Re_ Project_Update.eml");
+
+    wrapper.unmount();
   });
 });

--- a/src/__tests__/message-list-clicks.test.ts
+++ b/src/__tests__/message-list-clicks.test.ts
@@ -164,13 +164,8 @@ describe("MessageList click handling", () => {
     expect(row.element.tagName).toBe("DIV");
   });
 
-  it("Save as .eml context-menu item invokes the backend with sanitized filename", async () => {
-    const store = setupStores();
-    // Subject containing characters illegal on Windows ("/", ":") plus a
-    // path separator, to verify the renderer-side sanitizer doesn't leak
-    // them into the suggested filename — and that the ".eml" suffix is
-    // appended exactly once.
-    store.messages[0] = { ...store.messages[0], subject: "Re: Project/Update " };
+  it("Save as .eml context-menu item invokes the backend with the default filename", async () => {
+    setupStores();
     const wrapper = mount(MessageList, {
       attachTo: document.body,
       global: { plugins: [router] },
@@ -193,8 +188,8 @@ describe("MessageList click handling", () => {
     const args = (api.saveMessageAsEml as any).mock.calls[0];
     expect(args[0]).toBe("acc1");
     expect(args[1]).toBe("msg1");
-    // "/" and ":" must be replaced; trailing whitespace stripped; one ".eml".
-    expect(args[2]).toBe("Re_ Project_Update.eml");
+    // Default filename — user can rename in the native save dialog.
+    expect(args[2]).toBe("message.eml");
 
     wrapper.unmount();
   });

--- a/src/components/mail/MessageList.vue
+++ b/src/components/mail/MessageList.vue
@@ -381,26 +381,13 @@ const hasReadSelected = () => {
   return false;
 };
 
-function sanitizeFilename(name: string): string {
-  // Strip path separators, control chars, and chars that are illegal on
-  // Windows/macOS so the suggested filename works cross-platform.
-  const cleaned = name.replace(/[\\/:*?"<>|\x00-\x1f]/g, "_").trim();
-  // Avoid a leading dot (hidden file) and bound the length so the dialog
-  // remains usable on file systems with name-length limits.
-  const noDot = cleaned.replace(/^\.+/, "");
-  return noDot.slice(0, 200) || "message";
-}
-
 async function ctxSaveAsEml() {
   const msgId = contextMenu.value?.messageId;
   const accountId = accountsStore.activeAccountId;
   closeContextMenu();
   if (!msgId || !accountId) return;
-  const summary = messagesStore.messages.find(m => m.id === msgId);
-  const base = sanitizeFilename(summary?.subject || "message");
-  const suggested = base.toLowerCase().endsWith(".eml") ? base : `${base}.eml`;
   try {
-    await api.saveMessageAsEml(accountId, msgId, suggested);
+    await api.saveMessageAsEml(accountId, msgId, "message.eml");
   } catch (e) {
     console.error("Save as .eml failed:", e);
     const msg = e instanceof Error ? e.message : String(e);

--- a/src/components/mail/MessageList.vue
+++ b/src/components/mail/MessageList.vue
@@ -381,6 +381,32 @@ const hasReadSelected = () => {
   return false;
 };
 
+function sanitizeFilename(name: string): string {
+  // Strip path separators, control chars, and chars that are illegal on
+  // Windows/macOS so the suggested filename works cross-platform.
+  const cleaned = name.replace(/[\\/:*?"<>|\x00-\x1f]/g, "_").trim();
+  // Avoid a leading dot (hidden file) and bound the length so the dialog
+  // remains usable on file systems with name-length limits.
+  const noDot = cleaned.replace(/^\.+/, "");
+  return noDot.slice(0, 200) || "message";
+}
+
+async function ctxSaveAsEml() {
+  const msgId = contextMenu.value?.messageId;
+  const accountId = accountsStore.activeAccountId;
+  closeContextMenu();
+  if (!msgId || !accountId) return;
+  const summary = messagesStore.messages.find(m => m.id === msgId);
+  const base = sanitizeFilename(summary?.subject || "message");
+  const suggested = base.toLowerCase().endsWith(".eml") ? base : `${base}.eml`;
+  try {
+    await api.saveMessageAsEml(accountId, msgId, suggested);
+  } catch (e) {
+    console.error("Save as .eml failed:", e);
+    showToast(`Save as .eml failed: ${e}`, "error");
+  }
+}
+
 function ctxShowAsThread() {
   if (contextMenu.value) {
     messagesStore.showAsThread(contextMenu.value.messageId);
@@ -762,6 +788,10 @@ function resolveFolderName(path: string): string {
           <button class="ctx-item" data-testid="ctx-forward" @click="ctxForward">
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 17 20 12 15 7" /><path d="M4 18v-2a4 4 0 0 1 4-4h12" /></svg>
             Forward
+          </button>
+          <button class="ctx-item" data-testid="ctx-save-eml" @click="ctxSaveAsEml">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z" /><polyline points="17 21 17 13 7 13 7 21" /><polyline points="7 3 7 8 15 8" /></svg>
+            Save as .eml…
           </button>
           <div class="ctx-separator"></div>
         </template>

--- a/src/components/mail/MessageList.vue
+++ b/src/components/mail/MessageList.vue
@@ -403,7 +403,8 @@ async function ctxSaveAsEml() {
     await api.saveMessageAsEml(accountId, msgId, suggested);
   } catch (e) {
     console.error("Save as .eml failed:", e);
-    showToast(`Save as .eml failed: ${e}`, "error");
+    const msg = e instanceof Error ? e.message : String(e);
+    showToast(`Save as .eml failed: ${msg}`, "error");
   }
 }
 

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -138,6 +138,18 @@ export async function saveAttachment(
   });
 }
 
+export async function saveMessageAsEml(
+  accountId: string,
+  messageId: string,
+  suggestedFilename: string,
+): Promise<void> {
+  return invoke("save_message_as_eml", {
+    accountId,
+    messageId,
+    suggestedFilename,
+  });
+}
+
 export async function syncFolder(
   accountId: string,
   folderPath: string,


### PR DESCRIPTION
Adds a "Save as .eml..." item to the message-list context menu (single selection) that writes the raw RFC822 bytes to a user-chosen path. The backend reuses the existing on-demand body fetch so it works for IMAP, JMAP, and Graph accounts whose body hasn't been downloaded yet.

Refactors the on-demand fetch path out of get_message_body into ensure_message_body_on_disk, and the save-dialog + atomic-write logic out of save_attachment into prompt_save_and_write_bytes, so both commands share one implementation.

The suggested filename is derived from the message subject with path separators and Windows/macOS-illegal characters replaced.