### PR TITLE
fix(packaging): add PC/SC deps to Linux package builds

### DIFF
--- a/Dockerfile.arch
+++ b/Dockerfile.arch
@@ -17,6 +17,8 @@ RUN pacman -Syu --noconfirm \
     openssl \
     libsoup3 \
     librsvg \
+    # PC/SC smartcard support (pcsc-sys via libtumpa)
+    pcsclite \
     pango \
     gdk-pixbuf2 \
     curl wget file \
@@ -69,7 +71,7 @@ RUN VERSION=$(jq -r .version src-tauri/tauri.conf.json) && \
         'arch=("x86_64" "aarch64")' \
         'url="https://github.com/SUNET/chithi"' \
         'license=("GPL-3.0-only")' \
-        'depends=("webkit2gtk-4.1" "gtk3" "libayatana-appindicator" "openssl" "libsoup3")' \
+        'depends=("webkit2gtk-4.1" "gtk3" "libayatana-appindicator" "openssl" "libsoup3" "pcsclite")' \
         'source=("chithi" "icon.png" "LICENSE")' \
         'noextract=("chithi" "icon.png" "LICENSE")' \
         'sha256sums=("SKIP" "SKIP" "SKIP")' \

--- a/Dockerfile.deb
+++ b/Dockerfile.deb
@@ -25,6 +25,8 @@ RUN apt-get update && apt-get install -y \
     libgdk-pixbuf-2.0-dev \
     libsoup-3.0-dev \
     libjavascriptcoregtk-4.1-dev \
+    # PC/SC smartcard support (pcsc-sys via libtumpa)
+    libpcsclite-dev \
     # Build essentials
     build-essential \
     pkg-config \

--- a/Dockerfile.rpm
+++ b/Dockerfile.rpm
@@ -24,6 +24,8 @@ RUN dnf install -y \
     gtk3-devel \
     pango-devel \
     gdk-pixbuf2-devel \
+    # PC/SC smartcard support (pcsc-sys via libtumpa)
+    pcsc-lite-devel \
     # RPM build tools
     rpm-build \
     # Build essentials

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -40,7 +40,8 @@
           "libayatana-appindicator3-1",
           "libssl3",
           "libsoup-3.0-0",
-          "libjavascriptcoregtk-4.1-0"
+          "libjavascriptcoregtk-4.1-0",
+          "libpcsclite1"
         ]
       },
       "rpm": {
@@ -49,7 +50,8 @@
           "gtk3",
           "libayatana-appindicator-gtk3",
           "openssl-libs",
-          "libsoup3"
+          "libsoup3",
+          "pcsc-lite-libs"
         ]
       }
     }


### PR DESCRIPTION
## Summary

`just build-deb` fails since the OpenPGP work (6aae2280):
libtumpa's `card` feature pulls in `pcsc-sys`, which needs
libpcsclite at build time and links `libpcsclite.so.1` at
runtime. CI already installs it, but the Docker packaging
images did not.

- `Dockerfile.deb`: add `libpcsclite-dev` to build deps
- `Dockerfile.rpm`: add `pcsc-lite-devel` to build deps
- `Dockerfile.arch`: add `pcsclite` to build deps and to the
  generated PKGBUILD `depends`
- `tauri.conf.json`: add runtime deps `libpcsclite1` (deb) and
  `pcsc-lite-libs` (rpm) so the app starts on systems without
  PC/SC preinstalled

## Testing

- `just build-deb` (debian:13) passes end-to-end
- Verified the produced deb's `Depends` includes `libpcsclite1`