### PR TITLE
Harden Matrix and Talk meeting cleanup responses

### DIFF
--- a/src-tauri/src/meet/matrix.rs
+++ b/src-tauri/src/meet/matrix.rs
@@ -26,6 +26,7 @@ use serde::{Deserialize, Serialize};
 use crate::error::{Error, Result};
 
 const HTTP_TIMEOUT_SECS: u64 = 30;
+const MATRIX_ERROR_BODY_LIMIT: usize = 8 * 1024;
 const USER_AGENT: &str = concat!("Chithi/", env!("CARGO_PKG_VERSION"));
 const SSO_CALLBACK_TIMEOUT_SECS: u64 = 300;
 
@@ -448,8 +449,7 @@ pub async fn rename_room_with_client(
 /// Leave a Matrix room the app created via `create_call`. Matrix
 /// has no "delete room" API (rooms outlive everyone in them), but
 /// leaving drops the room from this user's room list — which is
-/// the closest analogue to "cancelled this call." 403/404 are
-/// treated as already-gone so the local cleanup is idempotent.
+/// the closest analogue to "cancelled this call."
 pub async fn leave_room(homeserver: &str, access_token: &str, room_id: &str) -> Result<()> {
     leave_room_with_client(homeserver, access_token, room_id, http_client()?).await
 }
@@ -467,7 +467,7 @@ pub async fn leave_room_with_client(
         normalize_base_url(homeserver),
         urlencoding::encode(room_id),
     );
-    let resp = client
+    let mut resp = client
         .post(&url)
         .bearer_auth(access_token)
         .header("Content-Type", "application/json")
@@ -476,15 +476,103 @@ pub async fn leave_room_with_client(
         .await
         .map_err(|e| Error::Other(format!("matrix leave_room request: {}", e)))?;
     let status = resp.status();
-    if status.is_success() || status.as_u16() == 403 || status.as_u16() == 404 {
+    if status.is_success() {
         return Ok(());
     }
-    let body = resp.text().await.unwrap_or_default();
+
+    let (body, truncated) = read_bounded_matrix_error(&mut resp).await?;
+    let matrix_error = if truncated {
+        None
+    } else {
+        serde_json::from_slice::<MatrixError>(&body).ok()
+    };
+
+    // Matrix uses M_FORBIDDEN for both an idempotent repeated leave and real
+    // authorization failures. Only explicit absent-membership wording is safe
+    // to discard; an unknown 403 must keep durable ownership for a later retry.
+    let already_gone = matrix_error.as_ref().is_some_and(|error| {
+        (status.is_client_error() && error.errcode == "M_NOT_FOUND")
+            || (status == reqwest::StatusCode::FORBIDDEN
+                && error.errcode == "M_FORBIDDEN"
+                && is_absent_membership_error(&error.error, room_id))
+    });
+    if already_gone {
+        return Ok(());
+    }
+
+    let body = String::from_utf8_lossy(&body);
+    let truncation = if truncated { " [truncated]" } else { "" };
     Err(Error::Other(format!(
-        "matrix leave_room: {} ({})",
+        "matrix leave_room: {} ({}{})",
         status,
         body.chars().take(500).collect::<String>(),
+        truncation,
     )))
+}
+
+#[derive(Deserialize)]
+struct MatrixError {
+    errcode: String,
+    error: String,
+}
+
+async fn read_bounded_matrix_error(response: &mut reqwest::Response) -> Result<(Vec<u8>, bool)> {
+    let mut body = Vec::with_capacity(MATRIX_ERROR_BODY_LIMIT.min(1024));
+    while let Some(chunk) = response
+        .chunk()
+        .await
+        .map_err(|e| Error::Other(format!("matrix leave_room response: {}", e)))?
+    {
+        let remaining = MATRIX_ERROR_BODY_LIMIT + 1 - body.len();
+        body.extend_from_slice(&chunk[..chunk.len().min(remaining)]);
+        if body.len() > MATRIX_ERROR_BODY_LIMIT {
+            body.truncate(MATRIX_ERROR_BODY_LIMIT);
+            return Ok((body, true));
+        }
+    }
+    Ok((body, false))
+}
+
+fn is_absent_membership_error(error: &str, room_id: &str) -> bool {
+    let normalized = error.split_whitespace().collect::<Vec<_>>().join(" ");
+    let Some(prefix) = normalized.strip_suffix(room_id) else {
+        return false;
+    };
+    let prefix = prefix.trim_end().to_ascii_lowercase();
+    if matches!(
+        prefix.as_str(),
+        "you are not in room"
+            | "you are not in the room"
+            | "you are not joined to room"
+            | "you are not joined to the room"
+            | "you already left room"
+            | "you already left the room"
+    ) {
+        return true;
+    }
+
+    ["user ", "the user ", "requesting user "]
+        .iter()
+        .find_map(|subject| prefix.strip_prefix(subject))
+        .and_then(|user_and_state| user_and_state.split_once(' '))
+        .is_some_and(|(user_id, state)| {
+            !user_id.is_empty()
+                && matches!(
+                    state,
+                    "not in room"
+                        | "not in the room"
+                        | "is not in room"
+                        | "is not in the room"
+                        | "not joined to room"
+                        | "not joined to the room"
+                        | "is not joined to room"
+                        | "is not joined to the room"
+                        | "no longer in room"
+                        | "no longer in the room"
+                        | "already left room"
+                        | "already left the room"
+                )
+        })
 }
 
 /// Pull just the host out of a homeserver URL, so the matrix.to
@@ -640,6 +728,17 @@ mod tests {
     fn mock_server(
         responses: Vec<(&'static str, &'static str)>,
     ) -> (String, std::thread::JoinHandle<Vec<String>>) {
+        mock_server_owned(
+            responses
+                .into_iter()
+                .map(|(status, body)| (status.to_string(), body.to_string()))
+                .collect(),
+        )
+    }
+
+    fn mock_server_owned(
+        responses: Vec<(String, String)>,
+    ) -> (String, std::thread::JoinHandle<Vec<String>>) {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let address = listener.local_addr().unwrap();
         let server = std::thread::spawn(move || {
@@ -787,5 +886,173 @@ mod tests {
             .to_ascii_lowercase()
             .contains("authorization: bearer matrix-token"));
         assert_eq!(result.meeting_id, "!room:matrix.example");
+    }
+
+    #[tokio::test]
+    async fn leave_room_accepts_success() {
+        let (root, server) = mock_server(vec![("204 No Content", "")]);
+
+        leave_room_with_client(
+            &root,
+            "matrix-token",
+            "!room:matrix.example",
+            &reqwest::Client::new(),
+        )
+        .await
+        .unwrap();
+        server.join().unwrap();
+    }
+
+    #[tokio::test]
+    async fn leave_room_accepts_repeated_leave() {
+        let (root, server) = mock_server(vec![(
+            "403 Forbidden",
+            r#"{"errcode":"M_FORBIDDEN","error":"User @alice:matrix.example not in room !room:matrix.example"}"#,
+        )]);
+
+        leave_room_with_client(
+            &root,
+            "matrix-token",
+            "!room:matrix.example",
+            &reqwest::Client::new(),
+        )
+        .await
+        .unwrap();
+        server.join().unwrap();
+    }
+
+    #[tokio::test]
+    async fn leave_room_accepts_missing_room() {
+        let (root, server) = mock_server(vec![(
+            "404 Not Found",
+            r#"{"errcode":"M_NOT_FOUND","error":"Room not found"}"#,
+        )]);
+
+        leave_room_with_client(
+            &root,
+            "matrix-token",
+            "!missing:matrix.example",
+            &reqwest::Client::new(),
+        )
+        .await
+        .unwrap();
+        server.join().unwrap();
+    }
+
+    #[tokio::test]
+    async fn leave_room_accepts_matrix_not_found_on_other_client_error() {
+        let (root, server) = mock_server(vec![(
+            "400 Bad Request",
+            r#"{"errcode":"M_NOT_FOUND","error":"Room not found"}"#,
+        )]);
+
+        leave_room_with_client(
+            &root,
+            "matrix-token",
+            "!missing:matrix.example",
+            &reqwest::Client::new(),
+        )
+        .await
+        .unwrap();
+        server.join().unwrap();
+    }
+
+    #[tokio::test]
+    async fn leave_room_rejects_genuine_authorization_failure() {
+        let (root, server) = mock_server(vec![(
+            "403 Forbidden",
+            r#"{"errcode":"M_FORBIDDEN","error":"You do not have permission to leave this room"}"#,
+        )]);
+
+        let error = leave_room_with_client(
+            &root,
+            "matrix-token",
+            "!room:matrix.example",
+            &reqwest::Client::new(),
+        )
+        .await
+        .unwrap_err();
+        server.join().unwrap();
+
+        assert!(error.to_string().contains("403 Forbidden"));
+    }
+
+    #[tokio::test]
+    async fn leave_room_rejects_malformed_and_unknown_forbidden_errors() {
+        let (root, server) = mock_server(vec![
+            ("403 Forbidden", "not json"),
+            (
+                "403 Forbidden",
+                r#"{"errcode":"M_FORBIDDEN","error":"Insufficient power level"}"#,
+            ),
+            (
+                "403 Forbidden",
+                r#"{"errcode":"M_FORBIDDEN","error":"You are not in the room's moderator list for !room:matrix.example"}"#,
+            ),
+        ]);
+        let client = reqwest::Client::new();
+
+        assert!(
+            leave_room_with_client(&root, "matrix-token", "!room:matrix.example", &client,)
+                .await
+                .is_err()
+        );
+        assert!(
+            leave_room_with_client(&root, "matrix-token", "!room:matrix.example", &client,)
+                .await
+                .is_err()
+        );
+        assert!(
+            leave_room_with_client(&root, "matrix-token", "!room:matrix.example", &client,)
+                .await
+                .is_err()
+        );
+        server.join().unwrap();
+    }
+
+    #[tokio::test]
+    async fn leave_room_rejects_oversized_error_body() {
+        let body = format!(
+            r#"{{"errcode":"M_NOT_FOUND","error":"{}"}}"#,
+            "x".repeat(MATRIX_ERROR_BODY_LIMIT)
+        );
+        let (root, server) = mock_server_owned(vec![("404 Not Found".to_string(), body)]);
+
+        let error = leave_room_with_client(
+            &root,
+            "matrix-token",
+            "!room:matrix.example",
+            &reqwest::Client::new(),
+        )
+        .await
+        .unwrap_err();
+        server.join().unwrap();
+
+        assert!(error.to_string().contains("[truncated]"));
+    }
+
+    #[tokio::test]
+    async fn leave_room_sends_expected_request() {
+        let (root, server) = mock_server(vec![("200 OK", "{}")]);
+        let homeserver = format!("{root}/tenant/");
+
+        leave_room_with_client(
+            &homeserver,
+            "matrix-token",
+            "!room:matrix.example",
+            &reqwest::Client::new(),
+        )
+        .await
+        .unwrap();
+        let requests = server.join().unwrap();
+        let (headers, body) = requests[0].split_once("\r\n\r\n").unwrap();
+
+        assert!(headers.starts_with(
+            "POST /tenant/_matrix/client/v3/rooms/%21room%3Amatrix.example/leave HTTP/1.1\r\n"
+        ));
+        assert!(headers
+            .to_ascii_lowercase()
+            .contains("authorization: bearer matrix-token"));
+        assert_eq!(body, "{}");
     }
 }

--- a/src-tauri/src/meet/matrix.rs
+++ b/src-tauri/src/meet/matrix.rs
@@ -492,6 +492,9 @@ pub async fn leave_room_with_client(
     // to discard; an unknown 403 must keep durable ownership for a later retry.
     let already_gone = matrix_error.as_ref().is_some_and(|error| {
         (status.is_client_error() && error.errcode == "M_NOT_FOUND")
+            || (status == reqwest::StatusCode::NOT_FOUND
+                && error.errcode == "M_UNKNOWN"
+                && error.error.trim() == "Not a known room")
             || (status == reqwest::StatusCode::FORBIDDEN
                 && error.errcode == "M_FORBIDDEN"
                 && is_absent_membership_error(&error.error, room_id))
@@ -926,6 +929,24 @@ mod tests {
         let (root, server) = mock_server(vec![(
             "404 Not Found",
             r#"{"errcode":"M_NOT_FOUND","error":"Room not found"}"#,
+        )]);
+
+        leave_room_with_client(
+            &root,
+            "matrix-token",
+            "!missing:matrix.example",
+            &reqwest::Client::new(),
+        )
+        .await
+        .unwrap();
+        server.join().unwrap();
+    }
+
+    #[tokio::test]
+    async fn leave_room_accepts_synapse_unknown_missing_room() {
+        let (root, server) = mock_server(vec![(
+            "404 Not Found",
+            r#"{"errcode":"M_UNKNOWN","error":"Not a known room"}"#,
         )]);
 
         leave_room_with_client(

--- a/src-tauri/src/meet/talk.rs
+++ b/src-tauri/src/meet/talk.rs
@@ -360,6 +360,30 @@ enum OcsDeleteStatus {
     Failure,
 }
 
+#[derive(Debug, PartialEq, Eq)]
+enum OcsDeleteMessageKind {
+    Success,
+    Unknown,
+}
+
+fn classify_ocs_delete_message(message: &str) -> OcsDeleteMessageKind {
+    let message = message
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_ascii_lowercase();
+    if matches!(
+        message.as_str(),
+        "ok" | "conversation deleted successfully"
+            | "room deleted successfully"
+            | "conversation successfully deleted"
+            | "room successfully deleted"
+    ) {
+        return OcsDeleteMessageKind::Success;
+    }
+    OcsDeleteMessageKind::Unknown
+}
+
 /// Delete a Talk room using an explicit HTTP client.
 pub async fn delete_room_with_client(
     server: &str,
@@ -444,22 +468,14 @@ pub async fn delete_room_with_client(
         ))
     })?;
     let meta = payload.ocs.meta;
+    let message_kind = classify_ocs_delete_message(&meta.message);
     if meta.status == OcsDeleteStatus::Ok
         && matches!(meta.statuscode, 100 | 200)
         && status == reqwest::StatusCode::OK
+        && message_kind == OcsDeleteMessageKind::Success
     {
         return Ok(());
     }
-    if meta.status == OcsDeleteStatus::Failure
-        && meta.statuscode == 404
-        && matches!(
-            status,
-            reqwest::StatusCode::OK | reqwest::StatusCode::NOT_FOUND
-        )
-    {
-        return Ok(());
-    }
-
     let ocs_status = match meta.status {
         OcsDeleteStatus::Ok => "ok",
         OcsDeleteStatus::Failure => "failure",
@@ -863,14 +879,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn delete_room_accepts_repeated_or_missing_room() {
+    async fn delete_room_rejects_missing_room_without_proof_of_deletion() {
         for http_status in ["200 OK", "404 Not Found"] {
             let (root, server) = mock_server(
                 http_status,
                 r#"{"ocs":{"meta":{"status":"failure","statuscode":404,"message":"Room not found"},"data":[]}}"#,
             );
 
-            delete_room_with_client(
+            let error = delete_room_with_client(
                 &root,
                 "alice",
                 "app-secret",
@@ -878,8 +894,12 @@ mod tests {
                 &reqwest::Client::new(),
             )
             .await
-            .unwrap();
+            .unwrap_err();
             server.join().unwrap();
+
+            assert!(error
+                .to_string()
+                .contains("talk delete_room: OCS failure 404: Room not found"));
         }
     }
 
@@ -958,6 +978,11 @@ mod tests {
         let bodies = [
             r#"{"ocs":{"meta":{"status":"ok","statuscode":404,"message":"Not found"}}}"#,
             r#"{"ocs":{"meta":{"status":"failure","statuscode":200,"message":"Failed"}}}"#,
+            r#"{"ocs":{"meta":{"status":"ok","statuscode":200,"message":"Forbidden"}}}"#,
+            r#"{"ocs":{"meta":{"status":"failure","statuscode":404,"message":"Forbidden"}}}"#,
+            r#"{"ocs":{"meta":{"status":"ok","statuscode":200,"message":"Done"}}}"#,
+            r#"{"ocs":{"meta":{"status":"ok","statuscode":200,"message":"Room was not deleted successfully"}}}"#,
+            r#"{"ocs":{"meta":{"status":"failure","statuscode":404,"message":"Room not found; authorization failed"}}}"#,
         ];
 
         for body in bodies {

--- a/src-tauri/src/meet/talk.rs
+++ b/src-tauri/src/meet/talk.rs
@@ -23,6 +23,8 @@ use crate::error::{Error, Result};
 
 const HTTP_TIMEOUT_SECS: u64 = 30;
 const USER_AGENT: &str = concat!("Chithi/", env!("CARGO_PKG_VERSION"));
+const DELETE_RESPONSE_LIMIT: usize = 64 * 1024;
+const DELETE_DIAGNOSTIC_LIMIT: usize = 500;
 
 /// Single shared `reqwest::Client` for the whole Talk module so
 /// the connection pool persists across the Login Flow v2 poll
@@ -334,6 +336,30 @@ pub async fn delete_room(
     delete_room_with_client(server, login_name, app_password, token, http_client()?).await
 }
 
+#[derive(Deserialize)]
+struct OcsDeleteEnvelope {
+    ocs: OcsDeleteResponse,
+}
+
+#[derive(Deserialize)]
+struct OcsDeleteResponse {
+    meta: OcsDeleteMeta,
+}
+
+#[derive(Deserialize)]
+struct OcsDeleteMeta {
+    status: OcsDeleteStatus,
+    statuscode: u16,
+    message: String,
+}
+
+#[derive(Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+enum OcsDeleteStatus {
+    Ok,
+    Failure,
+}
+
 /// Delete a Talk room using an explicit HTTP client.
 pub async fn delete_room_with_client(
     server: &str,
@@ -358,14 +384,94 @@ pub async fn delete_room_with_client(
         .await
         .map_err(|e| Error::Other(format!("talk delete_room request: {}", e)))?;
     let status = resp.status();
-    if status.is_success() || status.as_u16() == 404 {
+
+    if resp
+        .content_length()
+        .is_some_and(|length| length > u64::try_from(DELETE_RESPONSE_LIMIT).unwrap_or(u64::MAX))
+    {
+        return Err(Error::Other(format!(
+            "talk delete_room: {} response exceeds {} bytes",
+            status, DELETE_RESPONSE_LIMIT,
+        )));
+    }
+
+    let mut resp = resp;
+    let mut body = Vec::new();
+    while let Some(chunk) = resp
+        .chunk()
+        .await
+        .map_err(|e| Error::Other(format!("talk delete_room response: {}", e)))?
+    {
+        if body.len().saturating_add(chunk.len()) > DELETE_RESPONSE_LIMIT {
+            let diagnostic = String::from_utf8_lossy(&body)
+                .chars()
+                .take(DELETE_DIAGNOSTIC_LIMIT)
+                .collect::<String>();
+            return Err(Error::Other(format!(
+                "talk delete_room: {} response exceeds {} bytes ({})",
+                status, DELETE_RESPONSE_LIMIT, diagnostic,
+            )));
+        }
+        body.extend_from_slice(&chunk);
+    }
+    let diagnostic = String::from_utf8_lossy(&body)
+        .chars()
+        .take(DELETE_DIAGNOSTIC_LIMIT)
+        .collect::<String>();
+
+    if matches!(
+        status,
+        reqwest::StatusCode::UNAUTHORIZED | reqwest::StatusCode::FORBIDDEN
+    ) {
+        return Err(Error::Other(format!(
+            "talk delete_room: authorization failed: {} ({})",
+            status, diagnostic,
+        )));
+    }
+    if !status.is_success() && status != reqwest::StatusCode::NOT_FOUND {
+        return Err(Error::Other(format!(
+            "talk delete_room: {} ({})",
+            status, diagnostic,
+        )));
+    }
+
+    // OCS v2 communicates application success in the envelope, often while
+    // returning HTTP 200. A 204/empty body is therefore not proof of deletion.
+    let payload: OcsDeleteEnvelope = serde_json::from_slice(&body).map_err(|e| {
+        Error::Other(format!(
+            "talk delete_room: invalid OCS metadata: {} ({})",
+            e, diagnostic,
+        ))
+    })?;
+    let meta = payload.ocs.meta;
+    if meta.status == OcsDeleteStatus::Ok
+        && matches!(meta.statuscode, 100 | 200)
+        && status == reqwest::StatusCode::OK
+    {
         return Ok(());
     }
-    let body = resp.text().await.unwrap_or_default();
+    if meta.status == OcsDeleteStatus::Failure
+        && meta.statuscode == 404
+        && matches!(
+            status,
+            reqwest::StatusCode::OK | reqwest::StatusCode::NOT_FOUND
+        )
+    {
+        return Ok(());
+    }
+
+    let ocs_status = match meta.status {
+        OcsDeleteStatus::Ok => "ok",
+        OcsDeleteStatus::Failure => "failure",
+    };
+    let message = meta
+        .message
+        .chars()
+        .take(DELETE_DIAGNOSTIC_LIMIT)
+        .collect::<String>();
     Err(Error::Other(format!(
-        "talk delete_room: {} ({})",
-        status,
-        body.chars().take(500).collect::<String>(),
+        "talk delete_room: OCS {} {}: {} (HTTP {})",
+        ocs_status, meta.statuscode, message, status,
     )))
 }
 
@@ -540,6 +646,28 @@ mod tests {
         (format!("http://{address}"), server)
     }
 
+    fn mock_server_without_content_length(
+        status: &str,
+        body: &str,
+    ) -> (String, std::thread::JoinHandle<String>) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let status = status.to_string();
+        let body = body.to_string();
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0_u8; 4096];
+            let read = stream.read(&mut request).unwrap();
+            write!(
+                stream,
+                "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nConnection: close\r\n\r\n{body}",
+            )
+            .unwrap();
+            String::from_utf8(request[..read].to_vec()).unwrap()
+        });
+        (format!("http://{address}"), server)
+    }
+
     #[test]
     fn normalizes_trailing_slashes() {
         assert_eq!(normalize_base_url("https://x/"), "https://x");
@@ -701,5 +829,258 @@ mod tests {
         assert_eq!(body, "roomType=2&roomName=Team+sync");
         assert_eq!(result.meeting_id, "room-token");
         assert_eq!(result.join_url, format!("{root}/cloud/call/room-token"));
+    }
+
+    #[tokio::test]
+    async fn delete_room_validates_ocs_success_and_request() {
+        let (root, server) = mock_server(
+            "200 OK",
+            r#"{"ocs":{"meta":{"status":"ok","statuscode":200,"message":"OK"},"data":[]}}"#,
+        );
+        let server_url = format!("{root}/cloud/");
+
+        delete_room_with_client(
+            &server_url,
+            "alice",
+            "app-secret",
+            "room token/part",
+            &reqwest::Client::new(),
+        )
+        .await
+        .unwrap();
+        let request = server.join().unwrap();
+        let (headers, body) = request.split_once("\r\n\r\n").unwrap();
+        let headers = headers.to_ascii_lowercase();
+
+        assert!(headers.starts_with(
+            "delete /cloud/ocs/v2.php/apps/spreed/api/v4/room/room%20token%2fpart \
+             http/1.1\r\n"
+        ));
+        assert!(headers.contains("authorization: basic ywxpy2u6yxbwlxnly3jlda=="));
+        assert!(headers.contains("ocs-apirequest: true"));
+        assert!(headers.contains("accept: application/json"));
+        assert_eq!(body, "");
+    }
+
+    #[tokio::test]
+    async fn delete_room_accepts_repeated_or_missing_room() {
+        for http_status in ["200 OK", "404 Not Found"] {
+            let (root, server) = mock_server(
+                http_status,
+                r#"{"ocs":{"meta":{"status":"failure","statuscode":404,"message":"Room not found"},"data":[]}}"#,
+            );
+
+            delete_room_with_client(
+                &root,
+                "alice",
+                "app-secret",
+                "missing-room",
+                &reqwest::Client::new(),
+            )
+            .await
+            .unwrap();
+            server.join().unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn delete_room_rejects_ocs_auth_failure_wrapped_in_http_200() {
+        let (root, server) = mock_server(
+            "200 OK",
+            r#"{"ocs":{"meta":{"status":"failure","statuscode":403,"message":"Forbidden"},"data":[]}}"#,
+        );
+
+        let error = delete_room_with_client(
+            &root,
+            "alice",
+            "bad-secret",
+            "room-token",
+            &reqwest::Client::new(),
+        )
+        .await
+        .unwrap_err();
+        server.join().unwrap();
+
+        assert!(error.to_string().contains("OCS failure 403: Forbidden"));
+    }
+
+    #[tokio::test]
+    async fn delete_room_rejects_http_auth_failure() {
+        let (root, server) = mock_server(
+            "401 Unauthorized",
+            r#"{"ocs":{"meta":{"status":"ok","statuscode":200,"message":"OK"}}}"#,
+        );
+
+        let error = delete_room_with_client(
+            &root,
+            "alice",
+            "bad-secret",
+            "room-token",
+            &reqwest::Client::new(),
+        )
+        .await
+        .unwrap_err();
+        server.join().unwrap();
+
+        assert!(error.to_string().contains("authorization failed: 401"));
+    }
+
+    #[tokio::test]
+    async fn delete_room_rejects_malformed_or_missing_ocs_metadata() {
+        let bodies = [
+            "",
+            r#"{}"#,
+            r#"{"ocs":{}}"#,
+            r#"{"ocs":{"meta":{"status":"ok","statuscode":200}}}"#,
+            r#"{"ocs":{"meta":{"status":"ok","statuscode":"200","message":"OK"}}}"#,
+            "not json",
+        ];
+
+        for body in bodies {
+            let (root, server) = mock_server("200 OK", body);
+            let error = delete_room_with_client(
+                &root,
+                "alice",
+                "app-secret",
+                "room-token",
+                &reqwest::Client::new(),
+            )
+            .await
+            .unwrap_err();
+            server.join().unwrap();
+
+            assert!(error.to_string().contains("invalid OCS metadata"));
+        }
+    }
+
+    #[tokio::test]
+    async fn delete_room_rejects_contradictory_ocs_metadata() {
+        let bodies = [
+            r#"{"ocs":{"meta":{"status":"ok","statuscode":404,"message":"Not found"}}}"#,
+            r#"{"ocs":{"meta":{"status":"failure","statuscode":200,"message":"Failed"}}}"#,
+        ];
+
+        for body in bodies {
+            let (root, server) = mock_server("200 OK", body);
+            let error = delete_room_with_client(
+                &root,
+                "alice",
+                "app-secret",
+                "room-token",
+                &reqwest::Client::new(),
+            )
+            .await
+            .unwrap_err();
+            server.join().unwrap();
+
+            assert!(error.to_string().contains("talk delete_room: OCS"));
+        }
+    }
+
+    #[tokio::test]
+    async fn delete_room_rejects_undocumented_success_combinations() {
+        let cases = [
+            (
+                "202 Accepted",
+                r#"{"ocs":{"meta":{"status":"ok","statuscode":200,"message":"Accepted"}}}"#,
+            ),
+            (
+                "200 OK",
+                r#"{"ocs":{"meta":{"status":"ok","statuscode":206,"message":"Partial"}}}"#,
+            ),
+            (
+                "202 Accepted",
+                r#"{"ocs":{"meta":{"status":"failure","statuscode":404,"message":"Missing"}}}"#,
+            ),
+        ];
+
+        for (status, body) in cases {
+            let (root, server) = mock_server(status, body);
+            assert!(delete_room_with_client(
+                &root,
+                "alice",
+                "app-secret",
+                "room-token",
+                &reqwest::Client::new(),
+            )
+            .await
+            .is_err());
+            server.join().unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn delete_room_rejects_declared_oversized_response() {
+        let body = "x".repeat(DELETE_RESPONSE_LIMIT + 1);
+        let (root, server) = mock_server("200 OK", &body);
+
+        let error = delete_room_with_client(
+            &root,
+            "alice",
+            "app-secret",
+            "room-token",
+            &reqwest::Client::new(),
+        )
+        .await
+        .unwrap_err();
+        server.join().unwrap();
+
+        assert!(error.to_string().contains("response exceeds"));
+    }
+
+    #[tokio::test]
+    async fn delete_room_streaming_guard_rejects_oversized_response() {
+        let body = "x".repeat(DELETE_RESPONSE_LIMIT + 1);
+        let (root, server) = mock_server_without_content_length("200 OK", &body);
+
+        let error = delete_room_with_client(
+            &root,
+            "alice",
+            "app-secret",
+            "room-token",
+            &reqwest::Client::new(),
+        )
+        .await
+        .unwrap_err();
+        server.join().unwrap();
+
+        assert!(error.to_string().contains("response exceeds"));
+    }
+
+    #[tokio::test]
+    async fn delete_room_accepts_response_at_exact_size_limit() {
+        let base = r#"{"ocs":{"meta":{"status":"ok","statuscode":200,"message":"OK"}}}"#;
+        let body = format!("{}{}", base, " ".repeat(DELETE_RESPONSE_LIMIT - base.len()));
+        assert_eq!(body.len(), DELETE_RESPONSE_LIMIT);
+        let (root, server) = mock_server_without_content_length("200 OK", &body);
+
+        delete_room_with_client(
+            &root,
+            "alice",
+            "app-secret",
+            "room-token",
+            &reqwest::Client::new(),
+        )
+        .await
+        .unwrap();
+        server.join().unwrap();
+    }
+
+    #[tokio::test]
+    async fn delete_room_rejects_204_without_ocs_metadata() {
+        let (root, server) = mock_server("204 No Content", "");
+
+        let error = delete_room_with_client(
+            &root,
+            "alice",
+            "app-secret",
+            "room-token",
+            &reqwest::Client::new(),
+        )
+        .await
+        .unwrap_err();
+        server.join().unwrap();
+
+        assert!(error.to_string().contains("invalid OCS metadata"));
     }
 }


### PR DESCRIPTION
## Summary

- distinguish idempotent Matrix cleanup from genuine authorization failures
- validate Nextcloud Talk OCS metadata before releasing meeting ownership
- bound provider error responses and retain ambiguous failures for retry
- add coverage for success, repeated cleanup, missing rooms, authorization
  failures, malformed responses, and response-size limits

## Matrix

Matrix uses `M_FORBIDDEN` for both repeated leave attempts and real
authorization failures. Cleanup now accepts only narrowly recognized
membership-absent responses tied to the requested room ID.

Explicit `M_NOT_FOUND` client errors are also treated as idempotent success.
Unknown or malformed errors retain durable cleanup ownership.

## Nextcloud Talk

Talk cleanup now validates the OCS status, status code, and message instead
of relying on HTTP status alone. This catches application failures wrapped
in HTTP 200 responses.

Only documented success and missing-room combinations release ownership.
Empty, contradictory, authorization-failure, and oversized responses remain
retryable errors.

## Testing

- 680 Rust tests passed
- 1 test ignored
- strict Clippy passed
- formatting and diff checks passed
- independent review found no remaining issues

Closes #248