### PR TITLE
refactor(mail): introduce focused account configuration

### DIFF
--- a/src-tauri/src/account.rs
+++ b/src-tauri/src/account.rs
@@ -1,0 +1,27 @@
+//! Focused account views consumed by service and provider boundaries.
+
+/// Mail-only account configuration.
+///
+/// This is an owned snapshot because mail operations commonly cross spawned
+/// async and blocking task boundaries. It intentionally excludes calendar,
+/// contacts, meeting, UI, and OpenPGP settings. The password is loaded from
+/// the keyring through `AccountFull` and must remain backend-only.
+#[derive(Clone)]
+pub struct MailAccountConfig {
+    pub id: String,
+    pub display_name: String,
+    pub email: String,
+    pub protocol: String,
+    pub username: String,
+    pub password: String,
+    pub auth_method: String,
+    pub imap_host: String,
+    pub imap_port: u16,
+    pub smtp_host: String,
+    pub smtp_port: u16,
+    pub use_tls: bool,
+    pub jmap_url: String,
+    pub jmap_auth_method: String,
+    pub oidc_token_endpoint: String,
+    pub oidc_client_id: String,
+}

--- a/src-tauri/src/backend/mail/graph.rs
+++ b/src-tauri/src/backend/mail/graph.rs
@@ -2,8 +2,8 @@
 
 use async_trait::async_trait;
 
+use crate::account::MailAccountConfig;
 use crate::db;
-use crate::db::accounts::AccountFull;
 use crate::error::{Error, Result};
 use crate::event::{ApplicationEvent, SyncComplete, SyncStarted};
 use crate::mail::compat::{BackendMessageRef, BodyLocation};
@@ -79,6 +79,7 @@ const MAX_DELTA_PAGES_PER_CYCLE: usize = 25;
 async fn sync_graph_account(
     ctx: &MailSyncCtx,
     account_id: &str,
+    account_name: &str,
     current_folder: Option<&str>,
 ) -> Result<()> {
     use crate::mail::graph;
@@ -89,16 +90,10 @@ async fn sync_graph_account(
     // Mirror sync_account / sync_jmap_account: emit sync-started so the
     // activity store can mark the operation running and spin the StatusBar
     // icon. Without this, Graph syncs are silent on the frontend.
-    let account_name = {
-        let conn = db_arc.reader();
-        db::accounts::get_account_full(&conn, account_id)
-            .map(|a| a.display_name)
-            .unwrap_or_else(|_| account_id.to_string())
-    };
     ctx.events
         .publish(ApplicationEvent::SyncStarted(SyncStarted {
             account_id: account_id.to_string(),
-            account_name,
+            account_name: account_name.to_string(),
         }));
 
     let client = ctx
@@ -501,7 +496,7 @@ impl MailBackend for GraphMailBackend {
     async fn sync_account(
         &self,
         ctx: &MailSyncCtx,
-        account: &AccountFull,
+        account: &MailAccountConfig,
         current_folder: Option<String>,
     ) -> Result<()> {
         log::info!(
@@ -509,7 +504,13 @@ impl MailBackend for GraphMailBackend {
             account.display_name,
             account.email,
         );
-        sync_graph_account(ctx, &account.id, current_folder.as_deref()).await
+        sync_graph_account(
+            ctx,
+            &account.id,
+            &account.display_name,
+            current_folder.as_deref(),
+        )
+        .await
     }
 
     /// Sync exactly one folder via its delta link. Refreshes the folder's
@@ -518,7 +519,7 @@ impl MailBackend for GraphMailBackend {
     async fn sync_folder(
         &self,
         ctx: &MailSyncCtx,
-        account: &AccountFull,
+        account: &MailAccountConfig,
         folder_path: &str,
     ) -> Result<u32> {
         use crate::mail::graph;
@@ -565,7 +566,7 @@ impl MailBackend for GraphMailBackend {
     /// delegating there just produced failed selects after every sync.
     /// Instead, stream full MIME for the newest unfetched rows via the
     /// same `download_mime_to_file` path the on-demand fetch uses.
-    async fn prefetch_bodies(&self, ctx: &MailSyncCtx, account: &AccountFull) -> Result<u32> {
+    async fn prefetch_bodies(&self, ctx: &MailSyncCtx, account: &MailAccountConfig) -> Result<u32> {
         use crate::provider::GraphTokenPurpose;
 
         /// Bodies fetched per prefetch pass; the pass re-runs after every
@@ -636,7 +637,7 @@ impl MailBackend for GraphMailBackend {
     async fn fetch_body_to_disk(
         &self,
         ctx: &MailSyncCtx,
-        account: &AccountFull,
+        account: &MailAccountConfig,
         request: &BodyFetchRequest,
     ) -> Result<String> {
         let graph_msg_id = body_fetch_item_id(request)?;
@@ -658,7 +659,7 @@ impl MailBackend for GraphMailBackend {
     async fn search_messages(
         &self,
         ctx: &MailSyncCtx,
-        account: &AccountFull,
+        account: &MailAccountConfig,
         query: &SearchQuery,
     ) -> Result<Vec<SearchHit>> {
         validate_search_query(query)?;
@@ -677,7 +678,7 @@ impl MailBackend for GraphMailBackend {
     async fn save_draft(
         &self,
         ctx: &MailSyncCtx,
-        account: &AccountFull,
+        account: &MailAccountConfig,
         request: &super::DraftSaveRequest,
     ) -> Result<()> {
         let client = ctx

--- a/src-tauri/src/backend/mail/imap.rs
+++ b/src-tauri/src/backend/mail/imap.rs
@@ -6,8 +6,8 @@ use std::collections::BTreeMap;
 
 use async_trait::async_trait;
 
+use crate::account::MailAccountConfig;
 use crate::db;
-use crate::db::accounts::AccountFull;
 use crate::error::{Error, Result};
 use crate::event::{ApplicationEvent, SyncStarted};
 use crate::mail::imap::{ImapConfig, ImapConnection};
@@ -59,11 +59,11 @@ fn prefetch_connection_limit(auth_method: &str, folder_count: usize) -> usize {
 
 /// Build the connection config, refreshing the O365 IMAP-scoped token
 /// when needed.
-async fn build_imap_config(ctx: &MailSyncCtx, account: &AccountFull) -> Result<ImapConfig> {
+async fn build_imap_config(ctx: &MailSyncCtx, account: &MailAccountConfig) -> Result<ImapConfig> {
     let credentials = ctx
         .providers
         .credentials()
-        .mail_credentials(account)
+        .mail_credentials_for(account)
         .await?;
     Ok(ImapConfig {
         host: account.imap_host.clone(),
@@ -80,7 +80,10 @@ async fn build_imap_config(ctx: &MailSyncCtx, account: &AccountFull) -> Result<I
 /// SELECTs, spread over up to 3 parallel connections. Also used by
 /// the Graph backend — O365 accounts keep IMAP access and their
 /// Graph sync can leave on-demand rows behind.
-pub(super) async fn prefetch_pipeline(ctx: &MailSyncCtx, account: &AccountFull) -> Result<u32> {
+pub(super) async fn prefetch_pipeline(
+    ctx: &MailSyncCtx,
+    account: &MailAccountConfig,
+) -> Result<u32> {
     // Graph-protocol accounts without an IMAP binding have no host to
     // connect to. Without this guard every sync-complete kicked off a
     // doomed connect to ":993" plus keyring/token reads for credentials.
@@ -305,14 +308,14 @@ impl MailBackend for ImapMailBackend {
     /// account at a time. Identifying O365 via auth_method is more
     /// accurate than the legacy `provider` string since Phase 3
     /// dropped that column.
-    fn suspends_idle_for_ops(&self, account: &AccountFull) -> bool {
+    fn suspends_idle_for_ops(&self, account: &MailAccountConfig) -> bool {
         account.auth_method == "oauth-microsoft"
     }
 
     async fn sync_account(
         &self,
         ctx: &MailSyncCtx,
-        account: &AccountFull,
+        account: &MailAccountConfig,
         current_folder: Option<String>,
     ) -> Result<()> {
         log::info!(
@@ -340,7 +343,7 @@ impl MailBackend for ImapMailBackend {
     async fn sync_folder(
         &self,
         ctx: &MailSyncCtx,
-        account: &AccountFull,
+        account: &MailAccountConfig,
         folder_path: &str,
     ) -> Result<u32> {
         // sync_folder_envelopes_public is a low-level helper and
@@ -373,14 +376,14 @@ impl MailBackend for ImapMailBackend {
         .map_err(|e| Error::Sync(format!("Folder sync panicked: {}", e)))?
     }
 
-    async fn prefetch_bodies(&self, ctx: &MailSyncCtx, account: &AccountFull) -> Result<u32> {
+    async fn prefetch_bodies(&self, ctx: &MailSyncCtx, account: &MailAccountConfig) -> Result<u32> {
         prefetch_pipeline(ctx, account).await
     }
 
     async fn fetch_body_to_disk(
         &self,
         ctx: &MailSyncCtx,
-        account: &AccountFull,
+        account: &MailAccountConfig,
         request: &BodyFetchRequest,
     ) -> Result<String> {
         let (folder_path, uid) = body_fetch_target(request)?;
@@ -407,7 +410,7 @@ impl MailBackend for ImapMailBackend {
     async fn search_messages(
         &self,
         ctx: &MailSyncCtx,
-        account: &AccountFull,
+        account: &MailAccountConfig,
         query: &SearchQuery,
     ) -> Result<Vec<SearchHit>> {
         validate_search_query(query)?;
@@ -429,7 +432,7 @@ impl MailBackend for ImapMailBackend {
     async fn save_draft(
         &self,
         ctx: &MailSyncCtx,
-        account: &AccountFull,
+        account: &MailAccountConfig,
         request: &DraftSaveRequest,
     ) -> Result<()> {
         let imap_config = build_imap_config(ctx, account).await?;
@@ -474,7 +477,7 @@ impl MailBackend for ImapMailBackend {
 /// nudge.
 pub(crate) async fn sync_folder_quiet(
     ctx: &MailSyncCtx,
-    account: &AccountFull,
+    account: &MailAccountConfig,
     folder_path: &str,
 ) -> Result<()> {
     let imap_config = build_imap_config(ctx, account).await?;
@@ -565,7 +568,8 @@ impl ImapOpExecutor {
             let account = {
                 let conn = ctx.db.reader();
                 crate::db::accounts::get_account_full(&conn, account_id)?
-            };
+            }
+            .mail_config();
             let config = build_imap_config(ctx, &account).await?;
 
             let conn = tokio::task::spawn_blocking(move || ImapConnection::connect(&config))
@@ -613,7 +617,8 @@ impl ImapOpExecutor {
         let account = {
             let conn = ctx.db.reader();
             crate::db::accounts::get_account_full(&conn, account_id)?
-        };
+        }
+        .mail_config();
 
         // For O365 SMTP, refresh the OAuth token (XOAUTH2; SMTP shares
         // the IMAP scope set). For password accounts, just use the
@@ -622,7 +627,7 @@ impl ImapOpExecutor {
         let credentials = ctx
             .providers
             .credentials()
-            .mail_credentials(&account)
+            .mail_credentials_for(&account)
             .await?;
         let smtp_password = credentials.secret;
         let use_xoauth2 = credentials.use_xoauth2;

--- a/src-tauri/src/backend/mail/jmap.rs
+++ b/src-tauri/src/backend/mail/jmap.rs
@@ -4,7 +4,7 @@
 
 use async_trait::async_trait;
 
-use crate::db::accounts::AccountFull;
+use crate::account::MailAccountConfig;
 use crate::error::{Error, Result};
 use crate::mail::jmap_sync;
 use crate::mail::search::{SearchHit, SearchQuery};
@@ -20,12 +20,12 @@ pub struct JmapMailBackend;
 
 async fn connect(
     ctx: &MailSyncCtx,
-    account: &AccountFull,
+    account: &MailAccountConfig,
 ) -> Result<(
     crate::mail::jmap::JmapConfig,
     crate::mail::jmap::JmapConnection,
 )> {
-    let config = ctx.providers.credentials().jmap_config(account).await?;
+    let config = ctx.providers.credentials().jmap_config_for(account).await?;
     let connection = crate::mail::jmap::JmapConnection::connect_with_clients(
         &config,
         ctx.providers.transports.jmap_discovery_http.clone(),
@@ -53,7 +53,7 @@ impl MailBackend for JmapMailBackend {
     async fn sync_account(
         &self,
         ctx: &MailSyncCtx,
-        account: &AccountFull,
+        account: &MailAccountConfig,
         current_folder: Option<String>,
     ) -> Result<()> {
         log::info!(
@@ -77,7 +77,7 @@ impl MailBackend for JmapMailBackend {
     async fn sync_folder(
         &self,
         ctx: &MailSyncCtx,
-        account: &AccountFull,
+        account: &MailAccountConfig,
         folder_path: &str,
     ) -> Result<u32> {
         jmap_sync::sync_jmap_folder_public(
@@ -93,7 +93,7 @@ impl MailBackend for JmapMailBackend {
     async fn fetch_body_to_disk(
         &self,
         ctx: &MailSyncCtx,
-        account: &AccountFull,
+        account: &MailAccountConfig,
         request: &BodyFetchRequest,
     ) -> Result<String> {
         let email_id = body_fetch_email_id(request)?;
@@ -114,7 +114,7 @@ impl MailBackend for JmapMailBackend {
     async fn search_messages(
         &self,
         ctx: &MailSyncCtx,
-        account: &AccountFull,
+        account: &MailAccountConfig,
         query: &SearchQuery,
     ) -> Result<Vec<SearchHit>> {
         let (config, connection) = connect(ctx, account).await?;
@@ -128,7 +128,7 @@ impl MailBackend for JmapMailBackend {
     async fn save_draft(
         &self,
         ctx: &MailSyncCtx,
-        account: &AccountFull,
+        account: &MailAccountConfig,
         request: &DraftSaveRequest,
     ) -> Result<()> {
         let (config, connection) = connect(ctx, account).await?;
@@ -170,7 +170,8 @@ impl MailOpExecutor for JmapOpExecutor {
                 let account = {
                     let conn = ctx.db.reader();
                     crate::db::accounts::get_account_full(&conn, account_id)?
-                };
+                }
+                .mail_config();
                 let (jmap_config, conn_jmap) = connect(ctx, &account).await?;
                 conn_jmap
                     .copy_emails(&jmap_config, &email_ids, &target_folder)
@@ -199,7 +200,8 @@ impl MailOpExecutor for JmapOpExecutor {
                 let account = {
                     let conn = ctx.db.reader();
                     crate::db::accounts::get_account_full(&conn, account_id)?
-                };
+                }
+                .mail_config();
                 let (jmap_config, conn_jmap) = connect(ctx, &account).await?;
                 for (source_mailbox, email_ids) in by_mailbox {
                     conn_jmap
@@ -227,7 +229,8 @@ impl MailOpExecutor for JmapOpExecutor {
                 let account = {
                     let conn = ctx.db.reader();
                     crate::db::accounts::get_account_full(&conn, account_id)?
-                };
+                }
+                .mail_config();
                 let (jmap_config, conn_jmap) = connect(ctx, &account).await?;
                 conn_jmap.delete_emails(&jmap_config, &email_ids).await?;
             }
@@ -257,7 +260,8 @@ impl MailOpExecutor for JmapOpExecutor {
                 let account = {
                     let conn = ctx.db.reader();
                     crate::db::accounts::get_account_full(&conn, account_id)?
-                };
+                }
+                .mail_config();
                 let (jmap_config, conn_jmap) = connect(ctx, &account).await?;
                 for (email_ids, flags, add) in prepared {
                     let flag_strs: Vec<&str> = flags.iter().map(String::as_str).collect();
@@ -270,7 +274,8 @@ impl MailOpExecutor for JmapOpExecutor {
                 let account = {
                     let conn = ctx.db.reader();
                     crate::db::accounts::get_account_full(&conn, account_id)?
-                };
+                }
+                .mail_config();
                 let (jmap_config, conn_jmap) = connect(ctx, &account).await?;
                 conn_jmap.send_email(&jmap_config, &raw_message).await?;
             }

--- a/src-tauri/src/backend/mail/mod.rs
+++ b/src-tauri/src/backend/mail/mod.rs
@@ -10,7 +10,7 @@
 
 use async_trait::async_trait;
 
-use crate::db::accounts::AccountFull;
+use crate::account::MailAccountConfig;
 use crate::db::pool::DbPool;
 use crate::error::Result;
 use crate::event::SharedEventSink;
@@ -68,14 +68,14 @@ pub struct DraftSaveRequest {
 
 impl BodyFetchRequest {
     pub fn from_db_row(
-        account: &AccountFull,
+        account: &MailAccountConfig,
         message_id: &str,
         folder_path: &str,
         uid: u32,
         flags: Vec<String>,
         body_location: BodyLocation,
     ) -> Result<Self> {
-        let protocol = account.mail_protocol_str();
+        let protocol = account.protocol.as_str();
         let message_ref =
             BackendMessageRef::from_db_row(protocol, &account.id, message_id, folder_path, uid)
                 .or_else(|| {
@@ -110,7 +110,7 @@ pub trait MailBackend: Send + Sync {
     /// IDLE must be suspended around any other server operation. The
     /// command owns the suspend/resume because it owns the idle-handle
     /// state.
-    fn suspends_idle_for_ops(&self, _account: &AccountFull) -> bool {
+    fn suspends_idle_for_ops(&self, _account: &MailAccountConfig) -> bool {
         false
     }
 
@@ -120,7 +120,7 @@ pub trait MailBackend: Send + Sync {
     async fn sync_account(
         &self,
         ctx: &MailSyncCtx,
-        account: &AccountFull,
+        account: &MailAccountConfig,
         current_folder: Option<String>,
     ) -> Result<()>;
 
@@ -132,13 +132,17 @@ pub trait MailBackend: Send + Sync {
     async fn sync_folder(
         &self,
         ctx: &MailSyncCtx,
-        account: &AccountFull,
+        account: &MailAccountConfig,
         folder_path: &str,
     ) -> Result<u32>;
 
     /// Prefetch message bodies into the Maildir. Default no-op for
     /// providers that fetch bodies on demand (JMAP) or during sync.
-    async fn prefetch_bodies(&self, _ctx: &MailSyncCtx, _account: &AccountFull) -> Result<u32> {
+    async fn prefetch_bodies(
+        &self,
+        _ctx: &MailSyncCtx,
+        _account: &MailAccountConfig,
+    ) -> Result<u32> {
         Ok(0)
     }
 
@@ -147,7 +151,7 @@ pub trait MailBackend: Send + Sync {
     async fn fetch_body_to_disk(
         &self,
         ctx: &MailSyncCtx,
-        account: &AccountFull,
+        account: &MailAccountConfig,
         request: &BodyFetchRequest,
     ) -> Result<String>;
 
@@ -155,7 +159,7 @@ pub trait MailBackend: Send + Sync {
     async fn search_messages(
         &self,
         ctx: &MailSyncCtx,
-        account: &AccountFull,
+        account: &MailAccountConfig,
         query: &SearchQuery,
     ) -> Result<Vec<SearchHit>>;
 
@@ -166,7 +170,7 @@ pub trait MailBackend: Send + Sync {
     async fn save_draft(
         &self,
         ctx: &MailSyncCtx,
-        account: &AccountFull,
+        account: &MailAccountConfig,
         request: &DraftSaveRequest,
     ) -> Result<()>;
 
@@ -205,8 +209,8 @@ pub fn registry() -> &'static [&'static dyn MailBackend] {
 /// pre-trait dispatch chains all ended in an IMAP else-branch, and
 /// pre-binding accounts rely on it. Empty (no enabled mail binding)
 /// returns `None`; callers skip those accounts.
-pub fn for_account(account: &AccountFull) -> Option<&'static dyn MailBackend> {
-    let proto = account.mail_protocol_str();
+pub fn for_account(account: &MailAccountConfig) -> Option<&'static dyn MailBackend> {
+    let proto = account.protocol.as_str();
     if proto.is_empty() {
         return None;
     }
@@ -222,6 +226,7 @@ pub fn for_account(account: &AccountFull) -> Option<&'static dyn MailBackend> {
 #[cfg(test)]
 mod registry_tests {
     use super::*;
+    use crate::db::accounts::AccountFull;
     use crate::db::service_bindings::ServiceBinding;
     use crate::mail::compat::BodyLocation;
 
@@ -279,7 +284,8 @@ mod registry_tests {
     #[test]
     fn protocols_resolve_to_matching_backends() {
         for proto in ["imap", "jmap", "graph"] {
-            let b = for_account(&account(proto, "password")).expect(proto);
+            let config = account(proto, "password").mail_config();
+            let b = for_account(&config).expect(proto);
             assert_eq!(b.protocol(), proto);
         }
     }
@@ -293,20 +299,52 @@ mod registry_tests {
         ];
 
         for (protocol, expected) in cases {
-            let backend = for_account(&account(protocol, "password")).unwrap();
+            let config = account(protocol, "password").mail_config();
+            let backend = for_account(&config).unwrap();
             assert_eq!(backend.draft_storage_format(), expected);
         }
     }
 
     #[test]
     fn unknown_protocol_falls_back_to_imap() {
-        let b = for_account(&account("pop3", "password")).unwrap();
+        let config = account("pop3", "password").mail_config();
+        let b = for_account(&config).unwrap();
         assert_eq!(b.protocol(), "imap");
     }
 
     #[test]
     fn empty_protocol_is_none() {
-        assert!(for_account(&account("", "password")).is_none());
+        assert!(for_account(&account("", "password").mail_config()).is_none());
+    }
+
+    #[test]
+    fn focused_config_uses_enabled_binding_and_mail_fields() {
+        let mut account = account("imap", "oauth-microsoft");
+        account.imap_host = "imap.example.com".into();
+        account.imap_port = 993;
+        account.smtp_host = "smtp.example.com".into();
+        account.smtp_port = 587;
+        account.password = "keyring-secret".into();
+
+        let config = account.mail_config();
+
+        assert_eq!(config.protocol, "imap");
+        assert_eq!(config.id, "acc1");
+        assert_eq!(config.imap_host, "imap.example.com");
+        assert_eq!(config.smtp_host, "smtp.example.com");
+        assert_eq!(config.password, "keyring-secret");
+        assert_eq!(config.auth_method, "oauth-microsoft");
+    }
+
+    #[test]
+    fn focused_config_does_not_route_disabled_legacy_mail_protocol() {
+        let mut account = account("imap", "password");
+        account.bindings[0].enabled = false;
+
+        let config = account.mail_config();
+
+        assert!(config.protocol.is_empty());
+        assert!(for_account(&config).is_none());
     }
 
     #[test]
@@ -314,6 +352,9 @@ mod registry_tests {
         let imap_o365 = account("imap", "oauth-microsoft");
         let imap_plain = account("imap", "password");
         let graph = account("graph", "oauth-microsoft");
+        let imap_o365 = imap_o365.mail_config();
+        let imap_plain = imap_plain.mail_config();
+        let graph = graph.mail_config();
         assert!(for_account(&imap_o365)
             .unwrap()
             .suspends_idle_for_ops(&imap_o365));
@@ -332,7 +373,7 @@ mod registry_tests {
         ];
 
         for (protocol, message_id, folder, uid) in cases {
-            let account = account(protocol, "password");
+            let account = account(protocol, "password").mail_config();
             let request = BodyFetchRequest::from_db_row(
                 &account,
                 message_id,
@@ -348,7 +389,7 @@ mod registry_tests {
 
     #[test]
     fn body_fetch_request_preserves_legacy_jmap_raw_id_fallback() {
-        let account = account("jmap", "password");
+        let account = account("jmap", "password").mail_config();
         let request = BodyFetchRequest::from_db_row(
             &account,
             "raw_email_id",

--- a/src-tauri/src/commands/compose.rs
+++ b/src-tauri/src/commands/compose.rs
@@ -511,7 +511,8 @@ pub async fn save_draft(
         let conn = state.db.reader();
         db::accounts::get_account_full(&conn, &account_id)?
     };
-    let backend = crate::backend::mail::for_account(&account)
+    let mail_config = account.mail_config();
+    let backend = crate::backend::mail::for_account(&mail_config)
         .ok_or_else(|| Error::Other("Account has no enabled mail binding".into()))?;
 
     // Drafts peek rather than consume tokens: the user may save a draft
@@ -608,7 +609,7 @@ pub async fn save_draft(
     backend
         .save_draft(
             &ctx,
-            &account,
+            &mail_config,
             &crate::backend::mail::DraftSaveRequest {
                 raw_message,
                 to: message.to,

--- a/src-tauri/src/commands/mail.rs
+++ b/src-tauri/src/commands/mail.rs
@@ -125,8 +125,9 @@ pub async fn search_messages_server(
         let conn = state.db.reader();
         db::accounts::get_account_full(&conn, &account_id)?
     };
+    let mail_config = account.mail_config();
 
-    let backend = crate::backend::mail::for_account(&account).ok_or_else(|| {
+    let backend = crate::backend::mail::for_account(&mail_config).ok_or_else(|| {
         Error::Other(format!(
             "Account {} has no enabled mail service for server search",
             account_id
@@ -139,14 +140,14 @@ pub async fn search_messages_server(
         providers: state.providers.clone(),
     };
 
-    let suspended_idle = if backend.suspends_idle_for_ops(&account) {
+    let suspended_idle = if backend.suspends_idle_for_ops(&mail_config) {
         Some(suspend_imap_idle_for_operation(&app, &state, &account).await?)
     } else {
         None
     };
 
     let hits = if let Some(suspended_idle) = suspended_idle {
-        let search_account = account.clone();
+        let search_account = mail_config.clone();
         let resume_account = account.clone();
         let resume_app = app.clone();
         let task = spawn_with_imap_idle_resume(
@@ -167,7 +168,7 @@ pub async fn search_messages_server(
         task.await
             .map_err(|e| Error::Other(format!("Server search task panicked: {}", e)))??
     } else {
-        backend.search_messages(&ctx, &account, &query).await?
+        backend.search_messages(&ctx, &mail_config, &query).await?
     };
 
     log::info!("Server search returned {} hits", hits.len());
@@ -285,17 +286,18 @@ async fn ensure_message_body_on_disk(
         let (fp, u) = db::messages::get_folder_and_uid(&conn, message_id)?;
         (account, fp, u)
     };
+    let mail_config = account.mail_config();
 
     let flags = serde_json::from_str(flags_json).unwrap_or_default();
     let request = crate::backend::mail::BodyFetchRequest::from_db_row(
-        &account,
+        &mail_config,
         message_id,
         &folder_path,
         uid,
         flags,
         body_location,
     )?;
-    let backend = crate::backend::mail::for_account(&account).ok_or_else(|| {
+    let backend = crate::backend::mail::for_account(&mail_config).ok_or_else(|| {
         Error::Other(format!(
             "Account {} has no enabled mail service for body fetch",
             account_id
@@ -308,14 +310,14 @@ async fn ensure_message_body_on_disk(
         providers: state.providers.clone(),
     };
 
-    let suspended_idle = if backend.suspends_idle_for_ops(&account) {
+    let suspended_idle = if backend.suspends_idle_for_ops(&mail_config) {
         Some(suspend_imap_idle_for_operation(app, state, &account).await?)
     } else {
         None
     };
 
     if let Some(suspended_idle) = suspended_idle {
-        let fetch_account = account.clone();
+        let fetch_account = mail_config.clone();
         let resume_account = account;
         let resume_app = app.clone();
         let task = spawn_with_imap_idle_resume(
@@ -336,14 +338,14 @@ async fn ensure_message_body_on_disk(
         task.await
             .map_err(|e| Error::Other(format!("Body fetch owner task panicked: {}", e)))?
     } else {
-        fetch_body_and_record_path(backend, ctx, account, request).await
+        fetch_body_and_record_path(backend, ctx, mail_config, request).await
     }
 }
 
 async fn fetch_body_and_record_path(
     backend: &'static dyn crate::backend::mail::MailBackend,
     ctx: crate::backend::mail::MailSyncCtx,
-    account: db::accounts::AccountFull,
+    account: crate::account::MailAccountConfig,
     request: crate::backend::mail::BodyFetchRequest,
 ) -> Result<String> {
     log::info!(

--- a/src-tauri/src/commands/sync_cmd.rs
+++ b/src-tauri/src/commands/sync_cmd.rs
@@ -554,13 +554,14 @@ async fn run_mail_sync_once(
         );
         return Ok(());
     }
+    let mail_config = account.mail_config();
 
     // Non-empty protocol always resolves (unknown falls back to IMAP,
     // matching the pre-trait else-is-IMAP chain).
-    let backend = crate::backend::mail::for_account(&account)
+    let backend = crate::backend::mail::for_account(&mail_config)
         .expect("non-empty mail protocol resolves to a backend");
 
-    let suspended_idle = if backend.suspends_idle_for_ops(&account) {
+    let suspended_idle = if backend.suspends_idle_for_ops(&mail_config) {
         log::info!(
             "Suspending IMAP IDLE for account {} before sync",
             account_id
@@ -579,7 +580,9 @@ async fn run_mail_sync_once(
     };
     // Calendar sync is independent — triggered by its own interval,
     // not chained to mail sync. See CalendarView.vue / calendar.ts.
-    let sync_result = backend.sync_account(&ctx, &account, current_folder).await;
+    let sync_result = backend
+        .sync_account(&ctx, &mail_config, current_folder)
+        .await;
 
     let resume_result =
         resume_imap_idle_for_account(app, state, &resume_account, suspended_idle).await;
@@ -706,14 +709,15 @@ pub async fn sync_folder(
         );
         return Ok(0);
     }
+    let mail_config = account.mail_config();
 
     // sync-started is emitted by each backend's sync path, so the
     // activity store sees exactly one start per sync.
 
-    let backend = crate::backend::mail::for_account(&account)
+    let backend = crate::backend::mail::for_account(&mail_config)
         .expect("non-empty mail protocol resolves to a backend");
 
-    let suspended_idle = if backend.suspends_idle_for_ops(&account) {
+    let suspended_idle = if backend.suspends_idle_for_ops(&mail_config) {
         log::info!(
             "Suspending IMAP IDLE for account {} before single-folder sync",
             account_id
@@ -734,7 +738,7 @@ pub async fn sync_folder(
     // Every backend syncs exactly the requested folder synchronously —
     // a right-click "sync folder" must never escalate to a whole-account
     // sync (Graph used to background one here before delta sync).
-    let sync_result: Result<u32> = backend.sync_folder(&ctx, &account, &folder_path).await;
+    let sync_result: Result<u32> = backend.sync_folder(&ctx, &mail_config, &folder_path).await;
 
     let resume_result =
         resume_imap_idle_for_account(&app, &state, &resume_account, suspended_idle).await;
@@ -812,11 +816,12 @@ pub async fn prefetch_bodies(
             let conn = state.db.reader();
             db::accounts::get_account_full(&conn, &account_id)?
         };
+        let mail_config = account.mail_config();
 
         // JMAP inherits the trait's no-op prefetch (bodies are fetched on
         // demand via the JMAP API); accounts without a mail binding have
         // nothing to prefetch.
-        let Some(backend) = crate::backend::mail::for_account(&account) else {
+        let Some(backend) = crate::backend::mail::for_account(&mail_config) else {
             log::debug!(
                 "Prefetch: account {} has no enabled mail binding, skipping",
                 account_id
@@ -824,7 +829,7 @@ pub async fn prefetch_bodies(
             return Ok(0);
         };
 
-        let suspended_idle = if backend.suspends_idle_for_ops(&account) {
+        let suspended_idle = if backend.suspends_idle_for_ops(&mail_config) {
             log::info!(
                 "Suspending IMAP IDLE for account {} before body prefetch",
                 account_id
@@ -842,7 +847,7 @@ pub async fn prefetch_bodies(
             data_dir: state.data_dir.clone(),
             providers: state.providers.clone(),
         };
-        let prefetch_result = backend.prefetch_bodies(&ctx, &account).await;
+        let prefetch_result = backend.prefetch_bodies(&ctx, &mail_config).await;
         let resume_result =
             resume_imap_idle_for_account(&app, &state, &resume_account, suspended_idle).await;
 

--- a/src-tauri/src/db/accounts.rs
+++ b/src-tauri/src/db/accounts.rs
@@ -270,6 +270,29 @@ pub struct AccountFull {
 }
 
 impl AccountFull {
+    /// Build the backend-only mail view from this compatibility aggregate.
+    /// Routing follows the enabled mail binding rather than the legacy mirror.
+    pub fn mail_config(&self) -> crate::account::MailAccountConfig {
+        crate::account::MailAccountConfig {
+            id: self.id.clone(),
+            display_name: self.display_name.clone(),
+            email: self.email.clone(),
+            protocol: self.mail_protocol_str().to_string(),
+            username: self.username.clone(),
+            password: self.password.clone(),
+            auth_method: self.auth_method.clone(),
+            imap_host: self.imap_host.clone(),
+            imap_port: self.imap_port,
+            smtp_host: self.smtp_host.clone(),
+            smtp_port: self.smtp_port,
+            use_tls: self.use_tls,
+            jmap_url: self.jmap_url.clone(),
+            jmap_auth_method: self.jmap_auth_method.clone(),
+            oidc_token_endpoint: self.oidc_token_endpoint.clone(),
+            oidc_client_id: self.oidc_client_id.clone(),
+        }
+    }
+
     /// Look up the binding for a given service ("mail" | "calendar" |
     /// "contacts"). Returns `None` if the account has no binding for that
     /// service (e.g. a CalDAV-only account has no mail binding).

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 #![allow(clippy::too_many_arguments)]
 
+mod account;
 mod backend;
 mod calendar;
 mod commands;

--- a/src-tauri/src/mail/jmap/mod.rs
+++ b/src-tauri/src/mail/jmap/mod.rs
@@ -222,6 +222,10 @@ mod connect_tests {
 
 impl JmapConfig {
     pub fn from_account(account: &crate::db::accounts::AccountFull) -> Self {
+        Self::from_mail_account(&account.mail_config())
+    }
+
+    pub fn from_mail_account(account: &crate::account::MailAccountConfig) -> Self {
         // "bearer" mode stores the API token in the password field but the
         // server (e.g. Fastmail) expects Authorization: Bearer <token>, not
         // Basic auth. Promote it to access_token so apply_auth() routes it
@@ -315,7 +319,8 @@ mod from_account_tests {
 
     #[test]
     fn bearer_mode_moves_password_to_access_token() {
-        let cfg = JmapConfig::from_account(&account_with("bearer", "fmu1-secret-api-token"));
+        let account = account_with("bearer", "fmu1-secret-api-token").mail_config();
+        let cfg = JmapConfig::from_mail_account(&account);
         assert_eq!(cfg.password, "");
         assert_eq!(cfg.access_token.as_deref(), Some("fmu1-secret-api-token"));
     }

--- a/src-tauri/src/mail/jmap_sync.rs
+++ b/src-tauri/src/mail/jmap_sync.rs
@@ -18,7 +18,7 @@ pub(crate) async fn sync_jmap_account(
     events: SharedEventSink,
     db: Arc<DbPool>,
     _data_dir: PathBuf,
-    account: &crate::db::accounts::AccountFull,
+    account: &crate::account::MailAccountConfig,
     providers: Arc<ProviderServices>,
     current_folder: Option<String>,
 ) -> Result<()> {
@@ -28,7 +28,7 @@ pub(crate) async fn sync_jmap_account(
     }));
 
     let result = async {
-        let (jmap_config, conn_jmap) = providers.jmap_client(account).await?;
+        let (jmap_config, conn_jmap) = providers.jmap_client_for(account).await?;
         sync_jmap_account_inner(
             events.as_ref(),
             &db,
@@ -471,7 +471,7 @@ fn count_unread(conn: &rusqlite::Connection, account_id: &str, folder_path: &str
 pub(crate) async fn sync_jmap_folder_public(
     events: SharedEventSink,
     db: Arc<DbPool>,
-    account: &crate::db::accounts::AccountFull,
+    account: &crate::account::MailAccountConfig,
     mailbox_id: String,
     providers: Arc<ProviderServices>,
 ) -> Result<u32> {
@@ -482,7 +482,7 @@ pub(crate) async fn sync_jmap_folder_public(
 
     let folder_name = mailbox_id.clone();
     let result = async {
-        let (jmap_config, conn_jmap) = providers.jmap_client(account).await?;
+        let (jmap_config, conn_jmap) = providers.jmap_client_for(account).await?;
         sync_jmap_folder(
             &db,
             providers.as_ref(),
@@ -665,7 +665,7 @@ mod tests {
         let db = Arc::new(DbPool::new(&temp.path().join("test.db"), 1).unwrap());
         let recording = Arc::new(RecordingEvents::default());
         let events: SharedEventSink = recording.clone();
-        let account = jmap_account("http://mail.example.com");
+        let account = jmap_account("http://mail.example.com").mail_config();
 
         let result = sync_jmap_account(
             events,

--- a/src-tauri/src/ops/worker.rs
+++ b/src-tauri/src/ops/worker.rs
@@ -207,7 +207,7 @@ impl AccountWorker {
             let conn = self.db.reader();
             crate::db::accounts::get_account_full(&conn, &self.account_id)?
         };
-        self.backend = crate::backend::mail::for_account(&account);
+        self.backend = crate::backend::mail::for_account(&account.mail_config());
         self.executor = self.backend.map(|b| b.op_executor());
         let data_dir = self.app.state::<crate::state::AppState>().data_dir.clone();
         let providers = self.app.state::<crate::state::AppState>().providers.clone();
@@ -530,12 +530,12 @@ impl AccountWorker {
     /// the executor's.
     fn sync_target(
         &self,
-    ) -> Result<Option<(&'static dyn MailBackend, crate::db::accounts::AccountFull)>> {
+    ) -> Result<Option<(&'static dyn MailBackend, crate::account::MailAccountConfig)>> {
         let account = {
             let conn = self.db.reader();
             crate::db::accounts::get_account_full(&conn, &self.account_id)?
         };
-        Ok(self.backend.map(|b| (b, account)))
+        Ok(self.backend.map(|b| (b, account.mail_config())))
     }
 
     /// Delegate a full account sync to the backend. Deliberate

--- a/src-tauri/src/provider.rs
+++ b/src-tauri/src/provider.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 
+use crate::account::MailAccountConfig;
 use crate::db::accounts::AccountFull;
 use crate::error::{Error, Result};
 use crate::mail::jmap::JmapConfig;
@@ -171,8 +172,21 @@ pub trait ProviderCredentials: Send + Sync {
         account_id: &str,
         purpose: GraphTokenPurpose,
     ) -> Result<String>;
-    async fn mail_credentials(&self, account: &AccountFull) -> Result<MailCredentials>;
-    async fn jmap_config(&self, account: &AccountFull) -> Result<JmapConfig>;
+    async fn mail_credentials_for(&self, account: &MailAccountConfig) -> Result<MailCredentials>;
+    async fn jmap_config_for(&self, account: &MailAccountConfig) -> Result<JmapConfig>;
+
+    /// Compatibility wrapper for service paths not yet migrated to focused
+    /// account views.
+    async fn mail_credentials(&self, account: &AccountFull) -> Result<MailCredentials> {
+        let config = account.mail_config();
+        self.mail_credentials_for(&config).await
+    }
+
+    /// Compatibility wrapper for shared JMAP calendar/contact paths.
+    async fn jmap_config(&self, account: &AccountFull) -> Result<JmapConfig> {
+        let config = account.mail_config();
+        self.jmap_config_for(&config).await
+    }
     async fn jmap_push_access_token(
         &self,
         account_id: &str,
@@ -576,7 +590,15 @@ impl ProviderServices {
         &self,
         account: &AccountFull,
     ) -> Result<(JmapConfig, crate::mail::jmap::JmapConnection)> {
-        let config = self.credentials.jmap_config(account).await?;
+        let config = account.mail_config();
+        self.jmap_client_for(&config).await
+    }
+
+    pub async fn jmap_client_for(
+        &self,
+        account: &MailAccountConfig,
+    ) -> Result<(JmapConfig, crate::mail::jmap::JmapConnection)> {
+        let config = self.credentials.jmap_config_for(account).await?;
         let connection = crate::mail::jmap::JmapConnection::connect_with_clients(
             &config,
             self.transports.jmap_discovery_http.clone(),
@@ -637,7 +659,7 @@ impl ProviderCredentialService {
             .ok_or_else(|| Error::Other(missing_message.into()))
     }
 
-    async fn jmap_oidc_access_token(&self, account: &AccountFull) -> Result<Option<String>> {
+    async fn jmap_oidc_access_token(&self, account: &MailAccountConfig) -> Result<Option<String>> {
         if account.jmap_auth_method != "oidc" {
             return Ok(None);
         }
@@ -746,7 +768,7 @@ impl ProviderCredentials for ProviderCredentialService {
         Ok(refreshed.access_token)
     }
 
-    async fn mail_credentials(&self, account: &AccountFull) -> Result<MailCredentials> {
+    async fn mail_credentials_for(&self, account: &MailAccountConfig) -> Result<MailCredentials> {
         if account.auth_method != "oauth-microsoft" {
             return Ok(MailCredentials {
                 secret: account.password.clone(),
@@ -779,8 +801,8 @@ impl ProviderCredentials for ProviderCredentialService {
         })
     }
 
-    async fn jmap_config(&self, account: &AccountFull) -> Result<JmapConfig> {
-        let mut config = JmapConfig::from_account(account);
+    async fn jmap_config_for(&self, account: &MailAccountConfig) -> Result<JmapConfig> {
+        let mut config = JmapConfig::from_mail_account(account);
         if let Some(token) = self.jmap_oidc_access_token(account).await? {
             config.access_token = Some(token);
         }
@@ -1067,11 +1089,14 @@ mod tests {
             unreachable!()
         }
 
-        async fn mail_credentials(&self, _account: &AccountFull) -> Result<MailCredentials> {
+        async fn mail_credentials_for(
+            &self,
+            _account: &MailAccountConfig,
+        ) -> Result<MailCredentials> {
             unreachable!()
         }
 
-        async fn jmap_config(&self, _account: &AccountFull) -> Result<JmapConfig> {
+        async fn jmap_config_for(&self, _account: &MailAccountConfig) -> Result<JmapConfig> {
             unreachable!()
         }
 
@@ -1238,6 +1263,73 @@ mod tests {
             refresh_token: Some("rotated-refresh".into()),
             expires_at: Some(i64::MAX),
         }
+    }
+
+    fn mail_account(auth_method: &str, password: &str) -> MailAccountConfig {
+        MailAccountConfig {
+            id: "mail-focused".into(),
+            display_name: "Focused Mail".into(),
+            email: "user@example.com".into(),
+            protocol: "imap".into(),
+            username: "user@example.com".into(),
+            password: password.into(),
+            auth_method: auth_method.into(),
+            imap_host: "imap.example.com".into(),
+            imap_port: 993,
+            smtp_host: "smtp.example.com".into(),
+            smtp_port: 587,
+            use_tls: true,
+            jmap_url: String::new(),
+            jmap_auth_method: "basic".into(),
+            oidc_token_endpoint: String::new(),
+            oidc_client_id: String::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn focused_password_mail_credentials_preserve_keyring_secret() {
+        let service = ProviderCredentialService::new(
+            Arc::new(MemoryTokenStore::default()),
+            Arc::new(FakeTokenEndpoint {
+                refreshed: refreshed_tokens(),
+                scopes: Mutex::new(Vec::new()),
+            }),
+        );
+
+        let credentials = service
+            .mail_credentials_for(&mail_account("password", "keyring-secret"))
+            .await
+            .unwrap();
+
+        assert_eq!(credentials.secret, "keyring-secret");
+        assert!(!credentials.use_xoauth2);
+    }
+
+    #[tokio::test]
+    async fn focused_microsoft_mail_credentials_use_imap_scope_and_rotate() {
+        let store = Arc::new(MemoryTokenStore::default());
+        store.store("mail-focused", &expired_tokens()).unwrap();
+        let endpoint = Arc::new(FakeTokenEndpoint {
+            refreshed: refreshed_tokens(),
+            scopes: Mutex::new(Vec::new()),
+        });
+        let service = ProviderCredentialService::new(store.clone(), endpoint.clone());
+
+        let credentials = service
+            .mail_credentials_for(&mail_account("oauth-microsoft", "ignored"))
+            .await
+            .unwrap();
+
+        assert_eq!(credentials.secret, "fresh-access");
+        assert!(credentials.use_xoauth2);
+        assert_eq!(
+            endpoint.scopes.lock().unwrap().as_slice(),
+            [crate::oauth::MICROSOFT_IMAP_SCOPES]
+        );
+        assert_eq!(
+            store.load("mail-focused").unwrap().unwrap().refresh_token,
+            Some("rotated-refresh".into())
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Implements the first focused-account slice from ADR 0051 step 17.

- Adds an owned, backend-only `MailAccountConfig`.
- Migrates `MailBackend` and its IMAP, JMAP, and Graph implementations
  away from `AccountFull`.
- Converts `AccountFull` at command, worker, and persistence boundaries.
- Keeps compatibility wrappers for calendar and contacts paths that still
  use shared JMAP configuration.
- Removes an unnecessary Graph account/keyring reload.

## Compatibility

This preserves:

- Enabled and disabled mail-binding routing.
- Legacy unknown-protocol IMAP fallback.
- Keyring-backed password handling.
- Microsoft IMAP OAuth scopes and refresh-token rotation.
- JMAP basic, bearer, and OIDC authentication.
- Graph SMTP compatibility.
- Existing IPC and persistence formats.

`MailAccountConfig` is not serializable or exposed over IPC.

## Scope

This is intentionally incremental. `AccountFull` remains the persistence
and IPC compatibility aggregate. Executor paths still load it at the
persistence boundary before immediately creating a focused mail
configuration.

Calendar, contacts, meeting, PGP, and other account views are deferred to
later ADR 0051 slices.

## Testing

- Focused mail routing tests.
- Disabled-binding regression coverage.
- JMAP focused configuration coverage.
- Password credential parity coverage.
- Microsoft IMAP scope and token-rotation coverage.
- Full Rust suite: **685 passed, 1 ignored**.
- Strict Clippy passed.
- Formatting and `git diff --check` passed.
- Independent review found no correctness, security, or architecture
  issues.