### PR TITLE
feat(mail): restore last-viewed folder on startup

### DIFF
--- a/src-tauri/src/commands/app.rs
+++ b/src-tauri/src/commands/app.rs
@@ -1,4 +1,8 @@
-use tauri::AppHandle;
+use tauri::{AppHandle, State};
+
+use crate::db;
+use crate::error::Result;
+use crate::state::AppState;
 
 /// Cleanly exit the application from any window. The frontend uses this for
 /// the `File > Quit` menu item and the `Ctrl+Q` shortcut. Closing a single
@@ -7,4 +11,24 @@ use tauri::AppHandle;
 pub fn quit_app(app: AppHandle) {
     log::info!("Quit requested via menu/shortcut");
     app.exit(0);
+}
+
+/// Fetch the account/folder the user was last viewing, so the frontend can
+/// restore it on startup (#191). Either field is `None` on a fresh install.
+#[tauri::command]
+pub async fn get_last_view(state: State<'_, AppState>) -> Result<db::settings::LastView> {
+    let conn = state.db.reader();
+    db::settings::get_last_view(&conn)
+}
+
+/// Persist the account/folder the user is currently viewing (#191). The
+/// frontend calls this debounced, on every folder/account navigation.
+#[tauri::command]
+pub async fn save_last_view(
+    state: State<'_, AppState>,
+    account_id: String,
+    folder_path: String,
+) -> Result<()> {
+    let conn = state.db.writer().await;
+    db::settings::save_last_view(&conn, &account_id, &folder_path)
 }

--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -8,3 +8,4 @@ pub mod messages;
 pub mod pool;
 pub mod schema;
 pub mod service_bindings;
+pub mod settings;

--- a/src-tauri/src/db/settings.rs
+++ b/src-tauri/src/db/settings.rs
@@ -1,0 +1,96 @@
+use rusqlite::{params, Connection, OptionalExtension};
+use serde::{Deserialize, Serialize};
+
+use crate::error::Result;
+
+// `app_metadata` is a generic key/value table (see schema.rs); these are
+// the two keys used to remember what the user was looking at (#191).
+const KEY_LAST_ACCOUNT_ID: &str = "last_open_account_id";
+const KEY_LAST_FOLDER_PATH: &str = "last_open_folder_path";
+
+/// The account/folder the user was viewing when the app last closed (or
+/// last navigated to), used to restore that view on the next startup.
+/// Either field is `None` on a fresh install or before the first
+/// navigation is persisted.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct LastView {
+    pub account_id: Option<String>,
+    pub folder_path: Option<String>,
+}
+
+fn get_metadata(conn: &Connection, key: &str) -> Result<Option<String>> {
+    conn.query_row(
+        "SELECT value FROM app_metadata WHERE key = ?1",
+        params![key],
+        |row| row.get(0),
+    )
+    .optional()
+    .map_err(Into::into)
+}
+
+/// Read the last-viewed account/folder persisted by `save_last_view`.
+pub fn get_last_view(conn: &Connection) -> Result<LastView> {
+    Ok(LastView {
+        account_id: get_metadata(conn, KEY_LAST_ACCOUNT_ID)?,
+        folder_path: get_metadata(conn, KEY_LAST_FOLDER_PATH)?,
+    })
+}
+
+/// Persist the account/folder the user is currently viewing, so the next
+/// startup can restore it (issue #191). Called (debounced) by the
+/// frontend on every folder/account navigation.
+pub fn save_last_view(conn: &Connection, account_id: &str, folder_path: &str) -> Result<()> {
+    conn.execute(
+        "INSERT OR REPLACE INTO app_metadata (key, value) VALUES (?1, ?2)",
+        params![KEY_LAST_ACCOUNT_ID, account_id],
+    )?;
+    conn.execute(
+        "INSERT OR REPLACE INTO app_metadata (key, value) VALUES (?1, ?2)",
+        params![KEY_LAST_FOLDER_PATH, folder_path],
+    )?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn setup_db() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE app_metadata (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL
+            );",
+        )
+        .unwrap();
+        conn
+    }
+
+    #[test]
+    fn get_last_view_defaults_to_none_on_fresh_db() {
+        let conn = setup_db();
+        let view = get_last_view(&conn).unwrap();
+        assert_eq!(view.account_id, None);
+        assert_eq!(view.folder_path, None);
+    }
+
+    #[test]
+    fn save_and_get_last_view_round_trips() {
+        let conn = setup_db();
+        save_last_view(&conn, "acc-1", "INBOX").unwrap();
+        let view = get_last_view(&conn).unwrap();
+        assert_eq!(view.account_id.as_deref(), Some("acc-1"));
+        assert_eq!(view.folder_path.as_deref(), Some("INBOX"));
+    }
+
+    #[test]
+    fn save_last_view_overwrites_previous_value() {
+        let conn = setup_db();
+        save_last_view(&conn, "acc-1", "INBOX").unwrap();
+        save_last_view(&conn, "acc-2", "Archive").unwrap();
+        let view = get_last_view(&conn).unwrap();
+        assert_eq!(view.account_id.as_deref(), Some("acc-2"));
+        assert_eq!(view.folder_path.as_deref(), Some("Archive"));
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -41,6 +41,8 @@ pub fn run() {
         })
         .invoke_handler(tauri::generate_handler![
             commands::app::quit_app,
+            commands::app::get_last_view,
+            commands::app::save_last_view,
             commands::accounts::list_accounts,
             commands::accounts::add_account,
             commands::accounts::get_account_config,

--- a/src/__tests__/calendar.test.ts
+++ b/src/__tests__/calendar.test.ts
@@ -16,6 +16,8 @@ vi.mock("@/lib/tauri", () => ({
   respondToInvite: vi.fn().mockResolvedValue(undefined),
   sendInvites: vi.fn().mockResolvedValue(undefined),
   listFolders: vi.fn().mockResolvedValue([]),
+  getLastView: vi.fn().mockResolvedValue({ account_id: null, folder_path: null }),
+  saveLastView: vi.fn().mockResolvedValue(undefined),
   getMessages: vi.fn().mockResolvedValue({ messages: [], total: 0, page: 0, per_page: 100 }),
   getMessageBody: vi.fn().mockResolvedValue({
     id: "msg1", subject: "Test", from: { name: "Test", email: "test@example.com" },

--- a/src/__tests__/filters-view.test.ts
+++ b/src/__tests__/filters-view.test.ts
@@ -11,6 +11,8 @@ vi.mock("@/lib/tauri", () => ({
     { name: "Inbox", path: "INBOX", folder_type: "inbox", unread_count: 0, total_count: 0, children: [] },
   ]),
   triggerSync: vi.fn().mockResolvedValue(undefined),
+  getLastView: vi.fn().mockResolvedValue({ account_id: null, folder_path: null }),
+  saveLastView: vi.fn().mockResolvedValue(undefined),
 }));
 
 import * as api from "@/lib/tauri";

--- a/src/__tests__/last-view-tauri.test.ts
+++ b/src/__tests__/last-view-tauri.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Tests for the `lib/tauri.ts` wrappers backing #191 ("Open on Inbox of
+ * the first account (or last-viewed folder) on startup").
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Use vi.hoisted so the mock is available before vi.mock's hoisted factory runs
+const { invokeMock } = vi.hoisted(() => ({ invokeMock: vi.fn() }));
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...args: unknown[]) => invokeMock(...args),
+}));
+
+import { getLastView, saveLastView } from "@/lib/tauri";
+
+describe("lib/tauri: last-view wrappers (#191)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("getLastView invokes get_last_view", async () => {
+    invokeMock.mockResolvedValue({ account_id: "acc1", folder_path: "INBOX" });
+    const result = await getLastView();
+    expect(invokeMock).toHaveBeenCalledWith("get_last_view");
+    expect(result).toEqual({ account_id: "acc1", folder_path: "INBOX" });
+  });
+
+  it("saveLastView invokes save_last_view with camelCase args", async () => {
+    invokeMock.mockResolvedValue(undefined);
+    await saveLastView("acc1", "Archive");
+    expect(invokeMock).toHaveBeenCalledWith("save_last_view", {
+      accountId: "acc1",
+      folderPath: "Archive",
+    });
+  });
+
+  it("propagates errors from the backend", async () => {
+    invokeMock.mockRejectedValue(new Error("db error"));
+    await expect(getLastView()).rejects.toThrow("db error");
+  });
+});

--- a/src/__tests__/last-view.test.ts
+++ b/src/__tests__/last-view.test.ts
@@ -1,0 +1,314 @@
+/**
+ * Tests for restoring/persisting the last-viewed account+folder on
+ * startup (#191): "Open on Inbox of the first account (or last-viewed
+ * folder) on startup".
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { setActivePinia, createPinia } from "pinia";
+import { nextTick } from "vue";
+import type { Account, Folder } from "@/lib/types";
+import { OUTBOX_FOLDER } from "@/lib/types";
+
+vi.mock("@/lib/tauri", () => ({
+  listAccounts: vi.fn().mockResolvedValue([]),
+  addAccount: vi.fn().mockResolvedValue("new-acc"),
+  deleteAccount: vi.fn().mockResolvedValue(undefined),
+  listFolders: vi.fn().mockResolvedValue([]),
+  triggerSync: vi.fn().mockResolvedValue(undefined),
+  getLastView: vi.fn().mockResolvedValue({ account_id: null, folder_path: null }),
+  saveLastView: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn().mockResolvedValue(() => {}),
+}));
+
+import * as api from "@/lib/tauri";
+import { useAccountsStore } from "@/stores/accounts";
+import { useFoldersStore } from "@/stores/folders";
+
+function makeAccount(overrides: Partial<Account> = {}): Account {
+  return {
+    id: "acc1",
+    display_name: "A",
+    email: "a@x.com",
+    username: "",
+    provider: "generic",
+    mail_protocol: "imap",
+    enabled: true,
+    mail_sync_interval_seconds: null,
+    calendar_sync_interval_seconds: null,
+    contacts_sync_interval_seconds: null,
+    has_calendar_binding: false,
+    has_contacts_binding: false,
+    meet_protocol: "",
+    ...overrides,
+  };
+}
+
+function makeFolder(overrides: Partial<Folder> = {}): Folder {
+  return {
+    name: "Folder",
+    path: "Folder",
+    folder_type: null,
+    unread_count: 0,
+    total_count: 0,
+    children: [],
+    ...overrides,
+  };
+}
+
+describe("accounts store: restore last-viewed account on startup (#191)", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.mocked(api.getLastView).mockReset();
+    vi.mocked(api.listAccounts).mockReset();
+  });
+
+  it("restores the persisted account when it exists, is enabled, and mail-capable", async () => {
+    const accA = makeAccount({ id: "acc1", display_name: "A" });
+    const accB = makeAccount({ id: "acc2", display_name: "B" });
+    vi.mocked(api.listAccounts).mockResolvedValue([accA, accB]);
+    vi.mocked(api.getLastView).mockResolvedValue({
+      account_id: "acc2",
+      folder_path: "Archive",
+    });
+
+    const accounts = useAccountsStore();
+    await accounts.fetchAccounts();
+
+    expect(accounts.activeAccountId).toBe("acc2");
+  });
+
+  it("falls back to the first enabled mail account when the persisted account no longer exists", async () => {
+    const accA = makeAccount({ id: "acc1", display_name: "A" });
+    vi.mocked(api.listAccounts).mockResolvedValue([accA]);
+    vi.mocked(api.getLastView).mockResolvedValue({
+      account_id: "deleted-acc",
+      folder_path: "Archive",
+    });
+
+    const accounts = useAccountsStore();
+    await accounts.fetchAccounts();
+
+    expect(accounts.activeAccountId).toBe("acc1");
+  });
+
+  it("falls back to the first enabled mail account when the persisted account is disabled", async () => {
+    const disabled = makeAccount({ id: "acc1", display_name: "A", enabled: false });
+    const enabled = makeAccount({ id: "acc2", display_name: "B", enabled: true });
+    vi.mocked(api.listAccounts).mockResolvedValue([disabled, enabled]);
+    vi.mocked(api.getLastView).mockResolvedValue({
+      account_id: "acc1",
+      folder_path: "Archive",
+    });
+
+    const accounts = useAccountsStore();
+    await accounts.fetchAccounts();
+
+    expect(accounts.activeAccountId).toBe("acc2");
+  });
+
+  it("falls back to the first enabled mail account when the persisted account has no mail protocol", async () => {
+    // Calendar-/contacts-only account (#43) — FiltersView's account picker
+    // shares activeAccountId and lists these too, so a persisted
+    // last-view could in principle point at one.
+    const calOnly = makeAccount({ id: "acc1", display_name: "Cal", mail_protocol: "" });
+    const mailAcc = makeAccount({ id: "acc2", display_name: "Mail" });
+    vi.mocked(api.listAccounts).mockResolvedValue([calOnly, mailAcc]);
+    vi.mocked(api.getLastView).mockResolvedValue({
+      account_id: "acc1",
+      folder_path: "Archive",
+    });
+
+    const accounts = useAccountsStore();
+    await accounts.fetchAccounts();
+
+    expect(accounts.activeAccountId).toBe("acc2");
+  });
+
+  it("falls back to accounts[0] when no account is both enabled and mail-capable", async () => {
+    const calOnly = makeAccount({ id: "acc1", display_name: "Cal", mail_protocol: "" });
+    vi.mocked(api.listAccounts).mockResolvedValue([calOnly]);
+    vi.mocked(api.getLastView).mockResolvedValue({
+      account_id: null,
+      folder_path: null,
+    });
+
+    const accounts = useAccountsStore();
+    await accounts.fetchAccounts();
+
+    expect(accounts.activeAccountId).toBe("acc1");
+  });
+
+  it("does not consult last view when an active account is already set", async () => {
+    const accA = makeAccount({ id: "acc1" });
+    vi.mocked(api.listAccounts).mockResolvedValue([accA]);
+    vi.mocked(api.getLastView).mockResolvedValue({
+      account_id: "acc1",
+      folder_path: "INBOX",
+    });
+
+    const accounts = useAccountsStore();
+    accounts.activeAccountId = "acc1";
+    await accounts.fetchAccounts();
+
+    expect(api.getLastView).not.toHaveBeenCalled();
+  });
+});
+
+describe("folders store: restore last-viewed folder on startup (#191)", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.mocked(api.getLastView).mockReset();
+    vi.mocked(api.listFolders).mockReset();
+    vi.mocked(api.triggerSync).mockReset().mockResolvedValue(undefined);
+  });
+
+  it("restores the persisted folder path when it matches the active account and still exists", async () => {
+    const accounts = useAccountsStore();
+    accounts.accounts = [makeAccount({ id: "acc1" })];
+    accounts.activeAccountId = "acc1";
+
+    vi.mocked(api.getLastView).mockResolvedValue({
+      account_id: "acc1",
+      folder_path: "Archive",
+    });
+    vi.mocked(api.listFolders).mockResolvedValue([
+      makeFolder({ name: "Inbox", path: "INBOX", folder_type: "inbox" }),
+      makeFolder({ name: "Archive", path: "Archive" }),
+    ]);
+
+    const folders = useFoldersStore();
+    await folders.fetchFolders();
+
+    expect(folders.activeFolderPath).toBe("Archive");
+  });
+
+  it("falls back to Inbox when the persisted account doesn't match the resolved active account", async () => {
+    const accounts = useAccountsStore();
+    accounts.accounts = [makeAccount({ id: "acc1" })];
+    accounts.activeAccountId = "acc1";
+
+    // Simulates accounts.ts having fallen back to acc1 because the
+    // persisted account ("acc2") no longer existed — the persisted
+    // folder path is meaningless here.
+    vi.mocked(api.getLastView).mockResolvedValue({
+      account_id: "acc2",
+      folder_path: "Archive",
+    });
+    vi.mocked(api.listFolders).mockResolvedValue([
+      makeFolder({ name: "Inbox", path: "INBOX", folder_type: "inbox" }),
+      makeFolder({ name: "Archive", path: "Archive" }),
+    ]);
+
+    const folders = useFoldersStore();
+    await folders.fetchFolders();
+
+    expect(folders.activeFolderPath).toBe("INBOX");
+  });
+
+  it("falls back to Inbox when the persisted folder path no longer exists", async () => {
+    const accounts = useAccountsStore();
+    accounts.accounts = [makeAccount({ id: "acc1" })];
+    accounts.activeAccountId = "acc1";
+
+    vi.mocked(api.getLastView).mockResolvedValue({
+      account_id: "acc1",
+      folder_path: "Renamed/Away",
+    });
+    vi.mocked(api.listFolders).mockResolvedValue([
+      makeFolder({ name: "Inbox", path: "INBOX", folder_type: "inbox" }),
+    ]);
+
+    const folders = useFoldersStore();
+    await folders.fetchFolders();
+
+    expect(folders.activeFolderPath).toBe("INBOX");
+  });
+
+  it("treats the synthetic Outbox path as always valid", async () => {
+    const accounts = useAccountsStore();
+    accounts.accounts = [makeAccount({ id: "acc1" })];
+    accounts.activeAccountId = "acc1";
+
+    vi.mocked(api.getLastView).mockResolvedValue({
+      account_id: "acc1",
+      folder_path: OUTBOX_FOLDER,
+    });
+    vi.mocked(api.listFolders).mockResolvedValue([
+      makeFolder({ name: "Inbox", path: "INBOX", folder_type: "inbox" }),
+    ]);
+
+    const folders = useFoldersStore();
+    await folders.fetchFolders();
+
+    expect(folders.activeFolderPath).toBe(OUTBOX_FOLDER);
+  });
+});
+
+describe("folders store: debounced persistence of last view (#191)", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.mocked(api.getLastView).mockReset().mockResolvedValue({
+      account_id: null,
+      folder_path: null,
+    });
+    vi.mocked(api.listFolders).mockReset().mockResolvedValue([]);
+    vi.mocked(api.saveLastView).mockReset().mockResolvedValue(undefined);
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("persists the active account/folder after the debounce window", async () => {
+    const accounts = useAccountsStore();
+    accounts.accounts = [makeAccount({ id: "acc1" })];
+    accounts.activeAccountId = "acc1";
+
+    const folders = useFoldersStore();
+    folders.setActiveFolder("INBOX");
+    await nextTick();
+
+    expect(api.saveLastView).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(api.saveLastView).toHaveBeenCalledWith("acc1", "INBOX");
+  });
+
+  it("coalesces rapid navigation into a single save call", async () => {
+    const accounts = useAccountsStore();
+    accounts.accounts = [makeAccount({ id: "acc1" })];
+    accounts.activeAccountId = "acc1";
+
+    const folders = useFoldersStore();
+    folders.setActiveFolder("INBOX");
+    await nextTick();
+    await vi.advanceTimersByTimeAsync(200);
+    folders.setActiveFolder("Archive");
+    await nextTick();
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(api.saveLastView).toHaveBeenCalledOnce();
+    expect(api.saveLastView).toHaveBeenCalledWith("acc1", "Archive");
+  });
+
+  it("does not persist when the active account has no mail protocol (calendar-only)", async () => {
+    const accounts = useAccountsStore();
+    accounts.accounts = [
+      makeAccount({ id: "cal1", mail_protocol: "" }),
+    ];
+    accounts.activeAccountId = "cal1";
+
+    const folders = useFoldersStore();
+    // A stale folder path left over from a previously active mail
+    // account — must not be persisted alongside the calendar-only id.
+    folders.activeFolderPath = "INBOX";
+    await nextTick();
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(api.saveLastView).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/message-list-clicks.test.ts
+++ b/src/__tests__/message-list-clicks.test.ts
@@ -15,6 +15,8 @@ vi.mock("@/lib/tauri", () => ({
   setMessageFlags: vi.fn().mockResolvedValue(undefined),
   deleteMessages: vi.fn().mockResolvedValue(undefined),
   listFolders: vi.fn().mockResolvedValue([]),
+  getLastView: vi.fn().mockResolvedValue({ account_id: null, folder_path: null }),
+  saveLastView: vi.fn().mockResolvedValue(undefined),
   getThreadedMessages: vi.fn().mockResolvedValue({
     threads: [], total_threads: 0, total_messages: 0, page: 0, per_page: 100,
   }),

--- a/src/__tests__/messages-selection.test.ts
+++ b/src/__tests__/messages-selection.test.ts
@@ -17,6 +17,8 @@ vi.mock("@/lib/tauri", () => ({
   setMessageFlags: vi.fn().mockResolvedValue(undefined),
   deleteMessages: vi.fn().mockResolvedValue(undefined),
   listFolders: vi.fn().mockResolvedValue([]),
+  getLastView: vi.fn().mockResolvedValue({ account_id: null, folder_path: null }),
+  saveLastView: vi.fn().mockResolvedValue(undefined),
   getThreadedMessages: vi.fn().mockResolvedValue({
     threads: [], total_threads: 0, total_messages: 0, page: 0, per_page: 100,
   }),

--- a/src/__tests__/regression.test.ts
+++ b/src/__tests__/regression.test.ts
@@ -21,6 +21,8 @@ vi.mock("@/lib/tauri", () => ({
   setMessageFlags: vi.fn().mockResolvedValue(undefined),
   deleteMessages: vi.fn().mockResolvedValue(undefined),
   listFolders: vi.fn().mockResolvedValue([]),
+  getLastView: vi.fn().mockResolvedValue({ account_id: null, folder_path: null }),
+  saveLastView: vi.fn().mockResolvedValue(undefined),
   getThreadedMessages: vi.fn().mockResolvedValue({
     threads: [], total_threads: 0, total_messages: 0, page: 0, per_page: 100,
   }),

--- a/src/__tests__/server-search.test.ts
+++ b/src/__tests__/server-search.test.ts
@@ -14,6 +14,8 @@ vi.mock("@/lib/tauri", () => ({
   listAccounts: vi.fn().mockResolvedValue([]),
   listFolders: vi.fn().mockResolvedValue([]),
   triggerSync: vi.fn().mockResolvedValue(undefined),
+  getLastView: vi.fn().mockResolvedValue({ account_id: null, folder_path: null }),
+  saveLastView: vi.fn().mockResolvedValue(undefined),
   getMessages: vi
     .fn()
     .mockResolvedValue({ messages: [], total: 0, page: 0, per_page: 100 }),

--- a/src/__tests__/store-listeners.test.ts
+++ b/src/__tests__/store-listeners.test.ts
@@ -13,6 +13,8 @@ vi.mock("@/lib/tauri", () => ({
   listAccounts: vi.fn().mockResolvedValue([]),
   listFolders: vi.fn().mockResolvedValue([]),
   triggerSync: vi.fn().mockResolvedValue(undefined),
+  getLastView: vi.fn().mockResolvedValue({ account_id: null, folder_path: null }),
+  saveLastView: vi.fn().mockResolvedValue(undefined),
   getMessages: vi.fn().mockResolvedValue({ messages: [], total: 0, page: 0, per_page: 100 }),
   getThreadedMessages: vi.fn().mockResolvedValue({
     threads: [], total_threads: 0, total_messages: 0, page: 0, per_page: 100,

--- a/src/__tests__/threads-expansion.test.ts
+++ b/src/__tests__/threads-expansion.test.ts
@@ -14,6 +14,8 @@ vi.mock("@/lib/tauri", () => ({
   listAccounts: vi.fn().mockResolvedValue([]),
   listFolders: vi.fn().mockResolvedValue([]),
   triggerSync: vi.fn().mockResolvedValue(undefined),
+  getLastView: vi.fn().mockResolvedValue({ account_id: null, folder_path: null }),
+  saveLastView: vi.fn().mockResolvedValue(undefined),
   getMessages: vi
     .fn()
     .mockResolvedValue({ messages: [], total: 0, page: 0, per_page: 100 }),

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -4,6 +4,7 @@ import type {
   AccountConfig,
   AutoconfigResult,
   Folder,
+  LastView,
   MessagePage,
   MessageBody,
   SyncStatus,
@@ -14,6 +15,22 @@ import type {
 
 export async function listAccounts(): Promise<Account[]> {
   return invoke("list_accounts");
+}
+
+/// The account/folder the user was last viewing (#191), read once at
+/// startup by the accounts/folders stores to restore that view.
+export async function getLastView(): Promise<LastView> {
+  return invoke("get_last_view");
+}
+
+/// Persist the account/folder the user is currently viewing (#191).
+/// Called debounced, so callers should let rejections just log rather
+/// than surface an error to the user.
+export async function saveLastView(
+  accountId: string,
+  folderPath: string,
+): Promise<void> {
+  return invoke("save_last_view", { accountId, folderPath });
 }
 
 export async function addAccount(config: AccountConfig): Promise<string> {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -78,6 +78,14 @@ export interface Folder {
   children: Folder[];
 }
 
+// The account/folder the user was last viewing, persisted via
+// `save_last_view` and restored on startup (#191). Either field is
+// `null` on a fresh install or before the first navigation is saved.
+export interface LastView {
+  account_id: string | null;
+  folder_path: string | null;
+}
+
 export interface Address {
   name: string | null;
   email: string;

--- a/src/stores/accounts.ts
+++ b/src/stores/accounts.ts
@@ -26,6 +26,36 @@ export const useAccountsStore = defineStore("accounts", () => {
   // makes every caller await the same result.
   let inFlight: Promise<void> | null = null;
 
+  // #191: on cold start (no active account yet), prefer the account the
+  // user was last viewing over the alphabetically-first one. Falls back
+  // to the first enabled account with a mail backend — calendar-/
+  // contacts-only accounts (#43) have no folders to show in Mail — and
+  // finally to today's plain "first account" behavior if none qualify.
+  // The restore is mail-protocol-gated too: FiltersView's account picker
+  // (unlike Mail's) lists every account and shares this same
+  // activeAccountId, so a calendar-/contacts-only id could in principle
+  // end up persisted — restoring into one would leave Mail empty.
+  async function resolveInitialAccountId(): Promise<string> {
+    try {
+      const lastView = await api.getLastView();
+      if (lastView.account_id) {
+        const restored = accounts.value.find(
+          (a) =>
+            a.id === lastView.account_id &&
+            a.enabled &&
+            a.mail_protocol !== "",
+        );
+        if (restored) return restored.id;
+      }
+    } catch (e) {
+      console.error("Failed to load last view:", e);
+    }
+    const firstEnabledMail = accounts.value.find(
+      (a) => a.mail_protocol !== "" && a.enabled,
+    );
+    return (firstEnabledMail ?? accounts.value[0]).id;
+  }
+
   async function fetchAccounts(): Promise<void> {
     if (inFlight) return inFlight;
     loading.value = true;
@@ -33,7 +63,7 @@ export const useAccountsStore = defineStore("accounts", () => {
       try {
         accounts.value = await api.listAccounts();
         if (accounts.value.length > 0 && !activeAccountId.value) {
-          activeAccountId.value = accounts.value[0].id;
+          activeAccountId.value = await resolveInitialAccountId();
         }
       } finally {
         loading.value = false;

--- a/src/stores/folders.ts
+++ b/src/stores/folders.ts
@@ -1,7 +1,7 @@
 import { defineStore } from "pinia";
 import { ref, watch, onScopeDispose } from "vue";
 import { listen } from "@tauri-apps/api/event";
-import type { Folder } from "@/lib/types";
+import { OUTBOX_FOLDER, type Folder } from "@/lib/types";
 import * as api from "@/lib/tauri";
 import { useAccountsStore } from "./accounts";
 
@@ -32,12 +32,31 @@ export const useFoldersStore = defineStore("folders", () => {
     try {
       folders.value = await api.listFolders(accountId);
       foldersByAccount.value = { ...foldersByAccount.value, [accountId]: folders.value };
+
+      // #191: on cold start (nothing selected yet), try restoring the
+      // folder the user was last viewing — but only if it was saved for
+      // *this* account. If accounts.ts had to fall back to a different
+      // account (the saved one no longer exists/is disabled), the saved
+      // folder path is meaningless here and we fall through to the
+      // Inbox-default logic below instead.
+      if (activeFolderPath.value === null) {
+        try {
+          const lastView = await api.getLastView();
+          if (lastView.account_id === accountId && lastView.folder_path) {
+            activeFolderPath.value = lastView.folder_path;
+          }
+        } catch (e) {
+          console.error("Failed to load last view:", e);
+        }
+      }
+
       if (folders.value.length > 0) {
         // If no folder is selected, or the selected folder doesn't exist
-        // in this account, default to Inbox.
+        // in this account, default to Inbox. The synthetic Outbox path
+        // (never a row in `folders`) is always considered valid.
         const active = activeFolderPath.value;
         const currentValid = active !== null &&
-          findFolderInTree(folders.value, active) !== undefined;
+          (active === OUTBOX_FOLDER || findFolderInTree(folders.value, active) !== undefined);
         if (!currentValid) {
           const inbox = folders.value.find((f) => f.folder_type === "inbox");
           activeFolderPath.value = inbox?.path ?? folders.value[0].path;
@@ -104,6 +123,30 @@ export const useFoldersStore = defineStore("folders", () => {
     },
   );
 
+  // #191: persist the active account/folder (debounced) so the next
+  // startup can restore this view. Skipped while either half is unset
+  // (cold start, or an account with no folders yet), and while the
+  // active account isn't mail-capable: FiltersView's account picker
+  // (unlike Mail's) lists every account and shares this same
+  // activeAccountId, so switching to a calendar-/contacts-only account
+  // there must not overwrite the last *mail* view with a folder path
+  // that belongs to a different, unrelated account.
+  let saveViewTimer: ReturnType<typeof setTimeout> | null = null;
+  watch(
+    () => [accountsStore.activeAccountId, activeFolderPath.value] as const,
+    ([accountId, folderPath]) => {
+      if (!accountId || !folderPath) return;
+      const account = accountsStore.accounts.find((a) => a.id === accountId);
+      if (!account || account.mail_protocol === "") return;
+      if (saveViewTimer) clearTimeout(saveViewTimer);
+      saveViewTimer = setTimeout(() => {
+        api.saveLastView(accountId, folderPath).catch((e) =>
+          console.error("Failed to save last view:", e),
+        );
+      }, 500);
+    },
+  );
+
   // Subscribe to backend folder-change events with debounce
   let foldersRefreshTimer: ReturnType<typeof setTimeout> | null = null;
   let stopFoldersListener: null | (() => void) = null;
@@ -130,6 +173,7 @@ export const useFoldersStore = defineStore("folders", () => {
   onScopeDispose(() => {
     disposed = true;
     if (foldersRefreshTimer) clearTimeout(foldersRefreshTimer);
+    if (saveViewTimer) clearTimeout(saveViewTimer);
     stopFoldersListener?.();
   });
 

--- a/src/stores/folders.ts
+++ b/src/stores/folders.ts
@@ -140,6 +140,7 @@ export const useFoldersStore = defineStore("folders", () => {
       if (!account || account.mail_protocol === "") return;
       if (saveViewTimer) clearTimeout(saveViewTimer);
       saveViewTimer = setTimeout(() => {
+        saveViewTimer = null;
         api.saveLastView(accountId, folderPath).catch((e) =>
           console.error("Failed to save last view:", e),
         );


### PR DESCRIPTION
Falls back to the first enabled mail account's Inbox when there's no saved view yet, or the saved one no longer resolves.