### PR TITLE
fix(oauth): render denied callback responses

### DIFF
--- a/src-tauri/src/commands/meet.rs
+++ b/src-tauri/src/commands/meet.rs
@@ -366,6 +366,15 @@ pub async fn meet_zoom_login_start(
     })
 }
 
+fn map_zoom_callback_error(error: Error) -> Error {
+    match error {
+        Error::OAuthStateMissing | Error::OAuthStateMismatch => {
+            Error::Other("Zoom sign-in could not be verified — please try again.".into())
+        }
+        other => other,
+    }
+}
+
 /// Wait for the Zoom OAuth callback, validate state, and exchange the code.
 /// A supplied account id replaces that account's tokens; otherwise this
 /// persists a new account row and keyring entry.
@@ -394,9 +403,13 @@ pub async fn meet_zoom_login_complete(
         ..
     } = session;
 
-    let callback = tokio::task::spawn_blocking(move || crate::oauth::wait_for_callback(listener))
-        .await
-        .map_err(|e| Error::Other(format!("zoom oauth join: {}", e)))??;
+    let callback_expected_state = expected_state.clone();
+    let callback_result = tokio::task::spawn_blocking(move || {
+        crate::oauth::wait_for_callback(listener, &callback_expected_state)
+    })
+    .await
+    .map_err(|e| Error::Other(format!("zoom oauth join: {}", e)))?;
+    let callback = callback_result.map_err(map_zoom_callback_error)?;
 
     // Don't log raw `state` values — they're CSRF secrets.
     log::info!(
@@ -819,8 +832,8 @@ fn validate_returned_server_url(url: &str) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::{
-        cleanup_provider_for, complete_pending_discard, validate_returned_server_url,
-        validate_zoom_reauth_identity, zoom_reauth_identity,
+        cleanup_provider_for, complete_pending_discard, map_zoom_callback_error,
+        validate_returned_server_url, validate_zoom_reauth_identity, zoom_reauth_identity,
     };
     use crate::db;
     use crate::error::Error;
@@ -859,6 +872,19 @@ mod tests {
                 cfg!(debug_assertions)
             );
         }
+    }
+
+    #[test]
+    fn zoom_state_callback_errors_keep_friendly_message() {
+        let expected = "Zoom sign-in could not be verified — please try again.";
+        for error in [Error::OAuthStateMissing, Error::OAuthStateMismatch] {
+            assert_eq!(map_zoom_callback_error(error).to_string(), expected);
+        }
+
+        assert_eq!(
+            map_zoom_callback_error(Error::Other("provider denied access".into())).to_string(),
+            "provider denied access"
+        );
     }
 
     #[test]

--- a/src-tauri/src/commands/oauth.rs
+++ b/src-tauri/src/commands/oauth.rs
@@ -106,9 +106,12 @@ pub async fn oauth_complete(
     let code_verifier = session.verifier.clone();
 
     // Wait for callback in a blocking thread (TcpListener::accept blocks)
-    let result = tokio::task::spawn_blocking(move || oauth::wait_for_callback(session.listener))
-        .await
-        .map_err(|e| Error::Other(format!("OAuth callback task failed: {}", e)))??;
+    let callback_expected_state = expected_state.clone();
+    let result = tokio::task::spawn_blocking(move || {
+        oauth::wait_for_callback(session.listener, &callback_expected_state)
+    })
+    .await
+    .map_err(|e| Error::Other(format!("OAuth callback task failed: {}", e)))??;
 
     // Validate CSRF state parameter. Don't log the raw values — `state`
     // is a CSRF secret and logging it (or returning it in the error

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -35,6 +35,12 @@ pub enum Error {
     #[error("Re-authentication required: {0}")]
     AuthRequired(String),
 
+    #[error("OAuth2 callback missing required state parameter")]
+    OAuthStateMissing,
+
+    #[error("OAuth2 state mismatch (possible CSRF)")]
+    OAuthStateMismatch,
+
     #[error("{protocol} does not support {capability}")]
     UnsupportedCapability {
         protocol: &'static str,

--- a/src-tauri/src/oauth.rs
+++ b/src-tauri/src/oauth.rs
@@ -359,10 +359,55 @@ pub struct CallbackResult {
     pub state: Option<String>,
 }
 
+enum CallbackPage {
+    Success,
+    AccessDenied,
+    Failure,
+}
+
+fn write_callback_page(stream: &mut impl Write, page: CallbackPage) {
+    let (status, title, message) = match page {
+        CallbackPage::Success => (
+            "200 OK",
+            "Authorization successful!",
+            "You can close this window and return to Chithi.",
+        ),
+        CallbackPage::AccessDenied => (
+            "400 Bad Request",
+            "Authorization not completed",
+            "Access was not granted. Return to Chithi and try again.",
+        ),
+        CallbackPage::Failure => (
+            "400 Bad Request",
+            "Authorization failed",
+            "The provider did not complete authorization. Return to Chithi and try again.",
+        ),
+    };
+    let body = format!(
+        "<!doctype html><html><head><meta charset='utf-8'><title>{title}</title></head>\
+         <body><main><h2>{title}</h2><p>{message}</p></main></body></html>"
+    );
+    let response = format!(
+        "HTTP/1.1 {status}\r\n\
+         Content-Type: text/html; charset=utf-8\r\n\
+         Content-Length: {}\r\n\
+         Cache-Control: no-store\r\n\
+         Content-Security-Policy: default-src 'none'\r\n\
+         X-Content-Type-Options: nosniff\r\n\
+         Connection: close\r\n\r\n\
+         {body}",
+        body.len(),
+    );
+    // The browser may already have closed the tab. Callback processing must
+    // not fail merely because the informational response cannot be written.
+    stream.write_all(response.as_bytes()).ok();
+}
+
 /// Listen on the given listener for the OAuth2 redirect callback.
 /// Times out after 5 minutes to prevent indefinite resource holding.
-/// Returns the authorization code and state parameter.
-pub fn wait_for_callback(listener: TcpListener) -> Result<CallbackResult> {
+/// Validates the state parameter before reporting browser success and returns
+/// the authorization code plus the validated state.
+pub fn wait_for_callback(listener: TcpListener, expected_state: &str) -> Result<CallbackResult> {
     use std::time::{Duration, Instant};
 
     let timeout = Duration::from_secs(300);
@@ -427,23 +472,7 @@ pub fn wait_for_callback(listener: TcpListener) -> Result<CallbackResult> {
         })
         .unwrap_or_default();
 
-    let code = query_params.get("code").cloned().ok_or_else(|| {
-        let error = query_params
-            .get("error")
-            .cloned()
-            .unwrap_or_else(|| "unknown".to_string());
-        Error::Other(format!("OAuth2 authorization failed: {}", error))
-    })?;
-
     let state = query_params.get("state").cloned();
-
-    // Send a success response to the browser
-    let response = "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n\
-        <html><body style='font-family:sans-serif;text-align:center;padding:60px'>\
-        <h2>Authorization successful!</h2>\
-        <p>You can close this window and return to Chithi.</p>\
-        </body></html>";
-    stream.write_all(response.as_bytes()).ok();
 
     // Don't log the authorization `code` or `state` — both are secrets.
     log::info!(
@@ -454,6 +483,48 @@ pub fn wait_for_callback(listener: TcpListener) -> Result<CallbackResult> {
             .filter(|k| k.as_str() != "code" && k.as_str() != "state")
             .collect::<Vec<_>>(),
     );
+
+    match state.as_deref() {
+        Some(returned_state) if returned_state == expected_state => {}
+        Some(_) => {
+            write_callback_page(&mut stream, CallbackPage::Failure);
+            return Err(Error::OAuthStateMismatch);
+        }
+        None => {
+            write_callback_page(&mut stream, CallbackPage::Failure);
+            return Err(Error::OAuthStateMissing);
+        }
+    }
+
+    if let Some(error) = query_params.get("error").map(String::as_str) {
+        let access_denied = error == "access_denied";
+        write_callback_page(
+            &mut stream,
+            if access_denied {
+                CallbackPage::AccessDenied
+            } else {
+                CallbackPage::Failure
+            },
+        );
+        let message = if access_denied {
+            "OAuth2 authorization was denied or cancelled"
+        } else {
+            "OAuth2 authorization failed"
+        };
+        return Err(Error::Other(message.into()));
+    }
+
+    let code = match query_params.get("code").filter(|code| !code.is_empty()) {
+        Some(code) => code.clone(),
+        None => {
+            write_callback_page(&mut stream, CallbackPage::Failure);
+            return Err(Error::Other(
+                "OAuth2 callback did not contain an authorization code".into(),
+            ));
+        }
+    };
+
+    write_callback_page(&mut stream, CallbackPage::Success);
     Ok(CallbackResult { code, state })
 }
 
@@ -1610,6 +1681,128 @@ mod tests {
             }
         });
         (format!("http://{address}/token"), handle)
+    }
+
+    fn callback_request(target: &str, expected_state: &str) -> (Result<CallbackResult>, String) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let expected_state = expected_state.to_string();
+        let callback = std::thread::spawn(move || wait_for_callback(listener, &expected_state));
+
+        let mut stream = std::net::TcpStream::connect(address).unwrap();
+        stream
+            .write_all(
+                format!("GET {target} HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")
+                    .as_bytes(),
+            )
+            .unwrap();
+        stream.shutdown(std::net::Shutdown::Write).unwrap();
+
+        let mut response = String::new();
+        stream.read_to_string(&mut response).unwrap();
+        (callback.join().unwrap(), response)
+    }
+
+    fn assert_callback_response(response: &str, status: &str) {
+        let (headers, body) = response
+            .split_once("\r\n\r\n")
+            .expect("callback response has a header terminator");
+        assert!(headers.starts_with(&format!("HTTP/1.1 {status}\r\n")));
+        assert!(headers.contains("Content-Type: text/html; charset=utf-8\r\n"));
+        assert!(headers.contains("Cache-Control: no-store\r\n"));
+        assert!(headers.contains("Content-Security-Policy: default-src 'none'\r\n"));
+        assert!(headers.contains("X-Content-Type-Options: nosniff\r\n"));
+        assert!(headers.lines().any(|line| line == "Connection: close"));
+        let content_length = headers
+            .lines()
+            .find_map(|line| line.strip_prefix("Content-Length: "))
+            .expect("callback response has Content-Length")
+            .parse::<usize>()
+            .unwrap();
+        assert_eq!(content_length, body.len());
+    }
+
+    #[test]
+    fn callback_success_returns_code_and_browser_page() {
+        let (result, response) =
+            callback_request("/?code=test-code&state=test-state", "test-state");
+        let callback = result.unwrap();
+
+        assert_eq!(callback.code, "test-code");
+        assert_eq!(callback.state.as_deref(), Some("test-state"));
+        assert_callback_response(&response, "200 OK");
+        assert!(response.contains("Authorization successful!"));
+        assert!(!response.contains("test-code"));
+        assert!(!response.contains("test-state"));
+    }
+
+    #[test]
+    fn callback_access_denied_returns_safe_browser_page() {
+        let (result, response) = callback_request(
+            "/?error=access_denied&error_description=provider-marker-%3Cscript%3Ebad%3C%2Fscript%3E&state=test-state",
+            "test-state",
+        );
+        let error = match result {
+            Ok(_) => panic!("access_denied must fail"),
+            Err(error) => error.to_string(),
+        };
+
+        assert!(error.contains("denied or cancelled"));
+        assert_callback_response(&response, "400 Bad Request");
+        assert!(response.contains("Authorization not completed"));
+        assert!(response.contains("Access was not granted"));
+        assert!(!error.contains("provider-marker"));
+        assert!(!response.contains("provider-marker"));
+        assert!(!response.contains("<script>"));
+        assert!(!response.contains("test-state"));
+    }
+
+    #[test]
+    fn callback_without_code_returns_generic_browser_page() {
+        let (result, response) = callback_request("/?state=test-state", "test-state");
+        let error = match result {
+            Ok(_) => panic!("missing code must fail"),
+            Err(error) => error.to_string(),
+        };
+
+        assert!(error.contains("did not contain an authorization code"));
+        assert_callback_response(&response, "400 Bad Request");
+        assert!(response.contains("Authorization failed"));
+        assert!(!response.contains("test-state"));
+    }
+
+    #[test]
+    fn callback_rejects_empty_code_and_unverified_state() {
+        for (target, expected_state, expected_error) in [
+            (
+                "/?code=&state=test-state",
+                "test-state",
+                "did not contain an authorization code",
+            ),
+            (
+                "/?code=test-code",
+                "test-state",
+                "missing required state parameter",
+            ),
+            (
+                "/?code=test-code&state=wrong-state",
+                "test-state",
+                "state mismatch",
+            ),
+        ] {
+            let (result, response) = callback_request(target, expected_state);
+            let error = match result {
+                Ok(_) => panic!("invalid callback must fail"),
+                Err(error) => error.to_string(),
+            };
+
+            assert!(error.contains(expected_error));
+            assert_callback_response(&response, "400 Bad Request");
+            assert!(response.contains("Authorization failed"));
+            assert!(!response.contains("test-code"));
+            assert!(!response.contains("test-state"));
+            assert!(!response.contains("wrong-state"));
+        }
     }
 
     fn provider_at(

--- a/src/__tests__/account-form-sections.test.ts
+++ b/src/__tests__/account-form-sections.test.ts
@@ -60,6 +60,9 @@ describe("OauthSignInSection", () => {
       props: { provider: "google", status: null, inProgress: false },
     });
     expect(wrapper.text()).toContain("Sign in with Google");
+    expect(wrapper.get('[data-testid="google-oauth-hint"]').text()).toContain(
+      "select all requested permissions",
+    );
     await wrapper.find(".btn-oauth").trigger("click");
     expect(wrapper.emitted("signIn")).toHaveLength(1);
   });
@@ -69,6 +72,8 @@ describe("OauthSignInSection", () => {
       props: { provider: "microsoft", status: "Signed in with Microsoft", inProgress: false },
     });
     expect(wrapper.find(".oauth-status").text()).toContain("Signed in with Microsoft");
+    expect(wrapper.find('[data-testid="google-oauth-hint"]').exists()).toBe(false);
+    expect(wrapper.text()).not.toContain("select all requested permissions");
     await wrapper.find(".btn-reauth").trigger("click");
     expect(wrapper.emitted("reauth")).toHaveLength(1);
   });

--- a/src/components/settings/OauthSignInSection.vue
+++ b/src/components/settings/OauthSignInSection.vue
@@ -42,7 +42,11 @@ const emit = defineEmits<{ signIn: []; reauth: [] }>();
       </svg>
       {{ inProgress ? "Waiting for browser..." : (provider === 'google' ? "Sign in with Google" : "Sign in with Microsoft") }}
     </button>
-    <span v-if="provider === 'google'" class="field-hint">Sign in to sync Google Calendar and Contacts. IMAP/SMTP uses app password above.</span>
+    <span
+      v-if="provider === 'google'"
+      class="field-hint"
+      data-testid="google-oauth-hint"
+    >Sign in to sync Google Calendar and Contacts. On Google's consent screen, select all requested permissions. IMAP/SMTP uses the app password above.</span>
     <span v-else class="field-hint">Sign in to access mail, calendar, and contacts via Microsoft Graph API.</span>
   </div>
 </template>


### PR DESCRIPTION
## Summary

Improve browser-assisted OAuth callback handling for Google, Microsoft, and
Zoom.

## Problem

When Google returned `error=access_denied`, Chithi exited the callback handler
before writing an HTTP response. Firefox therefore displayed a misleading
localhost connection error instead of explaining that authorization was not
completed.

Google's consent screen also allows users to leave requested permissions
unchecked, which produces this denial without clear guidance in Chithi.

## Changes

- Always return a browser page for successful, denied, and malformed OAuth
  callbacks.
- Show clear guidance when authorization is denied or cancelled.
- Require a matching state value and nonempty authorization code before
  displaying success.
- Add typed missing/mismatched-state errors.
- Preserve Zoom's existing friendly state-verification message.
- Use static callback pages with:
  - no reflected provider query values;
  - Content Security Policy;
  - `Cache-Control: no-store`;
  - `X-Content-Type-Options: nosniff`;
  - byte-accurate `Content-Length`.
- Tell Gmail users to select all requested permissions on Google's consent
  screen.

OAuth URLs, scopes, PKCE, token exchange, and token storage remain unchanged.

## Verification

- Full Rust suite: **702 passed, 1 ignored**
- Callback socket regression tests passed
- Zoom state-error mapping test passed
- Frontend account-form tests: **9 passed**
- Frontend typecheck and production build passed
- Strict Clippy passed
- Formatting and `git diff --check` passed
