### PR TITLE
refactor(calendar): extract shared calendar models

### DIFF
--- a/src-tauri/src/backend/calendar/caldav.rs
+++ b/src-tauri/src/backend/calendar/caldav.rs
@@ -3,9 +3,9 @@
 use async_trait::async_trait;
 
 use crate::calendar::ical;
+use crate::calendar::CalendarEvent;
 use crate::db;
 use crate::db::accounts::AccountFull;
-use crate::db::calendar::CalendarEvent;
 use crate::error::Result;
 use crate::mail::caldav::{CalDavClient, CalDavConfig};
 

--- a/src-tauri/src/backend/calendar/google.rs
+++ b/src-tauri/src/backend/calendar/google.rs
@@ -2,9 +2,9 @@
 
 use async_trait::async_trait;
 
+use crate::calendar::CalendarEvent;
 use crate::db;
 use crate::db::accounts::AccountFull;
-use crate::db::calendar::CalendarEvent;
 use crate::error::{Error, Result};
 use crate::mail::google::{
     event_patch_to_google_json, event_to_google_json, send_updates_for, EventsPage,

--- a/src-tauri/src/backend/calendar/graph.rs
+++ b/src-tauri/src/backend/calendar/graph.rs
@@ -2,9 +2,10 @@
 
 use async_trait::async_trait;
 
+use crate::calendar::CalendarEvent;
 use crate::db;
 use crate::db::accounts::AccountFull;
-use crate::db::calendar::{CalendarEvent, NewCalendar};
+use crate::db::calendar::NewCalendar;
 use crate::error::Result;
 use crate::mail::graph::{event_patch_to_graph_json, event_to_graph_json};
 use crate::provider::GraphTokenPurpose;

--- a/src-tauri/src/backend/calendar/jmap.rs
+++ b/src-tauri/src/backend/calendar/jmap.rs
@@ -2,9 +2,9 @@
 
 use async_trait::async_trait;
 
+use crate::calendar::CalendarEvent;
 use crate::db;
 use crate::db::accounts::AccountFull;
-use crate::db::calendar::CalendarEvent;
 use crate::error::Result;
 use crate::mail::jmap::{JmapCalendarEvent, JmapConfig, JmapConnection};
 

--- a/src-tauri/src/backend/calendar/mod.rs
+++ b/src-tauri/src/backend/calendar/mod.rs
@@ -14,8 +14,8 @@
 
 use async_trait::async_trait;
 
+use crate::calendar::CalendarEvent;
 use crate::db::accounts::AccountFull;
-use crate::db::calendar::CalendarEvent;
 use crate::db::pool::DbPool;
 use crate::error::Result;
 use crate::provider::ProviderServices;

--- a/src-tauri/src/backend/mod.rs
+++ b/src-tauri/src/backend/mod.rs
@@ -17,8 +17,8 @@ pub mod mail;
 
 #[cfg(test)]
 pub(crate) mod testutil {
+    use crate::calendar::CalendarEvent;
     use crate::db::accounts::AccountFull;
-    use crate::db::calendar::CalendarEvent;
     use crate::db::contacts::Contact;
     use crate::db::pool::DbPool;
     use crate::db::service_bindings::ServiceBinding;

--- a/src-tauri/src/calendar/ical.rs
+++ b/src-tauri/src/calendar/ical.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 use mail_parser::{MessageParser, MimeHeaders};
 use serde::{Deserialize, Serialize};
 
-use crate::db::calendar::Attendee;
+use super::Attendee;
 
 /// A parsed calendar invite extracted from an email or raw iCalendar text.
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src-tauri/src/calendar/mod.rs
+++ b/src-tauri/src/calendar/mod.rs
@@ -1,2 +1,159 @@
+use serde::{Deserialize, Serialize};
+
 pub mod ical;
 pub mod timezone;
+
+/// Provider-neutral calendar event shared by persistence and backends.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CalendarEvent {
+    pub id: String,
+    pub account_id: String,
+    pub calendar_id: String,
+    pub uid: Option<String>,
+    pub title: String,
+    pub description: Option<String>,
+    pub location: Option<String>,
+    pub start_time: String,
+    pub end_time: String,
+    pub all_day: bool,
+    pub timezone: Option<String>,
+    pub recurrence_rule: Option<String>,
+    pub organizer_email: Option<String>,
+    pub attendees_json: Option<String>,
+    pub my_status: Option<String>,
+    pub source_message_id: Option<String>,
+    pub ical_data: Option<String>,
+    pub remote_id: Option<String>,
+    pub etag: Option<String>,
+}
+
+/// Attendee serialized inside [`CalendarEvent::attendees_json`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Attendee {
+    pub email: String,
+    pub name: Option<String>,
+    /// `accepted`, `tentative`, `declined`, or `needs-action`.
+    pub status: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Attendee, CalendarEvent};
+
+    #[test]
+    fn calendar_event_json_contract_is_stable() {
+        let event = CalendarEvent {
+            id: "event-1".into(),
+            account_id: "account-1".into(),
+            calendar_id: "calendar-1".into(),
+            uid: Some("uid-1".into()),
+            title: "Planning".into(),
+            description: Some("Quarterly planning".into()),
+            location: Some("Room 1".into()),
+            start_time: "2026-08-21T09:00:00Z".into(),
+            end_time: "2026-08-21T10:00:00Z".into(),
+            all_day: false,
+            timezone: Some("Europe/Stockholm".into()),
+            recurrence_rule: Some("FREQ=WEEKLY".into()),
+            organizer_email: Some("owner@example.com".into()),
+            attendees_json: Some("[]".into()),
+            my_status: Some("accepted".into()),
+            source_message_id: Some("message-1".into()),
+            ical_data: Some("BEGIN:VCALENDAR".into()),
+            remote_id: Some("remote-1".into()),
+            etag: Some("etag-1".into()),
+        };
+        let expected = serde_json::json!({
+            "id": "event-1",
+            "account_id": "account-1",
+            "calendar_id": "calendar-1",
+            "uid": "uid-1",
+            "title": "Planning",
+            "description": "Quarterly planning",
+            "location": "Room 1",
+            "start_time": "2026-08-21T09:00:00Z",
+            "end_time": "2026-08-21T10:00:00Z",
+            "all_day": false,
+            "timezone": "Europe/Stockholm",
+            "recurrence_rule": "FREQ=WEEKLY",
+            "organizer_email": "owner@example.com",
+            "attendees_json": "[]",
+            "my_status": "accepted",
+            "source_message_id": "message-1",
+            "ical_data": "BEGIN:VCALENDAR",
+            "remote_id": "remote-1",
+            "etag": "etag-1",
+        });
+
+        assert_eq!(serde_json::to_value(&event).unwrap(), expected);
+        let decoded: CalendarEvent = serde_json::from_value(expected.clone()).unwrap();
+        assert_eq!(serde_json::to_value(decoded).unwrap(), expected);
+
+        let minimal: CalendarEvent = serde_json::from_value(serde_json::json!({
+            "id": "event-2",
+            "account_id": "account-1",
+            "calendar_id": "calendar-1",
+            "title": "Minimal",
+            "start_time": "2026-08-22",
+            "end_time": "2026-08-23",
+            "all_day": true,
+        }))
+        .unwrap();
+        assert_eq!(
+            serde_json::to_value(minimal).unwrap(),
+            serde_json::json!({
+                "id": "event-2",
+                "account_id": "account-1",
+                "calendar_id": "calendar-1",
+                "uid": null,
+                "title": "Minimal",
+                "description": null,
+                "location": null,
+                "start_time": "2026-08-22",
+                "end_time": "2026-08-23",
+                "all_day": true,
+                "timezone": null,
+                "recurrence_rule": null,
+                "organizer_email": null,
+                "attendees_json": null,
+                "my_status": null,
+                "source_message_id": null,
+                "ical_data": null,
+                "remote_id": null,
+                "etag": null,
+            })
+        );
+    }
+
+    #[test]
+    fn attendee_json_contract_is_stable() {
+        let attendee = Attendee {
+            email: "guest@example.com".into(),
+            name: Some("Guest".into()),
+            status: "tentative".into(),
+        };
+        let expected = serde_json::json!({
+            "email": "guest@example.com",
+            "name": "Guest",
+            "status": "tentative",
+        });
+
+        assert_eq!(serde_json::to_value(&attendee).unwrap(), expected);
+        let decoded: Attendee = serde_json::from_value(expected.clone()).unwrap();
+        assert_eq!(serde_json::to_value(decoded).unwrap(), expected);
+
+        let unnamed: Attendee = serde_json::from_value(serde_json::json!({
+            "email": "guest@example.com",
+            "status": "needs-action",
+        }))
+        .unwrap();
+        assert_eq!(
+            serde_json::to_value(unnamed).unwrap(),
+            serde_json::json!({
+                "email": "guest@example.com",
+                "name": null,
+                "status": "needs-action",
+            })
+        );
+    }
+}

--- a/src-tauri/src/commands/calendar.rs
+++ b/src-tauri/src/commands/calendar.rs
@@ -7,9 +7,10 @@ use crate::backend::calendar::{
     RemoteRsvpRequest, RoomAvailability, RoomAvailabilityRequest, RoomSuggestion,
 };
 use crate::calendar::ical::{self, ParsedInvite};
+use crate::calendar::{Attendee, CalendarEvent};
 use crate::commands::sync_cmd::try_acquire_sync_guard;
 use crate::db;
-use crate::db::calendar::{Attendee, Calendar, CalendarEvent, Invite, NewCalendar};
+use crate::db::calendar::{Calendar, Invite, NewCalendar};
 use crate::error::Result;
 use crate::meet;
 use crate::message::BodyLocation;

--- a/src-tauri/src/db/calendar.rs
+++ b/src-tauri/src/db/calendar.rs
@@ -1,6 +1,7 @@
 use rusqlite::{params, Connection};
 use serde::{Deserialize, Serialize};
 
+use crate::calendar::{Attendee, CalendarEvent};
 use crate::error::Result;
 
 // ---------------------------------------------------------------------------
@@ -24,37 +25,6 @@ pub struct NewCalendar {
     pub name: String,
     pub color: String,
     pub is_default: bool,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct CalendarEvent {
-    pub id: String,
-    pub account_id: String,
-    pub calendar_id: String,
-    pub uid: Option<String>,
-    pub title: String,
-    pub description: Option<String>,
-    pub location: Option<String>,
-    pub start_time: String,
-    pub end_time: String,
-    pub all_day: bool,
-    pub timezone: Option<String>,
-    pub recurrence_rule: Option<String>,
-    pub organizer_email: Option<String>,
-    pub attendees_json: Option<String>,
-    pub my_status: Option<String>,
-    pub source_message_id: Option<String>,
-    pub ical_data: Option<String>,
-    pub remote_id: Option<String>,
-    pub etag: Option<String>,
-}
-
-/// Attendee for JSON serialization inside `attendees_json`.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Attendee {
-    pub email: String,
-    pub name: Option<String>,
-    pub status: String, // "accepted", "tentative", "declined", "needs-action"
 }
 
 /// A calendar invite — a `CalendarEvent` plus its row `created_at`

--- a/src-tauri/src/mail/google.rs
+++ b/src-tauri/src/mail/google.rs
@@ -5,7 +5,7 @@
 //! `ProviderCredentials`; this client just sends requests with a ready token,
 //! mirroring `GraphClient`.
 
-use crate::db::calendar::CalendarEvent;
+use crate::calendar::CalendarEvent;
 use crate::error::{Error, Result};
 
 #[derive(Debug, Clone, PartialEq)]

--- a/src-tauri/src/mail/graph.rs
+++ b/src-tauri/src/mail/graph.rs
@@ -2851,7 +2851,7 @@ fn graph_time_json(timestamp: &str, all_day: bool) -> serde_json::Value {
 /// Graph payload for creating an event. Includes the attendee list plus
 /// the organizer as an attendee with `response: organizer` — Exchange
 /// needs it to render the organizer row correctly.
-pub fn event_to_graph_json(event: &crate::db::calendar::CalendarEvent) -> serde_json::Value {
+pub fn event_to_graph_json(event: &crate::calendar::CalendarEvent) -> serde_json::Value {
     let mut graph_event = serde_json::json!({
         "subject": event.title,
         "start": graph_time_json(&event.start_time, event.all_day),
@@ -2896,7 +2896,7 @@ pub fn event_to_graph_json(event: &crate::db::calendar::CalendarEvent) -> serde_
 /// Graph payload for patching an event. Narrower than the create
 /// payload: raw timestamps (no all-day midnight anchoring) and no
 /// attendee rewrite, matching what update_event has always sent.
-pub fn event_patch_to_graph_json(event: &crate::db::calendar::CalendarEvent) -> serde_json::Value {
+pub fn event_patch_to_graph_json(event: &crate::calendar::CalendarEvent) -> serde_json::Value {
     let mut patch = serde_json::json!({
         "subject": event.title,
         "start": {"dateTime": event.start_time, "timeZone": "UTC"},
@@ -3515,7 +3515,7 @@ mod color_tests {
 #[cfg(test)]
 mod builder_tests {
     use super::{contact_to_graph_json, event_patch_to_graph_json, event_to_graph_json};
-    use crate::db::calendar::CalendarEvent;
+    use crate::calendar::CalendarEvent;
 
     fn event(all_day: bool, attendees_json: Option<&str>) -> CalendarEvent {
         CalendarEvent {


### PR DESCRIPTION
## Summary

Implements ADR 0051 step 18d by moving provider-neutral calendar models
out of the persistence layer.

## Changes

- Move `CalendarEvent` and `Attendee` into the neutral `calendar` module.
- Update DB, command, backend, iCalendar, Graph, and Google consumers.
- Keep persistence-owned `Calendar`, `NewCalendar`, and `Invite` models in
  `db/calendar.rs`.
- Add exact Serde contract tests for populated, missing, and null optional
  fields.
- Remove old import paths without adding compatibility re-exports.

## Compatibility

This preserves:

- Every field, field type, and derive.
- Existing snake-case JSON keys and null serialization.
- Missing optional-field deserialization.
- Flattened `Invite` serialization.
- `attendees_json` and attendee status semantics.
- Database schema and SQL row mapping.
- Graph, Google, JMAP, CalDAV, and iCalendar behavior.

No database migration, frontend change, or runtime behavior change is
required.

## Verification

- Full Rust suite: **696 passed, 1 ignored**
- Calendar-focused Rust suite: **113 passed**
- Strict Clippy passed
- Frontend calendar tests: **48 passed**
- Frontend invite tests: **15 passed**
- Frontend typecheck and production build passed
- Formatting and `git diff --check` passed
