### PR TITLE
sync: fix O365 Graph sync loop, adopt delta queries

### DIFF
--- a/src-tauri/src/auth.rs
+++ b/src-tauri/src/auth.rs
@@ -196,6 +196,9 @@ pub async fn get_imap_credentials(account: &AccountFull) -> Result<(String, bool
         return Ok((account.password.clone(), false));
     }
 
+    // Dead refresh token (invalid_grant)? Fail fast without a network call.
+    crate::oauth::ensure_not_reauth_required(&account.id)?;
+
     let tokens = crate::oauth::load_tokens(&account.id)?.ok_or_else(|| {
         Error::Other("No O365 OAuth tokens. Please sign in with Microsoft.".into())
     })?;
@@ -207,7 +210,8 @@ pub async fn get_imap_credentials(account: &AccountFull) -> Result<(String, bool
         &refresh_token,
         crate::oauth::MICROSOFT_IMAP_SCOPES,
     )
-    .await?;
+    .await
+    .map_err(|e| crate::oauth::auth_required_on_invalid_grant(&account.id, e))?;
     // Save the potentially rotated refresh token
     crate::oauth::store_tokens(&account.id, &imap_tokens)?;
     Ok((imap_tokens.access_token, true))

--- a/src-tauri/src/backend/mail/graph.rs
+++ b/src-tauri/src/backend/mail/graph.rs
@@ -169,6 +169,22 @@ async fn sync_graph_folder_delta(
         ids
     };
 
+    // A full (re-)enumeration — no stored link, e.g. first sync or after
+    // HTTP 410 expired the delta token — lists what exists NOW; it does
+    // not emit tombstones for messages deleted while no delta state was
+    // held. Track what the enumeration returns and prune the local rows
+    // it never mentioned once it completes. Full enumerations run to
+    // completion (no page cap) so that prune is sound; steady-state delta
+    // rounds are capped instead.
+    let full_enumeration = link.is_none();
+    let pre_existing: std::collections::HashSet<String> = if full_enumeration {
+        existing_ids.clone()
+    } else {
+        std::collections::HashSet::new()
+    };
+    let mut seen_ids: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut completed = false;
+
     let mut synced = 0u32;
     let mut new_ids: Vec<String> = Vec::new();
     let mut pages = 0usize;
@@ -191,28 +207,38 @@ async fn sync_graph_folder_delta(
 
         {
             let conn = db_arc.writer().await;
-            conn.execute_batch("BEGIN")?;
+            // rusqlite::Transaction rolls back on drop, so any `?` below
+            // cannot leave an open transaction on the pooled connection.
+            let tx = conn.unchecked_transaction()?;
 
             for removed in &page.removed_ids {
                 let id = format!("{}_{}", account_id, removed);
-                conn.execute("DELETE FROM messages WHERE id = ?1", rusqlite::params![id])
+                tx.execute("DELETE FROM messages WHERE id = ?1", rusqlite::params![id])
                     .ok();
                 existing_ids.remove(&id);
             }
 
             for msg in &page.messages {
                 let id = format!("{}_{}", account_id, msg.id);
-                let flags = if msg.is_read {
-                    vec!["seen".to_string()]
-                } else {
-                    vec![]
-                };
+                if full_enumeration {
+                    seen_ids.insert(id.clone());
+                }
+                // Mirror the full server-side flag state (read + flagged),
+                // not just read: replacing the array with only `seen`
+                // erased an existing `flagged` on every update.
+                let mut flags: Vec<String> = Vec::new();
+                if msg.is_read {
+                    flags.push("seen".to_string());
+                }
+                if msg.is_flagged {
+                    flags.push("flagged".to_string());
+                }
                 let flags_json = serde_json::to_string(&flags).unwrap_or_default();
 
                 if existing_ids.contains(&id) {
-                    // Updated message: mirror the server-side read state
-                    // (read/unread toggled on webmail).
-                    let _ = db::messages::update_flags(&conn, &id, &flags_json);
+                    // Updated message: mirror server-side flag changes
+                    // (read/unread or flag toggled on webmail).
+                    let _ = db::messages::update_flags(&tx, &id, &flags_json);
                     continue;
                 }
 
@@ -242,7 +268,7 @@ async fn sync_graph_folder_delta(
                     maildir_path: String::new(),
                     snippet: msg.preview.clone(),
                 };
-                db::messages::insert_message(&conn, &new_msg)?;
+                db::messages::insert_message(&tx, &new_msg)?;
                 existing_ids.insert(id.clone());
                 new_ids.push(id);
                 synced += 1;
@@ -252,15 +278,17 @@ async fn sync_graph_folder_delta(
             // sync continues from here instead of restarting the folder.
             let resume = page.next_link.as_deref().or(page.delta_link.as_deref());
             if let Some(l) = resume {
-                db::folders::update_graph_delta_link(&conn, account_id, &gf.id, Some(l))?;
+                db::folders::update_graph_delta_link(&tx, account_id, &gf.id, Some(l))?;
             }
 
-            conn.execute_batch("COMMIT")?;
+            tx.commit()?;
         }
 
         pages += 1;
         match page.next_link {
-            Some(next) if pages < MAX_DELTA_PAGES_PER_CYCLE => link = Some(next),
+            Some(next) if full_enumeration || pages < MAX_DELTA_PAGES_PER_CYCLE => {
+                link = Some(next)
+            }
             Some(_) => {
                 log::info!(
                     "Graph sync: '{}' has more pages after {} ({} new so far); resuming next cycle",
@@ -270,7 +298,36 @@ async fn sync_graph_folder_delta(
                 );
                 break;
             }
-            None => break,
+            None => {
+                completed = true;
+                break;
+            }
+        }
+    }
+
+    // Reconcile a completed full enumeration: local rows the snapshot
+    // never mentioned were deleted (or moved out) server-side while we
+    // had no delta state. A resumed enumeration (interrupted earlier;
+    // `full_enumeration` is false because a nextLink was stored) skips
+    // this — conservative, and the next 410-triggered resync heals it.
+    if full_enumeration && completed {
+        let stale: Vec<&String> = pre_existing.difference(&seen_ids).collect();
+        if !stale.is_empty() {
+            let conn = db_arc.writer().await;
+            let tx = conn.unchecked_transaction()?;
+            for id in &stale {
+                tx.execute(
+                    "DELETE FROM messages WHERE id = ?1",
+                    rusqlite::params![id.as_str()],
+                )
+                .ok();
+            }
+            tx.commit()?;
+            log::info!(
+                "Graph sync: pruned {} stale local row(s) in '{}' after full enumeration",
+                stale.len(),
+                gf.display_name
+            );
         }
     }
 

--- a/src-tauri/src/backend/mail/graph.rs
+++ b/src-tauri/src/backend/mail/graph.rs
@@ -78,7 +78,7 @@ async fn sync_graph_account(
                 &gf.display_name,
                 &gf.id,
                 folder_type,
-                None,
+                gf.parent_folder_id.as_deref(),
             )?;
             db::folders::update_folder_counts(
                 &conn,
@@ -275,7 +275,7 @@ async fn sync_graph_folder_delta(
                             // changes and mark it as confirmed-alive for a
                             // running full enumeration (see
                             // graph_prune_pending above).
-                            let _ = db::messages::update_flags(&tx, &id, &flags_json);
+                            db::messages::update_flags(&tx, &id, &flags_json)?;
                             tx.execute(
                                 "UPDATE messages SET graph_prune_pending = 0 WHERE id = ?1",
                                 rusqlite::params![id],
@@ -496,7 +496,7 @@ impl MailBackend for GraphMailBackend {
                 &gf.display_name,
                 &gf.id,
                 folder_type,
-                None,
+                gf.parent_folder_id.as_deref(),
             )?;
             db::folders::update_folder_counts(
                 &conn,

--- a/src-tauri/src/backend/mail/graph.rs
+++ b/src-tauri/src/backend/mail/graph.rs
@@ -13,17 +13,31 @@ use super::{MailBackend, MailOpExecutor, MailSyncCtx};
 
 pub struct GraphMailBackend;
 
-/// Sync an O365 account via Microsoft Graph API.
-/// Downloads full MIME bodies during sync and streams them to Maildir,
-/// so message reading works offline without live API calls.
-/// Two-phase: download without DB lock (UI stays responsive), then fast batch insert.
-async fn sync_graph_account(ctx: &MailSyncCtx, account_id: &str) -> Result<()> {
+/// Max delta pages (of up to 200 messages each) applied per folder per
+/// sync cycle. The initial enumeration of a huge folder resumes on the
+/// next cycle from the persisted `nextLink` instead of monopolizing this
+/// one; steady-state delta rounds are one page.
+const MAX_DELTA_PAGES_PER_CYCLE: usize = 25;
+
+/// Sync an O365 account via Microsoft Graph delta queries.
+///
+/// Envelope-only: message bodies are fetched on demand when a message is
+/// opened (`commands/mail.rs` handles the `graph:`/empty `maildir_path`
+/// cases). Each folder keeps a persisted delta link (`graph_delta_link`),
+/// so steady-state sync is ~1 request per folder and the server reports
+/// creations, flag changes, and removals (deletes *and* moves out of the
+/// folder) explicitly — the previous full-crawl implementation re-listed
+/// the newest 200 messages of every folder and downloaded full MIME for
+/// anything it didn't recognize, every cycle.
+async fn sync_graph_account(
+    ctx: &MailSyncCtx,
+    account_id: &str,
+    current_folder: Option<&str>,
+) -> Result<()> {
     use crate::mail::graph::{self, GraphClient};
-    use crate::mail::sync::{create_maildir_dirs, flags_to_maildir_suffix, sanitize_folder_name};
 
     let app = &ctx.app;
     let db_arc = &ctx.db;
-    let data_dir = ctx.data_dir.clone();
 
     // Mirror sync_account / sync_jmap_account: emit sync-started so the
     // activity store can mark the operation running and spin the StatusBar
@@ -76,188 +90,29 @@ async fn sync_graph_account(ctx: &MailSyncCtx, account_id: &str) -> Result<()> {
         }
     }
 
-    // Sync messages for each folder
+    // Sync order: the folder the user is looking at first, then Inbox,
+    // then the rest in walk order — same priority scheme as IMAP/JMAP.
+    // Matters most during the initial delta enumeration, which can take
+    // a while on big mailboxes.
+    let mut graph_folders = graph_folders;
+    graph_folders.sort_by_key(|gf| {
+        if current_folder == Some(gf.id.as_str()) {
+            0u8
+        } else if graph::guess_folder_type(&gf.display_name) == Some("inbox") {
+            1
+        } else {
+            2
+        }
+    });
+
+    // Sync messages for each folder via delta queries. Per-folder errors
+    // are logged and skipped so one throttled or broken folder can't
+    // starve the folders after it (new folders sort last in the walk).
     let mut grand_total = 0u32;
     for gf in &graph_folders {
-        let (messages, _total) = client.list_messages(&gf.id, 200, 0).await?;
-
-        if messages.is_empty() {
-            continue;
-        }
-
-        let existing_ids = {
-            let conn = db_arc.reader();
-            let mut stmt = conn
-                .prepare("SELECT id FROM messages WHERE account_id = ?1 AND folder_path = ?2")
-                .map_err(Error::Database)?;
-            let ids: std::collections::HashSet<String> = stmt
-                .query_map(rusqlite::params![account_id, gf.id], |row| row.get(0))
-                .map_err(Error::Database)?
-                .filter_map(|r| r.ok())
-                .collect();
-            ids
-        };
-
-        // Backfill: existing rows synced before threading worked have an
-        // empty thread_id. We also have a fresh In-Reply-To from
-        // internetMessageHeaders, which lets the frontend render the
-        // reply hierarchy for already-stored Graph messages without a
-        // re-download.
-        {
-            let conn = db_arc.writer().await;
-            let mut update_thread = conn.prepare(
-                "UPDATE messages SET thread_id = ?1
-                 WHERE id = ?2 AND (thread_id IS NULL OR thread_id = '')",
-            )?;
-            let mut update_irt = conn.prepare(
-                "UPDATE messages SET in_reply_to = ?1
-                 WHERE id = ?2 AND (in_reply_to IS NULL OR in_reply_to = '')",
-            )?;
-            for msg in &messages {
-                let id = format!("{}_{}", account_id, msg.id);
-                if !existing_ids.contains(&id) {
-                    continue;
-                }
-                if let Some(cid) = msg.conversation_id.as_deref() {
-                    if !cid.is_empty() {
-                        update_thread.execute(rusqlite::params![cid, id])?;
-                    }
-                }
-                if let Some(irt) = msg.in_reply_to.as_deref() {
-                    if !irt.is_empty() {
-                        update_irt.execute(rusqlite::params![irt, id])?;
-                    }
-                }
-            }
-        }
-
-        // Collect new messages
-        let mut new_messages = Vec::new();
-        for msg in &messages {
-            let id = format!("{}_{}", account_id, msg.id);
-            if existing_ids.contains(&id) {
-                continue;
-            }
-            new_messages.push(msg);
-        }
-
-        if new_messages.is_empty() {
-            continue;
-        }
-
-        // Prepare Maildir directory
-        let folder_dir = sanitize_folder_name(&gf.id);
-        let maildir_base = data_dir.join(account_id).join(&folder_dir);
-        create_maildir_dirs(&maildir_base)?;
-
-        // Phase 1: Stream MIME bodies to disk (no DB lock — UI stays responsive)
-        let mut downloaded: Vec<(&graph::GraphMessage, String)> = Vec::new();
-        for msg in &new_messages {
-            let flags = if msg.is_read {
-                vec!["seen".to_string()]
-            } else {
-                vec![]
-            };
-            let filename = format!("{}:2,{}", msg.id, flags_to_maildir_suffix(&flags));
-            let msg_path = maildir_base.join("cur").join(&filename);
-
-            let maildir_path = match client.download_mime_to_file(&msg.id, &msg_path).await {
-                Ok(bytes_written) => {
-                    log::debug!(
-                        "Graph sync: downloaded {} bytes for {}",
-                        bytes_written,
-                        msg.id
-                    );
-                    format!("{}/{}/cur/{}", account_id, folder_dir, filename)
-                }
-                Err(e) => {
-                    log::warn!("Graph sync: failed to download MIME for {}: {}", msg.id, e);
-                    // Clean up partial file
-                    let _ = std::fs::remove_file(&msg_path);
-                    String::new() // Empty = on-demand fetch later
-                }
-            };
-            downloaded.push((msg, maildir_path));
-        }
-
-        // Phase 2: Fast batch DB insert (lock held <10ms, not during downloads)
-        let conn = db_arc.writer().await;
-        conn.execute_batch("BEGIN")?;
-
-        let mut synced = 0u32;
-        let mut new_ids: Vec<String> = Vec::new();
-        for (msg, maildir_path) in &downloaded {
-            let id = format!("{}_{}", account_id, msg.id);
-            let flags = if msg.is_read {
-                vec!["seen".to_string()]
-            } else {
-                vec![]
-            };
-            let thread_id = msg.conversation_id.clone();
-
-            let new_msg = db::messages::NewMessage {
-                id: id.clone(),
-                account_id: account_id.to_string(),
-                folder_path: gf.id.clone(),
-                uid: 0,
-                message_id: msg.internet_message_id.clone(),
-                in_reply_to: msg.in_reply_to.clone(),
-                thread_id,
-                subject: msg.subject.clone(),
-                from_name: msg.from_name.clone(),
-                from_email: msg
-                    .from_email
-                    .clone()
-                    .unwrap_or_else(|| "unknown".to_string()),
-                to_addresses: msg.to_addresses.clone(),
-                cc_addresses: msg.cc_addresses.clone(),
-                date: msg.date.clone(),
-                size: 0,
-                has_attachments: msg.has_attachments,
-                is_encrypted: false,
-                is_signed: false,
-                flags: serde_json::to_string(&flags).unwrap_or_default(),
-                maildir_path: maildir_path.clone(),
-                snippet: msg.preview.clone(),
-            };
-            db::messages::insert_message(&conn, &new_msg)?;
-            new_ids.push(id);
-            synced += 1;
-        }
-
-        conn.execute_batch("COMMIT")?;
-        drop(conn);
-
-        if synced > 0 {
-            log::info!(
-                "Graph sync: {} new messages in '{}' (bodies streamed to disk)",
-                synced,
-                gf.display_name
-            );
-            grand_total += synced;
-        }
-
-        // Run filter rules against newly inserted messages. Errors are
-        // logged and swallowed so a transient Graph hiccup can't poison
-        // the sync — messages already landed in the DB.
-        if !new_ids.is_empty() {
-            match crate::commands::filters::apply_filters_to_new_messages(
-                db_arc, account_id, &gf.id, &new_ids,
-            )
-            .await
-            {
-                Ok(filtered) => {
-                    if filtered > 0 {
-                        log::info!(
-                            "Graph filters matched {} of {} new messages in '{}'",
-                            filtered,
-                            new_ids.len(),
-                            gf.display_name
-                        );
-                    }
-                }
-                Err(e) => log::warn!("Graph filter pass failed for '{}': {}", gf.display_name, e),
-            }
+        match sync_graph_folder_delta(ctx, &client, account_id, gf).await {
+            Ok(synced) => grand_total += synced,
+            Err(e) => log::warn!("Graph sync: skipping folder '{}': {}", gf.display_name, e),
         }
     }
 
@@ -280,43 +135,245 @@ async fn sync_graph_account(ctx: &MailSyncCtx, account_id: &str) -> Result<()> {
     Ok(())
 }
 
+/// Delta-sync one folder: apply creations, flag updates, and removals
+/// reported by Graph since the folder's stored delta link. With no stored
+/// link this is the initial full enumeration (paged, resumable). Returns
+/// the number of newly inserted messages.
+async fn sync_graph_folder_delta(
+    ctx: &MailSyncCtx,
+    client: &crate::mail::graph::GraphClient,
+    account_id: &str,
+    gf: &crate::mail::graph::GraphMailFolder,
+) -> Result<u32> {
+    use crate::mail::graph;
+
+    let db_arc = &ctx.db;
+
+    let mut link = {
+        let conn = db_arc.reader();
+        db::folders::get_graph_delta_link(&conn, account_id, &gf.id)?
+    };
+
+    // Known message ids in this folder, so delta "created or updated"
+    // entries split into insert vs flag-update without a per-row query.
+    let mut existing_ids: std::collections::HashSet<String> = {
+        let conn = db_arc.reader();
+        let mut stmt = conn
+            .prepare("SELECT id FROM messages WHERE account_id = ?1 AND folder_path = ?2")
+            .map_err(Error::Database)?;
+        let ids: std::collections::HashSet<String> = stmt
+            .query_map(rusqlite::params![account_id, gf.id], |row| row.get(0))
+            .map_err(Error::Database)?
+            .filter_map(|r| r.ok())
+            .collect();
+        ids
+    };
+
+    let mut synced = 0u32;
+    let mut new_ids: Vec<String> = Vec::new();
+    let mut pages = 0usize;
+
+    loop {
+        let page = match client.messages_delta_page(&gf.id, link.as_deref()).await {
+            Ok(p) => p,
+            Err(e) if graph::is_delta_resync_required(&e) => {
+                // Stored delta token expired server-side (HTTP 410). Clear
+                // it so the next cycle restarts with a full enumeration.
+                let conn = db_arc.writer().await;
+                db::folders::update_graph_delta_link(&conn, account_id, &gf.id, None)?;
+                return Err(Error::Sync(format!(
+                    "delta state expired for '{}'; full resync on next cycle",
+                    gf.display_name
+                )));
+            }
+            Err(e) => return Err(e),
+        };
+
+        {
+            let conn = db_arc.writer().await;
+            conn.execute_batch("BEGIN")?;
+
+            for removed in &page.removed_ids {
+                let id = format!("{}_{}", account_id, removed);
+                conn.execute("DELETE FROM messages WHERE id = ?1", rusqlite::params![id])
+                    .ok();
+                existing_ids.remove(&id);
+            }
+
+            for msg in &page.messages {
+                let id = format!("{}_{}", account_id, msg.id);
+                let flags = if msg.is_read {
+                    vec!["seen".to_string()]
+                } else {
+                    vec![]
+                };
+                let flags_json = serde_json::to_string(&flags).unwrap_or_default();
+
+                if existing_ids.contains(&id) {
+                    // Updated message: mirror the server-side read state
+                    // (read/unread toggled on webmail).
+                    let _ = db::messages::update_flags(&conn, &id, &flags_json);
+                    continue;
+                }
+
+                let new_msg = db::messages::NewMessage {
+                    id: id.clone(),
+                    account_id: account_id.to_string(),
+                    folder_path: gf.id.clone(),
+                    uid: 0,
+                    message_id: msg.internet_message_id.clone(),
+                    in_reply_to: msg.in_reply_to.clone(),
+                    thread_id: msg.conversation_id.clone(),
+                    subject: msg.subject.clone(),
+                    from_name: msg.from_name.clone(),
+                    from_email: msg
+                        .from_email
+                        .clone()
+                        .unwrap_or_else(|| "unknown".to_string()),
+                    to_addresses: msg.to_addresses.clone(),
+                    cc_addresses: msg.cc_addresses.clone(),
+                    date: msg.date.clone(),
+                    size: 0,
+                    has_attachments: msg.has_attachments,
+                    is_encrypted: false,
+                    is_signed: false,
+                    flags: flags_json,
+                    // Empty = body fetched on demand when the message is opened.
+                    maildir_path: String::new(),
+                    snippet: msg.preview.clone(),
+                };
+                db::messages::insert_message(&conn, &new_msg)?;
+                existing_ids.insert(id.clone());
+                new_ids.push(id);
+                synced += 1;
+            }
+
+            // Persist the resume point after every page: an interrupted
+            // sync continues from here instead of restarting the folder.
+            let resume = page.next_link.as_deref().or(page.delta_link.as_deref());
+            if let Some(l) = resume {
+                db::folders::update_graph_delta_link(&conn, account_id, &gf.id, Some(l))?;
+            }
+
+            conn.execute_batch("COMMIT")?;
+        }
+
+        pages += 1;
+        match page.next_link {
+            Some(next) if pages < MAX_DELTA_PAGES_PER_CYCLE => link = Some(next),
+            Some(_) => {
+                log::info!(
+                    "Graph sync: '{}' has more pages after {} ({} new so far); resuming next cycle",
+                    gf.display_name,
+                    pages,
+                    synced
+                );
+                break;
+            }
+            None => break,
+        }
+    }
+
+    if synced > 0 {
+        log::info!(
+            "Graph sync: {} new messages in '{}' (envelopes only; bodies on demand)",
+            synced,
+            gf.display_name
+        );
+    }
+
+    // Run filter rules against newly inserted messages. Errors are logged
+    // and swallowed so a transient Graph hiccup can't poison the sync —
+    // messages already landed in the DB.
+    if !new_ids.is_empty() {
+        match crate::commands::filters::apply_filters_to_new_messages(
+            db_arc, account_id, &gf.id, &new_ids,
+        )
+        .await
+        {
+            Ok(filtered) => {
+                if filtered > 0 {
+                    log::info!(
+                        "Graph filters matched {} of {} new messages in '{}'",
+                        filtered,
+                        new_ids.len(),
+                        gf.display_name
+                    );
+                }
+            }
+            Err(e) => log::warn!("Graph filter pass failed for '{}': {}", gf.display_name, e),
+        }
+    }
+
+    Ok(synced)
+}
+
 #[async_trait]
 impl MailBackend for GraphMailBackend {
     fn protocol(&self) -> &'static str {
         "graph"
     }
 
-    /// Microsoft Graph has no cheap per-folder fetch — every sync runs
-    /// against the whole account, so the command backgrounds it.
-    fn folder_sync_backgrounds(&self) -> bool {
-        true
-    }
-
     async fn sync_account(
         &self,
         ctx: &MailSyncCtx,
         account: &AccountFull,
-        _current_folder: Option<String>,
+        current_folder: Option<String>,
     ) -> Result<()> {
         log::info!(
             "Syncing account {} ({}) via Microsoft Graph",
             account.display_name,
             account.email,
         );
-        sync_graph_account(ctx, &account.id).await
+        sync_graph_account(ctx, &account.id, current_folder.as_deref()).await
     }
 
-    /// Never called: `folder_sync_backgrounds` routes the command to a
-    /// background [`Self::sync_account`] instead.
+    /// Sync exactly one folder via its delta link. Refreshes the folder's
+    /// name/counts from the server first, so this works even for a folder
+    /// the local DB hasn't seen yet.
     async fn sync_folder(
         &self,
-        _ctx: &MailSyncCtx,
-        _account: &AccountFull,
-        _folder_path: &str,
+        ctx: &MailSyncCtx,
+        account: &AccountFull,
+        folder_path: &str,
     ) -> Result<u32> {
-        Err(Error::Sync(
-            "Graph per-folder sync runs as a background account sync".into(),
-        ))
+        use crate::mail::graph::{self, GraphClient};
+
+        ctx.app
+            .emit(
+                "sync-started",
+                serde_json::json!({
+                    "account_id": account.id,
+                    "account_name": account.display_name,
+                }),
+            )
+            .ok();
+
+        let token = graph::get_graph_token(&account.id).await?;
+        let client = GraphClient::new(&token);
+
+        let gf = client.get_mail_folder(folder_path).await?;
+        {
+            let conn = ctx.db.writer().await;
+            let folder_type = graph::guess_folder_type(&gf.display_name);
+            db::folders::upsert_folder(
+                &conn,
+                &account.id,
+                &gf.display_name,
+                &gf.id,
+                folder_type,
+                None,
+            )?;
+            db::folders::update_folder_counts(
+                &conn,
+                &account.id,
+                &gf.id,
+                gf.unread_count,
+                gf.total_count,
+            )?;
+        }
+
+        sync_graph_folder_delta(ctx, &client, &account.id, &gf).await
     }
 
     /// O365 accounts keep IMAP access alongside Graph, and their Graph

--- a/src-tauri/src/backend/mail/graph.rs
+++ b/src-tauri/src/backend/mail/graph.rs
@@ -239,76 +239,95 @@ async fn sync_graph_folder_delta(
             // cannot leave an open transaction on the pooled connection.
             let tx = conn.unchecked_transaction()?;
 
-            for removed in &page.removed_ids {
-                let id = format!("{}_{}", account_id, removed);
-                tx.execute("DELETE FROM messages WHERE id = ?1", rusqlite::params![id])
-                    .ok();
-                existing_ids.remove(&id);
-            }
+            // Apply events strictly in server order: the same id can carry
+            // an update followed by a removal within one page, and playing
+            // removals and upserts as separate passes would resurrect the
+            // message. Errors propagate — a failed delete must roll the
+            // whole page (checkpoint included) back, or the server would
+            // never resend the tombstone.
+            for event in &page.events {
+                match event {
+                    graph::GraphDeltaEvent::Removed(removed) => {
+                        let id = format!("{}_{}", account_id, removed);
+                        tx.execute("DELETE FROM messages WHERE id = ?1", rusqlite::params![id])?;
+                        existing_ids.remove(&id);
+                        // A removed row owes no filter pass; drop it from
+                        // the batch if it was inserted earlier this cycle.
+                        new_ids.retain(|n| n != &id);
+                    }
+                    graph::GraphDeltaEvent::Upsert(msg) => {
+                        let id = format!("{}_{}", account_id, msg.id);
+                        // Mirror the full server-side flag state (read +
+                        // flagged), not just read: replacing the array with
+                        // only `seen` erased an existing `flagged` on every
+                        // update.
+                        let mut flags: Vec<String> = Vec::new();
+                        if msg.is_read {
+                            flags.push("seen".to_string());
+                        }
+                        if msg.is_flagged {
+                            flags.push("flagged".to_string());
+                        }
+                        let flags_json = serde_json::to_string(&flags).unwrap_or_default();
 
-            for msg in &page.messages {
-                let id = format!("{}_{}", account_id, msg.id);
-                // Mirror the full server-side flag state (read + flagged),
-                // not just read: replacing the array with only `seen`
-                // erased an existing `flagged` on every update.
-                let mut flags: Vec<String> = Vec::new();
-                if msg.is_read {
-                    flags.push("seen".to_string());
-                }
-                if msg.is_flagged {
-                    flags.push("flagged".to_string());
-                }
-                let flags_json = serde_json::to_string(&flags).unwrap_or_default();
+                        if existing_ids.contains(&id) {
+                            // Updated message: mirror server-side flag
+                            // changes and mark it as confirmed-alive for a
+                            // running full enumeration (see
+                            // graph_prune_pending above).
+                            let _ = db::messages::update_flags(&tx, &id, &flags_json);
+                            tx.execute(
+                                "UPDATE messages SET graph_prune_pending = 0 WHERE id = ?1",
+                                rusqlite::params![id],
+                            )?;
+                            continue;
+                        }
 
-                if existing_ids.contains(&id) {
-                    // Updated message: mirror server-side flag changes and
-                    // mark it as confirmed-alive for a running full
-                    // enumeration (see graph_prune_pending above).
-                    let _ = db::messages::update_flags(&tx, &id, &flags_json);
-                    tx.execute(
-                        "UPDATE messages SET graph_prune_pending = 0 WHERE id = ?1",
-                        rusqlite::params![id],
-                    )?;
-                    continue;
+                        let new_msg = db::messages::NewMessage {
+                            id: id.clone(),
+                            account_id: account_id.to_string(),
+                            folder_path: gf.id.clone(),
+                            uid: 0,
+                            message_id: msg.internet_message_id.clone(),
+                            in_reply_to: msg.in_reply_to.clone(),
+                            thread_id: msg.conversation_id.clone(),
+                            subject: msg.subject.clone(),
+                            from_name: msg.from_name.clone(),
+                            from_email: msg
+                                .from_email
+                                .clone()
+                                .unwrap_or_else(|| "unknown".to_string()),
+                            to_addresses: msg.to_addresses.clone(),
+                            cc_addresses: msg.cc_addresses.clone(),
+                            date: msg.date.clone(),
+                            size: 0,
+                            has_attachments: msg.has_attachments,
+                            is_encrypted: false,
+                            is_signed: false,
+                            flags: flags_json,
+                            // `graph:` marks the body as not yet downloaded
+                            // AND keeps the row out of the IMAP prefetch
+                            // pipeline (which selects `maildir_path = ''`
+                            // rows and cannot fetch Graph folders/UID 0).
+                            maildir_path: format!("graph:{}", msg.id),
+                            snippet: msg.preview.clone(),
+                        };
+                        db::messages::insert_message(&tx, &new_msg)?;
+                        // Durable "filter pass still owed" marker, committed
+                        // with the insert: a crash before the filter run is
+                        // retried on the next cycle instead of silently
+                        // skipped.
+                        tx.execute(
+                            "UPDATE messages SET graph_filters_pending = 1 WHERE id = ?1",
+                            rusqlite::params![id],
+                        )?;
+                        existing_ids.insert(id.clone());
+                        if !new_ids.contains(&id) {
+                            new_ids.push(id);
+                        }
+                        synced += 1;
+                    }
                 }
-
-                let new_msg = db::messages::NewMessage {
-                    id: id.clone(),
-                    account_id: account_id.to_string(),
-                    folder_path: gf.id.clone(),
-                    uid: 0,
-                    message_id: msg.internet_message_id.clone(),
-                    in_reply_to: msg.in_reply_to.clone(),
-                    thread_id: msg.conversation_id.clone(),
-                    subject: msg.subject.clone(),
-                    from_name: msg.from_name.clone(),
-                    from_email: msg
-                        .from_email
-                        .clone()
-                        .unwrap_or_else(|| "unknown".to_string()),
-                    to_addresses: msg.to_addresses.clone(),
-                    cc_addresses: msg.cc_addresses.clone(),
-                    date: msg.date.clone(),
-                    size: 0,
-                    has_attachments: msg.has_attachments,
-                    is_encrypted: false,
-                    is_signed: false,
-                    flags: flags_json,
-                    // Empty = body fetched on demand when the message is opened.
-                    maildir_path: String::new(),
-                    snippet: msg.preview.clone(),
-                };
-                db::messages::insert_message(&tx, &new_msg)?;
-                // Durable "filter pass still owed" marker, committed with
-                // the insert: a crash before the filter run is retried on
-                // the next cycle instead of silently skipped.
-                tx.execute(
-                    "UPDATE messages SET graph_filters_pending = 1 WHERE id = ?1",
-                    rusqlite::params![id],
-                )?;
-                existing_ids.insert(id.clone());
-                new_ids.push(id);
-                synced += 1;
             }
 
             // Persist the resume point after every page: an interrupted
@@ -381,14 +400,18 @@ async fn sync_graph_folder_delta(
         )
         .await
         {
-            Ok(filtered) => {
-                // Filter pass done: clear the pending markers. Rows the
+            Ok(outcome) => {
+                // Clear the pending marker ONLY for messages whose filter
+                // pass completed — messages with failed server-side
+                // actions stay marked and are retried next cycle. Rows the
                 // filters moved or deleted are already gone from the DB,
-                // so the UPDATE simply no-ops on them.
+                // so their UPDATE simply no-ops.
+                let failed: std::collections::HashSet<&String> =
+                    outcome.failed_db_ids.iter().collect();
                 {
                     let conn = db_arc.writer().await;
                     let tx = conn.unchecked_transaction()?;
-                    for id in &new_ids {
+                    for id in new_ids.iter().filter(|id| !failed.contains(id)) {
                         tx.execute(
                             "UPDATE messages SET graph_filters_pending = 0 WHERE id = ?1",
                             rusqlite::params![id],
@@ -396,10 +419,17 @@ async fn sync_graph_folder_delta(
                     }
                     tx.commit()?;
                 }
-                if filtered > 0 {
+                if !failed.is_empty() {
+                    log::warn!(
+                        "Graph filters: {} message(s) in '{}' kept pending after failed actions",
+                        failed.len(),
+                        gf.display_name
+                    );
+                }
+                if outcome.affected > 0 {
                     log::info!(
                         "Graph filters matched {} of {} new messages in '{}'",
-                        filtered,
+                        outcome.affected,
                         new_ids.len(),
                         gf.display_name
                     );
@@ -480,11 +510,81 @@ impl MailBackend for GraphMailBackend {
         sync_graph_folder_delta(ctx, &client, &account.id, &gf).await
     }
 
-    /// O365 accounts keep IMAP access alongside Graph, and their Graph
-    /// sync can leave rows behind for on-demand fetch — reuse the IMAP
-    /// prefetch pipeline exactly as the pre-trait command did.
+    /// Graph-native body prefetch. Graph message rows store the folder's
+    /// Graph id in `folder_path` and `uid = 0`, so the IMAP prefetch
+    /// pipeline (folder SELECT + fetch-by-UID) can never retrieve them —
+    /// delegating there just produced failed selects after every sync.
+    /// Instead, stream full MIME for the newest unfetched rows via the
+    /// same `download_mime_to_file` path the on-demand fetch uses.
     async fn prefetch_bodies(&self, ctx: &MailSyncCtx, account: &AccountFull) -> Result<u32> {
-        super::imap::prefetch_pipeline(ctx, account).await
+        use crate::mail::graph::{self, GraphClient};
+        use crate::mail::sync::{
+            create_maildir_dirs, flags_to_maildir_suffix, sanitize_folder_name,
+        };
+
+        /// Bodies fetched per prefetch pass; the pass re-runs after every
+        /// sync, so the backlog drains across cycles.
+        const MAX_PREFETCH_PER_PASS: u32 = 100;
+
+        let unfetched = {
+            let conn = ctx.db.reader();
+            db::messages::get_unfetched_graph_messages(&conn, &account.id, MAX_PREFETCH_PER_PASS)?
+        };
+        if unfetched.is_empty() {
+            return Ok(0);
+        }
+        log::info!(
+            "Graph prefetch: {} unfetched bodies for account {}",
+            unfetched.len(),
+            account.id
+        );
+
+        let token = graph::get_graph_token(&account.id).await?;
+        let client = GraphClient::new(&token);
+
+        let mut fetched = 0u32;
+        for (db_id, folder_path, maildir_path, flags_json) in &unfetched {
+            let graph_msg_id = maildir_path
+                .strip_prefix("graph:")
+                .map(|s| s.to_string())
+                .unwrap_or_else(|| {
+                    db_id
+                        .strip_prefix(&format!("{}_", account.id))
+                        .unwrap_or(db_id)
+                        .to_string()
+                });
+            let flags: Vec<String> = serde_json::from_str(flags_json).unwrap_or_default();
+
+            let folder_dir = sanitize_folder_name(folder_path);
+            let maildir_base = ctx.data_dir.join(&account.id).join(&folder_dir);
+            create_maildir_dirs(&maildir_base)?;
+            let filename = format!("{}:2,{}", graph_msg_id, flags_to_maildir_suffix(&flags));
+            let msg_path = maildir_base.join("cur").join(&filename);
+
+            match client.download_mime_to_file(&graph_msg_id, &msg_path).await {
+                Ok(bytes) => {
+                    let relative = format!("{}/{}/cur/{}", account.id, folder_dir, filename);
+                    let conn = ctx.db.writer().await;
+                    db::messages::update_maildir_path(&conn, db_id, &relative)?;
+                    log::debug!("Graph prefetch: {} ({} bytes)", relative, bytes);
+                    fetched += 1;
+                }
+                Err(e) => {
+                    // Clean up any partial file; the row stays unfetched
+                    // and is retried on a later pass or on demand.
+                    let _ = std::fs::remove_file(&msg_path);
+                    log::warn!("Graph prefetch: failed for {}: {}", graph_msg_id, e);
+                }
+            }
+        }
+
+        log::info!(
+            "Graph prefetch: {} of {} bodies fetched for account {}",
+            fetched,
+            unfetched.len(),
+            account.id
+        );
+        Ok(fetched)
     }
 
     fn op_executor(&self) -> Box<dyn MailOpExecutor> {

--- a/src-tauri/src/backend/mail/graph.rs
+++ b/src-tauri/src/backend/mail/graph.rs
@@ -172,21 +172,49 @@ async fn sync_graph_folder_delta(
     // A full (re-)enumeration — no stored link, e.g. first sync or after
     // HTTP 410 expired the delta token — lists what exists NOW; it does
     // not emit tombstones for messages deleted while no delta state was
-    // held. Track what the enumeration returns and prune the local rows
-    // it never mentioned once it completes. Full enumerations run to
-    // completion (no page cap) so that prune is sound; steady-state delta
-    // rounds are capped instead.
-    let full_enumeration = link.is_none();
-    let pre_existing: std::collections::HashSet<String> = if full_enumeration {
-        existing_ids.clone()
-    } else {
-        std::collections::HashSet::new()
-    };
-    let mut seen_ids: std::collections::HashSet<String> = std::collections::HashSet::new();
-    let mut completed = false;
+    // held. Mark every current row `graph_prune_pending` up front; the
+    // enumeration clears the mark on each message it lists, and whatever
+    // is still marked when the enumeration COMPLETES (possibly several
+    // capped cycles later — the marks are durable, unlike an in-memory
+    // seen-set) was deleted server-side and gets pruned.
+    if link.is_none() && !existing_ids.is_empty() {
+        let conn = db_arc.writer().await;
+        conn.execute(
+            "UPDATE messages SET graph_prune_pending = 1
+             WHERE account_id = ?1 AND folder_path = ?2",
+            rusqlite::params![account_id, gf.id],
+        )?;
+    }
 
+    // Rows whose sync-time filter pass never ran (crash or error after
+    // the insert transaction committed): pick them up in this cycle's
+    // filter batch. They are already in `existing_ids`, so the page loop
+    // below won't re-add them.
+    let mut new_ids: Vec<String> = {
+        let conn = db_arc.reader();
+        let mut stmt = conn
+            .prepare(
+                "SELECT id FROM messages
+                 WHERE account_id = ?1 AND folder_path = ?2 AND graph_filters_pending = 1",
+            )
+            .map_err(Error::Database)?;
+        let ids: Vec<String> = stmt
+            .query_map(rusqlite::params![account_id, gf.id], |row| row.get(0))
+            .map_err(Error::Database)?
+            .filter_map(|r| r.ok())
+            .collect();
+        ids
+    };
+    if !new_ids.is_empty() {
+        log::info!(
+            "Graph sync: {} message(s) in '{}' still awaiting their filter pass",
+            new_ids.len(),
+            gf.display_name
+        );
+    }
+
+    let mut completed = false;
     let mut synced = 0u32;
-    let mut new_ids: Vec<String> = Vec::new();
     let mut pages = 0usize;
 
     loop {
@@ -220,9 +248,6 @@ async fn sync_graph_folder_delta(
 
             for msg in &page.messages {
                 let id = format!("{}_{}", account_id, msg.id);
-                if full_enumeration {
-                    seen_ids.insert(id.clone());
-                }
                 // Mirror the full server-side flag state (read + flagged),
                 // not just read: replacing the array with only `seen`
                 // erased an existing `flagged` on every update.
@@ -236,9 +261,14 @@ async fn sync_graph_folder_delta(
                 let flags_json = serde_json::to_string(&flags).unwrap_or_default();
 
                 if existing_ids.contains(&id) {
-                    // Updated message: mirror server-side flag changes
-                    // (read/unread or flag toggled on webmail).
+                    // Updated message: mirror server-side flag changes and
+                    // mark it as confirmed-alive for a running full
+                    // enumeration (see graph_prune_pending above).
                     let _ = db::messages::update_flags(&tx, &id, &flags_json);
+                    tx.execute(
+                        "UPDATE messages SET graph_prune_pending = 0 WHERE id = ?1",
+                        rusqlite::params![id],
+                    )?;
                     continue;
                 }
 
@@ -269,6 +299,13 @@ async fn sync_graph_folder_delta(
                     snippet: msg.preview.clone(),
                 };
                 db::messages::insert_message(&tx, &new_msg)?;
+                // Durable "filter pass still owed" marker, committed with
+                // the insert: a crash before the filter run is retried on
+                // the next cycle instead of silently skipped.
+                tx.execute(
+                    "UPDATE messages SET graph_filters_pending = 1 WHERE id = ?1",
+                    rusqlite::params![id],
+                )?;
                 existing_ids.insert(id.clone());
                 new_ids.push(id);
                 synced += 1;
@@ -286,9 +323,7 @@ async fn sync_graph_folder_delta(
 
         pages += 1;
         match page.next_link {
-            Some(next) if full_enumeration || pages < MAX_DELTA_PAGES_PER_CYCLE => {
-                link = Some(next)
-            }
+            Some(next) if pages < MAX_DELTA_PAGES_PER_CYCLE => link = Some(next),
             Some(_) => {
                 log::info!(
                     "Graph sync: '{}' has more pages after {} ({} new so far); resuming next cycle",
@@ -305,27 +340,23 @@ async fn sync_graph_folder_delta(
         }
     }
 
-    // Reconcile a completed full enumeration: local rows the snapshot
-    // never mentioned were deleted (or moved out) server-side while we
-    // had no delta state. A resumed enumeration (interrupted earlier;
-    // `full_enumeration` is false because a nextLink was stored) skips
-    // this — conservative, and the next 410-triggered resync heals it.
-    if full_enumeration && completed {
-        let stale: Vec<&String> = pre_existing.difference(&seen_ids).collect();
-        if !stale.is_empty() {
-            let conn = db_arc.writer().await;
-            let tx = conn.unchecked_transaction()?;
-            for id in &stale {
-                tx.execute(
-                    "DELETE FROM messages WHERE id = ?1",
-                    rusqlite::params![id.as_str()],
-                )
-                .ok();
-            }
-            tx.commit()?;
+    // Reconcile on completion (reached the deltaLink): rows still marked
+    // graph_prune_pending were never listed by the enumeration that
+    // marked them — deleted or moved out server-side while we had no
+    // delta state. The marks are durable, so this fires correctly even
+    // when the enumeration spanned several page-capped cycles; ordinary
+    // delta rounds mark nothing, making this a no-op for them.
+    if completed {
+        let conn = db_arc.writer().await;
+        let pruned = conn.execute(
+            "DELETE FROM messages
+             WHERE account_id = ?1 AND folder_path = ?2 AND graph_prune_pending = 1",
+            rusqlite::params![account_id, gf.id],
+        )?;
+        if pruned > 0 {
             log::info!(
                 "Graph sync: pruned {} stale local row(s) in '{}' after full enumeration",
-                stale.len(),
+                pruned,
                 gf.display_name
             );
         }
@@ -339,9 +370,11 @@ async fn sync_graph_folder_delta(
         );
     }
 
-    // Run filter rules against newly inserted messages. Errors are logged
-    // and swallowed so a transient Graph hiccup can't poison the sync —
-    // messages already landed in the DB.
+    // Run filter rules against newly inserted messages (plus any picked
+    // up from an interrupted earlier run). Errors are logged and
+    // swallowed so a transient Graph hiccup can't poison the sync — the
+    // rows keep their graph_filters_pending marker and are retried on
+    // the next cycle.
     if !new_ids.is_empty() {
         match crate::commands::filters::apply_filters_to_new_messages(
             db_arc, account_id, &gf.id, &new_ids,
@@ -349,6 +382,20 @@ async fn sync_graph_folder_delta(
         .await
         {
             Ok(filtered) => {
+                // Filter pass done: clear the pending markers. Rows the
+                // filters moved or deleted are already gone from the DB,
+                // so the UPDATE simply no-ops on them.
+                {
+                    let conn = db_arc.writer().await;
+                    let tx = conn.unchecked_transaction()?;
+                    for id in &new_ids {
+                        tx.execute(
+                            "UPDATE messages SET graph_filters_pending = 0 WHERE id = ?1",
+                            rusqlite::params![id],
+                        )?;
+                    }
+                    tx.commit()?;
+                }
                 if filtered > 0 {
                     log::info!(
                         "Graph filters matched {} of {} new messages in '{}'",

--- a/src-tauri/src/backend/mail/imap.rs
+++ b/src-tauri/src/backend/mail/imap.rs
@@ -41,6 +41,17 @@ async fn build_imap_config(account: &AccountFull) -> Result<ImapConfig> {
 /// the Graph backend — O365 accounts keep IMAP access and their
 /// Graph sync can leave on-demand rows behind.
 pub(super) async fn prefetch_pipeline(ctx: &MailSyncCtx, account: &AccountFull) -> Result<u32> {
+    // Graph-protocol accounts without an IMAP binding have no host to
+    // connect to. Without this guard every sync-complete kicked off a
+    // doomed connect to ":993" plus keyring/token reads for credentials.
+    if account.imap_host.is_empty() {
+        log::debug!(
+            "Prefetch: account {} has no IMAP host configured, skipping",
+            account.id
+        );
+        return Ok(0);
+    }
+
     let account_id = account.id.clone();
     let imap_config = build_imap_config(account).await?;
     let data_dir = ctx.data_dir.clone();

--- a/src-tauri/src/backend/mail/mod.rs
+++ b/src-tauri/src/backend/mail/mod.rs
@@ -42,14 +42,6 @@ pub trait MailBackend: Send + Sync {
         false
     }
 
-    /// This provider has no cheap per-folder fetch — the command
-    /// spawns a whole-account [`Self::sync_account`] in the background
-    /// (holding the sync guard) and returns immediately so the UI's
-    /// per-folder spinner doesn't sit there for minutes.
-    fn folder_sync_backgrounds(&self) -> bool {
-        false
-    }
-
     /// Full account sync. Emits its own `sync-started` /
     /// `sync-complete` progress events (inside the provider sync
     /// loops); errors are emitted as `sync-error` by the command.
@@ -61,7 +53,10 @@ pub trait MailBackend: Send + Sync {
     ) -> Result<()>;
 
     /// Sync one folder's envelopes; returns the new-message count.
-    /// Not called when [`Self::folder_sync_backgrounds`] is true.
+    /// This must touch ONLY the requested folder — a user right-clicking
+    /// "sync" on a folder expects exactly that folder to sync and then
+    /// the operation to stop (Graph used to background a whole-account
+    /// sync here; delta sync made a true per-folder fetch possible).
     async fn sync_folder(
         &self,
         ctx: &MailSyncCtx,
@@ -211,18 +206,5 @@ mod registry_tests {
             .unwrap()
             .suspends_idle_for_ops(&imap_plain));
         assert!(!for_account(&graph).unwrap().suspends_idle_for_ops(&graph));
-    }
-
-    #[test]
-    fn only_graph_backgrounds_folder_sync() {
-        assert!(for_account(&account("graph", "oauth-microsoft"))
-            .unwrap()
-            .folder_sync_backgrounds());
-        assert!(!for_account(&account("imap", "password"))
-            .unwrap()
-            .folder_sync_backgrounds());
-        assert!(!for_account(&account("jmap", "password"))
-            .unwrap()
-            .folder_sync_backgrounds());
     }
 }

--- a/src-tauri/src/commands/filters.rs
+++ b/src-tauri/src/commands/filters.rs
@@ -714,23 +714,47 @@ async fn execute_graph_filter_actions(
     if !mark_read.is_empty() {
         log::info!("Graph: marking {} messages as read", mark_read.len());
         let graph_ids: Vec<String> = mark_read.iter().map(|(_, g)| g.clone()).collect();
-        if let Err(e) = client.set_read_status(&graph_ids, true).await {
-            log::warn!("Graph mark-read batch failed: {}", e);
-            result.errors.push(format!("mark-read: {}", e));
-            result
-                .failed_db_ids
-                .extend(mark_read.iter().map(|(d, _)| d.clone()));
+        match client.set_read_status_batch(&graph_ids, true).await {
+            Ok(outcomes) => {
+                for ((db_id, graph_id), outcome) in mark_read.iter().zip(outcomes) {
+                    if let Err(e) = outcome {
+                        log::warn!("Graph mark-read failed for id={}: {}", graph_id, e);
+                        result.errors.push(format!("mark-read {}: {}", graph_id, e));
+                        result.failed_db_ids.push(db_id.clone());
+                    }
+                }
+            }
+            Err(e) => {
+                log::warn!("Graph mark-read batch failed: {}", e);
+                result.errors.push(format!("mark-read: {}", e));
+                result
+                    .failed_db_ids
+                    .extend(mark_read.iter().map(|(d, _)| d.clone()));
+            }
         }
     }
     if !mark_unread.is_empty() {
         log::info!("Graph: marking {} messages as unread", mark_unread.len());
         let graph_ids: Vec<String> = mark_unread.iter().map(|(_, g)| g.clone()).collect();
-        if let Err(e) = client.set_read_status(&graph_ids, false).await {
-            log::warn!("Graph mark-unread batch failed: {}", e);
-            result.errors.push(format!("mark-unread: {}", e));
-            result
-                .failed_db_ids
-                .extend(mark_unread.iter().map(|(d, _)| d.clone()));
+        match client.set_read_status_batch(&graph_ids, false).await {
+            Ok(outcomes) => {
+                for ((db_id, graph_id), outcome) in mark_unread.iter().zip(outcomes) {
+                    if let Err(e) = outcome {
+                        log::warn!("Graph mark-unread failed for id={}: {}", graph_id, e);
+                        result
+                            .errors
+                            .push(format!("mark-unread {}: {}", graph_id, e));
+                        result.failed_db_ids.push(db_id.clone());
+                    }
+                }
+            }
+            Err(e) => {
+                log::warn!("Graph mark-unread batch failed: {}", e);
+                result.errors.push(format!("mark-unread: {}", e));
+                result
+                    .failed_db_ids
+                    .extend(mark_unread.iter().map(|(d, _)| d.clone()));
+            }
         }
     }
 

--- a/src-tauri/src/commands/filters.rs
+++ b/src-tauri/src/commands/filters.rs
@@ -706,8 +706,23 @@ async fn execute_graph_filter_actions(
     let mut moved_db_set: std::collections::HashSet<String> = std::collections::HashSet::new();
     let mut stale_count = 0u32;
 
+    // A message can carry several Move actions (multiple matching rules
+    // without stop-processing). Only the FIRST planned move is executed —
+    // `moves` preserves rule-priority order, and executing later ones
+    // would race a stale id anyway. Deduplicate BEFORE grouping by
+    // target: the group map iterates in arbitrary order, so without this
+    // the winning destination would be nondeterministic.
+    let mut planned_move: std::collections::HashSet<String> = std::collections::HashSet::new();
     let mut moves_by_target: HashMap<String, Vec<(String, String)>> = HashMap::new();
     for (db_id, graph_id, target) in &moves {
+        if !planned_move.insert(db_id.clone()) {
+            log::debug!(
+                "Graph: ignoring secondary move of {} to '{}' (first planned target wins)",
+                db_id,
+                target
+            );
+            continue;
+        }
         moves_by_target
             .entry(target.clone())
             .or_default()

--- a/src-tauri/src/commands/filters.rs
+++ b/src-tauri/src/commands/filters.rs
@@ -359,25 +359,36 @@ fn load_messages_by_ids_chunk(
     Ok(messages)
 }
 
+/// Outcome of a sync-time filter pass. `affected` counts messages that had
+/// at least one action planned; `failed_db_ids` lists messages whose
+/// planned server-side actions did not all complete — the Graph sync keeps
+/// their durable `graph_filters_pending` markers set so the pass is
+/// retried on the next cycle instead of being silently dropped.
+#[derive(Default)]
+pub(crate) struct FilterPassOutcome {
+    pub(crate) affected: u32,
+    pub(crate) failed_db_ids: Vec<String>,
+}
+
 /// Apply enabled filter rules to a bounded set of newly-synced messages in
 /// one folder, dispatching to the protocol-specific executor that matches the
 /// account's mail binding. Called from the sync paths for JMAP and Graph
 /// accounts; IMAP sync handles its own filter pass inline so it can reuse
 /// the open `imap::Session`.
 ///
-/// Returns the number of messages that had at least one action planned.
-/// Executor errors are logged and swallowed (returning `Ok(0)`) so a
-/// transient JMAP/Graph failure cannot poison the surrounding sync — the
-/// messages are already in the DB and the user can retry via the manual
-/// "Apply Filters" button.
+/// Executor errors are logged and folded into the outcome's
+/// `failed_db_ids` (a total executor failure marks every matched message
+/// failed) so a transient JMAP/Graph failure cannot poison the
+/// surrounding sync — the messages are already in the DB and are retried
+/// on the next cycle (Graph) or via the manual "Apply Filters" button.
 pub(crate) async fn apply_filters_to_new_messages(
     db: &Arc<DbPool>,
     account_id: &str,
     folder_path: &str,
     new_ids: &[String],
-) -> Result<u32> {
+) -> Result<FilterPassOutcome> {
     if new_ids.is_empty() {
-        return Ok(0);
+        return Ok(FilterPassOutcome::default());
     }
 
     let (rules, messages, account) = {
@@ -385,11 +396,11 @@ pub(crate) async fn apply_filters_to_new_messages(
         let all_rules = db::filters::list_filters(&conn, Some(account_id))?;
         let enabled_rules: Vec<FilterRule> = all_rules.into_iter().filter(|r| r.enabled).collect();
         if enabled_rules.is_empty() {
-            return Ok(0);
+            return Ok(FilterPassOutcome::default());
         }
         let messages = load_messages_by_ids(&conn, account_id, folder_path, new_ids)?;
         if messages.is_empty() {
-            return Ok(0);
+            return Ok(FilterPassOutcome::default());
         }
         let account = db::accounts::get_account_full(&conn, account_id)?;
         (enabled_rules, messages, account)
@@ -397,9 +408,10 @@ pub(crate) async fn apply_filters_to_new_messages(
 
     let action_plan = build_filter_action_plan(&rules, &messages);
     if action_plan.is_empty() {
-        return Ok(0);
+        return Ok(FilterPassOutcome::default());
     }
     let affected_count = action_plan.len() as u32;
+    let matched_ids: Vec<String> = action_plan.iter().map(|(m, _)| m.id.clone()).collect();
 
     log::info!(
         "Sync-time filters: {} new messages, {} matched in '{}' (protocol={})",
@@ -421,7 +433,10 @@ pub(crate) async fn apply_filters_to_new_messages(
                     folder_path,
                     e
                 );
-                return Ok(0);
+                return Ok(FilterPassOutcome {
+                    affected: 0,
+                    failed_db_ids: matched_ids,
+                });
             }
         },
         "graph" => match execute_graph_filter_actions(account_id, &action_plan).await {
@@ -432,16 +447,19 @@ pub(crate) async fn apply_filters_to_new_messages(
                     folder_path,
                     e
                 );
-                return Ok(0);
+                return Ok(FilterPassOutcome {
+                    affected: 0,
+                    failed_db_ids: matched_ids,
+                });
             }
         },
-        "imap" => return Ok(0),
+        "imap" => return Ok(FilterPassOutcome::default()),
         other => {
             log::debug!(
                 "Sync-time filters: protocol '{}' has no sync-time executor; skipping",
                 other
             );
-            return Ok(0);
+            return Ok(FilterPassOutcome::default());
         }
     };
 
@@ -465,7 +483,13 @@ pub(crate) async fn apply_filters_to_new_messages(
         );
     }
 
-    Ok(affected_count)
+    let mut failed_db_ids = result.failed_db_ids;
+    failed_db_ids.sort();
+    failed_db_ids.dedup();
+    Ok(FilterPassOutcome {
+        affected: affected_count,
+        failed_db_ids,
+    })
 }
 
 /// Result of executing a filter action plan against the server.
@@ -477,6 +501,11 @@ struct ExecutionResult {
     moved_db_ids: Vec<String>,
     deleted_db_ids: Vec<String>,
     errors: Vec<String>,
+    /// DB ids whose planned actions did NOT all complete server-side.
+    /// The Graph sync uses this to keep those messages' durable
+    /// `graph_filters_pending` markers set so the pass is retried, while
+    /// still clearing markers for messages that finished.
+    failed_db_ids: Vec<String>,
 }
 
 /// Execute filter actions over IMAP using a blocking connection.
@@ -638,11 +667,12 @@ async fn execute_graph_filter_actions(
     let client = crate::mail::graph::GraphClient::new(&token);
 
     // Pair every operation with its DB id so we can report which messages
-    // really changed server-side.
+    // really changed server-side — and, on failure, WHICH messages still
+    // owe their filter pass (result.failed_db_ids).
     let mut moves: Vec<(String, String, String)> = Vec::new(); // (db_id, graph_id, target)
     let mut deletes: Vec<(String, String)> = Vec::new(); // (db_id, graph_id)
-    let mut mark_read_ids: Vec<String> = Vec::new();
-    let mut mark_unread_ids: Vec<String> = Vec::new();
+    let mut mark_read: Vec<(String, String)> = Vec::new(); // (db_id, graph_id)
+    let mut mark_unread: Vec<(String, String)> = Vec::new(); // (db_id, graph_id)
 
     for (msg, actions) in action_plan {
         let graph_id = graph_id_from_db_id(account_id, &msg.id).to_string();
@@ -654,13 +684,13 @@ async fn execute_graph_filter_actions(
                 FilterAction::Delete => {
                     deletes.push((msg.id.clone(), graph_id.clone()));
                 }
-                FilterAction::MarkRead => mark_read_ids.push(graph_id.clone()),
-                FilterAction::MarkUnread => mark_unread_ids.push(graph_id.clone()),
+                FilterAction::MarkRead => mark_read.push((msg.id.clone(), graph_id.clone())),
+                FilterAction::MarkUnread => mark_unread.push((msg.id.clone(), graph_id.clone())),
                 FilterAction::Flag { value } if value.eq_ignore_ascii_case("seen") => {
-                    mark_read_ids.push(graph_id.clone());
+                    mark_read.push((msg.id.clone(), graph_id.clone()));
                 }
                 FilterAction::Unflag { value } if value.eq_ignore_ascii_case("seen") => {
-                    mark_unread_ids.push(graph_id.clone());
+                    mark_unread.push((msg.id.clone(), graph_id.clone()));
                 }
                 FilterAction::Flag { value } | FilterAction::Unflag { value } => {
                     log::warn!(
@@ -681,21 +711,26 @@ async fn execute_graph_filter_actions(
 
     let mut result = ExecutionResult::default();
 
-    if !mark_read_ids.is_empty() {
-        log::info!("Graph: marking {} messages as read", mark_read_ids.len());
-        if let Err(e) = client.set_read_status(&mark_read_ids, true).await {
+    if !mark_read.is_empty() {
+        log::info!("Graph: marking {} messages as read", mark_read.len());
+        let graph_ids: Vec<String> = mark_read.iter().map(|(_, g)| g.clone()).collect();
+        if let Err(e) = client.set_read_status(&graph_ids, true).await {
             log::warn!("Graph mark-read batch failed: {}", e);
             result.errors.push(format!("mark-read: {}", e));
+            result
+                .failed_db_ids
+                .extend(mark_read.iter().map(|(d, _)| d.clone()));
         }
     }
-    if !mark_unread_ids.is_empty() {
-        log::info!(
-            "Graph: marking {} messages as unread",
-            mark_unread_ids.len()
-        );
-        if let Err(e) = client.set_read_status(&mark_unread_ids, false).await {
+    if !mark_unread.is_empty() {
+        log::info!("Graph: marking {} messages as unread", mark_unread.len());
+        let graph_ids: Vec<String> = mark_unread.iter().map(|(_, g)| g.clone()).collect();
+        if let Err(e) = client.set_read_status(&graph_ids, false).await {
             log::warn!("Graph mark-unread batch failed: {}", e);
             result.errors.push(format!("mark-unread: {}", e));
+            result
+                .failed_db_ids
+                .extend(mark_unread.iter().map(|(d, _)| d.clone()));
         }
     }
 
@@ -753,6 +788,7 @@ async fn execute_graph_filter_actions(
                         Err(e) => {
                             log::warn!("Graph move failed for id={}: {}", graph_id, e);
                             result.errors.push(format!("move: {}", e));
+                            result.failed_db_ids.push(db_id.clone());
                         }
                     }
                 }
@@ -760,6 +796,9 @@ async fn execute_graph_filter_actions(
             Err(e) => {
                 log::warn!("Graph move batch to '{}' failed: {}", target, e);
                 result.errors.push(format!("move batch: {}", e));
+                result
+                    .failed_db_ids
+                    .extend(items.iter().map(|(d, _)| d.clone()));
             }
         }
     }
@@ -789,6 +828,7 @@ async fn execute_graph_filter_actions(
                         Err(e) => {
                             log::warn!("Graph delete failed for id={}: {}", graph_id, e);
                             result.errors.push(format!("delete: {}", e));
+                            result.failed_db_ids.push(db_id.clone());
                         }
                     }
                 }
@@ -796,6 +836,9 @@ async fn execute_graph_filter_actions(
             Err(e) => {
                 log::warn!("Graph delete batch failed: {}", e);
                 result.errors.push(format!("delete batch: {}", e));
+                result
+                    .failed_db_ids
+                    .extend(to_delete.iter().map(|(d, _)| d.clone()));
             }
         }
     }

--- a/src-tauri/src/commands/filters.rs
+++ b/src-tauri/src/commands/filters.rs
@@ -699,29 +699,52 @@ async fn execute_graph_filter_actions(
         }
     }
 
-    log::info!("Graph: moving {} messages", moves.len());
+    // Moves and deletes go through Graph JSON batching (20 sub-requests
+    // per round trip). The old one-HTTP-call-per-message loop turned a
+    // filter run over a large folder into hundreds of sequential round
+    // trips and a large slice of the mailbox throttling budget.
     let mut moved_db_set: std::collections::HashSet<String> = std::collections::HashSet::new();
     let mut stale_count = 0u32;
+
+    let mut moves_by_target: HashMap<String, Vec<(String, String)>> = HashMap::new();
     for (db_id, graph_id, target) in &moves {
-        match client.move_message(graph_id, target).await {
-            Ok(_) => {
-                moved_db_set.insert(db_id.clone());
-                result.moved_db_ids.push(db_id.clone());
-            }
-            Err(e) if is_graph_item_not_found(&e) => {
-                // Message no longer exists at this id — treat the local row
-                // as stale and prune it. A sync will repopulate the folder
-                // with current server state.
-                log::info!(
-                    "Graph move 404 for id={}: pruning stale local row",
-                    graph_id
-                );
-                result.deleted_db_ids.push(db_id.clone());
-                stale_count += 1;
+        moves_by_target
+            .entry(target.clone())
+            .or_default()
+            .push((db_id.clone(), graph_id.clone()));
+    }
+    for (target, items) in &moves_by_target {
+        log::info!("Graph: moving {} messages to '{}'", items.len(), target);
+        let graph_ids: Vec<String> = items.iter().map(|(_, gid)| gid.clone()).collect();
+        match client.move_messages_batch(&graph_ids, target).await {
+            Ok(outcomes) => {
+                for ((db_id, graph_id), outcome) in items.iter().zip(outcomes) {
+                    match outcome {
+                        Ok(()) => {
+                            moved_db_set.insert(db_id.clone());
+                            result.moved_db_ids.push(db_id.clone());
+                        }
+                        Err(e) if is_graph_item_not_found(&e) => {
+                            // Message no longer exists at this id — treat the
+                            // local row as stale and prune it. A sync will
+                            // repopulate the folder with current server state.
+                            log::info!(
+                                "Graph move 404 for id={}: pruning stale local row",
+                                graph_id
+                            );
+                            result.deleted_db_ids.push(db_id.clone());
+                            stale_count += 1;
+                        }
+                        Err(e) => {
+                            log::warn!("Graph move failed for id={}: {}", graph_id, e);
+                            result.errors.push(format!("move: {}", e));
+                        }
+                    }
+                }
             }
             Err(e) => {
-                log::warn!("Graph move failed for id={}: {}", graph_id, e);
-                result.errors.push(format!("move: {}", e));
+                log::warn!("Graph move batch to '{}' failed: {}", target, e);
+                result.errors.push(format!("move batch: {}", e));
             }
         }
     }
@@ -734,21 +757,30 @@ async fn execute_graph_filter_actions(
         .collect();
     if !to_delete.is_empty() {
         log::info!("Graph: deleting {} messages", to_delete.len());
-        for (db_id, graph_id) in &to_delete {
-            match client.delete_message(graph_id).await {
-                Ok(_) => result.deleted_db_ids.push(db_id.clone()),
-                Err(e) if is_graph_item_not_found(&e) => {
-                    log::info!(
-                        "Graph delete 404 for id={}: pruning stale local row",
-                        graph_id
-                    );
-                    result.deleted_db_ids.push(db_id.clone());
-                    stale_count += 1;
+        let graph_ids: Vec<String> = to_delete.iter().map(|(_, gid)| gid.clone()).collect();
+        match client.delete_messages_batch(&graph_ids).await {
+            Ok(outcomes) => {
+                for ((db_id, graph_id), outcome) in to_delete.iter().zip(outcomes) {
+                    match outcome {
+                        Ok(()) => result.deleted_db_ids.push(db_id.clone()),
+                        Err(e) if is_graph_item_not_found(&e) => {
+                            log::info!(
+                                "Graph delete 404 for id={}: pruning stale local row",
+                                graph_id
+                            );
+                            result.deleted_db_ids.push(db_id.clone());
+                            stale_count += 1;
+                        }
+                        Err(e) => {
+                            log::warn!("Graph delete failed for id={}: {}", graph_id, e);
+                            result.errors.push(format!("delete: {}", e));
+                        }
+                    }
                 }
-                Err(e) => {
-                    log::warn!("Graph delete failed for id={}: {}", graph_id, e);
-                    result.errors.push(format!("delete: {}", e));
-                }
+            }
+            Err(e) => {
+                log::warn!("Graph delete batch failed: {}", e);
+                result.errors.push(format!("delete batch: {}", e));
             }
         }
     }

--- a/src-tauri/src/commands/sync_cmd.rs
+++ b/src-tauri/src/commands/sync_cmd.rs
@@ -259,39 +259,9 @@ pub async fn sync_folder(
         data_dir: state.data_dir.clone(),
     };
 
-    if backend.folder_sync_backgrounds() {
-        // No cheap per-folder fetch for this provider (Graph) — every
-        // sync runs against the whole account. Spawn it in the
-        // background and return immediately so the UI's per-folder
-        // spinner doesn't sit there for multiple minutes. The
-        // per-account `_guard` rides along into the spawned task so
-        // the flag stays held for the real work and is released
-        // exactly once when the sync finishes.
-        let app_bg = app.clone();
-        let account_bg = account.clone();
-        let account_id_bg = account_id.clone();
-        tokio::spawn(async move {
-            let _hold_guard = _guard;
-            let result = backend.sync_account(&ctx, &account_bg, None).await;
-            match result {
-                Ok(()) => log::info!("Background Graph sync done for {}", account_id_bg),
-                Err(e) => {
-                    log::error!("Background Graph sync failed for {}: {}", account_id_bg, e);
-                    app_bg
-                        .emit(
-                            "sync-error",
-                            serde_json::json!({
-                                "account_id": account_id_bg,
-                                "error": e.to_string(),
-                            }),
-                        )
-                        .ok();
-                }
-            }
-        });
-        return Ok(0);
-    }
-
+    // Every backend syncs exactly the requested folder synchronously —
+    // a right-click "sync folder" must never escalate to a whole-account
+    // sync (Graph used to background one here before delta sync).
     let sync_result: Result<u32> = backend.sync_folder(&ctx, &account, &folder_path).await;
 
     let resume_result =

--- a/src-tauri/src/db/folders.rs
+++ b/src-tauri/src/db/folders.rs
@@ -314,14 +314,15 @@ pub fn get_graph_delta_link(
     account_id: &str,
     path: &str,
 ) -> Result<Option<String>> {
-    let link: Option<String> = conn
-        .query_row(
-            "SELECT graph_delta_link FROM folders WHERE account_id = ?1 AND path = ?2",
-            params![account_id, path],
-            |row| row.get(0),
-        )
-        .unwrap_or(None);
-    Ok(link)
+    match conn.query_row(
+        "SELECT graph_delta_link FROM folders WHERE account_id = ?1 AND path = ?2",
+        params![account_id, path],
+        |row| row.get(0),
+    ) {
+        Ok(link) => Ok(link),
+        Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+        Err(e) => Err(e.into()),
+    }
 }
 
 /// Store the Graph delta/next link for a folder. Pass `None` to clear it

--- a/src-tauri/src/db/folders.rs
+++ b/src-tauri/src/db/folders.rs
@@ -306,6 +306,39 @@ pub fn update_jmap_state(
     Ok(())
 }
 
+/// Get the stored Microsoft Graph delta/next link for a folder.
+/// `None` means the folder has no delta state and needs an initial
+/// full enumeration.
+pub fn get_graph_delta_link(
+    conn: &Connection,
+    account_id: &str,
+    path: &str,
+) -> Result<Option<String>> {
+    let link: Option<String> = conn
+        .query_row(
+            "SELECT graph_delta_link FROM folders WHERE account_id = ?1 AND path = ?2",
+            params![account_id, path],
+            |row| row.get(0),
+        )
+        .unwrap_or(None);
+    Ok(link)
+}
+
+/// Store the Graph delta/next link for a folder. Pass `None` to clear it
+/// (forces a full re-enumeration on the next sync, e.g. after HTTP 410).
+pub fn update_graph_delta_link(
+    conn: &Connection,
+    account_id: &str,
+    path: &str,
+    link: Option<&str>,
+) -> Result<()> {
+    conn.execute(
+        "UPDATE folders SET graph_delta_link = ?1 WHERE account_id = ?2 AND path = ?3",
+        params![link, account_id, path],
+    )?;
+    Ok(())
+}
+
 /// Recalculate folder counts from the messages table for all folders of an account.
 pub fn recalculate_folder_counts(conn: &Connection, account_id: &str) -> Result<()> {
     log::debug!("Recalculating folder counts for account {}", account_id);
@@ -556,6 +589,48 @@ mod tests {
             folder_path_by_type(&conn, "acc-none", "sent").unwrap(),
             None
         );
+    }
+
+    #[test]
+    fn test_graph_delta_link_roundtrip() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE folders (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                account_id TEXT NOT NULL,
+                name TEXT NOT NULL,
+                path TEXT NOT NULL,
+                graph_delta_link TEXT,
+                UNIQUE(account_id, path)
+            );",
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO folders (account_id, name, path) VALUES ('acc1', 'Inbox', 'fid-1')",
+            [],
+        )
+        .unwrap();
+
+        // No link stored yet; unknown folders are None, not an error.
+        assert_eq!(get_graph_delta_link(&conn, "acc1", "fid-1").unwrap(), None);
+        assert_eq!(
+            get_graph_delta_link(&conn, "acc1", "missing").unwrap(),
+            None
+        );
+
+        let link =
+            "https://graph.microsoft.com/v1.0/me/mailFolders/fid-1/messages/delta?$deltatoken=abc";
+        update_graph_delta_link(&conn, "acc1", "fid-1", Some(link)).unwrap();
+        assert_eq!(
+            get_graph_delta_link(&conn, "acc1", "fid-1")
+                .unwrap()
+                .as_deref(),
+            Some(link)
+        );
+
+        // Clearing (used on HTTP 410 resync) resets to None.
+        update_graph_delta_link(&conn, "acc1", "fid-1", None).unwrap();
+        assert_eq!(get_graph_delta_link(&conn, "acc1", "fid-1").unwrap(), None);
     }
 
     fn create_delete_test_db() -> Connection {

--- a/src-tauri/src/db/messages.rs
+++ b/src-tauri/src/db/messages.rs
@@ -650,6 +650,38 @@ pub fn get_unfetched_messages(
     Ok(rows)
 }
 
+/// Messages of a Graph account whose body is not on disk yet: either the
+/// `graph:{id}` marker written by delta sync or a legacy empty path from
+/// the pre-delta crawler. Returns `(id, folder_path, maildir_path, flags)`
+/// newest first. Kept separate from [`get_unfetched_messages`], which
+/// feeds the IMAP prefetch pipeline and must not see Graph rows (Graph
+/// folder ids and UID 0 cannot be fetched over IMAP).
+pub fn get_unfetched_graph_messages(
+    conn: &Connection,
+    account_id: &str,
+    limit: u32,
+) -> Result<Vec<(String, String, String, String)>> {
+    let mut stmt = conn.prepare(
+        "SELECT id, folder_path, maildir_path, flags
+         FROM messages
+         WHERE account_id = ?1
+           AND (maildir_path = '' OR maildir_path LIKE 'graph:%')
+         ORDER BY date DESC
+         LIMIT ?2",
+    )?;
+    let rows = stmt
+        .query_map(params![account_id, limit], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, String>(3)?,
+            ))
+        })?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    Ok(rows)
+}
+
 /// Compute a thread_id for a message using a multi-step strategy:
 ///
 /// 1. **In-Reply-To lookup**: If the message has an `In-Reply-To` header, find the

--- a/src-tauri/src/db/schema.rs
+++ b/src-tauri/src/db/schema.rs
@@ -68,7 +68,9 @@ pub fn initialize(conn: &Connection) -> Result<()> {
             is_signed INTEGER DEFAULT 0,
             flags TEXT DEFAULT '[]',
             maildir_path TEXT,
-            snippet TEXT
+            snippet TEXT,
+            graph_prune_pending INTEGER NOT NULL DEFAULT 0,
+            graph_filters_pending INTEGER NOT NULL DEFAULT 0
         );
         CREATE INDEX IF NOT EXISTS idx_msg_folder ON messages(account_id, folder_path);
         CREATE INDEX IF NOT EXISTS idx_msg_date ON messages(date);
@@ -507,6 +509,28 @@ fn run_migrations(conn: &Connection) -> Result<()> {
         conn.execute_batch("ALTER TABLE folders ADD COLUMN graph_delta_link TEXT;")?;
     }
 
+    // Graph sync durability markers on messages:
+    // - graph_prune_pending: set on every row of a folder when a full
+    //   delta enumeration starts, cleared as the enumeration lists each
+    //   message; rows still marked when the enumeration completes were
+    //   deleted server-side while we had no delta state. Survives
+    //   interrupted multi-cycle enumerations, unlike in-memory tracking.
+    // - graph_filters_pending: set (in the same transaction as the
+    //   insert) on rows whose sync-time filter run hasn't happened yet,
+    //   cleared after the filter pass; a crash between insert and filter
+    //   run is retried on the next cycle instead of silently skipped.
+    for col in ["graph_prune_pending", "graph_filters_pending"] {
+        let has_col: bool = conn
+            .prepare(&format!("SELECT {col} FROM messages LIMIT 0"))
+            .is_ok();
+        if !has_col {
+            log::info!("Migration: adding {col} column to messages table");
+            conn.execute_batch(&format!(
+                "ALTER TABLE messages ADD COLUMN {col} INTEGER NOT NULL DEFAULT 0;"
+            ))?;
+        }
+    }
+
     Ok(())
 }
 
@@ -757,4 +781,53 @@ pub fn set_migration(conn: &Connection, key: &str) -> crate::error::Result<()> {
         rusqlite::params![key, chrono::Utc::now().to_rfc3339()],
     )?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Fresh install and migration re-run must both yield the Graph sync
+    /// columns (delta link + durability markers) and be idempotent.
+    #[test]
+    fn graph_sync_columns_exist_and_migrations_are_idempotent() {
+        let conn = Connection::open_in_memory().unwrap();
+        initialize(&conn).unwrap();
+
+        for probe in [
+            "SELECT graph_delta_link FROM folders LIMIT 0",
+            "SELECT graph_prune_pending FROM messages LIMIT 0",
+            "SELECT graph_filters_pending FROM messages LIMIT 0",
+        ] {
+            conn.prepare(probe)
+                .unwrap_or_else(|e| panic!("missing column for `{probe}`: {e}"));
+        }
+
+        // Running initialize again must not fail (existence probes skip
+        // the ALTERs on an already-migrated database).
+        initialize(&conn).unwrap();
+
+        // Marker defaults: inserted rows start unmarked.
+        conn.execute(
+            "INSERT INTO accounts (id, display_name, email, username)
+             VALUES ('a1', 'Test', 't@example.com', 't@example.com')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO messages (id, account_id, folder_path, date)
+             VALUES ('a1_m1', 'a1', 'f1', '2026-07-23T00:00:00Z')",
+            [],
+        )
+        .unwrap();
+        let (prune, filters): (i64, i64) = conn
+            .query_row(
+                "SELECT graph_prune_pending, graph_filters_pending
+                 FROM messages WHERE id = 'a1_m1'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!((prune, filters), (0, 0));
+    }
 }

--- a/src-tauri/src/db/schema.rs
+++ b/src-tauri/src/db/schema.rs
@@ -43,6 +43,7 @@ pub fn initialize(conn: &Connection) -> Result<()> {
             total_count INTEGER DEFAULT 0,
             uid_next INTEGER DEFAULT 0,
             parent_id TEXT,
+            graph_delta_link TEXT,
             UNIQUE(account_id, path)
         );
         CREATE INDEX IF NOT EXISTS idx_folders_account ON folders(account_id);
@@ -493,6 +494,17 @@ fn run_migrations(conn: &Connection) -> Result<()> {
                 "ALTER TABLE accounts ADD COLUMN {col} INTEGER NOT NULL DEFAULT 1;"
             ))?;
         }
+    }
+
+    // Microsoft Graph incremental sync: per-folder delta/next link, the
+    // Graph analogue of `jmap_state`. NULL means "no delta state yet" and
+    // triggers a full initial enumeration of the folder.
+    let has_graph_delta_link: bool = conn
+        .prepare("SELECT graph_delta_link FROM folders LIMIT 0")
+        .is_ok();
+    if !has_graph_delta_link {
+        log::info!("Migration: adding graph_delta_link column to folders table");
+        conn.execute_batch("ALTER TABLE folders ADD COLUMN graph_delta_link TEXT;")?;
     }
 
     Ok(())

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -29,6 +29,12 @@ pub enum Error {
     #[error("Keyring error: {0}")]
     Keyring(String),
 
+    /// The account's OAuth refresh token was rejected (`invalid_grant`,
+    /// e.g. AADSTS70043 conditional-access lifetime limits). The user must
+    /// sign in again; automated retries are pointless until then.
+    #[error("Re-authentication required: {0}")]
+    AuthRequired(String),
+
     #[error("{0}")]
     Other(String),
 }

--- a/src-tauri/src/filters/engine.rs
+++ b/src-tauri/src/filters/engine.rs
@@ -41,6 +41,12 @@ pub fn matches_message(rule: &FilterRule, msg: &MessageData) -> bool {
 /// Run through all rules sorted by priority (highest first), collect actions
 /// from matching rules. If a matching rule has `stop_processing` set, stop
 /// evaluating further rules.
+///
+/// Move/Copy actions whose target equals the message's current folder are
+/// dropped: they are no-ops at best, and on Microsoft Graph a same-folder
+/// move mints a new message id, which made sync see the message as "new"
+/// again and re-run the same filter — an infinite download/move loop that
+/// also wiped the folder's local rows on every cycle.
 pub fn apply_filters(rules: &[FilterRule], msg: &MessageData) -> Vec<FilterAction> {
     let mut sorted: Vec<&FilterRule> = rules.iter().filter(|r| r.enabled).collect();
     sorted.sort_by_key(|r| std::cmp::Reverse(r.priority));
@@ -56,7 +62,26 @@ pub fn apply_filters(rules: &[FilterRule], msg: &MessageData) -> Vec<FilterActio
                 msg.id,
                 msg.subject
             );
-            collected_actions.extend(rule.actions.clone());
+            collected_actions.extend(
+                rule.actions
+                    .iter()
+                    .filter(|action| match action {
+                        FilterAction::Move { target } | FilterAction::Copy { target }
+                            if *target == msg.folder_path =>
+                        {
+                            log::debug!(
+                                "Filter '{}': skipping {:?} — message {} is already in '{}'",
+                                rule.name,
+                                action,
+                                msg.id,
+                                msg.folder_path
+                            );
+                            false
+                        }
+                        _ => true,
+                    })
+                    .cloned(),
+            );
 
             if rule.stop_processing {
                 log::debug!(
@@ -470,6 +495,76 @@ mod tests {
         };
 
         assert!(!matches_message(&rule, &msg));
+    }
+
+    /// Regression test for the Graph filter/sync infinite loop: a Move
+    /// action targeting the folder the message is already in must be
+    /// dropped, otherwise sync re-moves the message forever (Graph mints
+    /// a new id on every move) and prunes the local rows each cycle.
+    #[test]
+    fn test_move_to_current_folder_is_skipped() {
+        let mut msg = make_msg();
+        msg.folder_path = "oauth-wg-folder-id".to_string();
+
+        let rules = vec![FilterRule {
+            id: "r_loop".to_string(),
+            account_id: None,
+            name: "oauth".to_string(),
+            enabled: true,
+            priority: 0,
+            match_type: MatchType::All,
+            conditions: vec![Condition {
+                field: ConditionField::From,
+                op: ConditionOp::Contains,
+                value: "alice".to_string(),
+            }],
+            actions: vec![
+                FilterAction::Move {
+                    target: "oauth-wg-folder-id".to_string(),
+                },
+                FilterAction::MarkRead,
+            ],
+            stop_processing: false,
+        }];
+
+        let actions = apply_filters(&rules, &msg);
+        // The Move is dropped; unrelated actions from the same rule survive.
+        assert_eq!(actions.len(), 1);
+        assert!(matches!(actions[0], FilterAction::MarkRead));
+    }
+
+    /// A Move to a *different* folder must still go through, and Copy to
+    /// the current folder is dropped like Move.
+    #[test]
+    fn test_move_to_other_folder_and_copy_guard() {
+        let msg = make_msg(); // folder_path = "INBOX"
+
+        let rules = vec![FilterRule {
+            id: "r_ok".to_string(),
+            account_id: None,
+            name: "sort".to_string(),
+            enabled: true,
+            priority: 0,
+            match_type: MatchType::All,
+            conditions: vec![Condition {
+                field: ConditionField::From,
+                op: ConditionOp::Contains,
+                value: "alice".to_string(),
+            }],
+            actions: vec![
+                FilterAction::Move {
+                    target: "Archive".to_string(),
+                },
+                FilterAction::Copy {
+                    target: "INBOX".to_string(),
+                },
+            ],
+            stop_processing: false,
+        }];
+
+        let actions = apply_filters(&rules, &msg);
+        assert_eq!(actions.len(), 1);
+        assert!(matches!(&actions[0], FilterAction::Move { target } if target == "Archive"));
     }
 
     #[test]

--- a/src-tauri/src/mail/graph.rs
+++ b/src-tauri/src/mail/graph.rs
@@ -2420,7 +2420,7 @@ pub fn contact_to_graph_json(
 /// Always refreshes with Graph-specific scopes because the stored token
 /// may be IMAP-scoped (both share the same keyring entry and refresh token).
 pub async fn get_graph_token(account_id: &str) -> Result<String> {
-    get_graph_token_with_scopes(account_id, crate::oauth::MICROSOFT_GRAPH_SCOPES).await
+    get_graph_token_with_scopes(account_id, crate::oauth::MICROSOFT_GRAPH_SCOPES, true).await
 }
 
 /// Like [`get_graph_token`] but requests the room scopes (`Place.Read.All`).
@@ -2430,11 +2430,17 @@ pub async fn get_graph_token(account_id: &str) -> Result<String> {
 /// is expected: callers (room suggestion/availability commands) treat the
 /// error as "rooms unavailable" and never let it disrupt baseline Graph
 /// operations, which keep using the consent-safe [`get_graph_token`].
+/// Because this whole scope set is optional, failures here never latch the
+/// re-auth flag — a room lookup must not be able to take down mail sync.
 pub async fn get_graph_token_for_rooms(account_id: &str) -> Result<String> {
-    get_graph_token_with_scopes(account_id, crate::oauth::MICROSOFT_GRAPH_ROOM_SCOPES).await
+    get_graph_token_with_scopes(account_id, crate::oauth::MICROSOFT_GRAPH_ROOM_SCOPES, false).await
 }
 
-async fn get_graph_token_with_scopes(account_id: &str, scopes: &str) -> Result<String> {
+async fn get_graph_token_with_scopes(
+    account_id: &str,
+    scopes: &str,
+    latch_reauth: bool,
+) -> Result<String> {
     // Dead refresh token (invalid_grant)? Fail fast without a network call
     // until the user signs in again — see oauth::auth_required_on_invalid_grant.
     crate::oauth::ensure_not_reauth_required(account_id)?;
@@ -2451,7 +2457,13 @@ async fn get_graph_token_with_scopes(account_id: &str, scopes: &str) -> Result<S
     let new_tokens =
         crate::oauth::refresh_with_scopes(&crate::oauth::MICROSOFT, &refresh_token, scopes)
             .await
-            .map_err(|e| crate::oauth::auth_required_on_invalid_grant(account_id, e))?;
+            .map_err(|e| {
+                if latch_reauth {
+                    crate::oauth::auth_required_on_invalid_grant(account_id, e)
+                } else {
+                    e
+                }
+            })?;
     // Don't overwrite the stored tokens — IMAP sync needs the IMAP-scoped token.
     // The refresh_token may rotate, so save that part only.
     if new_tokens.refresh_token.is_some() {

--- a/src-tauri/src/mail/graph.rs
+++ b/src-tauri/src/mail/graph.rs
@@ -183,13 +183,17 @@ impl GraphClient {
     async fn get_beta(&self, path: &str, params: &[(&str, &str)]) -> Result<serde_json::Value> {
         let url = format!("{}{}", GRAPH_BETA_BASE, path);
         let resp = self
-            .http
-            .get(&url)
-            .bearer_auth(&self.access_token)
-            .query(params)
-            .send()
-            .await
-            .map_err(|e| Error::Other(format!("Graph beta GET {} failed: {}", path, e)))?;
+            .send_with_retry(
+                || {
+                    self.http
+                        .get(&url)
+                        .bearer_auth(&self.access_token)
+                        .query(params)
+                },
+                &format!("beta GET {}", path),
+                true,
+            )
+            .await?;
 
         let status = resp.status();
         let body = resp.text().await.unwrap_or_default();
@@ -260,12 +264,12 @@ impl GraphClient {
 
         let url = format!("{}{}", GRAPH_BASE, path);
         let resp = self
-            .http
-            .get(&url)
-            .bearer_auth(&self.access_token)
-            .send()
-            .await
-            .map_err(|e| Error::Other(format!("Graph GET {} failed: {}", path, e)))?;
+            .send_with_retry(
+                || self.http.get(&url).bearer_auth(&self.access_token),
+                &format!("GET {}", path),
+                true,
+            )
+            .await?;
 
         let status = resp.status();
         if !status.is_success() {
@@ -1024,26 +1028,38 @@ impl GraphClient {
             .await
     }
 
+    /// Mark messages as read or unread and return one outcome per input id.
+    pub async fn set_read_status_batch(
+        &self,
+        message_ids: &[String],
+        is_read: bool,
+    ) -> Result<Vec<Result<()>>> {
+        let requests: Vec<serde_json::Value> = message_ids
+            .iter()
+            .enumerate()
+            .map(|(i, id)| {
+                serde_json::json!({
+                    "id": format!("{}", i),
+                    "method": "PATCH",
+                    "url": format!("/me/messages/{}", id),
+                    "headers": { "Content-Type": "application/json" },
+                    "body": { "isRead": is_read }
+                })
+            })
+            .collect();
+        self.execute_batch_with_retry(requests).await
+    }
+
     /// Mark messages as read or unread.
     pub async fn set_read_status(&self, message_ids: &[String], is_read: bool) -> Result<()> {
-        // Batch up to 20 requests per $batch call (Graph API limit)
-        for chunk in message_ids.chunks(20) {
-            let requests: Vec<serde_json::Value> = chunk
-                .iter()
-                .enumerate()
-                .map(|(i, id)| {
-                    serde_json::json!({
-                        "id": format!("{}", i),
-                        "method": "PATCH",
-                        "url": format!("/me/messages/{}", id),
-                        "headers": { "Content-Type": "application/json" },
-                        "body": { "isRead": is_read }
-                    })
-                })
-                .collect();
-
-            let batch_body = serde_json::json!({ "requests": requests });
-            self.post_json("/$batch", &batch_body).await?;
+        let outcomes = self.set_read_status_batch(message_ids, is_read).await?;
+        for outcome in outcomes {
+            if let Err(e) = outcome {
+                return Err(Error::Other(format!(
+                    "Graph set-read-status batch item failed: {}",
+                    e
+                )));
+            }
         }
         Ok(())
     }

--- a/src-tauri/src/mail/graph.rs
+++ b/src-tauri/src/mail/graph.rs
@@ -17,9 +17,19 @@ const BATCH_SIZE: usize = 20;
 /// Fold a `$batch` response into per-item results. Sub-responses are keyed
 /// by the request "id" we set to the item's global index; they may arrive
 /// out of order.
-fn apply_batch_responses(resp: &serde_json::Value, results: &mut [Result<()>]) {
+///
+/// A batch can return outer HTTP 200 while individual sub-responses are
+/// throttled (429) or transient (503/504). Those items are NOT written
+/// into `results`; they come back as `(index, retry_after_secs)` so the
+/// caller can retry just the affected sub-requests after the per-item
+/// delay. Everything else is recorded as a final outcome.
+fn apply_batch_responses(
+    resp: &serde_json::Value,
+    results: &mut [Result<()>],
+) -> Vec<(usize, u64)> {
+    let mut retryable = Vec::new();
     let Some(responses) = resp["responses"].as_array() else {
-        return;
+        return retryable;
     };
     for r in responses {
         let Some(idx) = r["id"].as_str().and_then(|s| s.parse::<usize>().ok()) else {
@@ -29,17 +39,32 @@ fn apply_batch_responses(resp: &serde_json::Value, results: &mut [Result<()>]) {
             continue;
         }
         let status = r["status"].as_u64().unwrap_or(0) as u16;
-        results[idx] = if (200..300).contains(&status) {
-            Ok(())
+        if (200..300).contains(&status) {
+            results[idx] = Ok(());
+        } else if matches!(status, 429 | 503 | 504) {
+            let delay = batch_item_retry_after(r).unwrap_or(5);
+            retryable.push((idx, delay));
         } else {
             let body = r["body"].to_string();
-            Err(Error::Other(format!(
+            results[idx] = Err(Error::Other(format!(
                 "Graph $batch item returned {}: {}",
                 status,
                 truncate(&body, 300)
-            )))
-        };
+            )));
+        }
     }
+    retryable
+}
+
+/// Pull `Retry-After` (seconds) out of a `$batch` sub-response's headers,
+/// tolerating header-name casing differences.
+fn batch_item_retry_after(r: &serde_json::Value) -> Option<u64> {
+    let headers = r["headers"].as_object()?;
+    headers
+        .iter()
+        .find(|(k, _)| k.eq_ignore_ascii_case("retry-after"))
+        .and_then(|(_, v)| v.as_str())
+        .and_then(|s| s.parse::<u64>().ok())
 }
 
 // ---------------------------------------------------------------------------
@@ -72,14 +97,23 @@ impl GraphClient {
         }
     }
 
-    /// Send a request, retrying on throttled (429) and transient (503/504)
-    /// responses while honoring `Retry-After`. Exchange throttles mailbox
-    /// access aggressively; without this every 429 aborted the whole
-    /// account sync and the retry storm made the throttling worse.
+    /// Send a request, retrying on throttled (429) and — for idempotent
+    /// requests only — transient (503/504) responses, honoring
+    /// `Retry-After`. Exchange throttles mailbox access aggressively;
+    /// without this every 429 aborted the whole account sync and the
+    /// retry storm made the throttling worse.
+    ///
+    /// `retry_transient` must be `false` for non-idempotent requests
+    /// (POSTs like `/sendMail`, resource creation, `$batch` with moves):
+    /// a gateway 503/504 can arrive after Graph has already committed the
+    /// request, and a blind retry would duplicate mail or resources. 429
+    /// is always safe to retry — it means the request was rejected before
+    /// processing.
     async fn send_with_retry(
         &self,
         build: impl Fn() -> reqwest::RequestBuilder,
         what: &str,
+        retry_transient: bool,
     ) -> Result<reqwest::Response> {
         const MAX_ATTEMPTS: u32 = 3;
         const MAX_RETRY_AFTER_SECS: u64 = 120;
@@ -92,7 +126,8 @@ impl GraphClient {
                 .await
                 .map_err(|e| Error::Other(format!("Graph {} failed: {}", what, e)))?;
             let code = resp.status().as_u16();
-            if matches!(code, 429 | 503 | 504) && attempt < MAX_ATTEMPTS {
+            let retryable = code == 429 || (retry_transient && matches!(code, 503 | 504));
+            if retryable && attempt < MAX_ATTEMPTS {
                 let retry_after = resp
                     .headers()
                     .get("Retry-After")
@@ -126,6 +161,7 @@ impl GraphClient {
                         .query(params)
                 },
                 &format!("GET {}", path),
+                true,
             )
             .await?;
 
@@ -177,6 +213,7 @@ impl GraphClient {
             .send_with_retry(
                 || self.http.get(url).bearer_auth(&self.access_token),
                 "GET (absolute)",
+                true,
             )
             .await?;
 
@@ -275,6 +312,9 @@ impl GraphClient {
                         .json(body)
                 },
                 &format!("POST {}", path),
+                // POST is not idempotent (sendMail, resource creation,
+                // $batch moves): 429-only retry.
+                false,
             )
             .await?;
 
@@ -308,6 +348,7 @@ impl GraphClient {
                         .json(body)
                 },
                 &format!("PATCH {}", path),
+                true,
             )
             .await?;
 
@@ -330,6 +371,7 @@ impl GraphClient {
             .send_with_retry(
                 || self.http.delete(&url).bearer_auth(&self.access_token),
                 &format!("DELETE {}", path),
+                true,
             )
             .await?;
 
@@ -600,6 +642,7 @@ impl GraphClient {
                         .header("Prefer", "odata.maxpagesize=200")
                 },
                 &what,
+                true,
             )
             .await?;
 
@@ -830,7 +873,81 @@ impl GraphClient {
         Ok(())
     }
 
-    /// Move a message to a different folder.
+    /// Execute pre-built `$batch` sub-requests (each carrying an `id` set
+    /// to its global index), chunked at [`BATCH_SIZE`]. Sub-responses that
+    /// come back 429/503/504 are retried after their per-item
+    /// `Retry-After` delay, up to 3 rounds; a retried operation that
+    /// already committed server-side resolves to a 404
+    /// `ErrorItemNotFound`, which callers treat as a stale local row —
+    /// so retrying moves/deletes converges instead of duplicating work.
+    async fn execute_batch_with_retry(
+        &self,
+        requests: Vec<serde_json::Value>,
+    ) -> Result<Vec<Result<()>>> {
+        const MAX_ROUNDS: u32 = 3;
+        const MAX_RETRY_AFTER_SECS: u64 = 120;
+
+        let total = requests.len();
+        let mut results: Vec<Result<()>> = (0..total)
+            .map(|_| Err(Error::Other("no $batch response for item".into())))
+            .collect();
+
+        let mut pending = requests;
+        let mut round = 0u32;
+        while !pending.is_empty() {
+            round += 1;
+            let mut retry_indices: Vec<(usize, u64)> = Vec::new();
+            for chunk in pending.chunks(BATCH_SIZE) {
+                let resp = self
+                    .post_json("/$batch", &serde_json::json!({ "requests": chunk }))
+                    .await?;
+                retry_indices.extend(apply_batch_responses(&resp, &mut results));
+            }
+
+            if round >= MAX_ROUNDS {
+                for (idx, _) in &retry_indices {
+                    if *idx < total {
+                        results[*idx] = Err(Error::Other(
+                            "Graph $batch item still throttled after retries".into(),
+                        ));
+                    }
+                }
+                break;
+            }
+
+            let next: Vec<serde_json::Value> = pending
+                .iter()
+                .filter(|req| {
+                    req["id"]
+                        .as_str()
+                        .and_then(|s| s.parse::<usize>().ok())
+                        .map(|idx| retry_indices.iter().any(|(i, _)| *i == idx))
+                        .unwrap_or(false)
+                })
+                .cloned()
+                .collect();
+            if !next.is_empty() {
+                let delay = retry_indices
+                    .iter()
+                    .map(|(_, d)| *d)
+                    .max()
+                    .unwrap_or(5)
+                    .min(MAX_RETRY_AFTER_SECS);
+                log::warn!(
+                    "Graph $batch: {} throttled sub-request(s), retrying after {}s (round {}/{})",
+                    next.len(),
+                    delay,
+                    round,
+                    MAX_ROUNDS
+                );
+                tokio::time::sleep(std::time::Duration::from_secs(delay)).await;
+            }
+            pending = next;
+        }
+
+        Ok(results)
+    }
+
     /// Move messages to a destination folder using JSON batching (20
     /// sub-requests per round trip instead of one round trip per message).
     /// Returns one outcome per input id, in order. Item-level failures
@@ -841,63 +958,37 @@ impl GraphClient {
         message_ids: &[String],
         dest_folder_id: &str,
     ) -> Result<Vec<Result<()>>> {
-        let mut results: Vec<Result<()>> = message_ids
+        let requests: Vec<serde_json::Value> = message_ids
             .iter()
-            .map(|_| Err(Error::Other("no $batch response for item".into())))
-            .collect();
-
-        for (chunk_idx, chunk) in message_ids.chunks(BATCH_SIZE).enumerate() {
-            let base = chunk_idx * BATCH_SIZE;
-            let requests: Vec<serde_json::Value> = chunk
-                .iter()
-                .enumerate()
-                .map(|(i, id)| {
-                    serde_json::json!({
-                        "id": format!("{}", base + i),
-                        "method": "POST",
-                        "url": format!("/me/messages/{}/move", id),
-                        "headers": { "Content-Type": "application/json" },
-                        "body": { "destinationId": dest_folder_id }
-                    })
+            .enumerate()
+            .map(|(i, id)| {
+                serde_json::json!({
+                    "id": format!("{}", i),
+                    "method": "POST",
+                    "url": format!("/me/messages/{}/move", id),
+                    "headers": { "Content-Type": "application/json" },
+                    "body": { "destinationId": dest_folder_id }
                 })
-                .collect();
-            let resp = self
-                .post_json("/$batch", &serde_json::json!({ "requests": requests }))
-                .await?;
-            apply_batch_responses(&resp, &mut results);
-        }
-
-        Ok(results)
+            })
+            .collect();
+        self.execute_batch_with_retry(requests).await
     }
 
     /// Delete messages using JSON batching. Same contract as
     /// [`Self::move_messages_batch`].
     pub async fn delete_messages_batch(&self, message_ids: &[String]) -> Result<Vec<Result<()>>> {
-        let mut results: Vec<Result<()>> = message_ids
+        let requests: Vec<serde_json::Value> = message_ids
             .iter()
-            .map(|_| Err(Error::Other("no $batch response for item".into())))
-            .collect();
-
-        for (chunk_idx, chunk) in message_ids.chunks(BATCH_SIZE).enumerate() {
-            let base = chunk_idx * BATCH_SIZE;
-            let requests: Vec<serde_json::Value> = chunk
-                .iter()
-                .enumerate()
-                .map(|(i, id)| {
-                    serde_json::json!({
-                        "id": format!("{}", base + i),
-                        "method": "DELETE",
-                        "url": format!("/me/messages/{}", id),
-                    })
+            .enumerate()
+            .map(|(i, id)| {
+                serde_json::json!({
+                    "id": format!("{}", i),
+                    "method": "DELETE",
+                    "url": format!("/me/messages/{}", id),
                 })
-                .collect();
-            let resp = self
-                .post_json("/$batch", &serde_json::json!({ "requests": requests }))
-                .await?;
-            apply_batch_responses(&resp, &mut results);
-        }
-
-        Ok(results)
+            })
+            .collect();
+        self.execute_batch_with_retry(requests).await
     }
 
     pub async fn move_message(&self, message_id: &str, dest_folder_id: &str) -> Result<()> {
@@ -1607,6 +1698,8 @@ pub struct GraphMessage {
     pub cc_addresses: String,
     pub date: String,
     pub is_read: bool,
+    /// Graph `flag.flagStatus == "flagged"` — the server-side star/flag.
+    pub is_flagged: bool,
     pub has_attachments: bool,
     pub internet_message_id: Option<String>,
     pub conversation_id: Option<String>,
@@ -1846,6 +1939,7 @@ fn parse_graph_message(m: &serde_json::Value) -> GraphMessage {
         cc_addresses,
         date,
         is_read: m["isRead"].as_bool().unwrap_or(false),
+        is_flagged: m["flag"]["flagStatus"].as_str() == Some("flagged"),
         has_attachments: m["hasAttachments"].as_bool().unwrap_or(false),
         internet_message_id: m["internetMessageId"]
             .as_str()
@@ -2431,6 +2525,31 @@ mod batch_tests {
             results[1].is_err(),
             "unanswered items must not report success"
         );
+    }
+
+    /// Throttled sub-responses are returned for retry with their per-item
+    /// `Retry-After` (header casing varies), not recorded as final errors.
+    #[test]
+    fn batch_responses_report_throttled_items_for_retry() {
+        let resp = serde_json::json!({
+            "responses": [
+                { "id": "0", "status": 201 },
+                {
+                    "id": "1",
+                    "status": 429,
+                    "headers": { "Retry-After": "17" },
+                    "body": { "error": { "code": "ApplicationThrottled" } }
+                },
+                { "id": "2", "status": 503, "headers": { "retry-after": "3" } },
+            ]
+        });
+        let mut results = fresh_results(3);
+        let retryable = apply_batch_responses(&resp, &mut results);
+        assert!(results[0].is_ok());
+        // Throttled items keep their placeholder (not a final outcome yet).
+        assert!(results[1].is_err());
+        assert!(results[2].is_err());
+        assert_eq!(retryable, vec![(1, 17), (2, 3)]);
     }
 
     #[test]

--- a/src-tauri/src/mail/graph.rs
+++ b/src-tauri/src/mail/graph.rs
@@ -664,26 +664,7 @@ impl GraphClient {
         let resp: serde_json::Value = serde_json::from_str(&body)
             .map_err(|e| Error::Other(format!("Graph JSON parse failed: {}", e)))?;
 
-        let mut messages = Vec::new();
-        let mut removed_ids = Vec::new();
-        if let Some(values) = resp["value"].as_array() {
-            for m in values {
-                if m.get("@removed").is_some() {
-                    if let Some(id) = m["id"].as_str() {
-                        removed_ids.push(id.to_string());
-                    }
-                } else {
-                    messages.push(parse_graph_message(m));
-                }
-            }
-        }
-
-        Ok(GraphDeltaPage {
-            messages,
-            removed_ids,
-            next_link: resp["@odata.nextLink"].as_str().map(String::from),
-            delta_link: resp["@odata.deltaLink"].as_str().map(String::from),
-        })
+        Ok(parse_delta_page(&resp))
     }
 
     /// Search messages across all folders using `$search` (KQL).
@@ -1655,18 +1636,54 @@ fn looks_like_smtp_address(s: &str) -> bool {
     }
 }
 
+/// One entry of a messages-delta response, in server order.
+///
+/// The same message id can appear several times in one delta response
+/// (e.g. an update followed by a removal). Order matters: applying all
+/// removals first and all upserts second would resurrect a message whose
+/// final state is "removed".
+#[derive(Debug, Clone)]
+pub enum GraphDeltaEvent {
+    /// Created or updated message (full selected properties). Boxed to
+    /// keep the enum small next to the `Removed` variant.
+    Upsert(Box<GraphMessage>),
+    /// Message removed from the folder (deleted or moved out).
+    Removed(String),
+}
+
 /// One page of a Graph messages-delta response.
 #[derive(Debug, Clone)]
 pub struct GraphDeltaPage {
-    /// Created or updated messages (full selected properties).
-    pub messages: Vec<GraphMessage>,
-    /// Graph ids of messages removed from the folder (deleted or moved out).
-    pub removed_ids: Vec<String>,
+    /// Delta entries in the exact order the server returned them.
+    pub events: Vec<GraphDeltaEvent>,
     /// More pages are available right now (`@odata.nextLink`).
     pub next_link: Option<String>,
     /// Checkpoint to store for the next sync cycle (`@odata.deltaLink`).
     /// Present only on the final page of a round.
     pub delta_link: Option<String>,
+}
+
+/// Parse a delta-response body into an ordered page. Preserves server
+/// order: the same id can appear as an update and then a removal in one
+/// response, and the LAST event must win when applied sequentially.
+fn parse_delta_page(resp: &serde_json::Value) -> GraphDeltaPage {
+    let mut events = Vec::new();
+    if let Some(values) = resp["value"].as_array() {
+        for m in values {
+            if m.get("@removed").is_some() {
+                if let Some(id) = m["id"].as_str() {
+                    events.push(GraphDeltaEvent::Removed(id.to_string()));
+                }
+            } else {
+                events.push(GraphDeltaEvent::Upsert(Box::new(parse_graph_message(m))));
+            }
+        }
+    }
+    GraphDeltaPage {
+        events,
+        next_link: resp["@odata.nextLink"].as_str().map(String::from),
+        delta_link: resp["@odata.deltaLink"].as_str().map(String::from),
+    }
 }
 
 /// Marker embedded in the error for HTTP 410 on a delta call: the stored
@@ -2562,6 +2579,38 @@ mod batch_tests {
         assert!(results[1].is_err());
         assert!(results[2].is_err());
         assert_eq!(retryable, vec![(1, 17), (2, 3)]);
+    }
+
+    /// Regression: delta events must keep server order. An update followed
+    /// by an @removed tombstone for the same id must yield Upsert then
+    /// Removed — applying removals first would resurrect the message.
+    #[test]
+    fn delta_page_preserves_event_order() {
+        use super::{parse_delta_page, GraphDeltaEvent};
+        let resp = serde_json::json!({
+            "value": [
+                { "id": "m1", "subject": "updated then deleted", "isRead": true },
+                { "id": "m2", "subject": "still alive" },
+                { "id": "m1", "@removed": { "reason": "deleted" } },
+            ],
+            "@odata.deltaLink": "https://graph.microsoft.com/v1.0/delta?$deltatoken=t1"
+        });
+        let page = parse_delta_page(&resp);
+        assert_eq!(page.events.len(), 3);
+        assert!(
+            matches!(&page.events[0], GraphDeltaEvent::Upsert(m) if m.id == "m1"),
+            "first event must be the m1 upsert"
+        );
+        assert!(matches!(&page.events[1], GraphDeltaEvent::Upsert(m) if m.id == "m2"));
+        assert!(
+            matches!(&page.events[2], GraphDeltaEvent::Removed(id) if id == "m1"),
+            "the m1 removal must come after its upsert"
+        );
+        assert!(page.next_link.is_none());
+        assert_eq!(
+            page.delta_link.as_deref(),
+            Some("https://graph.microsoft.com/v1.0/delta?$deltatoken=t1")
+        );
     }
 
     #[test]

--- a/src-tauri/src/mail/graph.rs
+++ b/src-tauri/src/mail/graph.rs
@@ -11,6 +11,37 @@ use serde::{Deserialize, Serialize};
 const GRAPH_BASE: &str = "https://graph.microsoft.com/v1.0";
 const GRAPH_BETA_BASE: &str = "https://graph.microsoft.com/beta";
 
+/// Graph JSON batching allows at most 20 sub-requests per `$batch` call.
+const BATCH_SIZE: usize = 20;
+
+/// Fold a `$batch` response into per-item results. Sub-responses are keyed
+/// by the request "id" we set to the item's global index; they may arrive
+/// out of order.
+fn apply_batch_responses(resp: &serde_json::Value, results: &mut [Result<()>]) {
+    let Some(responses) = resp["responses"].as_array() else {
+        return;
+    };
+    for r in responses {
+        let Some(idx) = r["id"].as_str().and_then(|s| s.parse::<usize>().ok()) else {
+            continue;
+        };
+        if idx >= results.len() {
+            continue;
+        }
+        let status = r["status"].as_u64().unwrap_or(0) as u16;
+        results[idx] = if (200..300).contains(&status) {
+            Ok(())
+        } else {
+            let body = r["body"].to_string();
+            Err(Error::Other(format!(
+                "Graph $batch item returned {}: {}",
+                status,
+                truncate(&body, 300)
+            )))
+        };
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Graph client
 // ---------------------------------------------------------------------------
@@ -41,16 +72,62 @@ impl GraphClient {
         }
     }
 
+    /// Send a request, retrying on throttled (429) and transient (503/504)
+    /// responses while honoring `Retry-After`. Exchange throttles mailbox
+    /// access aggressively; without this every 429 aborted the whole
+    /// account sync and the retry storm made the throttling worse.
+    async fn send_with_retry(
+        &self,
+        build: impl Fn() -> reqwest::RequestBuilder,
+        what: &str,
+    ) -> Result<reqwest::Response> {
+        const MAX_ATTEMPTS: u32 = 3;
+        const MAX_RETRY_AFTER_SECS: u64 = 120;
+
+        let mut attempt = 0u32;
+        loop {
+            attempt += 1;
+            let resp = build()
+                .send()
+                .await
+                .map_err(|e| Error::Other(format!("Graph {} failed: {}", what, e)))?;
+            let code = resp.status().as_u16();
+            if matches!(code, 429 | 503 | 504) && attempt < MAX_ATTEMPTS {
+                let retry_after = resp
+                    .headers()
+                    .get("Retry-After")
+                    .and_then(|v| v.to_str().ok())
+                    .and_then(|s| s.parse::<u64>().ok())
+                    .unwrap_or(5)
+                    .min(MAX_RETRY_AFTER_SECS);
+                log::warn!(
+                    "Graph {} returned {} (attempt {}/{}), retrying after {}s",
+                    what,
+                    code,
+                    attempt,
+                    MAX_ATTEMPTS,
+                    retry_after
+                );
+                tokio::time::sleep(std::time::Duration::from_secs(retry_after)).await;
+                continue;
+            }
+            return Ok(resp);
+        }
+    }
+
     async fn get(&self, path: &str, params: &[(&str, &str)]) -> Result<serde_json::Value> {
         let url = format!("{}{}", GRAPH_BASE, path);
         let resp = self
-            .http
-            .get(&url)
-            .bearer_auth(&self.access_token)
-            .query(params)
-            .send()
-            .await
-            .map_err(|e| Error::Other(format!("Graph GET {} failed: {}", path, e)))?;
+            .send_with_retry(
+                || {
+                    self.http
+                        .get(&url)
+                        .bearer_auth(&self.access_token)
+                        .query(params)
+                },
+                &format!("GET {}", path),
+            )
+            .await?;
 
         let status = resp.status();
         let body = resp.text().await.unwrap_or_default();
@@ -97,12 +174,11 @@ impl GraphClient {
     /// which Graph returns as a fully-qualified URL rather than a path).
     async fn get_absolute(&self, url: &str) -> Result<serde_json::Value> {
         let resp = self
-            .http
-            .get(url)
-            .bearer_auth(&self.access_token)
-            .send()
-            .await
-            .map_err(|e| Error::Other(format!("Graph GET {} failed: {}", url, e)))?;
+            .send_with_retry(
+                || self.http.get(url).bearer_auth(&self.access_token),
+                "GET (absolute)",
+            )
+            .await?;
 
         let status = resp.status();
         let body = resp.text().await.unwrap_or_default();
@@ -191,13 +267,16 @@ impl GraphClient {
     async fn post_json(&self, path: &str, body: &serde_json::Value) -> Result<serde_json::Value> {
         let url = format!("{}{}", GRAPH_BASE, path);
         let resp = self
-            .http
-            .post(&url)
-            .bearer_auth(&self.access_token)
-            .json(body)
-            .send()
-            .await
-            .map_err(|e| Error::Other(format!("Graph POST {} failed: {}", path, e)))?;
+            .send_with_retry(
+                || {
+                    self.http
+                        .post(&url)
+                        .bearer_auth(&self.access_token)
+                        .json(body)
+                },
+                &format!("POST {}", path),
+            )
+            .await?;
 
         let status = resp.status();
         let text = resp.text().await.unwrap_or_default();
@@ -221,13 +300,16 @@ impl GraphClient {
     async fn patch_json(&self, path: &str, body: &serde_json::Value) -> Result<()> {
         let url = format!("{}{}", GRAPH_BASE, path);
         let resp = self
-            .http
-            .patch(&url)
-            .bearer_auth(&self.access_token)
-            .json(body)
-            .send()
-            .await
-            .map_err(|e| Error::Other(format!("Graph PATCH {} failed: {}", path, e)))?;
+            .send_with_retry(
+                || {
+                    self.http
+                        .patch(&url)
+                        .bearer_auth(&self.access_token)
+                        .json(body)
+                },
+                &format!("PATCH {}", path),
+            )
+            .await?;
 
         let status = resp.status();
         if !status.is_success() {
@@ -245,12 +327,11 @@ impl GraphClient {
     async fn delete(&self, path: &str) -> Result<()> {
         let url = format!("{}{}", GRAPH_BASE, path);
         let resp = self
-            .http
-            .delete(&url)
-            .bearer_auth(&self.access_token)
-            .send()
-            .await
-            .map_err(|e| Error::Other(format!("Graph DELETE {} failed: {}", path, e)))?;
+            .send_with_retry(
+                || self.http.delete(&url).bearer_auth(&self.access_token),
+                &format!("DELETE {}", path),
+            )
+            .await?;
 
         let status = resp.status();
         if !status.is_success() && status.as_u16() != 204 {
@@ -364,64 +445,48 @@ impl GraphClient {
     // Mail folders
     // -----------------------------------------------------------------------
 
-    /// List all mail folders.
+    /// List all mail folders, walking the entire hierarchy.
+    ///
+    /// Graph's `/me/mailFolders` returns only top-level folders, so children
+    /// are fetched per parent (breadth-first) with full pagination. The old
+    /// implementation fetched exactly one level of children with no `$top`
+    /// and no `nextLink` follow, which silently dropped grandchildren and
+    /// any child past Graph's default page size (10) — folders created in a
+    /// nested position on the web never appeared locally.
     pub async fn list_mail_folders(&self) -> Result<Vec<GraphMailFolder>> {
-        let mut folders = Vec::new();
-        let mut url = "/me/mailFolders".to_string();
+        const FOLDER_SELECT: &str =
+            "id,displayName,totalItemCount,unreadItemCount,parentFolderId,childFolderCount";
 
-        loop {
-            let resp = self
+        let mut folders = Vec::new();
+        // Parents whose children still need fetching; None = top level.
+        let mut pending_parents: Vec<Option<String>> = vec![None];
+
+        while let Some(parent) = pending_parents.pop() {
+            let path = match &parent {
+                None => "/me/mailFolders".to_string(),
+                Some(pid) => format!("/me/mailFolders/{}/childFolders", pid),
+            };
+
+            let mut page = self
                 .get(
-                    &url,
+                    &path,
                     &[
-                        (
-                            "$select",
-                            "id,displayName,totalItemCount,unreadItemCount,parentFolderId",
-                        ),
+                        ("$select", FOLDER_SELECT),
                         ("$top", "100"),
                         ("includeHiddenFolders", "true"),
                     ],
                 )
                 .await?;
 
-            if let Some(values) = resp["value"].as_array() {
-                for f in values {
-                    folders.push(GraphMailFolder {
-                        id: f["id"].as_str().unwrap_or("").to_string(),
-                        display_name: f["displayName"].as_str().unwrap_or("").to_string(),
-                        total_count: f["totalItemCount"].as_i64().unwrap_or(0),
-                        unread_count: f["unreadItemCount"].as_i64().unwrap_or(0),
-                        parent_folder_id: f["parentFolderId"].as_str().map(|s| s.to_string()),
-                    });
-                }
-            }
-
-            // Pagination
-            if let Some(next) = resp["@odata.nextLink"].as_str() {
-                // nextLink is a full URL — strip the base
-                url = next.replace(GRAPH_BASE, "");
-            } else {
-                break;
-            }
-        }
-
-        // Also fetch child folders (Graph only returns top-level by default)
-        let top_ids: Vec<String> = folders.iter().map(|f| f.id.clone()).collect();
-        for parent_id in &top_ids {
-            let child_resp = self
-                .get(
-                    &format!("/me/mailFolders/{}/childFolders", parent_id),
-                    &[(
-                        "$select",
-                        "id,displayName,totalItemCount,unreadItemCount,parentFolderId",
-                    )],
-                )
-                .await;
-            if let Ok(resp) = child_resp {
-                if let Some(values) = resp["value"].as_array() {
+            loop {
+                if let Some(values) = page["value"].as_array() {
                     for f in values {
+                        let id = f["id"].as_str().unwrap_or("").to_string();
+                        if f["childFolderCount"].as_i64().unwrap_or(0) > 0 && !id.is_empty() {
+                            pending_parents.push(Some(id.clone()));
+                        }
                         folders.push(GraphMailFolder {
-                            id: f["id"].as_str().unwrap_or("").to_string(),
+                            id,
                             display_name: f["displayName"].as_str().unwrap_or("").to_string(),
                             total_count: f["totalItemCount"].as_i64().unwrap_or(0),
                             unread_count: f["unreadItemCount"].as_i64().unwrap_or(0),
@@ -429,11 +494,38 @@ impl GraphClient {
                         });
                     }
                 }
+                let next = page["@odata.nextLink"].as_str().map(String::from);
+                match next {
+                    Some(next) => page = self.get_absolute(&next).await?,
+                    None => break,
+                }
             }
         }
 
         log::info!("Graph: found {} mail folders", folders.len());
         Ok(folders)
+    }
+
+    /// Fetch a single mail folder (fresh display name and counts).
+    /// Used by per-folder sync so it works even for folders the local DB
+    /// hasn't seen yet.
+    pub async fn get_mail_folder(&self, folder_id: &str) -> Result<GraphMailFolder> {
+        let f = self
+            .get(
+                &format!("/me/mailFolders/{}", folder_id),
+                &[(
+                    "$select",
+                    "id,displayName,totalItemCount,unreadItemCount,parentFolderId",
+                )],
+            )
+            .await?;
+        Ok(GraphMailFolder {
+            id: f["id"].as_str().unwrap_or(folder_id).to_string(),
+            display_name: f["displayName"].as_str().unwrap_or("").to_string(),
+            total_count: f["totalItemCount"].as_i64().unwrap_or(0),
+            unread_count: f["unreadItemCount"].as_i64().unwrap_or(0),
+            parent_folder_id: f["parentFolderId"].as_str().map(|s| s.to_string()),
+        })
     }
 
     // -----------------------------------------------------------------------
@@ -468,6 +560,87 @@ impl GraphClient {
         }
 
         Ok((messages, total))
+    }
+
+    /// Fetch one page of a messages delta query for a folder.
+    ///
+    /// With `link == None` this starts a fresh (full) enumeration; with a
+    /// stored `@odata.nextLink`/`@odata.deltaLink` it resumes/continues
+    /// incremental sync. `$select` deliberately omits
+    /// `internetMessageHeaders`: it forces Exchange to open the full
+    /// property bag per item, and threading on Graph uses `conversationId`.
+    ///
+    /// A stored link that the server has expired (HTTP 410) surfaces as an
+    /// error matched by [`is_delta_resync_required`]; the caller must clear
+    /// its stored link and restart a full enumeration.
+    pub async fn messages_delta_page(
+        &self,
+        folder_id: &str,
+        link: Option<&str>,
+    ) -> Result<GraphDeltaPage> {
+        const DELTA_SELECT: &str = "id,subject,from,toRecipients,ccRecipients,receivedDateTime,\
+                                    isRead,hasAttachments,flag,internetMessageId,conversationId,\
+                                    bodyPreview,importance";
+
+        let what = format!("GET messages/delta for {}", folder_id);
+        let resp = self
+            .send_with_retry(
+                || {
+                    let req = match link {
+                        Some(url) => self.http.get(url),
+                        None => self
+                            .http
+                            .get(format!(
+                                "{}/me/mailFolders/{}/messages/delta",
+                                GRAPH_BASE, folder_id
+                            ))
+                            .query(&[("$select", DELTA_SELECT)]),
+                    };
+                    req.bearer_auth(&self.access_token)
+                        .header("Prefer", "odata.maxpagesize=200")
+                },
+                &what,
+            )
+            .await?;
+
+        let status = resp.status();
+        if status.as_u16() == 410 {
+            return Err(Error::Other(format!(
+                "{DELTA_RESYNC_MARKER} for folder {folder_id}"
+            )));
+        }
+        let body = resp.text().await.unwrap_or_default();
+        if !status.is_success() {
+            return Err(Error::Other(format!(
+                "Graph {} returned {}: {}",
+                what,
+                status,
+                truncate(&body, 500)
+            )));
+        }
+        let resp: serde_json::Value = serde_json::from_str(&body)
+            .map_err(|e| Error::Other(format!("Graph JSON parse failed: {}", e)))?;
+
+        let mut messages = Vec::new();
+        let mut removed_ids = Vec::new();
+        if let Some(values) = resp["value"].as_array() {
+            for m in values {
+                if m.get("@removed").is_some() {
+                    if let Some(id) = m["id"].as_str() {
+                        removed_ids.push(id.to_string());
+                    }
+                } else {
+                    messages.push(parse_graph_message(m));
+                }
+            }
+        }
+
+        Ok(GraphDeltaPage {
+            messages,
+            removed_ids,
+            next_link: resp["@odata.nextLink"].as_str().map(String::from),
+            delta_link: resp["@odata.deltaLink"].as_str().map(String::from),
+        })
     }
 
     /// Search messages across all folders using `$search` (KQL).
@@ -658,6 +831,75 @@ impl GraphClient {
     }
 
     /// Move a message to a different folder.
+    /// Move messages to a destination folder using JSON batching (20
+    /// sub-requests per round trip instead of one round trip per message).
+    /// Returns one outcome per input id, in order. Item-level failures
+    /// carry the sub-response status and body, so a stale id shows up as
+    /// `404 ... ErrorItemNotFound` exactly like the single-message call.
+    pub async fn move_messages_batch(
+        &self,
+        message_ids: &[String],
+        dest_folder_id: &str,
+    ) -> Result<Vec<Result<()>>> {
+        let mut results: Vec<Result<()>> = message_ids
+            .iter()
+            .map(|_| Err(Error::Other("no $batch response for item".into())))
+            .collect();
+
+        for (chunk_idx, chunk) in message_ids.chunks(BATCH_SIZE).enumerate() {
+            let base = chunk_idx * BATCH_SIZE;
+            let requests: Vec<serde_json::Value> = chunk
+                .iter()
+                .enumerate()
+                .map(|(i, id)| {
+                    serde_json::json!({
+                        "id": format!("{}", base + i),
+                        "method": "POST",
+                        "url": format!("/me/messages/{}/move", id),
+                        "headers": { "Content-Type": "application/json" },
+                        "body": { "destinationId": dest_folder_id }
+                    })
+                })
+                .collect();
+            let resp = self
+                .post_json("/$batch", &serde_json::json!({ "requests": requests }))
+                .await?;
+            apply_batch_responses(&resp, &mut results);
+        }
+
+        Ok(results)
+    }
+
+    /// Delete messages using JSON batching. Same contract as
+    /// [`Self::move_messages_batch`].
+    pub async fn delete_messages_batch(&self, message_ids: &[String]) -> Result<Vec<Result<()>>> {
+        let mut results: Vec<Result<()>> = message_ids
+            .iter()
+            .map(|_| Err(Error::Other("no $batch response for item".into())))
+            .collect();
+
+        for (chunk_idx, chunk) in message_ids.chunks(BATCH_SIZE).enumerate() {
+            let base = chunk_idx * BATCH_SIZE;
+            let requests: Vec<serde_json::Value> = chunk
+                .iter()
+                .enumerate()
+                .map(|(i, id)| {
+                    serde_json::json!({
+                        "id": format!("{}", base + i),
+                        "method": "DELETE",
+                        "url": format!("/me/messages/{}", id),
+                    })
+                })
+                .collect();
+            let resp = self
+                .post_json("/$batch", &serde_json::json!({ "requests": requests }))
+                .await?;
+            apply_batch_responses(&resp, &mut results);
+        }
+
+        Ok(results)
+    }
+
     pub async fn move_message(&self, message_id: &str, dest_folder_id: &str) -> Result<()> {
         let body = serde_json::json!({ "destinationId": dest_folder_id });
         self.post_json(&format!("/me/messages/{}/move", message_id), &body)
@@ -1320,6 +1562,30 @@ fn looks_like_smtp_address(s: &str) -> bool {
         Some((local, domain)) => !local.is_empty() && domain.contains('.'),
         None => false,
     }
+}
+
+/// One page of a Graph messages-delta response.
+#[derive(Debug, Clone)]
+pub struct GraphDeltaPage {
+    /// Created or updated messages (full selected properties).
+    pub messages: Vec<GraphMessage>,
+    /// Graph ids of messages removed from the folder (deleted or moved out).
+    pub removed_ids: Vec<String>,
+    /// More pages are available right now (`@odata.nextLink`).
+    pub next_link: Option<String>,
+    /// Checkpoint to store for the next sync cycle (`@odata.deltaLink`).
+    /// Present only on the final page of a round.
+    pub delta_link: Option<String>,
+}
+
+/// Marker embedded in the error for HTTP 410 on a delta call: the stored
+/// delta token expired server-side and the folder needs a full resync.
+const DELTA_RESYNC_MARKER: &str = "graph delta resync required";
+
+/// True if the error is a delta-state expiry (HTTP 410). The caller should
+/// clear the stored delta link and restart a full enumeration.
+pub fn is_delta_resync_required(err: &crate::error::Error) -> bool {
+    err.to_string().contains(DELTA_RESYNC_MARKER)
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -2075,6 +2341,10 @@ pub async fn get_graph_token_for_rooms(account_id: &str) -> Result<String> {
 }
 
 async fn get_graph_token_with_scopes(account_id: &str, scopes: &str) -> Result<String> {
+    // Dead refresh token (invalid_grant)? Fail fast without a network call
+    // until the user signs in again — see oauth::auth_required_on_invalid_grant.
+    crate::oauth::ensure_not_reauth_required(account_id)?;
+
     let tokens = crate::oauth::load_tokens(account_id)?.ok_or_else(|| {
         Error::Other("No O365 OAuth tokens. Please sign in with Microsoft.".into())
     })?;
@@ -2085,7 +2355,9 @@ async fn get_graph_token_with_scopes(account_id: &str, scopes: &str) -> Result<S
 
     // Always refresh with Graph scopes — the cached token is likely IMAP-scoped
     let new_tokens =
-        crate::oauth::refresh_with_scopes(&crate::oauth::MICROSOFT, &refresh_token, scopes).await?;
+        crate::oauth::refresh_with_scopes(&crate::oauth::MICROSOFT, &refresh_token, scopes)
+            .await
+            .map_err(|e| crate::oauth::auth_required_on_invalid_grant(account_id, e))?;
     // Don't overwrite the stored tokens — IMAP sync needs the IMAP-scoped token.
     // The refresh_token may rotate, so save that part only.
     if new_tokens.refresh_token.is_some() {
@@ -2100,6 +2372,75 @@ async fn get_graph_token_with_scopes(account_id: &str, scopes: &str) -> Result<S
     }
 
     Ok(new_tokens.access_token)
+}
+
+#[cfg(test)]
+mod batch_tests {
+    use super::{apply_batch_responses, is_delta_resync_required, DELTA_RESYNC_MARKER};
+    use crate::error::Error;
+
+    fn fresh_results(n: usize) -> Vec<crate::error::Result<()>> {
+        (0..n)
+            .map(|_| Err(Error::Other("no $batch response for item".into())))
+            .collect()
+    }
+
+    #[test]
+    fn batch_responses_map_out_of_order_by_id() {
+        let resp = serde_json::json!({
+            "responses": [
+                { "id": "1", "status": 204 },
+                { "id": "0", "status": 201 },
+            ]
+        });
+        let mut results = fresh_results(2);
+        apply_batch_responses(&resp, &mut results);
+        assert!(results[0].is_ok());
+        assert!(results[1].is_ok());
+    }
+
+    #[test]
+    fn batch_responses_keep_item_errors_detectable() {
+        let resp = serde_json::json!({
+            "responses": [
+                { "id": "0", "status": 201 },
+                {
+                    "id": "1",
+                    "status": 404,
+                    "body": { "error": { "code": "ErrorItemNotFound" } }
+                },
+            ]
+        });
+        let mut results = fresh_results(2);
+        apply_batch_responses(&resp, &mut results);
+        assert!(results[0].is_ok());
+        // The stale-id detection in commands::filters matches on "404" +
+        // "ErrorItemNotFound" appearing in the error text.
+        let err = results[1].as_ref().unwrap_err().to_string();
+        assert!(err.contains("404"), "missing status in: {err}");
+        assert!(err.contains("ErrorItemNotFound"), "missing code in: {err}");
+    }
+
+    #[test]
+    fn batch_responses_missing_item_stays_err() {
+        let resp = serde_json::json!({ "responses": [ { "id": "0", "status": 200 } ] });
+        let mut results = fresh_results(2);
+        apply_batch_responses(&resp, &mut results);
+        assert!(results[0].is_ok());
+        assert!(
+            results[1].is_err(),
+            "unanswered items must not report success"
+        );
+    }
+
+    #[test]
+    fn delta_resync_marker_is_detected() {
+        let err = Error::Other(format!("{DELTA_RESYNC_MARKER} for folder abc"));
+        assert!(is_delta_resync_required(&err));
+        assert!(!is_delta_resync_required(&Error::Other(
+            "Graph GET x returned 429".into()
+        )));
+    }
 }
 
 #[cfg(test)]

--- a/src-tauri/src/mail/jmap_sync.rs
+++ b/src-tauri/src/mail/jmap_sync.rs
@@ -442,11 +442,11 @@ async fn sync_jmap_folder(
         )
         .await
         {
-            Ok(filtered) => {
-                if filtered > 0 {
+            Ok(outcome) => {
+                if outcome.affected > 0 {
                     log::info!(
                         "JMAP filters matched {} of {} new messages in '{}'",
-                        filtered,
+                        outcome.affected,
                         new_ids.len(),
                         folder_name
                     );

--- a/src-tauri/src/oauth.rs
+++ b/src-tauri/src/oauth.rs
@@ -1288,27 +1288,42 @@ pub fn ensure_not_reauth_required(account_id: &str) -> Result<()> {
     Ok(())
 }
 
-/// Inspect a token-refresh error: on `invalid_grant` mark the account as
-/// requiring re-authentication and convert the error into
+/// Inspect a token-refresh error: on a terminal `invalid_grant` mark the
+/// account as requiring re-authentication and convert the error into
 /// [`Error::AuthRequired`] so callers stop retrying. Other errors (network,
 /// keyring, throttling) pass through unchanged and stay retryable.
+///
+/// Microsoft also encodes *scope-consent* failures as `invalid_grant`
+/// (AADSTS65001 / `"suberror":"consent_required"`) — e.g. the optional
+/// room-scope refresh (`Place.Read.All`) on an account that never
+/// consented to it. Those mean "this scope needs consent", not "the
+/// refresh token is dead": the same token keeps working for the baseline
+/// scopes, so latching them would let a room-suggestion click take down
+/// mail/calendar/contacts sync until the user signs in again.
 pub fn auth_required_on_invalid_grant(account_id: &str, err: Error) -> Error {
-    if err.to_string().contains("invalid_grant") {
-        log::warn!(
-            "OAuth2: refresh token rejected (invalid_grant) for account {}; re-authentication required",
+    let msg = err.to_string();
+    if !msg.contains("invalid_grant") {
+        return err;
+    }
+    if msg.contains("consent_required") || msg.contains("AADSTS65001") {
+        log::info!(
+            "OAuth2: refresh for account {} needs additional scope consent (not latching re-auth)",
             account_id
         );
-        reauth_registry()
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
-            .insert(account_id.to_string());
-        Error::AuthRequired(format!(
-            "Sign-in expired for account {}. Open Settings and sign in again.",
-            account_id
-        ))
-    } else {
-        err
+        return err;
     }
+    log::warn!(
+        "OAuth2: refresh token rejected (invalid_grant) for account {}; re-authentication required",
+        account_id
+    );
+    reauth_registry()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .insert(account_id.to_string());
+    Error::AuthRequired(format!(
+        "Sign-in expired for account {}. Open Settings and sign in again.",
+        account_id
+    ))
 }
 
 fn clear_reauth_required(account_id: &str) {
@@ -1450,6 +1465,60 @@ pub fn delete_tokens(account_id: &str) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn is_flagged(account_id: &str) -> bool {
+        reauth_registry()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .contains(account_id)
+    }
+
+    /// A terminal invalid_grant (dead refresh token, e.g. AADSTS70043)
+    /// latches the re-auth flag and converts to AuthRequired.
+    #[test]
+    fn invalid_grant_latches_reauth() {
+        let acc = "test-latch-terminal";
+        let err = Error::Other(
+            "Token refresh error: {\"error\":\"invalid_grant\",\
+             \"error_description\":\"AADSTS70043: The refresh token has expired\",\
+             \"suberror\":\"token_expired\"}"
+                .into(),
+        );
+        let out = auth_required_on_invalid_grant(acc, err);
+        assert!(matches!(out, Error::AuthRequired(_)));
+        assert!(is_flagged(acc));
+        assert!(ensure_not_reauth_required(acc).is_err());
+        clear_reauth_required(acc);
+    }
+
+    /// A scope-consent failure (AADSTS65001 / consent_required) is also
+    /// encoded as invalid_grant by Microsoft, but the refresh token is
+    /// still good for baseline scopes — it must NOT latch, or a room
+    /// lookup on a pre-room-consent account would kill mail sync.
+    #[test]
+    fn consent_required_does_not_latch_reauth() {
+        let acc = "test-latch-consent";
+        let err = Error::Other(
+            "Token refresh error: {\"error\":\"invalid_grant\",\
+             \"error_description\":\"AADSTS65001: The user or administrator has not \
+             consented to use the application\",\"suberror\":\"consent_required\"}"
+                .into(),
+        );
+        let out = auth_required_on_invalid_grant(acc, err);
+        assert!(!matches!(out, Error::AuthRequired(_)));
+        assert!(!is_flagged(acc));
+        assert!(ensure_not_reauth_required(acc).is_ok());
+    }
+
+    /// Unrelated errors (network, throttling) pass through untouched.
+    #[test]
+    fn other_errors_do_not_latch_reauth() {
+        let acc = "test-latch-other";
+        let out =
+            auth_required_on_invalid_grant(acc, Error::Other("Token refresh failed: 503".into()));
+        assert!(!matches!(out, Error::AuthRequired(_)));
+        assert!(!is_flagged(acc));
+    }
 
     #[test]
     fn test_pkce_verifier_is_valid_length() {

--- a/src-tauri/src/oauth.rs
+++ b/src-tauri/src/oauth.rs
@@ -1293,23 +1293,14 @@ pub fn ensure_not_reauth_required(account_id: &str) -> Result<()> {
 /// [`Error::AuthRequired`] so callers stop retrying. Other errors (network,
 /// keyring, throttling) pass through unchanged and stay retryable.
 ///
-/// Microsoft also encodes *scope-consent* failures as `invalid_grant`
-/// (AADSTS65001 / `"suberror":"consent_required"`) — e.g. the optional
-/// room-scope refresh (`Place.Read.All`) on an account that never
-/// consented to it. Those mean "this scope needs consent", not "the
-/// refresh token is dead": the same token keeps working for the baseline
-/// scopes, so latching them would let a room-suggestion click take down
-/// mail/calendar/contacts sync until the user signs in again.
+/// Baseline Microsoft refreshes also encode scope-consent failures as
+/// `invalid_grant` (AADSTS65001 / `"suberror":"consent_required"`). Those
+/// still need user action and should latch here so periodic sync does not
+/// keep retrying the same rejected refresh. Optional scope probes, such as
+/// room lookup, bypass this helper instead of calling it.
 pub fn auth_required_on_invalid_grant(account_id: &str, err: Error) -> Error {
     let msg = err.to_string();
     if !msg.contains("invalid_grant") {
-        return err;
-    }
-    if msg.contains("consent_required") || msg.contains("AADSTS65001") {
-        log::info!(
-            "OAuth2: refresh for account {} needs additional scope consent (not latching re-auth)",
-            account_id
-        );
         return err;
     }
     log::warn!(
@@ -1491,12 +1482,11 @@ mod tests {
         clear_reauth_required(acc);
     }
 
-    /// A scope-consent failure (AADSTS65001 / consent_required) is also
-    /// encoded as invalid_grant by Microsoft, but the refresh token is
-    /// still good for baseline scopes — it must NOT latch, or a room
-    /// lookup on a pre-room-consent account would kill mail sync.
+    /// Baseline scope-consent failures (AADSTS65001 / consent_required)
+    /// are invalid_grant responses too and need user action. Optional
+    /// room-scope probes avoid latching by not calling this helper.
     #[test]
-    fn consent_required_does_not_latch_reauth() {
+    fn consent_required_latches_reauth_for_baseline_refresh() {
         let acc = "test-latch-consent";
         let err = Error::Other(
             "Token refresh error: {\"error\":\"invalid_grant\",\
@@ -1505,9 +1495,10 @@ mod tests {
                 .into(),
         );
         let out = auth_required_on_invalid_grant(acc, err);
-        assert!(!matches!(out, Error::AuthRequired(_)));
-        assert!(!is_flagged(acc));
-        assert!(ensure_not_reauth_required(acc).is_ok());
+        assert!(matches!(out, Error::AuthRequired(_)));
+        assert!(is_flagged(acc));
+        assert!(ensure_not_reauth_required(acc).is_err());
+        clear_reauth_required(acc);
     }
 
     /// Unrelated errors (network, throttling) pass through untouched.

--- a/src-tauri/src/oauth.rs
+++ b/src-tauri/src/oauth.rs
@@ -1258,7 +1258,70 @@ pub fn init_token_store(_data_dir: &std::path::Path) -> std::io::Result<()> {
     Ok(())
 }
 
+/// Accounts whose refresh token was rejected with `invalid_grant`.
+///
+/// Once a refresh token is dead (expired, revoked, or past a
+/// conditional-access lifetime cap like AADSTS70043), every refresh attempt
+/// fails the same way — but the periodic sync retried it every cycle,
+/// hammering the token endpoint and burying the real problem in log noise.
+/// This registry lets token getters fail fast until the user signs in
+/// again; a successful `store_tokens` clears the flag.
+static REAUTH_REQUIRED: std::sync::OnceLock<std::sync::Mutex<std::collections::HashSet<String>>> =
+    std::sync::OnceLock::new();
+
+fn reauth_registry() -> &'static std::sync::Mutex<std::collections::HashSet<String>> {
+    REAUTH_REQUIRED.get_or_init(|| std::sync::Mutex::new(std::collections::HashSet::new()))
+}
+
+/// Fail fast if the account is already known to need re-authentication.
+pub fn ensure_not_reauth_required(account_id: &str) -> Result<()> {
+    let flagged = reauth_registry()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .contains(account_id);
+    if flagged {
+        return Err(Error::AuthRequired(format!(
+            "Sign-in expired for account {}. Open Settings and sign in again.",
+            account_id
+        )));
+    }
+    Ok(())
+}
+
+/// Inspect a token-refresh error: on `invalid_grant` mark the account as
+/// requiring re-authentication and convert the error into
+/// [`Error::AuthRequired`] so callers stop retrying. Other errors (network,
+/// keyring, throttling) pass through unchanged and stay retryable.
+pub fn auth_required_on_invalid_grant(account_id: &str, err: Error) -> Error {
+    if err.to_string().contains("invalid_grant") {
+        log::warn!(
+            "OAuth2: refresh token rejected (invalid_grant) for account {}; re-authentication required",
+            account_id
+        );
+        reauth_registry()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .insert(account_id.to_string());
+        Error::AuthRequired(format!(
+            "Sign-in expired for account {}. Open Settings and sign in again.",
+            account_id
+        ))
+    } else {
+        err
+    }
+}
+
+fn clear_reauth_required(account_id: &str) {
+    reauth_registry()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .remove(account_id);
+}
+
 pub fn store_tokens(account_id: &str, tokens: &OAuthTokens) -> Result<()> {
+    // Fresh tokens (sign-in or successful refresh) mean the account no
+    // longer needs re-authentication.
+    clear_reauth_required(account_id);
     #[cfg(target_os = "android")]
     {
         android_store::store(account_id, tokens)?;

--- a/src-tauri/src/oauth.rs
+++ b/src-tauri/src/oauth.rs
@@ -1319,9 +1319,6 @@ fn clear_reauth_required(account_id: &str) {
 }
 
 pub fn store_tokens(account_id: &str, tokens: &OAuthTokens) -> Result<()> {
-    // Fresh tokens (sign-in or successful refresh) mean the account no
-    // longer needs re-authentication.
-    clear_reauth_required(account_id);
     #[cfg(target_os = "android")]
     {
         android_store::store(account_id, tokens)?;
@@ -1329,10 +1326,21 @@ pub fn store_tokens(account_id: &str, tokens: &OAuthTokens) -> Result<()> {
             "OAuth2: tokens stored in file store for account {}",
             account_id
         );
+        // Fresh tokens (sign-in or successful refresh) mean the account no
+        // longer needs re-authentication. Cleared only after persistence
+        // succeeded — clearing on a failed store would re-open the refresh
+        // retry loop with the old, rejected token still in place.
+        clear_reauth_required(account_id);
         return Ok(());
     }
     #[cfg(not(target_os = "android"))]
-    store_tokens_keyring(account_id, tokens)
+    {
+        store_tokens_keyring(account_id, tokens)?;
+        // See the android branch above: only a persisted fresh token set
+        // clears the re-auth flag.
+        clear_reauth_required(account_id);
+        Ok(())
+    }
 }
 
 #[cfg(not(target_os = "android"))]

--- a/src/views/MailView.vue
+++ b/src/views/MailView.vue
@@ -242,17 +242,25 @@ let syncIntervalId: ReturnType<typeof setInterval> | null = null;
 
 async function periodicSync() {
   // Skip calendar-/contacts-only accounts (mail_protocol === "" via #43).
-  for (const account of accountsStore.mailAccounts) {
-    if (!account.enabled) continue;
-    try {
-      await api.triggerSync(
-        account.id,
-        foldersStore.activeFolderPath ?? undefined,
-      );
-    } catch (e) {
-      console.error("Periodic sync error:", e);
-    }
-  }
+  // Accounts sync concurrently — the backend serializes per account via
+  // its sync guard, but one slow account (a large JMAP delta round, an
+  // O365 Graph cycle) must not delay the others' start. The active folder
+  // is a priority hint that only makes sense for the account it belongs to.
+  const enabled = accountsStore.mailAccounts.filter((a) => a.enabled);
+  await Promise.allSettled(
+    enabled.map(async (account) => {
+      try {
+        await api.triggerSync(
+          account.id,
+          accountsStore.activeAccountId === account.id
+            ? (foldersStore.activeFolderPath ?? undefined)
+            : undefined,
+        );
+      } catch (e) {
+        console.error("Periodic sync error:", e);
+      }
+    }),
+  );
 }
 
 onMounted(async () => {


### PR DESCRIPTION
Diagnosed from a production log (chithi.log): the same 200 messages in 'oauth-wg' were re-downloaded and re-moved every 2-minute cycle for weeks, wiping the folder's local rows each time, while a dead refresh token and a misrouted IMAP prefetch added a steady error loop.

Phase 8 (stop the bleeding):
- Filter engine now drops Move/Copy actions whose target equals the message's current folder. On Graph a same-folder move mints a new message id, so sync saw the messages as new again and re-ran the same filter forever, pruning local rows every cycle. Regression tests added.
- New Error::AuthRequired plus a per-account reauth registry in oauth. Once Microsoft rejects a refresh with invalid_grant (e.g. AADSTS70043, 30-day conditional-access cap), the Graph token getter and the O365 IMAP credential path fail fast without network calls until the user signs in again. A successful token store clears the flag.
- prefetch_pipeline skips accounts with no IMAP host, ending the doomed ":993" connects and keyring reads after every Graph sync.

Phase 9 (Graph incremental sync):
- Per-folder /messages/delta with a persisted graph_delta_link column (schema migration + db::folders helpers). Steady-state sync is about one request per folder; delta reports creations, flag changes, and removals, so web-side deletes/moves/read-state finally reconcile and the permanent 200-message-per-folder cap is gone. Rounds are capped at 25 pages x 200 per folder per cycle and resume from the persisted nextLink; HTTP 410 clears the link for a full resync.
- Envelope-only sync: full MIME download removed from the sync loop; bodies come from the existing on-demand fetch and prefetch paths. The expensive internetMessageHeaders/$count selects and the per-sync thread-id backfill UPDATE loop are removed.
- Central send_with_retry in GraphClient honors Retry-After on 429/503/ 504 for all request helpers. The folder loop logs and continues on per-folder errors instead of aborting the whole account sync.
- Folder discovery is now a recursive breadth-first walk with pagination at every level. The old code fetched one level of children with no paging (Graph default page size 10), so nested or 11th-child folders never appeared locally.

Phase 10 (throughput and fairness):
- Graph filter moves/deletes use /$batch (20 sub-requests per round trip) with per-item status mapping; stale 404 ErrorItemNotFound rows are still pruned individually. Tests added.
- periodicSync fires per-account syncs concurrently and passes the active-folder hint only to the account it belongs to, so a large JMAP account no longer delays the O365 sync every cycle.
- True per-folder sync: right-clicking "sync" on a folder now delta- syncs exactly that folder synchronously and stops. The folder_sync_backgrounds escape hatch (which silently escalated Graph folder syncs to background whole-account syncs) is removed from the MailBackend trait and the sync_folder command. The Graph account sync also gained IMAP/JMAP-style priority ordering (current folder, then Inbox, then the rest).