### PR TITLE
Composer: Render markdown

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3462,6 +3462,15 @@ dependencies = [
 
 [[package]]
 name = "markup5ever"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5cab8f2cadc416a82d2e783a1946388b31654d391d1c7d92cc1f03e295b1deb"
+dependencies = [
+ "unicode-id",
+]
+
+[[package]]
+name = "markup5ever"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8983d30f2915feeaaab2d6babdd6bc7e9ed1a00b66b5e6d74df19aa9c0e91862"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -808,6 +808,7 @@ dependencies = [
  "mail-parser",
  "maildir",
  "mailparse 0.16.1",
+ "markdown",
  "mime_guess",
  "native-tls",
  "openssl",
@@ -3451,6 +3452,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
+name = "markdown"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5cab8f2cadc416a82d2e783a1946388b31654d391d1c7d92cc1f03e295b1deb"
+dependencies = [
+ "unicode-id",
+]
+
+[[package]]
 name = "markup5ever"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4272,7 +4282,7 @@ dependencies = [
  "aes-gcm",
  "aes-kw",
  "argon2",
- "base64 0.21.7",
+ "base64 0.22.1",
  "bitfields",
  "block-padding",
  "blowfish",
@@ -6878,6 +6888,12 @@ name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
+
+[[package]]
+name = "unicode-id"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ba288e709927c043cbe476718d37be306be53fb1fafecd0dbe36d072be2580"
 
 [[package]]
 name = "unicode-ident"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3462,15 +3462,6 @@ dependencies = [
 
 [[package]]
 name = "markup5ever"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5cab8f2cadc416a82d2e783a1946388b31654d391d1c7d92cc1f03e295b1deb"
-dependencies = [
- "unicode-id",
-]
-
-[[package]]
-name = "markup5ever"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8983d30f2915feeaaab2d6babdd6bc7e9ed1a00b66b5e6d74df19aa9c0e91862"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -36,6 +36,7 @@ dirs = "6"
 lettre = { version = "0.11", features = ["tokio1-native-tls", "builder"] }
 regex = "1"
 mailparse = "0.16"
+markdown = "1"
 jmap-client = "0.4"
 reqwest = { version = "0.12", features = ["json", "stream", "gzip", "deflate"] }
 url = "2"

--- a/src-tauri/src/commands/compose.rs
+++ b/src-tauri/src/commands/compose.rs
@@ -552,6 +552,12 @@ pub async fn save_draft(
     let (in_reply_to, references) =
         resolve_reply_headers(&state, &account_id, message.reply_to_message_id.as_deref());
 
+    // Render the HTML alternative for Markdown drafts too, so the draft is
+    // stored as multipart/alternative(Markdown source, rendered HTML). On
+    // resume the composer detects that HTML alternative and re-arms
+    // Markdown mode, so a resumed-then-sent Markdown draft keeps its HTML.
+    let body_html = resolve_body_html(&message);
+
     let raw_message = smtp::build_raw_message(
         &account.email,
         &draft_to,
@@ -559,7 +565,7 @@ pub async fn save_draft(
         &message.bcc,
         &message.subject,
         &message.body_text,
-        message.body_html.as_deref(),
+        body_html.as_deref(),
         &attachment_data,
         in_reply_to.as_deref(),
         &references,
@@ -604,7 +610,16 @@ pub async fn save_draft(
     };
 
     if account.mail_protocol_str() == "graph" {
-        // Save draft via Graph API: POST /me/messages creates a draft without sending
+        // Save draft via Graph API: POST /me/messages creates a draft
+        // without sending. Known limitation: this JSON path stores only
+        // `body_text` as a single `contentType: Text` body, so it drops
+        // the `multipart/alternative` we built in `raw_message` — a
+        // Markdown draft's rendered-HTML alternative is not persisted, and
+        // on resume Markdown mode can't be re-armed (the user re-toggles
+        // before sending; the send itself is unaffected). Same root cause
+        // as the encrypted-drafts-on-Graph fallback above. Fixing this
+        // means saving the draft as MIME (`Content-Type: text/plain`,
+        // base64 `raw_message`) — tracked in #215.
         log::info!(
             "Saving draft via Microsoft Graph for account {}",
             account.email

--- a/src-tauri/src/commands/compose.rs
+++ b/src-tauri/src/commands/compose.rs
@@ -1402,7 +1402,10 @@ mod markdown_body_tests {
         let html = resolve_body_html(&msg("# Title\n\nsome **bold** text", None, true))
             .expect("markdown should render html");
         assert!(html.contains("<h1>"), "heading should render: {html}");
-        assert!(html.contains("<strong>bold</strong>"), "bold should render: {html}");
+        assert!(
+            html.contains("<strong>bold</strong>"),
+            "bold should render: {html}"
+        );
     }
 
     /// Safety: raw HTML in the Markdown source must NOT pass through as
@@ -1410,12 +1413,8 @@ mod markdown_body_tests {
     /// default), so a `<script>` becomes inert text, never an element.
     #[test]
     fn markdown_escapes_raw_html() {
-        let html = resolve_body_html(&msg(
-            "hi <script>alert('xss')</script> there",
-            None,
-            true,
-        ))
-        .expect("render");
+        let html = resolve_body_html(&msg("hi <script>alert('xss')</script> there", None, true))
+            .expect("render");
         assert!(
             !html.contains("<script>"),
             "raw <script> must be escaped, not emitted live: {html}"

--- a/src-tauri/src/commands/compose.rs
+++ b/src-tauri/src/commands/compose.rs
@@ -29,6 +29,42 @@ pub struct ComposeMessage {
     pub pgp_sign: bool,
     #[serde(default)]
     pub pgp_encrypt: bool,
+    /// "Compose in Markdown" toggle. When true, `body_text` is treated as
+    /// Markdown source: the backend renders it to safe HTML and ships a
+    /// `multipart/alternative` carrying the Markdown source as the
+    /// plaintext part and the rendered HTML as the html part. Ignored
+    /// when `body_html` is already populated (an explicit HTML body wins).
+    #[serde(default)]
+    pub markdown: bool,
+}
+
+/// Resolve the effective HTML body for an outgoing message.
+///
+/// An explicit `body_html` always wins — the renderer already decided
+/// the HTML. Otherwise, when the "Compose in Markdown" toggle is on, the
+/// Markdown source in `body_text` is rendered to HTML with the `markdown`
+/// crate's GFM flavour. Raw-HTML passthrough and dangerous protocols stay
+/// disabled (markdown-rs's default), so the output is safe to send
+/// without further sanitisation. On the rare render error we log and fall
+/// back to `None` so the message still goes out as plaintext-only rather
+/// than failing the send.
+///
+/// Shared by every send path (and reusable by the mobile composer once it
+/// exists) so Markdown rendering lives in one place, not per-platform.
+fn resolve_body_html(message: &ComposeMessage) -> Option<String> {
+    if let Some(html) = &message.body_html {
+        return Some(html.clone());
+    }
+    if !message.markdown {
+        return None;
+    }
+    match markdown::to_html_with_options(&message.body_text, &markdown::Options::gfm()) {
+        Ok(html) => Some(html),
+        Err(e) => {
+            log::warn!("Markdown render failed, sending plaintext only: {e}");
+            None
+        }
+    }
 }
 
 /// An attachment referenced by the renderer. `token` is the opaque handle
@@ -111,6 +147,12 @@ pub async fn send_message(
     let (in_reply_to, references) =
         resolve_reply_headers(&state, &account_id, message.reply_to_message_id.as_deref());
 
+    // Resolve the HTML alternative: an explicit body_html, or Markdown
+    // rendered to safe HTML when "Compose in Markdown" is on. `body_text`
+    // (the Markdown source, when in Markdown mode) always rides as the
+    // plaintext part, so recipients get both.
+    let body_html = resolve_body_html(&message);
+
     // Build the plain MIME bytes. `plain_raw` stays a `Vec<u8>` so the
     // optional PGP wrap and Autocrypt header inject below can each
     // consume and replace it cheaply. Only the FINAL `raw_message` is
@@ -124,7 +166,7 @@ pub async fn send_message(
         &message.bcc,
         &message.subject,
         &message.body_text,
-        message.body_html.as_deref(),
+        body_html.as_deref(),
         &attachment_data,
         in_reply_to.as_deref(),
         &references,
@@ -1323,6 +1365,75 @@ pub async fn pgp_check_recipients(
         out.push(status);
     }
     Ok(out)
+}
+
+#[cfg(test)]
+mod markdown_body_tests {
+    use super::{resolve_body_html, ComposeMessage};
+
+    fn msg(body_text: &str, body_html: Option<&str>, markdown: bool) -> ComposeMessage {
+        ComposeMessage {
+            to: vec![],
+            cc: vec![],
+            bcc: vec![],
+            subject: String::new(),
+            body_text: body_text.to_string(),
+            body_html: body_html.map(|s| s.to_string()),
+            attachments: vec![],
+            reply_to_message_id: None,
+            pgp_sign: false,
+            pgp_encrypt: false,
+            markdown,
+        }
+    }
+
+    /// Markdown off and no explicit HTML → plaintext-only (None), so the
+    /// message keeps shipping as a single text/plain part.
+    #[test]
+    fn no_markdown_no_html_is_none() {
+        assert!(resolve_body_html(&msg("# Hello", None, false)).is_none());
+    }
+
+    /// Markdown on → body_text is rendered to HTML. GFM constructs work
+    /// (heading, bold), and the Markdown source is preserved as-is for the
+    /// plaintext part by the caller.
+    #[test]
+    fn markdown_on_renders_html() {
+        let html = resolve_body_html(&msg("# Title\n\nsome **bold** text", None, true))
+            .expect("markdown should render html");
+        assert!(html.contains("<h1>"), "heading should render: {html}");
+        assert!(html.contains("<strong>bold</strong>"), "bold should render: {html}");
+    }
+
+    /// Safety: raw HTML in the Markdown source must NOT pass through as
+    /// live markup — markdown-rs escapes it (dangerous-HTML off by
+    /// default), so a `<script>` becomes inert text, never an element.
+    #[test]
+    fn markdown_escapes_raw_html() {
+        let html = resolve_body_html(&msg(
+            "hi <script>alert('xss')</script> there",
+            None,
+            true,
+        ))
+        .expect("render");
+        assert!(
+            !html.contains("<script>"),
+            "raw <script> must be escaped, not emitted live: {html}"
+        );
+        assert!(
+            html.contains("&lt;script&gt;"),
+            "the script tag should survive as escaped text: {html}"
+        );
+    }
+
+    /// An explicit body_html always wins, even with the Markdown toggle
+    /// on — the renderer already decided the HTML.
+    #[test]
+    fn explicit_html_wins_over_markdown() {
+        let html = resolve_body_html(&msg("# ignored", Some("<p>explicit</p>"), true))
+            .expect("explicit html");
+        assert_eq!(html, "<p>explicit</p>");
+    }
 }
 
 #[cfg(test)]

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -416,6 +416,10 @@ export interface ComposeMessage {
   /** OpenPGP toggles. Default false. */
   pgp_sign?: boolean;
   pgp_encrypt?: boolean;
+  /** "Compose in Markdown": when true the backend treats `body_text` as
+   *  Markdown, rendering it to safe HTML and sending both parts. Ignored
+   *  when `body_html` is already set. Default false. */
+  markdown?: boolean;
 }
 
 export interface PgpRecipientStatus {

--- a/src/views/ComposeView.vue
+++ b/src/views/ComposeView.vue
@@ -429,13 +429,19 @@ async function loadDraft(accountId: string) {
     // Subject). For a plaintext draft it also gives the body.
     const envelope = await api.getMessageBody(accountId, draftId);
     let body = envelope.body_text ?? "";
+    // An HTML alternative on a chithi-authored draft means it was composed
+    // in Markdown (that's the only path that stores one). Re-arm the toggle
+    // so a resumed-then-sent Markdown draft keeps its HTML alternative.
+    let htmlAlternative = envelope.body_html;
     if (envelope.pgp_kind === "mimeEncrypted") {
       // Encrypted draft: decrypt for the real body. pgp_decrypt_message
       // drives the passphrase / card-PIN dialog through the pgp-prompts
       // store, which this window is already subscribed to.
       const decrypted = await api.pgpDecryptMessage(accountId, draftId);
       body = decrypted.plaintextBody.body_text ?? "";
+      htmlAlternative = decrypted.plaintextBody.body_html;
     }
+    markdownMode.value = !!htmlAlternative && htmlAlternative.trim().length > 0;
     prefillFromDraft(envelope, body);
   } catch (e) {
     draftDecryptError.value = String(e);
@@ -583,6 +589,7 @@ async function saveDraft(): Promise<boolean> {
       body_html: null,
       attachments: attachments.value,
       reply_to_message_id: replyToMessageId || null,
+      markdown: markdownMode.value,
     });
     // The account asked for encrypted drafts but the backend had to
     // store this one in plaintext (Graph account, or no usable public

--- a/src/views/ComposeView.vue
+++ b/src/views/ComposeView.vue
@@ -26,6 +26,9 @@ const pgpPrompts = usePgpPromptsStore();
 // PGP toggles.
 const pgpSign = ref(false);
 const pgpEncrypt = ref(false);
+// "Compose in Markdown": when on, the body is Markdown source and the
+// backend renders it to HTML, sending both plaintext + HTML parts.
+const markdownMode = ref(false);
 // Per-recipient key availability for the encrypt flow.
 const recipientStatuses = ref<PgpRecipientStatus[]>([]);
 const missingRecipientCount = computed(
@@ -717,6 +720,7 @@ async function send() {
       reply_to_message_id: replyToMessageId || null,
       pgp_sign: pgpSign.value,
       pgp_encrypt: pgpEncrypt.value,
+      markdown: markdownMode.value,
     });
     if (replyToMessageId) {
       api.setMessageFlags(accountId, [replyToMessageId], ["answered"], true)
@@ -783,6 +787,19 @@ async function send() {
           class="pgp-missing-badge"
           :title="`Missing keys: ${recipientStatuses.filter(s => !s.hasKey).map(s => s.email).join(', ')}`"
         >{{ missingRecipientCount }}</span>
+      </button>
+      <button
+        class="toolbar-btn"
+        :class="{ active: markdownMode }"
+        data-testid="compose-markdown"
+        title="Compose in Markdown — sends both plain text and rendered HTML"
+        :aria-pressed="markdownMode"
+        @click="markdownMode = !markdownMode"
+      >
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <rect x="2" y="5" width="20" height="14" rx="2" /><path d="M6 15V9l3 3 3-3v6" /><path d="M17 9v6M14.5 12.5 17 15l2.5-2.5" />
+        </svg>
+        Markdown
       </button>
       <button class="toolbar-btn">
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
@@ -971,6 +988,14 @@ async function send() {
         data-testid="compose-body"
         autofocus
       ></textarea>
+
+      <div
+        v-if="markdownMode"
+        class="compose-markdown-hint"
+        data-testid="compose-markdown-hint"
+      >
+        Markdown mode — sent as plain text and rendered HTML.
+      </div>
 
       <!-- Attachment list -->
       <div v-if="attachments.length > 0" class="attachment-bar">
@@ -1304,6 +1329,13 @@ async function send() {
 .compose-textarea:focus {
   outline: none;
   border-color: var(--color-accent);
+}
+
+.compose-markdown-hint {
+  margin: -8px 16px 8px;
+  font-size: 12px;
+  color: var(--color-text-muted);
+  flex-shrink: 0;
 }
 
 /* Attachment bar */


### PR DESCRIPTION

Add a "Compose in Markdown" toggle to the desktop composer. When on,
the backend renders body_text (Markdown, GFM) to safe HTML via the
markdown crate and sends multipart/alternative with the Markdown source
as plaintext and the rendered HTML alongside. Rendering lives in a
shared backend helper so the mobile composer can reuse it later.

Part of: #212 