### PR TITLE
refactor(contact): extract shared contact model

### DIFF
--- a/src-tauri/src/backend/contacts/carddav.rs
+++ b/src-tauri/src/backend/contacts/carddav.rs
@@ -2,9 +2,9 @@
 
 use async_trait::async_trait;
 
+use crate::contact::Contact;
 use crate::db;
 use crate::db::accounts::AccountFull;
-use crate::db::contacts::Contact;
 use crate::error::Result;
 use crate::mail::carddav::{contact_to_vcard, parse_vcard};
 
@@ -99,11 +99,10 @@ impl ContactBackend for CardDavContactBackend {
 
                 // Get existing local contacts for this book
                 let local_contacts = db::contacts::list_contacts(&conn, &book_id)?;
-                let mut local_by_uid: std::collections::HashMap<String, db::contacts::Contact> =
-                    local_contacts
-                        .into_iter()
-                        .filter_map(|c| c.uid.clone().map(|uid| (uid, c)))
-                        .collect();
+                let mut local_by_uid: std::collections::HashMap<String, Contact> = local_contacts
+                    .into_iter()
+                    .filter_map(|c| c.uid.clone().map(|uid| (uid, c)))
+                    .collect();
 
                 // Upsert server contacts
                 for sc in &server_contacts {
@@ -117,7 +116,7 @@ impl ContactBackend for CardDavContactBackend {
                     if let Some(existing) = local_by_uid.remove(&sc.uid) {
                         // Update if etag changed
                         if existing.etag.as_deref() != Some(&sc.etag) {
-                            let updated = db::contacts::Contact {
+                            let updated = Contact {
                                 display_name: parsed.display_name,
                                 emails_json,
                                 phones_json,
@@ -133,7 +132,7 @@ impl ContactBackend for CardDavContactBackend {
                         }
                     } else {
                         // New contact from server
-                        let contact = db::contacts::Contact {
+                        let contact = Contact {
                             id: uuid::Uuid::new_v4().to_string(),
                             book_id: book_id.clone(),
                             uid: Some(sc.uid.clone()),

--- a/src-tauri/src/backend/contacts/google.rs
+++ b/src-tauri/src/backend/contacts/google.rs
@@ -2,8 +2,8 @@
 
 use async_trait::async_trait;
 
+use crate::contact::Contact;
 use crate::db::accounts::AccountFull;
-use crate::db::contacts::Contact;
 use crate::error::Result;
 use crate::mail::google::contact_to_person_json;
 

--- a/src-tauri/src/backend/contacts/graph.rs
+++ b/src-tauri/src/backend/contacts/graph.rs
@@ -5,8 +5,8 @@
 
 use async_trait::async_trait;
 
+use crate::contact::Contact;
 use crate::db::accounts::AccountFull;
-use crate::db::contacts::Contact;
 use crate::error::Result;
 use crate::mail::graph::contact_to_graph_json;
 use crate::provider::GraphTokenPurpose;

--- a/src-tauri/src/backend/contacts/jmap.rs
+++ b/src-tauri/src/backend/contacts/jmap.rs
@@ -2,8 +2,8 @@
 
 use async_trait::async_trait;
 
+use crate::contact::Contact;
 use crate::db::accounts::AccountFull;
-use crate::db::contacts::Contact;
 use crate::error::Result;
 
 use super::{BookRef, ContactBackend, ContactBackendCtx, PushedContact};

--- a/src-tauri/src/backend/contacts/mod.rs
+++ b/src-tauri/src/backend/contacts/mod.rs
@@ -14,8 +14,8 @@
 
 use async_trait::async_trait;
 
+use crate::contact::Contact;
 use crate::db::accounts::AccountFull;
-use crate::db::contacts::Contact;
 use crate::db::pool::DbPool;
 use crate::error::Result;
 use crate::provider::ProviderServices;

--- a/src-tauri/src/backend/mod.rs
+++ b/src-tauri/src/backend/mod.rs
@@ -18,8 +18,8 @@ pub mod mail;
 #[cfg(test)]
 pub(crate) mod testutil {
     use crate::calendar::CalendarEvent;
+    use crate::contact::Contact;
     use crate::db::accounts::AccountFull;
-    use crate::db::contacts::Contact;
     use crate::db::pool::DbPool;
     use crate::db::service_bindings::ServiceBinding;
 

--- a/src-tauri/src/commands/contacts.rs
+++ b/src-tauri/src/commands/contacts.rs
@@ -1,8 +1,9 @@
 use serde::Deserialize;
 use tauri::State;
 
+use crate::contact::Contact;
 use crate::db;
-use crate::db::contacts::{CollectedContact, Contact, ContactBook};
+use crate::db::contacts::{CollectedContact, ContactBook};
 use crate::error::Result;
 use crate::state::AppState;
 

--- a/src-tauri/src/contact.rs
+++ b/src-tauri/src/contact.rs
@@ -1,0 +1,90 @@
+use serde::{Deserialize, Serialize};
+
+/// Provider-neutral contact shared by persistence and backends.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Contact {
+    pub id: String,
+    pub book_id: String,
+    pub uid: Option<String>,
+    pub display_name: String,
+    pub emails_json: String,
+    pub phones_json: String,
+    pub addresses_json: String,
+    pub organization: Option<String>,
+    pub title: Option<String>,
+    pub notes: Option<String>,
+    pub vcard_data: Option<String>,
+    pub remote_id: Option<String>,
+    pub etag: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Contact;
+
+    #[test]
+    fn contact_json_contract_is_stable() {
+        let contact = Contact {
+            id: "contact-1".into(),
+            book_id: "book-1".into(),
+            uid: Some("uid-1".into()),
+            display_name: "Ada Lovelace".into(),
+            emails_json: r#"[{"email":"ada@example.com","label":"work"}]"#.into(),
+            phones_json: r#"[{"number":"+46701234567","label":"mobile"}]"#.into(),
+            addresses_json: r#"[{"city":"London","country":"UK"}]"#.into(),
+            organization: Some("Analytical Engines".into()),
+            title: Some("Programmer".into()),
+            notes: Some("First algorithm".into()),
+            vcard_data: Some("BEGIN:VCARD".into()),
+            remote_id: Some("remote-1".into()),
+            etag: Some("etag-1".into()),
+        };
+        let expected = serde_json::json!({
+            "id": "contact-1",
+            "book_id": "book-1",
+            "uid": "uid-1",
+            "display_name": "Ada Lovelace",
+            "emails_json": r#"[{"email":"ada@example.com","label":"work"}]"#,
+            "phones_json": r#"[{"number":"+46701234567","label":"mobile"}]"#,
+            "addresses_json": r#"[{"city":"London","country":"UK"}]"#,
+            "organization": "Analytical Engines",
+            "title": "Programmer",
+            "notes": "First algorithm",
+            "vcard_data": "BEGIN:VCARD",
+            "remote_id": "remote-1",
+            "etag": "etag-1",
+        });
+
+        assert_eq!(serde_json::to_value(&contact).unwrap(), expected);
+        let decoded: Contact = serde_json::from_value(expected.clone()).unwrap();
+        assert_eq!(serde_json::to_value(decoded).unwrap(), expected);
+
+        let minimal: Contact = serde_json::from_value(serde_json::json!({
+            "id": "contact-2",
+            "book_id": "book-1",
+            "display_name": "Minimal",
+            "emails_json": "[]",
+            "phones_json": "[]",
+            "addresses_json": "[]",
+        }))
+        .unwrap();
+        assert_eq!(
+            serde_json::to_value(minimal).unwrap(),
+            serde_json::json!({
+                "id": "contact-2",
+                "book_id": "book-1",
+                "uid": null,
+                "display_name": "Minimal",
+                "emails_json": "[]",
+                "phones_json": "[]",
+                "addresses_json": "[]",
+                "organization": null,
+                "title": null,
+                "notes": null,
+                "vcard_data": null,
+                "remote_id": null,
+                "etag": null,
+            })
+        );
+    }
+}

--- a/src-tauri/src/db/contacts.rs
+++ b/src-tauri/src/db/contacts.rs
@@ -1,6 +1,7 @@
 use rusqlite::{params, Connection};
 use serde::{Deserialize, Serialize};
 
+use crate::contact::Contact;
 use crate::error::Result;
 
 // ---------------------------------------------------------------------------
@@ -14,23 +15,6 @@ pub struct ContactBook {
     pub name: String,
     pub remote_id: Option<String>,
     pub sync_type: String,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Contact {
-    pub id: String,
-    pub book_id: String,
-    pub uid: Option<String>,
-    pub display_name: String,
-    pub emails_json: String,
-    pub phones_json: String,
-    pub addresses_json: String,
-    pub organization: Option<String>,
-    pub title: Option<String>,
-    pub notes: Option<String>,
-    pub vcard_data: Option<String>,
-    pub remote_id: Option<String>,
-    pub etag: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,6 +5,7 @@ mod account;
 mod backend;
 mod calendar;
 mod commands;
+mod contact;
 mod db;
 mod error;
 mod event;

--- a/src-tauri/src/mail/carddav.rs
+++ b/src-tauri/src/mail/carddav.rs
@@ -4,6 +4,7 @@
 //! auth) and adds CardDAV-specific discovery, address book listing, contact
 //! fetching, and vCard parsing/generation.
 
+use crate::contact::Contact;
 use crate::error::{Error, Result};
 use crate::mail::caldav::{
     find_elements, find_text_in, has_descendant, parse_href_from_xml, resolve_dav_url, DavAuth,
@@ -619,9 +620,9 @@ pub fn generate_vcard(
     lines.join("\r\n")
 }
 
-/// Generate a vCard from a stored contact row, converting its JSON
+/// Generate a vCard from a contact, converting its JSON
 /// email/phone lists to vCard entries (labels default to "work").
-pub fn contact_to_vcard(uid: &str, contact: &crate::db::contacts::Contact) -> String {
+pub fn contact_to_vcard(uid: &str, contact: &Contact) -> String {
     let emails: Vec<VCardEmail> =
         serde_json::from_str::<Vec<serde_json::Value>>(&contact.emails_json)
             .unwrap_or_default()
@@ -838,7 +839,7 @@ mod tests {
 
     #[test]
     fn contact_to_vcard_converts_json_lists() {
-        let contact = crate::db::contacts::Contact {
+        let contact = Contact {
             id: "c1".into(),
             book_id: "b1".into(),
             uid: Some("uid-1".into()),
@@ -867,7 +868,7 @@ mod tests {
 
     #[test]
     fn contact_to_vcard_handles_malformed_json() {
-        let contact = crate::db::contacts::Contact {
+        let contact = Contact {
             id: "c1".into(),
             book_id: "b1".into(),
             uid: None,


### PR DESCRIPTION
## Summary

Implements ADR 0051 step 18e by moving the provider-neutral `Contact`
model out of the persistence layer.

This completes ADR 0051 step 18.

## Changes

- Add a neutral `contact` module containing `Contact`.
- Update the DB adapter, Tauri commands, backend contracts, provider
  backends, and CardDAV conversion code.
- Keep persistence-owned `ContactBook` and `CollectedContact` models in
  `db/contacts.rs`.
- Add exact Serde contract coverage for all contact fields.
- Remove old import paths without adding compatibility re-exports.

## Compatibility

This preserves:

- All 13 fields, field types, and derives.
- Existing snake-case IPC keys and explicit null serialization.
- Deserialization with optional fields omitted.
- `emails_json`, `phones_json`, and `addresses_json` as opaque strings.
- Database schema, SQL queries, and row mapping.
- JMAP, Graph, Google, and CardDAV behavior.
- Existing vCard conversion and malformed-JSON handling.

No database migration, frontend change, or runtime behavior change is
required.

## Verification

- Contact-focused Rust suite: **22 passed**
- Full Rust suite: **697 passed, 1 ignored**
- Strict Clippy passed
- Frontend contact tests: **41 passed across 8 files**
- Frontend typecheck and production build passed
- Formatting and `git diff --check` passed
- Two independent reviews found no issues
