### PR TITLE
Centralize provider message references and body locations

### DIFF
--- a/docs/adr/0051-rust-architecture-boundary-refactor.md
+++ b/docs/adr/0051-rust-architecture-boundary-refactor.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Date
 
@@ -85,6 +85,14 @@ The explicit refinements are:
    remains keyed on the book's `sync_type`. ADR 0051 allows lookup-boundary
    normalization only; no `contact_books.sync_type` migration is part of this
    ADR.
+7. **ADR 0025 Graph body download timing.** ADR 0025 described normal Graph
+   sync as downloading full MIME before inserting each message. The current
+   delta-sync architecture instead inserts envelope metadata with a
+   `graph:{message_id}` remote-body marker, then streams full MIME to Maildir
+   during explicit prefetch or the first body request. ADR 0051 accepts that
+   timing while preserving ADR 0025's bounded-memory streaming, short database
+   lock durations, partial-file cleanup and offline-local-body goals. Once
+   fetched, the marker is replaced with the relative Maildir path.
 
 ## Compatibility and security invariants
 
@@ -156,10 +164,11 @@ Every phase of this refactor must preserve these prior-ADR invariants.
 - OpenPGP-enabled outgoing mail preserves ADR 0047's raw-MIME invariant. The
   PGP-wrapped bytes are persisted to outbox and sent/replayed verbatim unless a
   future ADR explicitly changes the send architecture.
-- Graph normal sync must remain two-phase as in ADR 0025: stream full MIME to
-  Maildir with bounded memory and without holding the DB lock, then perform a
-  short DB transaction. Legacy `graph:` body paths are compatibility/self-heal
-  paths, not a return to normal live Graph body fetching for synced messages.
+- Graph delta sync may persist envelope metadata with a `graph:{message_id}`
+  remote-body marker. Explicit prefetch or the first body request must stream
+  full MIME to Maildir with bounded memory and without holding the DB lock,
+  then replace the marker in a short DB transaction. Failed downloads must not
+  replace the marker with a local path, and partial files must be cleaned up.
 - IMAP TLS mode remains port-authoritative (993 = implicit TLS; other ports =
   STARTTLS) and plaintext authentication remains unsupported (ADR 0024).
 - IMAP sync optimizations from ADR 0041 and ADR 0023 remain regression
@@ -363,8 +372,9 @@ centralize parsing and formatting so commands no longer call `splitn(3, '_')`,
 `strip_prefix("graph:")` or similar provider-specific parsing directly.
 
 This is a compatibility/parser refactor, not a change to normal sync storage
-semantics. In particular, Graph normal sync continues to download full MIME to
-Maildir; `graph:` handling is legacy/self-heal compatibility.
+semantics. In particular, Graph delta sync continues to persist
+`graph:{message_id}` until explicit prefetch or the first body request streams
+full MIME to Maildir and replaces the marker with the relative local path.
 
 ### 5. Expand provider traits by capability, not by rewrite
 

--- a/src-tauri/src/backend/mail/graph.rs
+++ b/src-tauri/src/backend/mail/graph.rs
@@ -7,6 +7,7 @@ use crate::db;
 use crate::db::accounts::AccountFull;
 use crate::error::{Error, Result};
 use crate::event::{emit_folders_changed, emit_messages_changed};
+use crate::mail::compat::{BackendMessageRef, BodyLocation};
 use crate::ops::queue::MailOp;
 
 use super::{MailBackend, MailOpExecutor, MailSyncCtx};
@@ -248,7 +249,7 @@ async fn sync_graph_folder_delta(
             for event in &page.events {
                 match event {
                     graph::GraphDeltaEvent::Removed(removed) => {
-                        let id = format!("{}_{}", account_id, removed);
+                        let id = BackendMessageRef::graph(removed).to_db_id(account_id);
                         tx.execute("DELETE FROM messages WHERE id = ?1", rusqlite::params![id])?;
                         existing_ids.remove(&id);
                         // A removed row owes no filter pass; drop it from
@@ -256,7 +257,8 @@ async fn sync_graph_folder_delta(
                         new_ids.retain(|n| n != &id);
                     }
                     graph::GraphDeltaEvent::Upsert(msg) => {
-                        let id = format!("{}_{}", account_id, msg.id);
+                        let message_ref = BackendMessageRef::graph(&msg.id);
+                        let id = message_ref.to_db_id(account_id);
                         // Mirror the full server-side flag state (read +
                         // flagged), not just read: replacing the array with
                         // only `seen` erased an existing `flagged` on every
@@ -309,7 +311,7 @@ async fn sync_graph_folder_delta(
                             // AND keeps the row out of the IMAP prefetch
                             // pipeline (which selects `maildir_path = ''`
                             // rows and cannot fetch Graph folders/UID 0).
-                            maildir_path: format!("graph:{}", msg.id),
+                            maildir_path: BodyLocation::GraphRemote(msg.id.clone()).to_persisted(),
                             snippet: msg.preview.clone(),
                         };
                         db::messages::insert_message(&tx, &new_msg)?;
@@ -544,14 +546,14 @@ impl MailBackend for GraphMailBackend {
 
         let mut fetched = 0u32;
         for (db_id, folder_path, maildir_path, flags_json) in &unfetched {
-            let graph_msg_id = maildir_path
-                .strip_prefix("graph:")
-                .map(|s| s.to_string())
+            let body_location = BodyLocation::from_persisted(maildir_path);
+            let graph_msg_id = body_location
+                .graph_item_id()
+                .map(str::to_string)
                 .unwrap_or_else(|| {
-                    db_id
-                        .strip_prefix(&format!("{}_", account.id))
-                        .unwrap_or(db_id)
-                        .to_string()
+                    BackendMessageRef::graph_from_db_id(&account.id, db_id)
+                        .into_graph_item_id()
+                        .expect("Graph parser must return a Graph reference")
                 });
             let flags: Vec<String> = serde_json::from_str(flags_json).unwrap_or_default();
 

--- a/src-tauri/src/commands/actions.rs
+++ b/src-tauri/src/commands/actions.rs
@@ -8,6 +8,7 @@ use crate::commands::sync_cmd::{
 use crate::db;
 use crate::error::{Error, Result};
 use crate::event::{emit_folders_changed, emit_messages_changed};
+use crate::mail::compat::BodyLocation;
 use crate::mail::imap::{ImapConfig, ImapConnection};
 use crate::ops::queue::{MailOp, OpEntry, OpPriority};
 use crate::state::AppState;
@@ -448,15 +449,16 @@ pub async fn move_messages_cross_account(
         })?;
         let mut paths = Vec::with_capacity(maildir_paths.len());
         for (msg_id, maildir_path) in &maildir_paths {
-            if maildir_path.starts_with("graph:") {
+            let body_location = BodyLocation::from_persisted(maildir_path);
+            let Some(local_path) = body_location.local_path() else {
                 return Err(Error::Other(format!(
                     "Message {} is not stored on disk (Graph API). \
                      Cross-account move requires locally synced messages.",
                     msg_id
                 )));
-            }
+            };
             let canonical =
-                crate::path_validation::resolve_under_canonical(&canonical_data_dir, maildir_path)
+                crate::path_validation::resolve_under_canonical(&canonical_data_dir, local_path)
                     .map_err(|e| {
                         Error::Other(format!(
                             "Invalid maildir path for message {}: {}",

--- a/src-tauri/src/commands/calendar.rs
+++ b/src-tauri/src/commands/calendar.rs
@@ -7,6 +7,7 @@ use crate::commands::sync_cmd::try_acquire_sync_guard;
 use crate::db;
 use crate::db::calendar::{Attendee, Calendar, CalendarEvent, Invite, NewCalendar};
 use crate::error::Result;
+use crate::mail::compat::BodyLocation;
 use crate::meet;
 use crate::state::AppState;
 
@@ -1028,7 +1029,7 @@ pub async fn get_email_invites(
     let (maildir_path, _from_email, _to, _cc, _flags, _encrypted, _signed) =
         db::messages::get_message_metadata(&conn, &account_id, &message_id)?;
 
-    if maildir_path.is_empty() {
+    if BodyLocation::from_persisted(&maildir_path).needs_fetch() {
         log::debug!("get_email_invites: message body not fetched yet");
         return Ok(vec![]);
     }
@@ -1110,7 +1111,7 @@ pub async fn respond_to_invite(
         let (maildir_path, _from_email, _to, _cc, _flags, _encrypted, _signed) =
             db::messages::get_message_metadata(&conn, &account_id, &message_id)?;
 
-        if maildir_path.is_empty() {
+        if BodyLocation::from_persisted(&maildir_path).needs_fetch() {
             return Err(crate::error::Error::Other(
                 "Message body not fetched yet".to_string(),
             ));
@@ -1917,6 +1918,11 @@ pub async fn process_invite_reply(
         let conn = state.db.writer().await;
         let (maildir_path, _, _, _, _, _, _) =
             db::messages::get_message_metadata(&conn, &account_id, &message_id)?;
+        if BodyLocation::from_persisted(&maildir_path).needs_fetch() {
+            return Err(crate::error::Error::Other(
+                "Message body not fetched yet".to_string(),
+            ));
+        }
         let full_path = crate::path_validation::resolve_under(&state.data_dir, &maildir_path)?;
         std::fs::read(&full_path)
             .map_err(|e| crate::error::Error::Other(format!("Failed to read message: {}", e)))?
@@ -2057,6 +2063,11 @@ pub async fn process_cancelled_invite(
         let conn = state.db.reader();
         let (maildir_path, _, _, _, _, _, _) =
             db::messages::get_message_metadata(&conn, &account_id, &message_id)?;
+        if BodyLocation::from_persisted(&maildir_path).needs_fetch() {
+            return Err(crate::error::Error::Other(
+                "Message body not fetched yet".to_string(),
+            ));
+        }
         let full_path = crate::path_validation::resolve_under(&state.data_dir, &maildir_path)?;
         std::fs::read(&full_path)
             .map_err(|e| crate::error::Error::Other(format!("Failed to read message: {}", e)))?
@@ -2154,7 +2165,7 @@ pub fn auto_process_calendar_emails(
             }
         };
 
-        if maildir_path.is_empty() {
+        if BodyLocation::from_persisted(&maildir_path).needs_fetch() {
             continue; // Body not fetched yet
         }
 

--- a/src-tauri/src/commands/mail.rs
+++ b/src-tauri/src/commands/mail.rs
@@ -8,6 +8,7 @@ use crate::db;
 use crate::db::messages::{MessageSummary, ThreadedPage};
 use crate::error::{Error, Result};
 use crate::event::{emit_folders_changed, emit_messages_changed};
+use crate::mail::compat::{BackendMessageRef, BodyLocation};
 use crate::mail::imap::ImapConfig;
 use crate::mail::jmap_sync;
 use crate::mail::parser;
@@ -212,19 +213,20 @@ pub async fn import_search_hit(
         // Format matches sync_cmd::sync_graph_account: `{account_id}_{graph_id}`,
         // and `graph:{graph_id}` in maildir_path triggers the on-demand stream
         // path in get_message_body.
-        let id = format!("{}_{}", account_id, hit.backend_id);
-        let maildir = format!("graph:{}", hit.backend_id);
+        let message_ref = BackendMessageRef::graph(&hit.backend_id);
+        let id = message_ref.to_db_id(&account_id);
+        let maildir = BodyLocation::GraphRemote(hit.backend_id.clone()).to_persisted();
         (id, 0u32, maildir)
     } else if account.mail_protocol_str() == "jmap" {
         // Format matches jmap_sync: `{account_id}_{mailbox_id}_{email_id}`.
-        let id = format!("{}_{}_{}", account_id, hit.folder_path, hit.backend_id);
+        let id = BackendMessageRef::jmap(&hit.folder_path, &hit.backend_id).to_db_id(&account_id);
         (id, 0u32, String::new())
     } else {
         // IMAP: `{account_id}_{folder_path}_{uid}`.
         let uid = hit
             .uid
             .ok_or_else(|| Error::Other("IMAP search hit is missing UID".into()))?;
-        let id = format!("{}_{}_{}", account_id, hit.folder_path, uid);
+        let id = BackendMessageRef::imap(&hit.folder_path, uid).to_db_id(&account_id);
         (id, uid, String::new())
     };
 
@@ -283,8 +285,9 @@ async fn ensure_message_body_on_disk(
     maildir_path: &str,
     flags_json: &str,
 ) -> Result<String> {
-    if !maildir_path.is_empty() && !maildir_path.starts_with("graph:") {
-        return Ok(maildir_path.to_string());
+    let body_location = BodyLocation::from_persisted(maildir_path);
+    if let Some(local_path) = body_location.local_path() {
+        return Ok(local_path.to_string());
     }
 
     let (account, folder_path, uid) = {
@@ -300,13 +303,12 @@ async fn ensure_message_body_on_disk(
     let relative_path = if account.mail_protocol_str() == "graph" {
         log::info!("Body not on disk for {}, streaming from Graph", message_id);
 
-        let graph_msg_id = if let Some(gid) = maildir_path.strip_prefix("graph:") {
-            gid.to_string()
+        let graph_msg_id = if let Some(item_id) = body_location.graph_item_id() {
+            item_id.to_string()
         } else {
-            message_id
-                .strip_prefix(&format!("{}_", account_id))
-                .unwrap_or(message_id)
-                .to_string()
+            BackendMessageRef::graph_from_db_id(account_id, message_id)
+                .into_graph_item_id()
+                .expect("Graph parser must return a Graph reference")
         };
 
         let token = crate::mail::graph::get_graph_token(account_id).await?;
@@ -334,16 +336,17 @@ async fn ensure_message_body_on_disk(
 
         let jmap_config = crate::auth::build_jmap_config(&account).await?;
 
-        let jmap_email_id = message_id
-            .strip_prefix(&format!("{}_{}_", account_id, folder_path))
-            .unwrap_or(message_id);
+        let jmap_email_id =
+            BackendMessageRef::jmap_from_db_id(account_id, &folder_path, message_id)
+                .and_then(BackendMessageRef::into_jmap_email_id)
+                .unwrap_or_else(|| message_id.to_string());
 
         jmap_sync::fetch_and_store_jmap_body(
             &jmap_config,
             &data_dir,
             account_id,
             &folder_path,
-            jmap_email_id,
+            &jmap_email_id,
             &flags,
         )
         .await?
@@ -479,7 +482,7 @@ pub async fn get_message_html_with_images(
         mp
     };
 
-    if maildir_path.is_empty() || maildir_path.starts_with("graph:") {
+    if BodyLocation::from_persisted(&maildir_path).needs_fetch() {
         return Err(Error::Other(
             "Remote images not supported for messages without local body".to_string(),
         ));
@@ -925,7 +928,7 @@ pub async fn save_attachment(
         mp
     };
 
-    if maildir_path.is_empty() || maildir_path.starts_with("graph:") {
+    if BodyLocation::from_persisted(&maildir_path).needs_fetch() {
         return Err(Error::Other(
             "Attachment save not supported for messages without local body".to_string(),
         ));

--- a/src-tauri/src/commands/pgp.rs
+++ b/src-tauri/src/commands/pgp.rs
@@ -18,6 +18,7 @@ use tauri_plugin_dialog::DialogExt;
 use zeroize::Zeroizing;
 
 use crate::error::{Error, Result};
+use crate::mail::compat::BodyLocation;
 use crate::state::{AppState, PendingSecret};
 
 /// Tauri event emitted when the backend needs a passphrase or PIN.
@@ -976,7 +977,7 @@ async fn load_raw_with_metadata(
         let conn = state.db.reader();
         crate::db::messages::get_message_metadata(&conn, account_id, message_id)?
     };
-    if maildir_path.is_empty() || maildir_path.starts_with("graph:") {
+    if BodyLocation::from_persisted(&maildir_path).needs_fetch() {
         return Err(Error::Other(
             "pgp: message body not on disk — open the message normally once first".into(),
         ));

--- a/src-tauri/src/filters/service.rs
+++ b/src-tauri/src/filters/service.rs
@@ -6,14 +6,8 @@ use crate::db::pool::DbPool;
 use crate::error::{Error, Result};
 use crate::filters::engine::{self, AddressEntry, MessageData};
 use crate::filters::rules::{FilterAction, FilterRule};
+use crate::mail::compat::BackendMessageRef;
 use crate::mail::imap::{ImapConfig, ImapConnection};
-
-/// Strip the `{account_id}_` prefix from a composite DB id to recover the Graph message id.
-fn graph_id_from_db_id<'a>(account_id: &str, db_id: &'a str) -> &'a str {
-    db_id
-        .strip_prefix(&format!("{}_", account_id))
-        .unwrap_or(db_id)
-}
 
 /// Detect Graph "item not found" errors — i.e. the local id is stale because
 /// the message was moved or deleted server-side. Matches both the HTTP 404
@@ -22,16 +16,6 @@ fn graph_id_from_db_id<'a>(account_id: &str, db_id: &'a str) -> &'a str {
 fn is_graph_item_not_found(err: &Error) -> bool {
     let s = err.to_string();
     s.contains("404") && s.contains("ErrorItemNotFound")
-}
-
-/// Extract the JMAP email id from a composite DB id of form
-/// `{account_id}_{mailbox_id}_{email_id}` by stripping the known
-/// `{account_id}_{mailbox_id}_` prefix. Splitting on `_` is unsafe because
-/// JMAP mailbox ids and email ids are server-opaque and may legally contain
-/// underscores.
-fn jmap_id_from_db_id(account_id: &str, mailbox_id: &str, db_id: &str) -> Option<String> {
-    let prefix = format!("{}_{}_", account_id, mailbox_id);
-    db_id.strip_prefix(&prefix).map(|s| s.to_string())
 }
 
 /// Apply all enabled filters for an account to all messages in a given folder.
@@ -623,7 +607,9 @@ async fn execute_graph_filter_actions(
     let mut mark_unread: Vec<(String, String)> = Vec::new(); // (db_id, graph_id)
 
     for (msg, actions) in action_plan {
-        let graph_id = graph_id_from_db_id(account_id, &msg.id).to_string();
+        let graph_id = BackendMessageRef::graph_from_db_id(account_id, &msg.id)
+            .into_graph_item_id()
+            .expect("Graph parser must return a Graph reference");
         for action in actions {
             match action {
                 FilterAction::Move { target } => {
@@ -849,7 +835,10 @@ async fn execute_jmap_filter_actions(
         // The JMAP mailbox id is stored as `folder_path`; use that to strip
         // the exact prefix instead of splitting on `_`, which is unsafe
         // because mailbox ids and email ids are server-opaque.
-        let Some(jmap_id) = jmap_id_from_db_id(&account.id, &msg.folder_path, &msg.id) else {
+        let Some(jmap_id) =
+            BackendMessageRef::jmap_from_db_id(&account.id, &msg.folder_path, &msg.id)
+                .and_then(BackendMessageRef::into_jmap_email_id)
+        else {
             log::warn!(
                 "Skipping JMAP filter action for message '{}' with unexpected id format",
                 msg.id
@@ -1032,50 +1021,6 @@ fn capitalize_flag(s: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_graph_id_from_db_id_strips_account_prefix() {
-        let acc = "acc123";
-        let db_id = "acc123_AAMkAGI2T-foo_bar";
-        assert_eq!(graph_id_from_db_id(acc, db_id), "AAMkAGI2T-foo_bar");
-    }
-
-    #[test]
-    fn test_graph_id_from_db_id_returns_input_when_prefix_missing() {
-        assert_eq!(
-            graph_id_from_db_id("acc123", "raw_graph_id"),
-            "raw_graph_id"
-        );
-    }
-
-    #[test]
-    fn test_jmap_id_from_db_id_strips_known_prefix() {
-        let id = jmap_id_from_db_id("acc1", "inbox", "acc1_inbox_M123");
-        assert_eq!(id.as_deref(), Some("M123"));
-    }
-
-    #[test]
-    fn test_jmap_id_from_db_id_preserves_underscores_in_email_id() {
-        // Email id contains underscores; previous splitn(3, '_') would have
-        // truncated this. Prefix-strip handles it correctly.
-        let id = jmap_id_from_db_id("acc1", "box", "acc1_box_email_with_underscores");
-        assert_eq!(id.as_deref(), Some("email_with_underscores"));
-    }
-
-    #[test]
-    fn test_jmap_id_from_db_id_handles_underscore_in_mailbox_id() {
-        // Server-opaque mailbox id with underscores — splitn-based parsing
-        // would have returned "child_M9" or worse here; prefix-strip is exact.
-        let id = jmap_id_from_db_id("acc1", "parent_child", "acc1_parent_child_M9");
-        assert_eq!(id.as_deref(), Some("M9"));
-    }
-
-    #[test]
-    fn test_jmap_id_from_db_id_returns_none_when_prefix_missing() {
-        assert!(jmap_id_from_db_id("acc1", "inbox", "different_acc_inbox_M1").is_none());
-        assert!(jmap_id_from_db_id("acc1", "inbox", "acc1_other_M1").is_none());
-        assert!(jmap_id_from_db_id("acc1", "inbox", "no_underscores").is_none());
-    }
 
     #[test]
     fn test_is_graph_item_not_found_matches_404_with_code() {

--- a/src-tauri/src/mail/compat.rs
+++ b/src-tauri/src/mail/compat.rs
@@ -1,0 +1,225 @@
+//! Compatibility types for persisted provider message references and bodies.
+
+/// A provider-specific message identity.
+///
+/// Database ids retain their existing underscore-delimited representation.
+/// Parsing therefore requires the account and, for JMAP, mailbox context.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BackendMessageRef {
+    Imap {
+        folder_path: String,
+        uid: u32,
+    },
+    Jmap {
+        mailbox_id: String,
+        email_id: String,
+    },
+    Graph {
+        item_id: String,
+    },
+}
+
+impl BackendMessageRef {
+    pub fn imap(folder_path: impl Into<String>, uid: u32) -> Self {
+        Self::Imap {
+            folder_path: folder_path.into(),
+            uid,
+        }
+    }
+
+    pub fn jmap(mailbox_id: impl Into<String>, email_id: impl Into<String>) -> Self {
+        Self::Jmap {
+            mailbox_id: mailbox_id.into(),
+            email_id: email_id.into(),
+        }
+    }
+
+    pub fn graph(item_id: impl Into<String>) -> Self {
+        Self::Graph {
+            item_id: item_id.into(),
+        }
+    }
+
+    /// Recover a Graph item id from the existing `{account_id}_{item_id}` form.
+    ///
+    /// Raw ids remain accepted for compatibility with older call sites.
+    pub fn graph_from_db_id(account_id: &str, db_id: &str) -> Self {
+        let prefix = format!("{}_", account_id);
+        Self::graph(db_id.strip_prefix(&prefix).unwrap_or(db_id))
+    }
+
+    /// Recover a JMAP email id by stripping the exact known prefix.
+    ///
+    /// JMAP ids are opaque and may contain underscores, so delimiter splitting
+    /// cannot recover this identity safely.
+    pub fn jmap_from_db_id(account_id: &str, mailbox_id: &str, db_id: &str) -> Option<Self> {
+        let prefix = format!("{}_{}_", account_id, mailbox_id);
+        db_id
+            .strip_prefix(&prefix)
+            .map(|email_id| Self::jmap(mailbox_id, email_id))
+    }
+
+    /// Format the existing persisted `messages.id` representation.
+    pub fn to_db_id(&self, account_id: &str) -> String {
+        match self {
+            Self::Imap { folder_path, uid } => {
+                format!("{}_{}_{}", account_id, folder_path, uid)
+            }
+            Self::Jmap {
+                mailbox_id,
+                email_id,
+            } => format!("{}_{}_{}", account_id, mailbox_id, email_id),
+            Self::Graph { item_id } => format!("{}_{}", account_id, item_id),
+        }
+    }
+
+    pub fn graph_item_id(&self) -> Option<&str> {
+        match self {
+            Self::Graph { item_id } => Some(item_id),
+            _ => None,
+        }
+    }
+
+    pub fn into_graph_item_id(self) -> Option<String> {
+        match self {
+            Self::Graph { item_id } => Some(item_id),
+            _ => None,
+        }
+    }
+
+    pub fn jmap_email_id(&self) -> Option<&str> {
+        match self {
+            Self::Jmap { email_id, .. } => Some(email_id),
+            _ => None,
+        }
+    }
+
+    pub fn into_jmap_email_id(self) -> Option<String> {
+        match self {
+            Self::Jmap { email_id, .. } => Some(email_id),
+            _ => None,
+        }
+    }
+}
+
+/// The meaning of a persisted `messages.maildir_path` value.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BodyLocation {
+    NotFetched,
+    Local(String),
+    GraphRemote(String),
+}
+
+impl BodyLocation {
+    pub fn from_persisted(value: &str) -> Self {
+        if value.is_empty() {
+            Self::NotFetched
+        } else if let Some(item_id) = value.strip_prefix("graph:") {
+            Self::GraphRemote(item_id.to_string())
+        } else {
+            Self::Local(value.to_string())
+        }
+    }
+
+    pub fn to_persisted(&self) -> String {
+        match self {
+            Self::NotFetched => String::new(),
+            Self::Local(path) => path.clone(),
+            Self::GraphRemote(item_id) => format!("graph:{}", item_id),
+        }
+    }
+
+    pub fn local_path(&self) -> Option<&str> {
+        match self {
+            Self::Local(path) => Some(path),
+            _ => None,
+        }
+    }
+
+    pub fn graph_item_id(&self) -> Option<&str> {
+        match self {
+            Self::GraphRemote(item_id) => Some(item_id),
+            _ => None,
+        }
+    }
+
+    pub fn needs_fetch(&self) -> bool {
+        !matches!(self, Self::Local(_))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{BackendMessageRef, BodyLocation};
+
+    #[test]
+    fn formats_existing_database_ids() {
+        assert_eq!(
+            BackendMessageRef::imap("Archive_2026", 42).to_db_id("acc_1"),
+            "acc_1_Archive_2026_42"
+        );
+        assert_eq!(
+            BackendMessageRef::jmap("parent_child", "email_with_underscores").to_db_id("acc_1"),
+            "acc_1_parent_child_email_with_underscores"
+        );
+        assert_eq!(
+            BackendMessageRef::graph("AAMk_opaque").to_db_id("acc_1"),
+            "acc_1_AAMk_opaque"
+        );
+    }
+
+    #[test]
+    fn parses_graph_database_ids_with_legacy_raw_fallback() {
+        let prefixed = BackendMessageRef::graph_from_db_id("acc_1", "acc_1_AAMk_opaque");
+        assert_eq!(prefixed.graph_item_id(), Some("AAMk_opaque"));
+
+        let raw = BackendMessageRef::graph_from_db_id("acc_1", "AAMk_opaque");
+        assert_eq!(raw.graph_item_id(), Some("AAMk_opaque"));
+    }
+
+    #[test]
+    fn parses_jmap_ids_using_the_known_prefix() {
+        let parsed = BackendMessageRef::jmap_from_db_id(
+            "acc_1",
+            "parent_child",
+            "acc_1_parent_child_email_with_underscores",
+        )
+        .unwrap();
+        assert_eq!(parsed.jmap_email_id(), Some("email_with_underscores"));
+    }
+
+    #[test]
+    fn rejects_jmap_ids_with_the_wrong_context() {
+        assert!(
+            BackendMessageRef::jmap_from_db_id("acc_1", "inbox", "different_inbox_email").is_none()
+        );
+        assert!(
+            BackendMessageRef::jmap_from_db_id("acc_1", "inbox", "acc_1_archive_email").is_none()
+        );
+    }
+
+    #[test]
+    fn body_locations_round_trip_existing_values() {
+        for persisted in ["", "graph:AAMk_opaque", "graph:", "acc/inbox/cur/42:2,S"] {
+            assert_eq!(
+                BodyLocation::from_persisted(persisted).to_persisted(),
+                persisted
+            );
+        }
+    }
+
+    #[test]
+    fn classifies_body_locations_without_validating_paths() {
+        let not_fetched = BodyLocation::from_persisted("");
+        assert!(not_fetched.needs_fetch());
+        assert_eq!(not_fetched.local_path(), None);
+
+        let graph = BodyLocation::from_persisted("graph:AAMk_opaque");
+        assert!(graph.needs_fetch());
+        assert_eq!(graph.graph_item_id(), Some("AAMk_opaque"));
+
+        let local = BodyLocation::from_persisted("future:value");
+        assert!(!local.needs_fetch());
+        assert_eq!(local.local_path(), Some("future:value"));
+    }
+}

--- a/src-tauri/src/mail/graph.rs
+++ b/src-tauri/src/mail/graph.rs
@@ -298,24 +298,42 @@ impl GraphClient {
         let mut file = tokio::fs::File::create(dest).await.map_err(|e| {
             Error::Other(format!("Failed to create file {}: {}", dest.display(), e))
         })?;
-        let mut stream = resp.bytes_stream();
-        let mut total: u64 = 0;
+        let result = async {
+            let mut stream = resp.bytes_stream();
+            let mut total: u64 = 0;
 
-        use futures::StreamExt;
-        while let Some(chunk) = stream.next().await {
-            let chunk =
-                chunk.map_err(|e| Error::Other(format!("Graph stream read failed: {}", e)))?;
-            file.write_all(&chunk).await.map_err(|e| {
-                Error::Other(format!("Failed to write to {}: {}", dest.display(), e))
-            })?;
-            total += chunk.len() as u64;
+            use futures::StreamExt;
+            while let Some(chunk) = stream.next().await {
+                let chunk =
+                    chunk.map_err(|e| Error::Other(format!("Graph stream read failed: {}", e)))?;
+                file.write_all(&chunk).await.map_err(|e| {
+                    Error::Other(format!("Failed to write to {}: {}", dest.display(), e))
+                })?;
+                total += chunk.len() as u64;
+            }
+
+            file.flush()
+                .await
+                .map_err(|e| Error::Other(format!("Failed to flush {}: {}", dest.display(), e)))?;
+
+            Ok(total)
+        }
+        .await;
+
+        drop(file);
+        if result.is_err() {
+            if let Err(cleanup_err) = tokio::fs::remove_file(dest).await {
+                if cleanup_err.kind() != std::io::ErrorKind::NotFound {
+                    log::warn!(
+                        "Failed to remove partial Graph download {}: {}",
+                        dest.display(),
+                        cleanup_err
+                    );
+                }
+            }
         }
 
-        file.flush()
-            .await
-            .map_err(|e| Error::Other(format!("Failed to flush {}: {}", dest.display(), e)))?;
-
-        Ok(total)
+        result
     }
 
     async fn post_json(&self, path: &str, body: &serde_json::Value) -> Result<serde_json::Value> {

--- a/src-tauri/src/mail/jmap_sync.rs
+++ b/src-tauri/src/mail/jmap_sync.rs
@@ -6,6 +6,7 @@ use crate::db;
 use crate::db::pool::DbPool;
 use crate::error::{Error, Result};
 use crate::event::{emit_folders_changed, emit_messages_changed};
+use crate::mail::compat::BackendMessageRef;
 use crate::mail::jmap::{JmapConfig, JmapConnection};
 
 #[derive(Clone, serde::Serialize)]
@@ -303,13 +304,14 @@ async fn sync_jmap_folder(
 
         for email in &filtered_emails {
             // Use the JMAP email ID as the unique identifier
-            let id = format!("{}_{}_{}", account_id, mailbox_id, email.id);
+            let message_ref = BackendMessageRef::jmap(mailbox_id, &email.id);
+            let id = message_ref.to_db_id(account_id);
 
             // Check if this message already exists (by JMAP ID in the folder)
             if jmap_message_exists(&conn, account_id, mailbox_id, &email.id)? {
                 // Update flags in case they changed on the server (read/unread, flagged, etc.)
                 let new_flags = serde_json::to_string(&email.flags).unwrap_or_default();
-                let msg_id = format!("{}_{}_{}", account_id, mailbox_id, email.id);
+                let msg_id = message_ref.to_db_id(account_id);
                 let _ = db::messages::update_flags(&conn, &msg_id, &new_flags);
                 continue;
             }
@@ -394,10 +396,10 @@ async fn sync_jmap_folder(
                 .filter_map(|r| r.ok())
                 .collect();
             for local_id in &local_ids {
-                let jmap_id = local_id
-                    .strip_prefix(&format!("{}_{}_", account_id, mailbox_id))
-                    .unwrap_or(local_id);
-                if !server_ids.contains(jmap_id) {
+                let jmap_id = BackendMessageRef::jmap_from_db_id(account_id, mailbox_id, local_id)
+                    .and_then(BackendMessageRef::into_jmap_email_id)
+                    .unwrap_or_else(|| local_id.clone());
+                if !server_ids.contains(&jmap_id) {
                     conn.execute(
                         "DELETE FROM messages WHERE id = ?1",
                         rusqlite::params![local_id],
@@ -412,7 +414,7 @@ async fn sync_jmap_folder(
             // mailbox. Both reduce to the same DB op (drop the per-folder
             // composite row); apply them together.
             for jmap_id in destroyed.iter().chain(moved_out.iter()) {
-                let composite = format!("{}_{}_{}", account_id, mailbox_id, jmap_id);
+                let composite = BackendMessageRef::jmap(mailbox_id, jmap_id).to_db_id(account_id);
                 if conn
                     .execute(
                         "DELETE FROM messages WHERE id = ?1",
@@ -484,7 +486,7 @@ fn jmap_message_exists(
     mailbox_id: &str,
     jmap_email_id: &str,
 ) -> Result<bool> {
-    let id = format!("{}_{}_{}", account_id, mailbox_id, jmap_email_id);
+    let id = BackendMessageRef::jmap(mailbox_id, jmap_email_id).to_db_id(account_id);
     let count: i64 = conn.query_row(
         "SELECT COUNT(*) FROM messages WHERE id = ?1",
         rusqlite::params![id],

--- a/src-tauri/src/mail/mod.rs
+++ b/src-tauri/src/mail/mod.rs
@@ -1,6 +1,7 @@
 pub mod autoconfig;
 pub mod caldav;
 pub mod carddav;
+pub mod compat;
 pub mod dav_http;
 pub mod google;
 pub mod graph;

--- a/src-tauri/src/mail/parser.rs
+++ b/src-tauri/src/mail/parser.rs
@@ -1,6 +1,7 @@
 use mail_parser::{Address as MailAddress, HeaderValue, MessageParser, MimeHeaders};
 
 use crate::db::messages::{Address, Attachment, MessageBody, NewMessage};
+use crate::mail::compat::BackendMessageRef;
 
 fn mail_address_to_list(addr: &MailAddress<'_>) -> Vec<Address> {
     match addr {
@@ -91,7 +92,7 @@ pub fn parse_envelope(
         .map(|ct| ct.ctype() == "multipart" && ct.subtype().map(|s| s == "signed").unwrap_or(false))
         .unwrap_or(false);
 
-    let id = format!("{}_{}_{}", account_id, folder_path, uid);
+    let id = BackendMessageRef::imap(folder_path, uid).to_db_id(account_id);
 
     Some(NewMessage {
         id,

--- a/src-tauri/src/mail/sync.rs
+++ b/src-tauri/src/mail/sync.rs
@@ -8,6 +8,7 @@ use crate::error::{Error, Result};
 use crate::event::{emit_folders_changed, emit_messages_changed};
 use crate::filters::engine::{self, AddressEntry, MessageData};
 use crate::filters::rules::FilterAction;
+use crate::mail::compat::BackendMessageRef;
 use crate::mail::imap::{ImapConfig, ImapConnection};
 
 #[derive(Clone, serde::Serialize)]
@@ -520,7 +521,7 @@ fn sync_folder_envelopes(
                 .as_deref()
                 .map(|s| s.chars().take(200).collect());
 
-            let id = format!("{}_{}_{}", account_id, folder_path, env.uid);
+            let id = BackendMessageRef::imap(folder_path, env.uid).to_db_id(account_id);
 
             // Thread computation still needs DB queries for cross-references,
             // but the in_reply_to lookup is fast with index.


### PR DESCRIPTION
## Summary

- accept ADR 0051 and correct its description of Graph body-fetch timing
- add typed `BackendMessageRef` compatibility helpers for IMAP, JMAP,
  and Graph
- add typed `BodyLocation` handling for local, unfetched, and Graph
  remote bodies
- replace direct message-ID formatting and body-location parsing in
  low-risk mail, sync, filtering, calendar, attachment, and PGP paths
- preserve all existing database and IPC string formats

## Compatibility

This is a parser and formatting refactor only. It does not introduce a
database migration or rewrite existing message IDs or body locations.

Graph delta sync continues storing `graph:{message_id}` until prefetch or
the first body request streams the MIME body to Maildir.

The remaining JMAP `splitn` parsing in mail action commands is deliberately
deferred to the upcoming operation-pipeline work, where references can be
captured before optimistic database mutations.

## Testing

- `cargo fmt --all -- --check`
- `cargo check --locked`
- `cargo clippy --locked --all-targets -- -D warnings`
- `with-secret-service cargo test --locked --all-targets`

Result: 435 passed, 0 failed, 1 ignored. The ignored test requires a
running `tcli agent`.