### PR TITLE
Harden IMAP sync safety and Exchange receive handling

### DIFF
--- a/src-tauri/src/backend/mail/imap.rs
+++ b/src-tauri/src/backend/mail/imap.rs
@@ -187,16 +187,17 @@ pub(super) async fn prefetch_pipeline(ctx: &MailSyncCtx, account: &AccountFull) 
                                     let relative_path =
                                         format!("{}/{}/cur/{}", account_id, sanitized, filename);
                                     db_updates.push((message_id.clone(), relative_path));
-                                    count += 1;
                                 }
 
                                 if !db_updates.is_empty() {
+                                    let saved = db_updates.len() as u32;
                                     let conn = rt.block_on(db.writer());
-                                    conn.execute_batch("BEGIN").ok();
+                                    let tx = conn.unchecked_transaction()?;
                                     for (msg_id, path) in &db_updates {
-                                        db::messages::update_maildir_path(&conn, msg_id, path).ok();
+                                        db::messages::update_maildir_path(&tx, msg_id, path)?;
                                     }
-                                    conn.execute_batch("COMMIT").ok();
+                                    tx.commit()?;
+                                    count += saved;
                                     log::info!(
                                         "Prefetch[{}]: saved {} bodies in '{}'",
                                         thread_idx,

--- a/src-tauri/src/backend/mail/imap.rs
+++ b/src-tauri/src/backend/mail/imap.rs
@@ -223,7 +223,24 @@ pub(super) async fn prefetch_pipeline(ctx: &MailSyncCtx, account: &AccountFull) 
                 .collect()
         });
 
-        let total: u32 = results.into_iter().flatten().sum();
+        let mut total = 0u32;
+        let mut first_error: Option<Error> = None;
+        for result in results {
+            match result {
+                Ok(count) => total += count,
+                Err(e) => {
+                    log::error!("Prefetch worker failed for account {}: {}", account_id, e);
+                    if first_error.is_none() {
+                        first_error = Some(e);
+                    }
+                }
+            }
+        }
+
+        if let Some(e) = first_error {
+            return Err(e);
+        }
+
         log::info!(
             "Prefetch: completed for account {}, {} bodies fetched",
             account_id,

--- a/src-tauri/src/commands/compose.rs
+++ b/src-tauri/src/commands/compose.rs
@@ -136,7 +136,7 @@ pub async fn send_message(
     // pattern as the existing encrypt-to-self fallback in
     // apply_pgp_envelope.
     if message.pgp_sign && account.pgp_attach_pubkey_on_sign {
-        if let Some(att) = build_signer_pubkey_attachment(&state, &account.email) {
+        if let Some(att) = build_signer_pubkey_attachment(&state, &account.email).await {
             attachment_data.push(att);
         }
     }
@@ -204,7 +204,7 @@ pub async fn send_message(
     // silently when the sender has no usable key in the keystore — the
     // header is an enhancement, not a guarantee.
     let raw_message = if account.pgp_autocrypt_header {
-        match build_autocrypt_header(&state, &account.email) {
+        match build_autocrypt_header(&state, &account.email).await {
             Some(header_line) => smtp::insert_header_before_body(&raw_message, &header_line),
             None => raw_message,
         }
@@ -990,7 +990,7 @@ async fn apply_pgp_envelope(
             .filter(|s| !s.trim().is_empty())
             .cloned()
             .collect();
-        if has_resolvable_public_key(&store, &account.email) {
+        if has_resolvable_public_key(&store, &account.email).await {
             if !recipients_contain(&visible_recipients, &account.email)
                 && !recipients_contain(&hidden_recipients, &account.email)
             {
@@ -1162,13 +1162,19 @@ fn recipients_contain(list: &[String], email: &str) -> bool {
 /// convention matches Thunderbird and Enigmail: `OpenPGP_0x<long-keyid>.asc`
 /// where `<long-keyid>` is the last 16 hex chars of the fingerprint, so
 /// receiving MUAs that file attached keys by name don't collide.
-fn build_signer_pubkey_attachment(
+async fn build_signer_pubkey_attachment(
     state: &State<'_, AppState>,
     sender_email: &str,
 ) -> Option<smtp::AttachmentData> {
     let store = state.pgp_store().ok()?;
-    let guard = store.lock().expect("pgp keystore mutex poisoned");
-    signer_pubkey_attachment_from_store(&guard, sender_email)
+    let sender_email = sender_email.to_string();
+    tokio::task::spawn_blocking(move || {
+        let guard = store.lock().expect("pgp keystore mutex poisoned");
+        signer_pubkey_attachment_from_store(&guard, &sender_email)
+    })
+    .await
+    .ok()
+    .flatten()
 }
 
 /// Pure helper extracted out of `build_signer_pubkey_attachment` so the
@@ -1214,21 +1220,28 @@ fn signer_pubkey_attachment_from_store(
 /// `smtp::format_autocrypt_header`. The returned string is the header
 /// line WITHOUT a trailing CRLF — `insert_header_before_body` adds the
 /// framing.
-fn build_autocrypt_header(state: &State<'_, AppState>, sender_email: &str) -> Option<String> {
+async fn build_autocrypt_header(state: &State<'_, AppState>, sender_email: &str) -> Option<String> {
     let store = state.pgp_store().ok()?;
-    let guard = store.lock().expect("pgp keystore mutex poisoned");
-    let (_signer_data, signer_info) = libtumpa::store::resolve_signer(&guard, sender_email).ok()?;
-    let addr = extract_addr_spec(sender_email);
-    match libtumpa::key::export_public_for_autocrypt(&guard, &signer_info.fingerprint, &addr) {
-        Ok(keydata) => Some(smtp::format_autocrypt_header(&addr, &keydata)),
-        Err(e) => {
-            log::debug!(
-                "openpgp: no Autocrypt header for {} — export_public_for_autocrypt failed: {e}",
-                sender_email
-            );
-            None
+    let sender_email = sender_email.to_string();
+    tokio::task::spawn_blocking(move || {
+        let guard = store.lock().expect("pgp keystore mutex poisoned");
+        let (_signer_data, signer_info) =
+            libtumpa::store::resolve_signer(&guard, &sender_email).ok()?;
+        let addr = extract_addr_spec(&sender_email);
+        match libtumpa::key::export_public_for_autocrypt(&guard, &signer_info.fingerprint, &addr) {
+            Ok(keydata) => Some(smtp::format_autocrypt_header(&addr, &keydata)),
+            Err(e) => {
+                log::debug!(
+                    "openpgp: no Autocrypt header for {} — export_public_for_autocrypt failed: {e}",
+                    sender_email
+                );
+                None
+            }
         }
-    }
+    })
+    .await
+    .ok()
+    .flatten()
 }
 
 /// Encrypt a draft `raw_message` to the sender's own public key, in the
@@ -1248,8 +1261,7 @@ async fn encrypt_draft_to_self(
     raw_message: &[u8],
 ) -> Option<Vec<u8>> {
     let store = state.pgp_store().ok()?;
-    // Cheap precheck so we don't spawn a blocking task just to fail.
-    if !has_resolvable_public_key(&store, sender_email) {
+    if !has_resolvable_public_key(&store, sender_email).await {
         log::warn!(
             "openpgp: encrypt-drafts is on but no usable public key for {} — \
              saving plaintext draft",
@@ -1299,15 +1311,21 @@ fn encrypt_draft_core(
 /// true iff `resolve_recipient` returns Ok AND the key passes
 /// `ensure_key_usable_for_encryption`. Used as a precheck for the
 /// encrypt-to-self addition so we can skip it instead of failing the send.
-fn has_resolvable_public_key(
+async fn has_resolvable_public_key(
     store: &std::sync::Arc<std::sync::Mutex<libtumpa::KeyStore>>,
     id: &str,
 ) -> bool {
-    let guard = store.lock().expect("pgp keystore mutex poisoned");
-    match libtumpa::store::resolve_recipient(&guard, id) {
-        Ok((_data, info)) => libtumpa::store::ensure_key_usable_for_encryption(&info).is_ok(),
-        Err(_) => false,
-    }
+    let store = store.clone();
+    let id = id.to_string();
+    tokio::task::spawn_blocking(move || {
+        let guard = store.lock().expect("pgp keystore mutex poisoned");
+        match libtumpa::store::resolve_recipient(&guard, &id) {
+            Ok((_data, info)) => libtumpa::store::ensure_key_usable_for_encryption(&info).is_ok(),
+            Err(_) => false,
+        }
+    })
+    .await
+    .unwrap_or(false)
 }
 
 /// Strip a display name to just the addr-spec ("Alice <a@x>" -> "a@x").

--- a/src-tauri/src/commands/pgp.rs
+++ b/src-tauri/src/commands/pgp.rs
@@ -157,27 +157,35 @@ fn summary_to_dto(s: KeySummary, card_idents: Vec<String>) -> PgpKeySummary {
 #[tauri::command]
 pub async fn pgp_list_keys(state: State<'_, AppState>) -> Result<Vec<PgpKeySummary>> {
     let store = state.pgp_store().map_err(lt_err)?;
-    let guard = store.lock().expect("pgp keystore mutex poisoned");
-    let summaries = guard.list_keys_summary().map_err(|e| lt_err(e.into()))?;
-    let links = card_link::card_idents_map(&guard).map_err(lt_err)?;
-    Ok(summaries
-        .into_iter()
-        .map(|s| {
-            let idents = links.get(&s.fingerprint).cloned().unwrap_or_default();
-            summary_to_dto(s, idents)
-        })
-        .collect())
+    tokio::task::spawn_blocking(move || {
+        let guard = store.lock().expect("pgp keystore mutex poisoned");
+        let summaries = guard.list_keys_summary().map_err(|e| lt_err(e.into()))?;
+        let links = card_link::card_idents_map(&guard).map_err(lt_err)?;
+        Ok(summaries
+            .into_iter()
+            .map(|s| {
+                let idents = links.get(&s.fingerprint).cloned().unwrap_or_default();
+                summary_to_dto(s, idents)
+            })
+            .collect())
+    })
+    .await
+    .map_err(|e| Error::Other(format!("key list task join failed: {e}")))?
 }
 
 #[tauri::command]
 pub async fn pgp_get_key(state: State<'_, AppState>, fingerprint: String) -> Result<PgpKeySummary> {
     let store = state.pgp_store().map_err(lt_err)?;
-    let guard = store.lock().expect("pgp keystore mutex poisoned");
-    let summary = guard
-        .get_key_summary(&fingerprint)
-        .map_err(|e| lt_err(e.into()))?;
-    let idents = card_link::card_idents_for_key(&guard, &fingerprint).map_err(lt_err)?;
-    Ok(summary_to_dto(summary, idents))
+    tokio::task::spawn_blocking(move || {
+        let guard = store.lock().expect("pgp keystore mutex poisoned");
+        let summary = guard
+            .get_key_summary(&fingerprint)
+            .map_err(|e| lt_err(e.into()))?;
+        let idents = card_link::card_idents_for_key(&guard, &fingerprint).map_err(lt_err)?;
+        Ok(summary_to_dto(summary, idents))
+    })
+    .await
+    .map_err(|e| Error::Other(format!("key get task join failed: {e}")))?
 }
 
 // ---------------------------------------------------------------------------
@@ -187,12 +195,16 @@ pub async fn pgp_get_key(state: State<'_, AppState>, fingerprint: String) -> Res
 #[tauri::command]
 pub async fn pgp_import_key(state: State<'_, AppState>, data: Vec<u8>) -> Result<PgpImportResult> {
     let store = state.pgp_store().map_err(lt_err)?;
-    let guard = store.lock().expect("pgp keystore mutex poisoned");
-    let info = key::import_any(&guard, &data).map_err(lt_err)?;
-    Ok(PgpImportResult {
-        fingerprint: info.fingerprint,
-        is_secret: info.is_secret,
+    tokio::task::spawn_blocking(move || {
+        let guard = store.lock().expect("pgp keystore mutex poisoned");
+        let info = key::import_any(&guard, &data).map_err(lt_err)?;
+        Ok(PgpImportResult {
+            fingerprint: info.fingerprint,
+            is_secret: info.is_secret,
+        })
     })
+    .await
+    .map_err(|e| Error::Other(format!("key import task join failed: {e}")))?
 }
 
 /// Open the native file picker, read the chosen file, and import it.
@@ -222,27 +234,39 @@ pub async fn pgp_pick_and_import_key(
         .ok_or_else(|| Error::Other("picked path was not on local filesystem".into()))?;
     let bytes = std::fs::read(path)?;
     let store = state.pgp_store().map_err(lt_err)?;
-    let guard = store.lock().expect("pgp keystore mutex poisoned");
-    let info = key::import_any(&guard, &bytes).map_err(lt_err)?;
-    Ok(Some(PgpImportResult {
-        fingerprint: info.fingerprint,
-        is_secret: info.is_secret,
-    }))
+    let result = tokio::task::spawn_blocking(move || -> Result<PgpImportResult> {
+        let guard = store.lock().expect("pgp keystore mutex poisoned");
+        let info = key::import_any(&guard, &bytes).map_err(lt_err)?;
+        Ok(PgpImportResult {
+            fingerprint: info.fingerprint,
+            is_secret: info.is_secret,
+        })
+    })
+    .await
+    .map_err(|e| Error::Other(format!("key import task join failed: {e}")))??;
+    Ok(Some(result))
 }
 
 #[tauri::command]
 pub async fn pgp_delete_key(state: State<'_, AppState>, fingerprint: String) -> Result<()> {
     let store = state.pgp_store().map_err(lt_err)?;
-    let guard = store.lock().expect("pgp keystore mutex poisoned");
-    key::delete(&guard, &fingerprint).map_err(lt_err)?;
-    Ok(())
+    tokio::task::spawn_blocking(move || {
+        let guard = store.lock().expect("pgp keystore mutex poisoned");
+        key::delete(&guard, &fingerprint).map_err(lt_err)
+    })
+    .await
+    .map_err(|e| Error::Other(format!("key delete task join failed: {e}")))?
 }
 
 #[tauri::command]
 pub async fn pgp_export_public(state: State<'_, AppState>, fingerprint: String) -> Result<String> {
     let store = state.pgp_store().map_err(lt_err)?;
-    let guard = store.lock().expect("pgp keystore mutex poisoned");
-    key::export_public_armored(&guard, &fingerprint).map_err(lt_err)
+    tokio::task::spawn_blocking(move || {
+        let guard = store.lock().expect("pgp keystore mutex poisoned");
+        key::export_public_armored(&guard, &fingerprint).map_err(lt_err)
+    })
+    .await
+    .map_err(|e| Error::Other(format!("key export task join failed: {e}")))?
 }
 
 // ---------------------------------------------------------------------------

--- a/src-tauri/src/commands/sync_cmd.rs
+++ b/src-tauri/src/commands/sync_cmd.rs
@@ -368,13 +368,23 @@ pub async fn prefetch_bodies(
         db: state.db.clone(),
         data_dir: state.data_dir.clone(),
     };
-    // Errors propagate without resuming IDLE, matching the pre-trait
-    // flow (only the success and nothing-to-do paths resume).
-    let fetched_count = backend.prefetch_bodies(&ctx, &account).await?;
+    let prefetch_result = backend.prefetch_bodies(&ctx, &account).await;
+    let resume_result =
+        resume_imap_idle_for_account(&app, &state, &resume_account, suspended_idle).await;
 
-    resume_imap_idle_for_account(&app, &state, &resume_account, suspended_idle).await?;
-
-    Ok(fetched_count)
+    match (prefetch_result, resume_result) {
+        (Ok(fetched_count), Ok(())) => Ok(fetched_count),
+        (Ok(_), Err(e)) => Err(e),
+        (Err(prefetch_error), Ok(())) => Err(prefetch_error),
+        (Err(prefetch_error), Err(resume_error)) => {
+            log::error!(
+                "Failed to resume IMAP IDLE after prefetch error for account {}: {}",
+                account_id,
+                resume_error
+            );
+            Err(prefetch_error)
+        }
+    }
 }
 
 /// Start IMAP IDLE and JMAP push for all enabled accounts. Call on app startup.
@@ -531,27 +541,93 @@ async fn start_jmap_push(
 /// Stop all IMAP IDLE loops and JMAP push tasks.
 #[tauri::command]
 pub async fn stop_idle(state: State<'_, AppState>) -> Result<()> {
-    // Stop IMAP IDLE threads
-    let mut handles = state.idle_handles.lock().unwrap();
-    for (account_id, handle) in handles.drain() {
-        log::info!("Stopping IDLE loop for account {}", account_id);
-        handle
-            .stop_flag
-            .store(true, std::sync::atomic::Ordering::Relaxed);
-        if let Some(thread) = handle.thread {
-            drop(thread);
+    let idle_threads = {
+        let mut handles = state.idle_handles.lock().unwrap();
+        let mut threads = Vec::new();
+        for (account_id, mut handle) in handles.drain() {
+            log::info!("Stopping IDLE loop for account {}", account_id);
+            handle
+                .stop_flag
+                .store(true, std::sync::atomic::Ordering::Relaxed);
+            if let Some(thread) = handle.thread.take() {
+                threads.push((account_id, thread));
+            }
+        }
+        threads
+    };
+
+    let mut stop_error: Option<Error> = None;
+    for (account_id, thread) in idle_threads {
+        match tokio::task::spawn_blocking(move || thread.join()).await {
+            Ok(Ok(())) => {}
+            Ok(Err(_)) => {
+                let msg = format!("IDLE loop for account {} panicked during stop", account_id);
+                log::error!("{}", msg);
+                stop_error.get_or_insert_with(|| Error::Sync(msg));
+            }
+            Err(e) => {
+                let msg = format!(
+                    "Stopping IDLE loop for account {} panicked: {}",
+                    account_id, e
+                );
+                log::error!("{}", msg);
+                stop_error.get_or_insert_with(|| Error::Sync(msg));
+            }
         }
     }
-    drop(handles);
 
-    // Stop JMAP push tasks
-    let mut jmap_handles = state.jmap_push_handles.lock().unwrap();
-    for (account_id, handle) in jmap_handles.drain() {
-        log::info!("Stopping JMAP push for account {}", account_id);
-        handle
-            .stop_flag
-            .store(true, std::sync::atomic::Ordering::Relaxed);
-        handle.task.abort();
+    let jmap_tasks = {
+        let mut jmap_handles = state.jmap_push_handles.lock().unwrap();
+        let mut tasks = Vec::new();
+        for (account_id, handle) in jmap_handles.drain() {
+            log::info!("Stopping JMAP push for account {}", account_id);
+            handle
+                .stop_flag
+                .store(true, std::sync::atomic::Ordering::Relaxed);
+            tasks.push((account_id, handle.task));
+        }
+        tasks
+    };
+
+    for (account_id, mut task) in jmap_tasks {
+        match tokio::time::timeout(std::time::Duration::from_secs(5), &mut task).await {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) if e.is_cancelled() => {
+                log::debug!(
+                    "JMAP push task for account {} was already cancelled",
+                    account_id
+                );
+            }
+            Ok(Err(e)) => {
+                let msg = format!(
+                    "JMAP push task for account {} failed during stop: {}",
+                    account_id, e
+                );
+                log::error!("{}", msg);
+                stop_error.get_or_insert_with(|| Error::Sync(msg));
+            }
+            Err(_) => {
+                log::warn!(
+                    "JMAP push task for account {} did not stop gracefully; aborting",
+                    account_id
+                );
+                task.abort();
+                if let Err(e) = task.await {
+                    if !e.is_cancelled() {
+                        let msg = format!(
+                            "JMAP push task for account {} failed after abort: {}",
+                            account_id, e
+                        );
+                        log::error!("{}", msg);
+                        stop_error.get_or_insert_with(|| Error::Sync(msg));
+                    }
+                }
+            }
+        }
+    }
+
+    if let Some(error) = stop_error {
+        return Err(error);
     }
 
     Ok(())

--- a/src-tauri/src/commands/sync_cmd.rs
+++ b/src-tauri/src/commands/sync_cmd.rs
@@ -546,9 +546,7 @@ pub async fn stop_idle(state: State<'_, AppState>) -> Result<()> {
         let mut threads = Vec::new();
         for (account_id, mut handle) in handles.drain() {
             log::info!("Stopping IDLE loop for account {}", account_id);
-            handle
-                .stop_flag
-                .store(true, std::sync::atomic::Ordering::Relaxed);
+            handle.stop_flag.store(true, Ordering::Relaxed);
             if let Some(thread) = handle.thread.take() {
                 threads.push((account_id, thread));
             }
@@ -556,38 +554,18 @@ pub async fn stop_idle(state: State<'_, AppState>) -> Result<()> {
         threads
     };
 
-    let mut stop_error: Option<Error> = None;
-    for (account_id, thread) in idle_threads {
-        match tokio::task::spawn_blocking(move || thread.join()).await {
-            Ok(Ok(())) => {}
-            Ok(Err(_)) => {
-                let msg = format!("IDLE loop for account {} panicked during stop", account_id);
-                log::error!("{}", msg);
-                stop_error.get_or_insert_with(|| Error::Sync(msg));
-            }
-            Err(e) => {
-                let msg = format!(
-                    "Stopping IDLE loop for account {} panicked: {}",
-                    account_id, e
-                );
-                log::error!("{}", msg);
-                stop_error.get_or_insert_with(|| Error::Sync(msg));
-            }
-        }
-    }
-
     let jmap_tasks = {
         let mut jmap_handles = state.jmap_push_handles.lock().unwrap();
         let mut tasks = Vec::new();
         for (account_id, handle) in jmap_handles.drain() {
             log::info!("Stopping JMAP push for account {}", account_id);
-            handle
-                .stop_flag
-                .store(true, std::sync::atomic::Ordering::Relaxed);
+            handle.stop_flag.store(true, Ordering::Relaxed);
             tasks.push((account_id, handle.task));
         }
         tasks
     };
+
+    let mut stop_error: Option<Error> = None;
 
     for (account_id, mut task) in jmap_tasks {
         match tokio::time::timeout(std::time::Duration::from_secs(5), &mut task).await {
@@ -622,6 +600,32 @@ pub async fn stop_idle(state: State<'_, AppState>) -> Result<()> {
                         stop_error.get_or_insert_with(|| Error::Sync(msg));
                     }
                 }
+            }
+        }
+    }
+
+    for (account_id, thread) in idle_threads {
+        let join_task = tokio::task::spawn_blocking(move || thread.join());
+        match tokio::time::timeout(std::time::Duration::from_secs(5), join_task).await {
+            Ok(Ok(Ok(()))) => {}
+            Ok(Ok(Err(_))) => {
+                let msg = format!("IDLE loop for account {} panicked during stop", account_id);
+                log::error!("{}", msg);
+                stop_error.get_or_insert_with(|| Error::Sync(msg));
+            }
+            Ok(Err(e)) => {
+                let msg = format!(
+                    "Stopping IDLE loop for account {} panicked: {}",
+                    account_id, e
+                );
+                log::error!("{}", msg);
+                stop_error.get_or_insert_with(|| Error::Sync(msg));
+            }
+            Err(_) => {
+                log::warn!(
+                    "IDLE loop for account {} did not stop within 5s; it will exit after IDLE returns",
+                    account_id
+                );
             }
         }
     }

--- a/src-tauri/src/db/folders.rs
+++ b/src-tauri/src/db/folders.rs
@@ -238,23 +238,41 @@ pub fn update_last_seen_uid(
     Ok(())
 }
 
-/// Get the stored sync state (uid_next, total_count) for preflight checks.
+/// Get the stored sync state for preflight checks.
 pub fn get_folder_sync_state(
     conn: &Connection,
     account_id: &str,
     path: &str,
-) -> Result<(u32, i64)> {
+) -> Result<(u32, u32, i64)> {
     let result = conn.query_row(
-        "SELECT uid_next, total_count FROM folders WHERE account_id = ?1 AND path = ?2",
+        "SELECT uidvalidity, uid_next, total_count
+         FROM folders WHERE account_id = ?1 AND path = ?2",
         params![account_id, path],
         |row| {
             Ok((
                 row.get::<_, u32>(0).unwrap_or(0),
-                row.get::<_, i64>(1).unwrap_or(0),
+                row.get::<_, u32>(1).unwrap_or(0),
+                row.get::<_, i64>(2).unwrap_or(0),
             ))
         },
     );
-    Ok(result.unwrap_or((0, 0)))
+    Ok(result.unwrap_or((0, 0, 0)))
+}
+
+/// Update the stored IMAP UID epoch and next UID after a successful folder sync.
+pub fn update_uid_state(
+    conn: &Connection,
+    account_id: &str,
+    path: &str,
+    uidvalidity: u32,
+    uid_next: u32,
+) -> Result<()> {
+    conn.execute(
+        "UPDATE folders SET uidvalidity = ?1, uid_next = ?2
+         WHERE account_id = ?3 AND path = ?4",
+        params![uidvalidity, uid_next, account_id, path],
+    )?;
+    Ok(())
 }
 
 /// Update the stored uid_next after a successful folder sync.

--- a/src-tauri/src/mail/imap.rs
+++ b/src-tauri/src/mail/imap.rs
@@ -70,6 +70,11 @@ pub struct ImapConnection {
     session: Session<TlsStream<TcpStream>>,
 }
 
+/// Keep comma-separated UID FETCH commands below conservative server argument
+/// limits. Exchange/M365 rejects large explicit UID sets before we reach the
+/// database batch size used by sync.
+const IMAP_FETCH_UID_CHUNK_SIZE: usize = 100;
+
 impl ImapConnection {
     /// Connect and authenticate. Must be called from a blocking context.
     pub fn connect(config: &ImapConfig) -> Result<Self> {
@@ -216,39 +221,46 @@ impl ImapConnection {
             return Ok(vec![]);
         }
 
-        let uid_set: String = uids
-            .iter()
-            .map(|u| u.to_string())
-            .collect::<Vec<_>>()
-            .join(",");
-
-        log::debug!(
-            "IMAP fetching {} envelopes (UIDs: {}...)",
-            uids.len(),
-            &uid_set[..uid_set.len().min(80)]
-        );
-
-        let fetches = self
-            .session
-            .uid_fetch(&uid_set, "(UID ENVELOPE FLAGS RFC822.SIZE)")
-            .map_err(|e| {
-                log::error!("IMAP FETCH envelopes failed: {}", e);
-                Error::Imap(e.to_string())
-            })?;
+        log::debug!("IMAP fetching {} envelopes", uids.len());
 
         let mut results = Vec::new();
-        for fetch in fetches.iter() {
-            let uid = match fetch.uid {
-                Some(u) => u,
-                None => continue,
-            };
-            let flags: Vec<String> = fetch.flags().iter().map(|f| flag_to_string(f)).collect();
-            let size = fetch.size.unwrap_or(0) as u64;
+        for chunk in uids.chunks(IMAP_FETCH_UID_CHUNK_SIZE) {
+            let uid_set = uid_set_string(chunk);
+            log::debug!(
+                "IMAP fetching {} envelopes (UIDs: {}...)",
+                chunk.len(),
+                &uid_set[..uid_set.len().min(80)]
+            );
 
-            // Parse ENVELOPE
-            let envelope = fetch.envelope();
-            let (subject, from_name, from_email, to_json, cc_json, date_str, msg_id, in_reply_to) =
-                if let Some(env) = envelope {
+            let fetches = self
+                .session
+                .uid_fetch(&uid_set, "(UID ENVELOPE FLAGS RFC822.SIZE)")
+                .map_err(|e| {
+                    log::error!("IMAP FETCH envelopes failed: {}", e);
+                    Error::Imap(e.to_string())
+                })?;
+
+            let mut chunk_results = Vec::new();
+            for fetch in fetches.iter() {
+                let uid = match fetch.uid {
+                    Some(u) => u,
+                    None => continue,
+                };
+                let flags: Vec<String> = fetch.flags().iter().map(|f| flag_to_string(f)).collect();
+                let size = fetch.size.unwrap_or(0) as u64;
+
+                // Parse ENVELOPE
+                let envelope = fetch.envelope();
+                let (
+                    subject,
+                    from_name,
+                    from_email,
+                    to_json,
+                    cc_json,
+                    date_str,
+                    msg_id,
+                    in_reply_to,
+                ) = if let Some(env) = envelope {
                     let subject = env.subject.as_ref().map(|s| decode_imap_str(s));
 
                     let (fname, femail) = env
@@ -302,38 +314,40 @@ impl ImapConnection {
                     )
                 };
 
-            // Check for attachments from BODYSTRUCTURE
-            // Simple heuristic: if the response text mentions "attachment", it likely has one
-            // More accurate: check if it's multipart/mixed (indicates attachments)
-            let has_attachments = size > 10000; // rough heuristic; will improve later
+                // Check for attachments from BODYSTRUCTURE
+                // Simple heuristic: if the response text mentions "attachment", it likely has one
+                // More accurate: check if it's multipart/mixed (indicates attachments)
+                let has_attachments = size > 10000; // rough heuristic; will improve later
 
-            results.push(EnvelopeData {
-                uid,
-                subject,
-                from_name,
-                from_email,
-                to_addresses: to_json,
-                cc_addresses: cc_json,
-                date: date_str,
-                message_id: msg_id,
-                in_reply_to,
-                references: Vec::new(),
-                flags,
-                size,
-                has_attachments,
-            });
+                chunk_results.push(EnvelopeData {
+                    uid,
+                    subject,
+                    from_name,
+                    from_email,
+                    to_addresses: to_json,
+                    cc_addresses: cc_json,
+                    date: date_str,
+                    message_id: msg_id,
+                    in_reply_to,
+                    references: Vec::new(),
+                    flags,
+                    size,
+                    has_attachments,
+                });
+            }
+
+            // References travels in a second, header-only fetch. Combining it
+            // with ENVELOPE in one FETCH triggers an imap-proto parse error on
+            // some servers (the literal-string framing of the body fetch leaks
+            // into the next command's response). A second pass is one extra
+            // round-trip per chunk but keeps the connection state clean.
+            if !chunk_results.is_empty() {
+                self.populate_references(&mut chunk_results, &uid_set);
+                results.extend(chunk_results);
+            }
         }
+
         log::info!("IMAP envelope batch: {} envelopes fetched", results.len());
-
-        // References travels in a second, header-only fetch. Combining it
-        // with ENVELOPE in one FETCH triggers an imap-proto parse error on
-        // some servers (the literal-string framing of the body fetch leaks
-        // into the next command's response). A second pass is one extra
-        // round-trip per batch but keeps the connection state clean.
-        if !results.is_empty() {
-            self.populate_references(&mut results, &uid_set);
-        }
-
         Ok(results)
     }
 

--- a/src-tauri/src/mail/sync.rs
+++ b/src-tauri/src/mail/sync.rs
@@ -328,11 +328,19 @@ fn sync_folder_envelopes(
 
     let (exists, uid_validity, uid_next) = conn_imap.select_folder(folder_path)?;
 
+    let has_local_uid_state = last_uid > 0 || stored_uid_next > 0 || stored_total > 0;
+    let unknown_uidvalidity_with_local_state =
+        stored_uid_validity == 0 && uid_validity > 0 && has_local_uid_state;
     let uidvalidity_changed =
         stored_uid_validity > 0 && uid_validity > 0 && stored_uid_validity != uid_validity;
     let stale_uid_epoch = uid_next > 0 && last_uid >= uid_next;
-    if uidvalidity_changed || stale_uid_epoch {
-        if uidvalidity_changed {
+    if unknown_uidvalidity_with_local_state || uidvalidity_changed || stale_uid_epoch {
+        if unknown_uidvalidity_with_local_state {
+            log::warn!(
+                "Folder '{}' has local IMAP UID state without UIDVALIDITY; resetting",
+                folder_path
+            );
+        } else if uidvalidity_changed {
             log::warn!(
                 "Folder '{}' UIDVALIDITY changed from {} to {}; resetting local IMAP sync state",
                 folder_path,

--- a/src-tauri/src/mail/sync.rs
+++ b/src-tauri/src/mail/sync.rs
@@ -459,8 +459,7 @@ fn sync_folder_envelopes(
 
         let rt = tokio::runtime::Handle::current();
         let conn = rt.block_on(db.writer());
-
-        conn.execute_batch("BEGIN")?;
+        let tx = conn.unchecked_transaction()?;
 
         for env in &envelopes {
             // In-memory existence check instead of per-message DB query
@@ -489,7 +488,7 @@ fn sync_folder_envelopes(
                 Some(env.references.as_slice())
             };
             let thread_id = db::messages::compute_thread_id(
-                &conn,
+                &tx,
                 account_id,
                 env.message_id.as_deref(),
                 env.in_reply_to.as_deref(),
@@ -522,16 +521,16 @@ fn sync_folder_envelopes(
                 maildir_path: String::new(),
                 snippet,
             };
-            db::messages::insert_message(&conn, &new_msg)?;
+            db::messages::insert_message(&tx, &new_msg)?;
             new_message_ids.push(id);
             total_synced += 1;
         }
 
         if let Some(&max_uid) = chunk.iter().max() {
-            db::folders::update_last_seen_uid(&conn, account_id, folder_path, max_uid)?;
+            db::folders::update_last_seen_uid(&tx, account_id, folder_path, max_uid)?;
         }
 
-        conn.execute_batch("COMMIT")?;
+        tx.commit()?;
     }
 
     // Run filter rules on newly synced messages

--- a/src-tauri/src/mail/sync.rs
+++ b/src-tauri/src/mail/sync.rs
@@ -318,14 +318,48 @@ fn sync_folder_envelopes(
     conn_imap: &mut ImapConnection,
     folder_path: &str,
 ) -> Result<u32> {
-    let (last_uid, stored_uid_next, stored_total) = {
+    let (mut last_uid, stored_uid_validity, stored_uid_next, stored_total) = {
         let conn = db.reader();
         let last_uid = db::folders::get_last_seen_uid(&conn, account_id, folder_path)?;
-        let (uid_next, total) = db::folders::get_folder_sync_state(&conn, account_id, folder_path)?;
-        (last_uid, uid_next, total)
+        let (uid_validity, uid_next, total) =
+            db::folders::get_folder_sync_state(&conn, account_id, folder_path)?;
+        (last_uid, uid_validity, uid_next, total)
     };
 
-    let (exists, _uid_validity, uid_next) = conn_imap.select_folder(folder_path)?;
+    let (exists, uid_validity, uid_next) = conn_imap.select_folder(folder_path)?;
+
+    let uidvalidity_changed =
+        stored_uid_validity > 0 && uid_validity > 0 && stored_uid_validity != uid_validity;
+    let stale_uid_epoch = uid_next > 0 && last_uid >= uid_next;
+    if uidvalidity_changed || stale_uid_epoch {
+        if uidvalidity_changed {
+            log::warn!(
+                "Folder '{}' UIDVALIDITY changed from {} to {}; resetting local IMAP sync state",
+                folder_path,
+                stored_uid_validity,
+                uid_validity
+            );
+        } else {
+            log::warn!(
+                "Folder '{}' has stale IMAP UID state (last_seen_uid={} >= uidnext={}); resetting",
+                folder_path,
+                last_uid,
+                uid_next
+            );
+        }
+        let rt = tokio::runtime::Handle::current();
+        let conn = rt.block_on(db.writer());
+        let tx = conn.unchecked_transaction()?;
+        tx.execute(
+            "DELETE FROM messages WHERE account_id = ?1 AND folder_path = ?2",
+            rusqlite::params![account_id, folder_path],
+        )?;
+        db::folders::update_last_seen_uid(&tx, account_id, folder_path, 0)?;
+        db::folders::update_uid_state(&tx, account_id, folder_path, uid_validity, uid_next)?;
+        db::folders::update_folder_counts(&tx, account_id, folder_path, 0, 0)?;
+        tx.commit()?;
+        last_uid = 0;
+    }
 
     // Preflight: if UIDNEXT and EXISTS haven't changed since last sync, the
     // folder is unchanged — skip deletion reconciliation, flag sync, and
@@ -430,7 +464,7 @@ fn sync_folder_envelopes(
         let unread = count_unread(&conn, account_id, folder_path)?;
         db::folders::update_folder_counts(&conn, account_id, folder_path, unread, page.total)?;
         if uid_next > 0 {
-            db::folders::update_uid_next(&conn, account_id, folder_path, uid_next)?;
+            db::folders::update_uid_state(&conn, account_id, folder_path, uid_validity, uid_next)?;
         }
         return Ok(0);
     }
@@ -576,7 +610,7 @@ fn sync_folder_envelopes(
         db::folders::update_folder_counts(&conn, account_id, folder_path, unread, page.total)?;
         // Store uid_next for preflight optimization on next sync
         if uid_next > 0 {
-            db::folders::update_uid_next(&conn, account_id, folder_path, uid_next)?;
+            db::folders::update_uid_state(&conn, account_id, folder_path, uid_validity, uid_next)?;
         }
     }
 


### PR DESCRIPTION
- Use rollback-safe SQLite transactions for IMAP sync/prefetch writes.
- Resume IMAP IDLE after prefetch failures.
- Stop IMAP/JMAP push loops more deterministically.
- Move remaining synchronous OpenPGP keystore work off async workers.
- Chunk IMAP envelope UID FETCH commands for Exchange/M365.
- Reset stale IMAP folder UID state when last_seen_uid is impossible for
  the selected mailbox epoch.