### PR TITLE
fix(mail): make background delivery duplicate-resistant

### DIFF
--- a/docs/adr/0009-jmap-send-via-submission.md
+++ b/docs/adr/0009-jmap-send-via-submission.md
@@ -19,12 +19,47 @@ When a JMAP account tried to send via SMTP, it failed because `smtp_host` was em
 The `send_message` command checks `account.mail_protocol` and routes to the appropriate sending method:
 
 - **IMAP accounts**: Send via SMTP using `lettre` (existing behavior).
-- **JMAP accounts**: Send via JMAP Submission using three steps:
-  1. **Upload blob**: POST the raw RFC5322 message to the JMAP upload endpoint as `message/rfc822`.
-  2. **Email/import**: Import the blob into the Sent mailbox with `$seen` keyword set.
-  3. **EmailSubmission/set**: Create a submission referencing the imported email and the account's identity ID (fetched via `Identity/get`).
+- **JMAP accounts**: Send via JMAP Submission after resolving every
+  server-side prerequisite before blob upload:
+  1. Validate SMTPUTF8 support, when required, against
+     `accounts[accountId].accountCapabilities` in the JMAP Session.
+  2. Fetch `id` and `email` via `Identity/get`. Select the first exact
+     sender match, or the first `*@same-domain` identity only when there
+     is no exact match. Local-part comparisons are case-sensitive;
+     domains use case-insensitive IDNA comparison.
+  3. Resolve the Sent mailbox, querying Inbox lazily only when Sent is
+     absent.
+  4. **Upload blob**: POST the unchanged raw RFC5322 message to the JMAP
+     upload endpoint as `message/rfc822`.
+  5. **Email/import** and **EmailSubmission/set**: import the blob into
+     Sent with `$seen`, then create a submission referencing the imported
+     email and selected identity. The submission carries a mandatory
+     explicit RFC 8621 envelope assembled from the authoritative sender
+     and To, Cc, and Bcc fields.
 
 The raw RFC5322 message is built using `lettre`'s message builder (`build_raw_message`) — the same code path as SMTP, just without the transport step. This ensures consistent message formatting regardless of the sending protocol.
+
+The original implementation omitted the JMAP `envelope` property and relied on the server to derive recipients from the imported message headers. That lost Bcc delivery whenever Bcc was absent from the raw MIME. Since 2026-08-21, `JmapSubmissionEnvelope` validates display-name mailboxes before upload, preserves the first parsed addr-spec, and deduplicates by semantic quoted local-part plus canonical IDNA domain. Bcc appears only in `rcptTo`; the uploaded MIME remains byte-for-byte unchanged.
+
+RFC 8621 envelope address objects always include `parameters`. Ordinary
+addresses use `null`. If an emitted envelope addr-spec or transmitted RFC 5322
+header contains UTF-8, only `mailFrom.parameters` contains
+`{ "SMTPUTF8": null }`; all `rcptTo` parameters remain `null`. Submission
+fails before upload when the selected account does not advertise that
+extension.
+
+Success requires positive, correctly correlated `Email/import` (`i1`) and
+`EmailSubmission/set` (`s1`) creation responses. Chithi makes a best-effort
+`Email/set` cleanup request only when import succeeds and submission is
+explicitly rejected. A missing, malformed, contradictory, `serverPartialFail`,
+or transport-lost successful submission response has an indeterminate delivery
+outcome: the outbox row is quarantined for manual review without cleanup or
+automatic replay. HTTP 4xx request rejection and connection failure before the
+request reaches the JMAP server remain definite, retryable failures; HTTP 5xx
+gateway/server responses are indeterminate. Bcc values and server-returned
+response descriptions and bodies are excluded from JMAP send
+errors and logs; ordinary compose telemetry may still include visible To
+recipients.
 
 The identity ID is fetched dynamically via `Identity/get` rather than assumed to be the account ID, since Stalwart (and other JMAP servers) use separate identity identifiers.
 
@@ -33,4 +68,11 @@ The identity ID is fetched dynamically via `Identity/get` rather than assumed to
 - JMAP accounts can send email without any SMTP configuration.
 - The Sent mailbox is found by querying for the mailbox with `role: "sent"`, falling back to Inbox if no Sent folder exists.
 - The message building code is shared between SMTP and JMAP paths via `smtp::build_raw_message()`.
+- Invalid senders, invalid recipients, empty recipient lists, unsupported
+  SMTPUTF8, missing matching identities, and missing mailboxes fail before a
+  JMAP blob is uploaded.
+- JMAP delivery no longer depends on recipient headers in the MIME; outbox retries persist and replay the same explicit To, Cc, and Bcc envelope data.
+- Definite submission rejections remain retryable, but an outcome without
+  trustworthy completion evidence requires an explicit manual retry to avoid
+  duplicate delivery.
 - Background body prefetch (`prefetch_bodies`) is skipped for JMAP accounts since bodies are fetched on-demand via the JMAP API.

--- a/docs/adr/0009-jmap-send-via-submission.md
+++ b/docs/adr/0009-jmap-send-via-submission.md
@@ -16,9 +16,13 @@ When a JMAP account tried to send via SMTP, it failed because `smtp_host` was em
 
 ## Decision
 
-The `send_message` command checks `account.mail_protocol` and routes to the appropriate sending method:
+The `send_message` command resolves the enabled mail binding and routes to the
+appropriate sending method:
 
-- **IMAP accounts**: Send via SMTP using `lettre` (existing behavior).
+- **IMAP accounts and legacy unknown non-empty protocols**: send via SMTP and
+  perform a best-effort IMAP Sent-folder append after delivery is complete.
+- **Microsoft Graph accounts**: send via SMTP with Outlook-scoped XOAUTH2, but
+  do not attempt IMAP Sent-folder handling.
 - **JMAP accounts**: Send via JMAP Submission after resolving every
   server-side prerequisite before blob upload:
   1. Validate SMTPUTF8 support, when required, against
@@ -36,6 +40,7 @@ The `send_message` command checks `account.mail_protocol` and routes to the appr
      email and selected identity. The submission carries a mandatory
      explicit RFC 8621 envelope assembled from the authoritative sender
      and To, Cc, and Bcc fields.
+- **No enabled mail binding**: fail before outbox persistence or transport.
 
 The raw RFC5322 message is built using `lettre`'s message builder (`build_raw_message`) — the same code path as SMTP, just without the transport step. This ensures consistent message formatting regardless of the sending protocol.
 
@@ -49,17 +54,19 @@ fails before upload when the selected account does not advertise that
 extension.
 
 Success requires positive, correctly correlated `Email/import` (`i1`) and
-`EmailSubmission/set` (`s1`) creation responses. Chithi makes a best-effort
-`Email/set` cleanup request only when import succeeds and submission is
-explicitly rejected. A missing, malformed, contradictory, `serverPartialFail`,
-or transport-lost successful submission response has an indeterminate delivery
-outcome: the outbox row is quarantined for manual review without cleanup or
-automatic replay. HTTP 4xx request rejection and connection failure before the
-request reaches the JMAP server remain definite, retryable failures; HTTP 5xx
-gateway/server responses are indeterminate. Bcc values and server-returned
-response descriptions and bodies are excluded from JMAP send
-errors and logs; ordinary compose telemetry may still include visible To
-recipients.
+`EmailSubmission/set` (`s1`) creation responses for the expected account ID.
+Chithi makes a best-effort `Email/set` cleanup request only when import
+succeeds and submission is explicitly rejected. The final compound submission
+POST uses a dedicated no-redirect client: every HTTP 3xx response is
+indeterminate and is never followed with a replayed POST. A missing, malformed,
+contradictory, `serverPartialFail`, or transport-lost successful submission
+response is also indeterminate. In those cases the outbox row is quarantined
+for manual review without cleanup or automatic replay. HTTP 4xx request
+rejection and connection failure before the request reaches the JMAP server
+remain definite, retryable failures; HTTP 5xx gateway/server responses are
+indeterminate. Bcc values and server-returned response descriptions and bodies
+are excluded from JMAP send errors and logs; ordinary compose telemetry may
+still include visible To recipients.
 
 The identity ID is fetched dynamically via `Identity/get` rather than assumed to be the account ID, since Stalwart (and other JMAP servers) use separate identity identifiers.
 

--- a/docs/adr/0039-background-send-and-operations-panel.md
+++ b/docs/adr/0039-background-send-and-operations-panel.md
@@ -43,7 +43,8 @@ Restructure `send_message` in `compose.rs` to split into synchronous and asynchr
 1. Connect to SMTP server or JMAP
 2. Transmit the message
 3. On success: emit `send-complete`, auto-collect recipient contacts
-4. On definite failure: atomically return the outbox row to `pending` and emit
+4. On definite failure: atomically return the outbox row to `pending`, or mark
+   it `dead` immediately when that failure reaches the retry limit, and emit
    `send-failed`
 5. When completion is unknown: atomically quarantine the row as `dead` and
    emit `send-unknown`
@@ -70,7 +71,7 @@ A collapsible panel between the main content area and the status bar, showing al
 - Slide-up animation from the status bar
 - Shows operations from `useActivityStore().recentOperations`
 - Each row displays: status icon (animated spinner / checkmark / error X), label, detail text, operation type badge
-- Running operations sorted to the top
+- Operations sorted by start time, newest first
 - Max height 40% of viewport, scrollable
 - Close button in header
 
@@ -82,7 +83,7 @@ A collapsible panel between the main content area and the status bar, showing al
 - Failed operations remain visible for 5 minutes (previously 15 seconds)
 - This gives users time to open the panel and see what happened
 
-**Layout in App.vue**:
+**Layout in `src/components/shell/DesktopShell.vue`**:
 ```
 <main class="app-content">
   <router-view />
@@ -107,33 +108,82 @@ A collapsible panel between the main content area and the status bar, showing al
 - The operations panel adds visual complexity to the UI
 - Toast notifications from the main window may not be visible if the user has switched to another application
 
+### Remaining limitations
+
+- A panic or forced cancellation inside a detached first-attempt send can
+  leave its row in `sending` until restart. Startup then quarantines that row;
+  it is never automatically replayed. Exact in-process task supervision is a
+  follow-up.
+- Calendar invitation and RSVP mail uses the same SMTP/JMAP delivery
+  classification, but is not yet represented by this durable Outbox state
+  machine. Indeterminate outcomes are returned to the caller and are not
+  automatically retried; durable calendar-specific recovery is a follow-up.
+- Best-effort IMAP Sent-folder maintenance is not itself durable. A crash after
+  recipient delivery can omit the Sent copy rather than risk resubmission.
+
 ### Send persistence
 
 The built `raw_message` is base64-encoded and saved to the `outbox` table (action_type = "send") **before** the background task is spawned. This ensures the message survives an app crash during sending:
 - On success: the claimed outbox entry is deleted.
+- Delivery completion and `send-complete` are persisted/emitted before
+  best-effort IMAP Sent-folder append and sync work. A crash may therefore
+  leave no Sent copy, but cannot turn accepted delivery into an automatic
+  recipient resend.
 - On a definite failure: the outbox entry becomes `pending` for automatic
-  replay and the `send-failed` event is emitted.
+  replay and the `send-failed` event is emitted. The failure that reaches the
+  retry limit transitions directly to `dead`; it is never left looking queued
+  until another sync.
 - When SMTP or JMAP does not provide trustworthy completion evidence: the
   outbox entry becomes `dead`, remains visible, and requires a deliberate
   manual retry because delivery may already have occurred.
 - On a crash: an entry stranded in `sending` is quarantined as `dead` on the
   next startup for the same duplicate-prevention reason.
+- Startup acquires an exclusive lock for the data directory before opening the
+  database or quarantining rows. A second process cannot steal a live send
+  claim from the process that owns it.
 - Before replay transport begins, the worker atomically claims the exact
   pending row as `sending`. Stale snapshots cannot submit, and retry/discard
   commands cannot mutate an in-flight row.
+- Manual retry and discard commands require both the row ID and its active
+  account ID. A stale renderer cannot mutate a row belonging to another
+  account.
 - Unknown rows are labeled "Delivery status unknown". Manual retry requires
   confirmation that it may duplicate delivery; discard explains that removing
   the local record cannot cancel a message already accepted remotely.
 
-### Files modified
+### Implementation locations
 
 **Backend:**
 - `src-tauri/src/commands/compose.rs` — split `send_message` into sync + async phases, emit send events
+- `src-tauri/src/backend/mail/mod.rs` and `backend/mail/imap.rs` — separate
+  definitive SMTP delivery from best-effort Sent-folder postprocessing
+- `src-tauri/src/commands/outbox.rs` — account-scoped listing, manual retry,
+  and discard commands
+- `src-tauri/src/error.rs` — typed indeterminate-delivery classification
+- `src-tauri/src/mail/smtp.rs` — final-response validation and bounded
+  post-acceptance connection cleanup
+- `src-tauri/src/mail/jmap/mail.rs` and `src-tauri/src/provider.rs` —
+  no-redirect final submission and correlated response validation
+- `src-tauri/src/ops/offline.rs` — atomic send claim, completion, retry-limit,
+  and quarantine transitions
+- `src-tauri/src/ops/worker.rs` — replay routing and correlated send events
+- `src-tauri/src/state.rs` — exclusive data-directory ownership before startup
+  recovery
 
 **Frontend:**
-- `src/stores/activity.ts` — listen for `send-started`/`send-complete`/`send-failed`, show toasts
+- `src/stores/activity.ts` — transactionally register
+  `send-started`/`send-complete`/`send-failed`/`send-unknown` listeners and
+  show correlated toasts
+- `src/main.ts` — make bounded activity-listener attempts before mounting,
+  always mount, and surface/retry persistent initialization failures
+- `src/lib/tauri.ts` and `src/lib/types.ts` — typed, account-scoped Outbox IPC
+- `src/components/mail/OutboxList.vue` — generation-safe refreshes, delivery
+  status, and guarded manual actions
+- `src/components/common/ToastContainer.vue` — accessible send-status
+  announcements
 - `src/stores/ui.ts` — `operationsPanelOpen` state, `toggleOperationsPanel()`
 - `src/stores/ops.ts` — centralized `op-failed` and `offline-queue-changed` tracking
 - `src/components/common/OperationsPanel.vue` — new slide-up panel component
 - `src/components/common/StatusBar.vue` — operations toggle button with badge
-- `src/App.vue` — mount OperationsPanel between content and status bar
+- `src/components/shell/DesktopShell.vue` — mount `OperationsPanel` between
+  main content and `StatusBar`

--- a/docs/adr/0039-background-send-and-operations-panel.md
+++ b/docs/adr/0039-background-send-and-operations-panel.md
@@ -34,21 +34,30 @@ Restructure `send_message` in `compose.rs` to split into synchronous and asynchr
 2. Read attachment files from disk
 3. Build RFC5322 message using `lettre`
 4. Refresh OAuth token for O365 accounts
-5. Emit `send-started` event
-6. Return `Ok(())` to the frontend
+5. Persist the complete message and envelope in the outbox with status
+   `sending`
+6. Emit a correlated `send-started` event
+7. Return `Ok(())` to the frontend
 
 **Asynchronous phase** (runs in `tokio::spawn` after command returns):
 1. Connect to SMTP server or JMAP
 2. Transmit the message
 3. On success: emit `send-complete`, auto-collect recipient contacts
-4. On failure: emit `send-failed` with error details
+4. On definite failure: atomically return the outbox row to `pending` and emit
+   `send-failed`
+5. When completion is unknown: atomically quarantine the row as `dead` and
+   emit `send-unknown`
 
 This means the compose window closes almost instantly (only waits for local I/O), while the actual network send happens in the background.
 
 **Events emitted:**
-- `send-started` — `{account_id, subject}` — triggers toast "Sending..."
-- `send-complete` — `{account_id, subject}` — triggers toast "Sent"
-- `send-failed` — `{account_id, subject, error}` — triggers error toast (10s)
+- `send-started` — `{account_id, subject, outbox_id}` — triggers toast
+  "Sending..."
+- `send-complete` — `{account_id, subject, outbox_id}` — triggers toast "Sent"
+- `send-failed` — `{account_id, subject, outbox_id, error}` — reports a
+  definite failure
+- `send-unknown` — `{account_id, subject, outbox_id, error}` — warns that
+  delivery may already have occurred
 
 The activity store listens for these events and tracks send operations alongside sync operations.
 
@@ -92,16 +101,29 @@ A collapsible panel between the main content area and the status bar, showing al
 - Failed sends are clearly surfaced with error details
 
 ### Negative
-- If the background send fails, the compose window is already closed. The user sees an error toast but cannot retry from the compose window. The failed message is persisted in the outbox table for future retry, but no automatic retry mechanism is implemented yet.
+- If the background send fails, the compose window is already closed. The user
+  sees an error toast and must use the outbox controls to inspect or manually
+  retry an indeterminate delivery.
 - The operations panel adds visual complexity to the UI
 - Toast notifications from the main window may not be visible if the user has switched to another application
 
 ### Send persistence
 
 The built `raw_message` is base64-encoded and saved to the `outbox` table (action_type = "send") **before** the background task is spawned. This ensures the message survives an app crash during sending:
-- On success: the outbox entry is deleted via `mark_completed()`
-- On failure: the outbox entry is marked failed via `mark_failed()` and the `send-failed` event is emitted
-- On crash: the outbox entry remains with status "pending" for future replay
+- On success: the claimed outbox entry is deleted.
+- On a definite failure: the outbox entry becomes `pending` for automatic
+  replay and the `send-failed` event is emitted.
+- When SMTP or JMAP does not provide trustworthy completion evidence: the
+  outbox entry becomes `dead`, remains visible, and requires a deliberate
+  manual retry because delivery may already have occurred.
+- On a crash: an entry stranded in `sending` is quarantined as `dead` on the
+  next startup for the same duplicate-prevention reason.
+- Before replay transport begins, the worker atomically claims the exact
+  pending row as `sending`. Stale snapshots cannot submit, and retry/discard
+  commands cannot mutate an in-flight row.
+- Unknown rows are labeled "Delivery status unknown". Manual retry requires
+  confirmation that it may duplicate delivery; discard explains that removing
+  the local record cannot cancel a message already accepted remotely.
 
 ### Files modified
 

--- a/docs/adr/0047-openpgp-integration.md
+++ b/docs/adr/0047-openpgp-integration.md
@@ -151,11 +151,20 @@ XOAUTH2 with the Microsoft IMAP/SMTP scope), while JMAP retains native
 JMAP Submission. The PGP-wrapped raw bytes are persisted for every
 backend and replayed unchanged. SMTP replay also passes the separately
 persisted sender and recipient envelope unchanged. Native JMAP
-Submission receives only the raw MIME, with no explicit JMAP envelope;
-this leaves a known Bcc-delivery limitation when Bcc recipients are not
-present in those bytes, queued for a separate fix. Graph replay never
-converts the MIME to a Graph `sendMail` payload or invokes IMAP
-Sent-folder handling.
+Submission now receives a mandatory explicit RFC 8621 envelope built
+from the separately persisted sender and To/Cc/Bcc fields; Bcc is
+therefore delivered through `rcptTo` without being added to the raw MIME.
+Envelope addresses always include RFC 8621 `parameters`; SMTPUTF8 is
+advertised only on `mailFrom` and is gated by the selected account's JMAP
+Submission capability before upload. The submission identity must match the
+sender exactly (or authorize its domain with `*@domain`), and successful
+delivery requires positively correlated import and submission creation
+responses. Errors and logs omit server descriptions and bodies that could
+echo Bcc data.
+The earlier implementation passed only the MIME and could lose Bcc on
+JMAP sends; that limitation was resolved on 2026-08-21 while retaining
+the byte-exact MIME path. Graph replay never converts the MIME to a Graph
+`sendMail` payload or invokes IMAP Sent-folder handling.
 
 ### Receive path
 `pgp_decrypt_message` extracts the ciphertext, then tries a **software**

--- a/docs/adr/0047-openpgp-integration.md
+++ b/docs/adr/0047-openpgp-integration.md
@@ -145,11 +145,17 @@ card public-only bytes into the software signing API produces opaque
 "expected SecretKey, got PublicKey" parse errors. Software keys use the
 passphrase API instead.
 
-**Wire transmission:** all outgoing mail -- IMAP, JMAP, and Microsoft
-Graph accounts alike -- is transmitted via SMTP (`smtp::send_raw`; Graph
-accounts use the IMAP/SMTP binding with XOAUTH2). The PGP-wrapped bytes
-are persisted to the outbox and sent verbatim, so the envelope survives
-the first-attempt send and any later outbox replay identically.
+**Wire transmission (current state, 2026-08-21):** IMAP and Microsoft
+Graph accounts transmit through SMTP (`smtp::send_raw`; Graph uses
+XOAUTH2 with the Microsoft IMAP/SMTP scope), while JMAP retains native
+JMAP Submission. The PGP-wrapped raw bytes are persisted for every
+backend and replayed unchanged. SMTP replay also passes the separately
+persisted sender and recipient envelope unchanged. Native JMAP
+Submission receives only the raw MIME, with no explicit JMAP envelope;
+this leaves a known Bcc-delivery limitation when Bcc recipients are not
+present in those bytes, queued for a separate fix. Graph replay never
+converts the MIME to a Graph `sendMail` payload or invokes IMAP
+Sent-folder handling.
 
 ### Receive path
 `pgp_decrypt_message` extracts the ciphertext, then tries a **software**
@@ -242,7 +248,8 @@ Design decisions for this layer:
 
 The attach-pubkey, Autocrypt, and protected-subject features only alter
 outgoing MIME bytes, so they work uniformly across IMAP/JMAP/Graph (all
-send via SMTP). Only encrypted drafts diverge by backend, as above.
+transmit the same final bytes, via SMTP or native JMAP Submission). Only
+encrypted drafts diverge by backend, as above.
 
 ## Security considerations
 - **Secrets:** passphrases and PINs enter only through the prompt

--- a/src-tauri/src/backend/mail/graph.rs
+++ b/src-tauri/src/backend/mail/graph.rs
@@ -851,12 +851,11 @@ impl MailOpExecutor for GraphOpExecutor {
                     client.set_flags(&item_ids, &flags, add).await?;
                 }
             }
-            MailOp::SendRaw { .. } => {
-                // O365 delivery belongs to SMTP+XOAUTH2. Never reinterpret
-                // raw MIME as a Graph sendMail payload.
-                return Err(Error::Other(
-                    "Graph cannot send raw mail; O365 delivery must use SMTP+XOAUTH2.".into(),
-                ));
+            send @ MailOp::SendRaw { .. } => {
+                // O365 delivery belongs to SMTP+XOAUTH2. The shared replay
+                // path preserves the raw MIME and envelope and deliberately
+                // skips IMAP's Sent-folder hook for Graph accounts.
+                super::replay_send_raw_via_smtp(ctx, account_id, send).await?;
             }
             _ => {}
         }

--- a/src-tauri/src/backend/mail/imap.rs
+++ b/src-tauri/src/backend/mail/imap.rs
@@ -591,59 +591,19 @@ impl ImapOpExecutor {
 
     /// Send a queued `MailOp::SendRaw` over the account's SMTP host —
     /// not the persistent IMAP connection, so a stalled mail server
-    /// doesn't gate retries of a queued send.
+    /// doesn't gate retries of a queued send. SMTP delivery is shared
+    /// with Graph; only IMAP runs the post-delivery Sent hook below.
     async fn execute_smtp_send(
         &mut self,
         ctx: &MailSyncCtx,
         account_id: &str,
         op: MailOp,
     ) -> Result<()> {
-        let MailOp::SendRaw {
+        let super::RawSmtpDelivery {
+            account,
+            credentials,
             raw_message,
-            from,
-            to,
-            cc,
-            bcc,
-            ..
-        } = op
-        else {
-            return Err(Error::Other(
-                "execute_smtp_send called with non-SendRaw op".into(),
-            ));
-        };
-
-        let account = {
-            let conn = ctx.db.reader();
-            crate::db::accounts::get_account_full(&conn, account_id)?
-        }
-        .mail_config();
-
-        // For O365 SMTP, refresh the OAuth token (XOAUTH2; SMTP shares
-        // the IMAP scope set). For password accounts, just use the
-        // stored password.
-        let smtp_username = account.username.clone();
-        let credentials = ctx
-            .providers
-            .credentials()
-            .mail_credentials_for(&account)
-            .await?;
-        let smtp_password = credentials.secret;
-        let use_xoauth2 = credentials.use_xoauth2;
-
-        crate::mail::smtp::send_raw(
-            &account.smtp_host,
-            account.smtp_port,
-            &smtp_username,
-            &smtp_password,
-            account.use_tls,
-            use_xoauth2,
-            &from,
-            &to,
-            &cc,
-            &bcc,
-            &raw_message,
-        )
-        .await?;
+        } = super::replay_send_raw_via_smtp(ctx, account_id, op).await?;
 
         // Best-effort APPEND to Sent (#189). Same rule as the live-send
         // path in `commands::compose`: a failure here MUST NOT propagate,
@@ -658,10 +618,10 @@ impl ImapOpExecutor {
         let imap_config = ImapConfig {
             host: account.imap_host.clone(),
             port: account.imap_port,
-            username: smtp_username,
-            password: smtp_password,
+            username: account.username.clone(),
+            password: credentials.secret,
             use_tls: account.use_tls,
-            use_xoauth2,
+            use_xoauth2: credentials.use_xoauth2,
         };
         let account_id_append = account_id.to_string();
         let append_result = tokio::task::spawn_blocking(move || {

--- a/src-tauri/src/backend/mail/imap.rs
+++ b/src-tauri/src/backend/mail/imap.rs
@@ -593,85 +593,88 @@ impl ImapOpExecutor {
     /// not the persistent IMAP connection, so a stalled mail server
     /// doesn't gate retries of a queued send. SMTP delivery is shared
     /// with Graph; only IMAP runs the post-delivery Sent hook below.
-    async fn execute_smtp_send(
+    async fn deliver_smtp_send(
         &mut self,
         ctx: &MailSyncCtx,
         account_id: &str,
         op: MailOp,
-    ) -> Result<()> {
-        let super::RawSmtpDelivery {
-            account,
-            credentials,
-            raw_message,
-        } = super::replay_send_raw_via_smtp(ctx, account_id, op).await?;
+    ) -> Result<super::SendPostprocess> {
+        let delivery = super::replay_send_raw_via_smtp(ctx, account_id, op).await?;
+        Ok(super::SendPostprocess::ImapSent(Box::new(delivery)))
+    }
+}
 
-        // Best-effort APPEND to Sent (#189). Same rule as the live-send
-        // path in `commands::compose`: a failure here MUST NOT propagate,
-        // because the message has been delivered and the outbox would
-        // otherwise retry the send and duplicate it for the recipient.
-        let sent_folder_path = {
-            let conn = ctx.db.reader();
-            crate::db::folders::folder_path_by_type(&conn, account_id, "sent")
-                .ok()
-                .flatten()
-        };
-        let imap_config = ImapConfig {
-            host: account.imap_host.clone(),
-            port: account.imap_port,
-            username: account.username.clone(),
-            password: credentials.secret,
-            use_tls: account.use_tls,
-            use_xoauth2: credentials.use_xoauth2,
-        };
-        let account_id_append = account_id.to_string();
-        let append_result = tokio::task::spawn_blocking(move || {
-            crate::mail::imap::append_message_to_sent(
-                &imap_config,
-                sent_folder_path.as_deref(),
-                &raw_message,
-            )
-        })
-        .await;
-        match append_result {
-            Ok(Ok(sent_folder)) => {
-                log::info!(
-                    "Outbox replay: APPENDed sent message to '{}' for account {}",
-                    sent_folder,
-                    account_id_append
-                );
-                // Nudge a targeted sync of the Sent folder so the
-                // freshly-APPENDed message surfaces in the UI without
-                // waiting for the next scheduled sync.
-                if let Err(e) = sync_folder_quiet(ctx, &account, &sent_folder).await {
-                    log::warn!(
-                        "Outbox replay: Sent-folder sync nudge failed for account {}: {}",
-                        account_id_append,
-                        e
-                    );
-                }
-            }
-            Ok(Err(e)) => log::warn!(
-                "Outbox replay: delivered but APPEND to Sent failed for account {}: {}",
-                account_id_append,
-                e
-            ),
-            Err(e) => {
-                let kind = if e.is_panic() {
-                    "panicked"
-                } else if e.is_cancelled() {
-                    "cancelled"
-                } else {
-                    "failed"
-                };
+pub(super) async fn postprocess_smtp_delivery(
+    ctx: &MailSyncCtx,
+    account_id: &str,
+    delivery: super::RawSmtpDelivery,
+) {
+    let super::RawSmtpDelivery {
+        account,
+        credentials,
+        raw_message,
+    } = delivery;
+
+    // Delivery is already complete in the outbox. APPEND and the resulting
+    // sync are best-effort only and must never cause recipient resubmission.
+    let sent_folder_path = {
+        let conn = ctx.db.reader();
+        crate::db::folders::folder_path_by_type(&conn, account_id, "sent")
+            .ok()
+            .flatten()
+    };
+    let imap_config = ImapConfig {
+        host: account.imap_host.clone(),
+        port: account.imap_port,
+        username: account.username.clone(),
+        password: credentials.secret,
+        use_tls: account.use_tls,
+        use_xoauth2: credentials.use_xoauth2,
+    };
+    let account_id_append = account_id.to_string();
+    let append_result = tokio::task::spawn_blocking(move || {
+        crate::mail::imap::append_message_to_sent(
+            &imap_config,
+            sent_folder_path.as_deref(),
+            &raw_message,
+        )
+    })
+    .await;
+    match append_result {
+        Ok(Ok(sent_folder)) => {
+            log::info!(
+                "Outbox replay: APPENDed sent message to '{}' for account {}",
+                sent_folder,
+                account_id_append
+            );
+            if let Err(e) = sync_folder_quiet(ctx, &account, &sent_folder).await {
                 log::warn!(
-                    "Outbox replay: APPEND-to-Sent task {} for account {}: {}",
-                    kind,
+                    "Outbox replay: Sent-folder sync nudge failed for account {}: {}",
                     account_id_append,
                     e
                 );
             }
         }
-        Ok(())
+        Ok(Err(e)) => log::warn!(
+            "Outbox replay: delivered but APPEND to Sent failed for account {}: {}",
+            account_id_append,
+            e
+        ),
+        Err(e) => {
+            let kind = if e.is_panic() {
+                "panicked"
+            } else if e.is_cancelled() {
+                "cancelled"
+            } else {
+                "failed"
+            };
+            log::warn!(
+                "Outbox replay: APPEND-to-Sent task {} for account {}: {}",
+                kind,
+                account_id_append,
+                e
+            );
+        }
     }
 }
 
@@ -682,7 +685,9 @@ impl MailOpExecutor for ImapOpExecutor {
         // IMAP connection. Branch before we touch IMAP state so a stalled
         // mail server doesn't gate retries of a queued send.
         if let MailOp::SendRaw { .. } = op {
-            return self.execute_smtp_send(ctx, account_id, op).await;
+            let postprocess = self.deliver_smtp_send(ctx, account_id, op).await?;
+            postprocess.run_best_effort(ctx, account_id).await;
+            return Ok(());
         }
 
         // Ensure we have a live connection
@@ -710,6 +715,15 @@ impl MailOpExecutor for ImapOpExecutor {
         }
 
         result
+    }
+
+    async fn execute_replayed_send(
+        &mut self,
+        ctx: &MailSyncCtx,
+        account_id: &str,
+        op: MailOp,
+    ) -> Result<super::SendPostprocess> {
+        self.deliver_smtp_send(ctx, account_id, op).await
     }
 
     async fn shutdown(&mut self) {

--- a/src-tauri/src/backend/mail/jmap.rs
+++ b/src-tauri/src/backend/mail/jmap.rs
@@ -30,6 +30,7 @@ async fn connect(
         &config,
         ctx.providers.transports.jmap_discovery_http.clone(),
         ctx.providers.transports.jmap_api_http.clone(),
+        ctx.providers.transports.jmap_submission_http.clone(),
     )
     .await?;
     Ok((config, connection))

--- a/src-tauri/src/backend/mail/jmap.rs
+++ b/src-tauri/src/backend/mail/jmap.rs
@@ -270,14 +270,25 @@ impl MailOpExecutor for JmapOpExecutor {
                         .await?;
                 }
             }
-            MailOp::SendRaw { raw_message, .. } => {
+            MailOp::SendRaw {
+                raw_message,
+                from,
+                to,
+                cc,
+                bcc,
+                ..
+            } => {
+                let envelope =
+                    crate::mail::jmap::JmapSubmissionEnvelope::new(&from, &to, &cc, &bcc)?;
                 let account = {
                     let conn = ctx.db.reader();
                     crate::db::accounts::get_account_full(&conn, account_id)?
                 }
                 .mail_config();
                 let (jmap_config, conn_jmap) = connect(ctx, &account).await?;
-                conn_jmap.send_email(&jmap_config, &raw_message).await?;
+                conn_jmap
+                    .send_email(&jmap_config, &raw_message, &envelope)
+                    .await?;
             }
             _ => {}
         }

--- a/src-tauri/src/backend/mail/mod.rs
+++ b/src-tauri/src/backend/mail/mod.rs
@@ -293,6 +293,9 @@ mod registry_tests {
     use std::sync::{Arc, Mutex};
 
     use async_trait::async_trait;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::{TcpListener, TcpStream};
+    use tokio::sync::oneshot;
 
     use super::*;
     use crate::db::accounts::AccountFull;
@@ -306,6 +309,179 @@ mod registry_tests {
     use crate::provider::{
         OAuthTokenStore, ProviderCredentialService, ProviderTransports, TokenEndpointClient,
     };
+
+    struct CapturedHttpRequest {
+        method: String,
+        path: String,
+        body: Vec<u8>,
+    }
+
+    async fn read_http_request(stream: &mut TcpStream) -> CapturedHttpRequest {
+        let mut bytes = Vec::new();
+        let mut chunk = [0; 4096];
+        let header_end = loop {
+            let read = stream.read(&mut chunk).await.unwrap();
+            assert!(read > 0, "request ended before headers were complete");
+            bytes.extend_from_slice(&chunk[..read]);
+            if let Some(index) = bytes.windows(4).position(|part| part == b"\r\n\r\n") {
+                break index + 4;
+            }
+        };
+
+        let (method, path, content_length) = {
+            let headers = std::str::from_utf8(&bytes[..header_end]).unwrap();
+            let content_length = headers
+                .lines()
+                .find_map(|line| {
+                    let (name, value) = line.split_once(':')?;
+                    name.eq_ignore_ascii_case("content-length")
+                        .then(|| value.trim().parse::<usize>().unwrap())
+                })
+                .unwrap_or(0);
+            let mut request_line = headers.lines().next().unwrap().split_whitespace();
+            (
+                request_line.next().unwrap().to_string(),
+                request_line.next().unwrap().to_string(),
+                content_length,
+            )
+        };
+        while bytes.len() < header_end + content_length {
+            let read = stream.read(&mut chunk).await.unwrap();
+            assert!(read > 0, "request ended before its body was complete");
+            bytes.extend_from_slice(&chunk[..read]);
+        }
+
+        CapturedHttpRequest {
+            method,
+            path,
+            body: bytes[header_end..header_end + content_length].to_vec(),
+        }
+    }
+
+    async fn write_json_response(stream: &mut TcpStream, body: serde_json::Value) {
+        let body = body.to_string();
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        stream.write_all(response.as_bytes()).await.unwrap();
+    }
+
+    fn loopback_http_client() -> reqwest::Client {
+        reqwest::Client::builder()
+            .no_proxy()
+            .timeout(std::time::Duration::from_secs(2))
+            .build()
+            .unwrap()
+    }
+
+    async fn jmap_submission_server() -> (String, oneshot::Receiver<Vec<CapturedHttpRequest>>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let base_url = format!("http://{}", listener.local_addr().unwrap());
+        let server_base_url = base_url.clone();
+        let (requests_tx, requests_rx) = oneshot::channel();
+
+        tokio::spawn(async move {
+            let mut requests = Vec::new();
+            loop {
+                let (mut stream, _) = listener.accept().await.unwrap();
+                let request = read_http_request(&mut stream).await;
+                let (response, is_final) = if request.method == "GET" {
+                    (
+                        serde_json::json!({
+                            "apiUrl": format!("{server_base_url}/api"),
+                            "downloadUrl": format!(
+                                "{server_base_url}/download/{{accountId}}/{{blobId}}/{{name}}"
+                            ),
+                            "uploadUrl": format!("{server_base_url}/upload/{{accountId}}"),
+                            "capabilities": {
+                                "urn:ietf:params:jmap:core": {},
+                                "urn:ietf:params:jmap:mail": {},
+                                "urn:ietf:params:jmap:submission": {}
+                            },
+                            "accounts": {
+                                "account-1": {
+                                    "accountCapabilities": {
+                                        "urn:ietf:params:jmap:mail": {},
+                                        "urn:ietf:params:jmap:submission": {
+                                            "maxDelayedSend": 0,
+                                            "submissionExtensions": {}
+                                        }
+                                    }
+                                }
+                            },
+                            "primaryAccounts": {
+                                "urn:ietf:params:jmap:mail": "account-1"
+                            }
+                        }),
+                        false,
+                    )
+                } else if request.path == "/upload/account-1" {
+                    (serde_json::json!({ "blobId": "blob-1" }), false)
+                } else {
+                    let body: serde_json::Value = serde_json::from_slice(&request.body).unwrap();
+                    match body["methodCalls"][0][0].as_str().unwrap() {
+                        "Mailbox/get" => (
+                            serde_json::json!({
+                                "methodResponses": [["Mailbox/get", {
+                                    "accountId": "account-1",
+                                    "state": "mailbox-state",
+                                    "list": [{ "id": "sent-1", "role": "sent" }],
+                                    "notFound": []
+                                }, "r1"]]
+                            }),
+                            false,
+                        ),
+                        "Identity/get" => (
+                            serde_json::json!({
+                                "methodResponses": [["Identity/get", {
+                                    "accountId": "account-1",
+                                    "state": "identity-state",
+                                    "list": [{
+                                        "id": "identity-1",
+                                        "email": "Sender@example.test"
+                                    }],
+                                    "notFound": []
+                                }, "id1"]]
+                            }),
+                            false,
+                        ),
+                        "Email/import" => (
+                            serde_json::json!({
+                                "methodResponses": [
+                                    ["Email/import", {
+                                        "accountId": "account-1",
+                                        "oldState": "email-old",
+                                        "newState": "email-new",
+                                        "created": { "draft": { "id": "email-1" } }
+                                    }, "i1"],
+                                    ["EmailSubmission/set", {
+                                        "accountId": "account-1",
+                                        "oldState": "submission-old",
+                                        "newState": "submission-new",
+                                        "created": {
+                                            "sub1": { "id": "submission-1" }
+                                        }
+                                    }, "s1"]
+                                ]
+                            }),
+                            true,
+                        ),
+                        method => panic!("unexpected JMAP method: {method}"),
+                    }
+                };
+                write_json_response(&mut stream, response).await;
+                requests.push(request);
+                if is_final {
+                    break;
+                }
+            }
+            requests_tx.send(requests).ok();
+        });
+
+        (base_url, requests_rx)
+    }
 
     #[derive(Default)]
     struct MemoryTokenStore {
@@ -512,9 +688,7 @@ mod registry_tests {
             account_id: account_id.into(),
             action_type: action_type.into(),
             payload_json: payload.to_string(),
-            status: "pending".into(),
             retry_count: 0,
-            error_message: None,
         };
         let replayed = outbox_to_mail_op(&entry).expect("valid send must replay from outbox");
         assert_eq!(replayed, original);
@@ -766,12 +940,12 @@ mod registry_tests {
             .await
             .unwrap_err()
             .to_string();
-        // JMAP resolves this account's fresh in-memory OIDC token, then
-        // rejects the cleartext fixture URL before making a request. No
-        // password or persistent keyring secret participates in the test.
-        assert!(token_store.was_loaded(&jmap_id));
+        // JMAP validates its mandatory explicit envelope before resolving
+        // credentials or opening a connection. The distinct error proves the
+        // replay stayed on the native JMAP path rather than SMTP.
+        assert!(!token_store.was_loaded(&jmap_id));
         assert!(
-            jmap_error.contains("URL must use https://"),
+            jmap_error.contains("Invalid JMAP submission mail-from address"),
             "JMAP SendRaw must retain native JMAP submission: {jmap_error}"
         );
         assert!(!jmap_error.contains("SMTP send_raw"));
@@ -781,6 +955,163 @@ mod registry_tests {
                 crate::oauth::MICROSOFT_IMAP_SCOPES,
                 crate::oauth::MICROSOFT_IMAP_SCOPES,
             ]
+        );
+    }
+
+    #[tokio::test]
+    async fn persisted_jmap_send_retains_bcc_in_explicit_envelope() {
+        let (jmap_url, requests_rx) = jmap_submission_server().await;
+        let temp = tempfile::tempdir().unwrap();
+        let db = Arc::new(DbPool::new(&temp.path().join("jmap-outbox.db"), 1).unwrap());
+        {
+            let conn = db.writer().await;
+            crate::db::schema::initialize(&conn).unwrap();
+        }
+
+        let account_id = format!("jmap-outbox-{}", uuid::Uuid::new_v4());
+        insert_executor_account(&db, &account_id, "jmap", "password").await;
+        {
+            let conn = db.writer().await;
+            conn.execute(
+                "UPDATE service_bindings SET config_json = ?1
+                 WHERE account_id = ?2 AND service = 'mail'",
+                rusqlite::params![
+                    serde_json::json!({
+                        "url": jmap_url,
+                        "auth_method": "basic",
+                    })
+                    .to_string(),
+                    account_id,
+                ],
+            )
+            .unwrap();
+        }
+
+        let token_store = Arc::new(MemoryTokenStore::default());
+        let endpoint = Arc::new(ScopeRecordingEndpoint::default());
+        let credentials = Arc::new(ProviderCredentialService::new(
+            token_store.clone(),
+            endpoint.clone(),
+        ));
+        let mut transports = ProviderTransports::production().unwrap();
+        transports.jmap_api_http = loopback_http_client();
+        transports.jmap_discovery_http = loopback_http_client();
+        let providers = Arc::new(ProviderServices::new(
+            credentials,
+            token_store,
+            endpoint,
+            transports,
+        ));
+        let ctx = MailSyncCtx {
+            events: Arc::new(NoopEventSink),
+            db: db.clone(),
+            data_dir: temp.path().to_path_buf(),
+            providers,
+        };
+
+        let bcc = "Hidden Recipient <hidden@example.test>";
+        let raw_message =
+            b"From: Sender <Sender@Example.test>\r\nTo: visible@example.test\r\nSubject: outbox\r\n\r\nbody\r\n"
+                .to_vec();
+        assert!(!String::from_utf8_lossy(&raw_message).contains("hidden@example.test"));
+        let original = MailOp::SendRaw {
+            raw_message: raw_message.clone(),
+            from: "Sender <Sender@Example.test>".into(),
+            to: vec!["Visible Recipient <visible@example.test>".into()],
+            cc: Vec::new(),
+            bcc: vec![bcc.into()],
+            subject: "outbox".into(),
+        };
+        let (action_type, payload) = mail_op_to_outbox(&original).unwrap();
+        let replayed = outbox_to_mail_op(&OutboxEntry {
+            id: 1,
+            account_id: account_id.clone(),
+            action_type: action_type.into(),
+            payload_json: payload.to_string(),
+            retry_count: 0,
+        })
+        .unwrap();
+        assert_eq!(replayed, original);
+
+        let account = {
+            let conn = db.reader();
+            crate::db::accounts::get_account_full(&conn, &account_id)
+                .unwrap()
+                .mail_config()
+        };
+        let mut executor = for_account(&account).unwrap().op_executor();
+        tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            executor.execute(&ctx, &account_id, replayed),
+        )
+        .await
+        .expect("JMAP outbox execution timed out")
+        .unwrap();
+
+        let requests = tokio::time::timeout(std::time::Duration::from_secs(2), requests_rx)
+            .await
+            .unwrap()
+            .unwrap();
+        let upload = requests
+            .iter()
+            .find(|request| request.path == "/upload/account-1")
+            .unwrap();
+        assert_eq!(upload.body, raw_message);
+
+        let identity_index = requests
+            .iter()
+            .position(|request| request.body.windows(12).any(|part| part == b"Identity/get"))
+            .unwrap();
+        let upload_index = requests
+            .iter()
+            .position(|request| request.path == "/upload/account-1")
+            .unwrap();
+        assert!(
+            identity_index < upload_index,
+            "identity must resolve before upload"
+        );
+
+        let mailbox_requests = requests
+            .iter()
+            .filter(|request| request.body.windows(11).any(|part| part == b"Mailbox/get"))
+            .count();
+        assert_eq!(
+            mailbox_requests, 1,
+            "Inbox fallback must stay lazy when Sent exists"
+        );
+
+        let submission = requests
+            .iter()
+            .filter(|request| request.path == "/api")
+            .find_map(|request| {
+                let body: serde_json::Value = serde_json::from_slice(&request.body).unwrap();
+                (body["methodCalls"][0][0] == "Email/import").then_some(body)
+            })
+            .unwrap();
+        let envelope = &submission["methodCalls"][1][1]["create"]["sub1"]["envelope"];
+        assert_eq!(
+            envelope,
+            &serde_json::json!({
+                "mailFrom": {
+                    "email": "Sender@Example.test",
+                    "parameters": null
+                },
+                "rcptTo": [
+                    { "email": "visible@example.test", "parameters": null },
+                    { "email": "hidden@example.test", "parameters": null }
+                ]
+            })
+        );
+        assert!(submission["methodCalls"][1][1]
+            .get("onSuccessUpdateEmail")
+            .is_none());
+        assert_eq!(
+            serde_json::to_string(&submission)
+                .unwrap()
+                .matches("hidden@example.test")
+                .count(),
+            1,
+            "Bcc must appear only in the explicit submission rcptTo"
         );
     }
 }

--- a/src-tauri/src/backend/mail/mod.rs
+++ b/src-tauri/src/backend/mail/mod.rs
@@ -16,7 +16,7 @@ use crate::error::Result;
 use crate::event::SharedEventSink;
 use crate::message::{BackendMessageRef, BodyLocation, SearchHit, SearchQuery};
 use crate::ops::queue::MailOp;
-use crate::provider::ProviderServices;
+use crate::provider::{MailCredentials, ProviderServices};
 
 pub mod graph;
 pub mod imap;
@@ -30,6 +30,71 @@ pub struct MailSyncCtx {
     pub db: std::sync::Arc<DbPool>,
     pub data_dir: std::path::PathBuf,
     pub providers: std::sync::Arc<ProviderServices>,
+}
+
+/// State retained after SMTP accepts a replayed message. Only the IMAP
+/// executor consumes it for its best-effort APPEND-to-Sent hook.
+struct RawSmtpDelivery {
+    account: MailAccountConfig,
+    credentials: MailCredentials,
+    raw_message: Vec<u8>,
+}
+
+/// Replay a persisted raw send through the account's current SMTP settings.
+///
+/// The account and credentials are deliberately reloaded for each attempt so
+/// password changes and Microsoft IMAP/SMTP-scoped OAuth tokens are current.
+/// The persisted envelope and RFC 5322 bytes are passed to SMTP unchanged.
+async fn replay_send_raw_via_smtp(
+    ctx: &MailSyncCtx,
+    account_id: &str,
+    op: MailOp,
+) -> Result<RawSmtpDelivery> {
+    let MailOp::SendRaw {
+        raw_message,
+        from,
+        to,
+        cc,
+        bcc,
+        ..
+    } = op
+    else {
+        return Err(crate::error::Error::Other(
+            "SMTP replay received a non-SendRaw operation".into(),
+        ));
+    };
+
+    let account = {
+        let conn = ctx.db.reader();
+        crate::db::accounts::get_account_full(&conn, account_id)?
+    }
+    .mail_config();
+    let credentials = ctx
+        .providers
+        .credentials()
+        .mail_credentials_for(&account)
+        .await?;
+
+    crate::mail::smtp::send_raw(
+        &account.smtp_host,
+        account.smtp_port,
+        &account.username,
+        &credentials.secret,
+        account.use_tls,
+        credentials.use_xoauth2,
+        &from,
+        &to,
+        &cc,
+        &bcc,
+        &raw_message,
+    )
+    .await?;
+
+    Ok(RawSmtpDelivery {
+        account,
+        credentials,
+        raw_message,
+    })
 }
 
 /// Provider-neutral inputs for fetching one raw RFC 822 body into Maildir.
@@ -224,10 +289,114 @@ pub fn for_account(account: &MailAccountConfig) -> Option<&'static dyn MailBacke
 
 #[cfg(test)]
 mod registry_tests {
+    use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
+
+    use async_trait::async_trait;
+
     use super::*;
     use crate::db::accounts::AccountFull;
+    use crate::db::pool::DbPool;
     use crate::db::service_bindings::ServiceBinding;
+    use crate::error::Error;
+    use crate::event::{ApplicationEvent, EventSink};
     use crate::message::BodyLocation;
+    use crate::oauth::{OAuthProvider, OAuthTokens};
+    use crate::ops::offline::{mail_op_to_outbox, outbox_to_mail_op, OutboxEntry};
+    use crate::provider::{
+        OAuthTokenStore, ProviderCredentialService, ProviderTransports, TokenEndpointClient,
+    };
+
+    #[derive(Default)]
+    struct MemoryTokenStore {
+        tokens: Mutex<HashMap<String, OAuthTokens>>,
+        loads: Mutex<Vec<String>>,
+    }
+
+    impl MemoryTokenStore {
+        fn was_loaded(&self, account_id: &str) -> bool {
+            self.loads
+                .lock()
+                .unwrap()
+                .iter()
+                .any(|loaded| loaded == account_id)
+        }
+    }
+
+    impl OAuthTokenStore for MemoryTokenStore {
+        fn load(&self, account_id: &str) -> Result<Option<OAuthTokens>> {
+            self.loads.lock().unwrap().push(account_id.to_string());
+            Ok(self.tokens.lock().unwrap().get(account_id).cloned())
+        }
+
+        fn store(&self, account_id: &str, tokens: &OAuthTokens) -> Result<()> {
+            self.tokens
+                .lock()
+                .unwrap()
+                .insert(account_id.to_string(), tokens.clone());
+            Ok(())
+        }
+
+        fn delete(&self, account_id: &str) -> Result<()> {
+            self.tokens.lock().unwrap().remove(account_id);
+            Ok(())
+        }
+    }
+
+    #[derive(Default)]
+    struct ScopeRecordingEndpoint {
+        scopes: Mutex<Vec<String>>,
+    }
+
+    #[async_trait]
+    impl TokenEndpointClient for ScopeRecordingEndpoint {
+        async fn exchange_code(
+            &self,
+            _provider: &OAuthProvider,
+            _code: &str,
+            _port: u16,
+            _code_verifier: Option<&str>,
+        ) -> Result<OAuthTokens> {
+            Err(Error::Other("unexpected code exchange".into()))
+        }
+
+        async fn refresh(
+            &self,
+            _provider: &OAuthProvider,
+            _refresh_token: &str,
+        ) -> Result<OAuthTokens> {
+            Err(Error::Other("unexpected unscoped refresh".into()))
+        }
+
+        async fn refresh_scoped(
+            &self,
+            _provider: &OAuthProvider,
+            _refresh_token: &str,
+            scopes: &str,
+        ) -> Result<OAuthTokens> {
+            self.scopes.lock().unwrap().push(scopes.to_string());
+            Ok(OAuthTokens {
+                access_token: "smtp-access-token".into(),
+                refresh_token: Some("rotated-refresh-token".into()),
+                expires_at: Some(i64::MAX),
+            })
+        }
+
+        async fn refresh_dynamic(
+            &self,
+            _token_url: &str,
+            _refresh_token: &str,
+            _client_id: &str,
+        ) -> Result<OAuthTokens> {
+            Err(Error::Other("unexpected dynamic refresh".into()))
+        }
+    }
+
+    struct NoopEventSink;
+
+    impl EventSink for NoopEventSink {
+        fn publish(&self, _event: ApplicationEvent) {}
+    }
 
     fn account(mail_protocol: &str, auth_method: &str) -> AccountFull {
         let bindings = if mail_protocol.is_empty() {
@@ -278,6 +447,85 @@ mod registry_tests {
             pgp_encrypt_subject: false,
             pgp_encrypt_drafts: false,
         }
+    }
+
+    async fn insert_executor_account(
+        db: &DbPool,
+        account_id: &str,
+        protocol: &str,
+        auth_method: &str,
+    ) {
+        let config_json = match protocol {
+            "imap" => serde_json::json!({
+                "imap_host": "imap.example.test",
+                "imap_port": 993,
+                "smtp_host": "smtp.example.test",
+                "smtp_port": 587,
+                "use_tls": true,
+            }),
+            "jmap" => serde_json::json!({
+                "url": "http://example.test/jmap",
+                "auth_method": "oidc",
+            }),
+            _ => serde_json::json!({}),
+        };
+        let conn = db.writer().await;
+        conn.execute(
+            "INSERT INTO accounts
+             (id, display_name, email, username, auth_method)
+             VALUES (?1, ?2, ?3, ?3, ?4)",
+            rusqlite::params![
+                account_id,
+                format!("{protocol} executor"),
+                format!("{protocol}@example.test"),
+                auth_method,
+            ],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO service_bindings
+             (id, account_id, service, protocol, enabled, config_json)
+             VALUES (?1, ?2, 'mail', ?3, 1, ?4)",
+            rusqlite::params![
+                format!("{account_id}-mail"),
+                account_id,
+                protocol,
+                config_json.to_string(),
+            ],
+        )
+        .unwrap();
+    }
+
+    fn persisted_send_with_invalid_sender(account_id: &str) -> MailOp {
+        let original = MailOp::SendRaw {
+            raw_message: b"From: sender@example.test\r\nTo: recipient@example.test\r\n\r\nbody"
+                .to_vec(),
+            from: "invalid sender".into(),
+            to: vec!["recipient@example.test".into()],
+            cc: Vec::new(),
+            bcc: Vec::new(),
+            subject: "routing fixture".into(),
+        };
+        let (action_type, payload) = mail_op_to_outbox(&original).unwrap();
+        let entry = OutboxEntry {
+            id: 1,
+            account_id: account_id.into(),
+            action_type: action_type.into(),
+            payload_json: payload.to_string(),
+            status: "pending".into(),
+            retry_count: 0,
+            error_message: None,
+        };
+        let replayed = outbox_to_mail_op(&entry).expect("valid send must replay from outbox");
+        assert_eq!(replayed, original);
+        replayed
+    }
+
+    fn assert_invalid_sender_error(protocol: &str, error: &str) {
+        assert!(
+            error.starts_with("Invalid SMTP address 'invalid sender':"),
+            "{protocol} SendRaw must reach SMTP sender validation: {error}"
+        );
     }
 
     #[test]
@@ -401,6 +649,138 @@ mod registry_tests {
         assert_eq!(
             request.message_ref.into_jmap_email_id().as_deref(),
             Some("raw_email_id")
+        );
+    }
+
+    #[tokio::test]
+    async fn send_raw_routing_uses_smtp_for_graph_and_imap_but_jmap_submission() {
+        let temp = tempfile::tempdir().unwrap();
+        let db = Arc::new(DbPool::new(&temp.path().join("mail-routing.db"), 1).unwrap());
+        {
+            let conn = db.writer().await;
+            crate::db::schema::initialize(&conn).unwrap();
+        }
+
+        let suffix = uuid::Uuid::new_v4();
+        let graph_id = format!("graph-{suffix}");
+        let imap_id = format!("imap-{suffix}");
+        let jmap_id = format!("jmap-{suffix}");
+        insert_executor_account(&db, &graph_id, "graph", "oauth-microsoft").await;
+        insert_executor_account(&db, &imap_id, "imap", "oauth-microsoft").await;
+        insert_executor_account(&db, &jmap_id, "jmap", "oauth-jmap-oidc").await;
+
+        let token_store = Arc::new(MemoryTokenStore::default());
+        for account_id in [&graph_id, &imap_id] {
+            token_store
+                .store(
+                    account_id,
+                    &OAuthTokens {
+                        access_token: "stale-access-token".into(),
+                        refresh_token: Some("refresh-token".into()),
+                        expires_at: Some(0),
+                    },
+                )
+                .unwrap();
+        }
+        token_store
+            .store(
+                &jmap_id,
+                &OAuthTokens {
+                    access_token: "jmap-oidc-access-token".into(),
+                    refresh_token: Some("jmap-refresh-token".into()),
+                    expires_at: Some(i64::MAX),
+                },
+            )
+            .unwrap();
+        let endpoint = Arc::new(ScopeRecordingEndpoint::default());
+        let credentials = Arc::new(ProviderCredentialService::new(
+            token_store.clone(),
+            endpoint.clone(),
+        ));
+        let providers = Arc::new(ProviderServices::new(
+            credentials,
+            token_store.clone(),
+            endpoint.clone(),
+            ProviderTransports::production().unwrap(),
+        ));
+        let ctx = MailSyncCtx {
+            events: Arc::new(NoopEventSink),
+            db: db.clone(),
+            data_dir: temp.path().to_path_buf(),
+            providers,
+        };
+
+        let graph_account = {
+            let conn = db.reader();
+            crate::db::accounts::get_account_full(&conn, &graph_id)
+                .unwrap()
+                .mail_config()
+        };
+        let mut graph = for_account(&graph_account).unwrap().op_executor();
+        let graph_error = graph
+            .execute(
+                &ctx,
+                &graph_id,
+                persisted_send_with_invalid_sender(&graph_id),
+            )
+            .await
+            .unwrap_err()
+            .to_string();
+        assert_invalid_sender_error("Graph", &graph_error);
+        assert!(!graph_error.contains("Graph cannot send raw mail"));
+        assert_eq!(
+            *endpoint.scopes.lock().unwrap(),
+            vec![crate::oauth::MICROSOFT_IMAP_SCOPES]
+        );
+
+        let imap_account = {
+            let conn = db.reader();
+            crate::db::accounts::get_account_full(&conn, &imap_id)
+                .unwrap()
+                .mail_config()
+        };
+        let mut imap = for_account(&imap_account).unwrap().op_executor();
+        let imap_error = imap
+            .execute(&ctx, &imap_id, persisted_send_with_invalid_sender(&imap_id))
+            .await
+            .unwrap_err()
+            .to_string();
+        assert_invalid_sender_error("IMAP", &imap_error);
+        assert_eq!(
+            *endpoint.scopes.lock().unwrap(),
+            vec![
+                crate::oauth::MICROSOFT_IMAP_SCOPES,
+                crate::oauth::MICROSOFT_IMAP_SCOPES,
+            ]
+        );
+
+        let jmap_account = {
+            let conn = db.reader();
+            crate::db::accounts::get_account_full(&conn, &jmap_id)
+                .unwrap()
+                .mail_config()
+        };
+        let mut jmap = for_account(&jmap_account).unwrap().op_executor();
+        let jmap_error = jmap
+            .execute(&ctx, &jmap_id, persisted_send_with_invalid_sender(&jmap_id))
+            .await
+            .unwrap_err()
+            .to_string();
+        // JMAP resolves this account's fresh in-memory OIDC token, then
+        // rejects the cleartext fixture URL before making a request. No
+        // password or persistent keyring secret participates in the test.
+        assert!(token_store.was_loaded(&jmap_id));
+        assert!(
+            jmap_error.contains("URL must use https://"),
+            "JMAP SendRaw must retain native JMAP submission: {jmap_error}"
+        );
+        assert!(!jmap_error.contains("SMTP send_raw"));
+        assert_eq!(
+            *endpoint.scopes.lock().unwrap(),
+            vec![
+                crate::oauth::MICROSOFT_IMAP_SCOPES,
+                crate::oauth::MICROSOFT_IMAP_SCOPES,
+            ]
         );
     }
 }

--- a/src-tauri/src/backend/mail/mod.rs
+++ b/src-tauri/src/backend/mail/mod.rs
@@ -34,10 +34,27 @@ pub struct MailSyncCtx {
 
 /// State retained after SMTP accepts a replayed message. Only the IMAP
 /// executor consumes it for its best-effort APPEND-to-Sent hook.
-struct RawSmtpDelivery {
+pub struct RawSmtpDelivery {
     account: MailAccountConfig,
     credentials: MailCredentials,
     raw_message: Vec<u8>,
+}
+
+/// Work that is safe to run only after send completion is durable locally.
+pub enum SendPostprocess {
+    None,
+    ImapSent(Box<RawSmtpDelivery>),
+}
+
+impl SendPostprocess {
+    pub(crate) async fn run_best_effort(self, ctx: &MailSyncCtx, account_id: &str) {
+        match self {
+            Self::None => {}
+            Self::ImapSent(delivery) => {
+                imap::postprocess_smtp_delivery(ctx, account_id, *delivery).await;
+            }
+        }
+    }
 }
 
 /// Replay a persisted raw send through the account's current SMTP settings.
@@ -254,6 +271,18 @@ pub trait MailOpExecutor: Send {
     /// this; the worker handles them directly.
     async fn execute(&mut self, ctx: &MailSyncCtx, account_id: &str, op: MailOp) -> Result<()>;
 
+    /// Deliver a replayed send and return any best-effort work that must run
+    /// only after the worker has durably completed its outbox claim.
+    async fn execute_replayed_send(
+        &mut self,
+        ctx: &MailSyncCtx,
+        account_id: &str,
+        op: MailOp,
+    ) -> Result<SendPostprocess> {
+        self.execute(ctx, account_id, op).await?;
+        Ok(SendPostprocess::None)
+    }
+
     /// Called once when the worker shuts down; close connections.
     async fn shutdown(&mut self) {}
 }
@@ -418,7 +447,13 @@ mod registry_tests {
                         false,
                     )
                 } else if request.path == "/upload/account-1" {
-                    (serde_json::json!({ "blobId": "blob-1" }), false)
+                    (
+                        serde_json::json!({
+                            "accountId": "account-1",
+                            "blobId": "blob-1"
+                        }),
+                        false,
+                    )
                 } else {
                     let body: serde_json::Value = serde_json::from_slice(&request.body).unwrap();
                     match body["methodCalls"][0][0].as_str().unwrap() {

--- a/src-tauri/src/commands/calendar.rs
+++ b/src-tauri/src/commands/calendar.rs
@@ -1339,7 +1339,16 @@ async fn apply_invite_response(
                     &reply_ical,
                 )?;
 
-                jmap_conn.send_email(&jmap_config, &raw_message).await?;
+                let envelope = crate::mail::jmap::JmapSubmissionEnvelope::new(
+                    &account.email,
+                    std::slice::from_ref(organizer_email),
+                    &[],
+                    &[],
+                )?;
+
+                jmap_conn
+                    .send_email(&jmap_config, &raw_message, &envelope)
+                    .await?;
             }
             InviteReplyDelivery::Provider => {
                 // O365/Graph accounts have no SMTP host configured. The reply
@@ -1699,15 +1708,13 @@ fn build_calendar_reply_message(
     body_text: &str,
     ical_reply: &str,
 ) -> Result<Vec<u8>> {
-    use lettre::message::{header::ContentType, Mailbox, MultiPart, SinglePart};
+    use lettre::message::{header::ContentType, MultiPart, SinglePart};
     use lettre::Message;
 
-    let from_mailbox: Mailbox = from.parse().map_err(|e| {
-        crate::error::Error::Other(format!("Invalid 'from' address '{}': {}", from, e))
-    })?;
-    let to_mailbox: Mailbox = to
-        .parse()
-        .map_err(|e| crate::error::Error::Other(format!("Invalid 'to' address '{}': {}", to, e)))?;
+    let from_mailbox = crate::mail::smtp::parse_mailbox(from)
+        .map_err(|_| crate::error::Error::Other("Invalid calendar reply sender".into()))?;
+    let to_mailbox = crate::mail::smtp::parse_mailbox(to)
+        .map_err(|_| crate::error::Error::Other("Invalid calendar reply recipient".into()))?;
 
     let message = Message::builder()
         .from(from_mailbox)
@@ -1748,69 +1755,21 @@ async fn send_raw_smtp(
     to: &str,
     raw_message: &[u8],
 ) -> Result<()> {
-    use lettre::transport::smtp::authentication::{Credentials, Mechanism};
-    use lettre::{AsyncSmtpTransport, AsyncTransport, Tokio1Executor};
-
-    log::info!(
-        "send_raw_smtp: from={} to={} via {}:{} (xoauth2={})",
-        from,
-        to,
+    let recipients = [to.to_string()];
+    crate::mail::smtp::send_raw(
         smtp_host,
         smtp_port,
+        username,
+        password,
+        use_tls,
         use_xoauth2,
-    );
-
-    let creds = Credentials::new(username.to_string(), password.to_string());
-    let auth_mechanisms = if use_xoauth2 {
-        vec![Mechanism::Xoauth2]
-    } else {
-        vec![Mechanism::Plain, Mechanism::Login]
-    };
-
-    let transport = if smtp_port == 587 {
-        AsyncSmtpTransport::<Tokio1Executor>::starttls_relay(smtp_host)
-            .map_err(|e| crate::error::Error::Other(format!("SMTP setup failed: {}", e)))?
-            .port(smtp_port)
-            .credentials(creds)
-            .authentication(auth_mechanisms)
-            .build()
-    } else if use_tls || smtp_port == 465 {
-        AsyncSmtpTransport::<Tokio1Executor>::relay(smtp_host)
-            .map_err(|e| crate::error::Error::Other(format!("SMTP setup failed: {}", e)))?
-            .port(smtp_port)
-            .credentials(creds)
-            .authentication(auth_mechanisms)
-            .build()
-    } else {
-        AsyncSmtpTransport::<Tokio1Executor>::starttls_relay(smtp_host)
-            .map_err(|e| crate::error::Error::Other(format!("SMTP setup failed: {}", e)))?
-            .port(smtp_port)
-            .credentials(creds)
-            .authentication(auth_mechanisms)
-            .build()
-    };
-
-    // Build an envelope from the from/to addresses
-    let from_addr: lettre::Address = from
-        .parse()
-        .map_err(|e| crate::error::Error::Other(format!("Invalid from address: {}", e)))?;
-    let to_addr: lettre::Address = to
-        .parse()
-        .map_err(|e| crate::error::Error::Other(format!("Invalid to address: {}", e)))?;
-
-    let envelope = lettre::address::Envelope::new(Some(from_addr), vec![to_addr])
-        .map_err(|e| crate::error::Error::Other(format!("Failed to create envelope: {}", e)))?;
-
-    transport
-        .send_raw(&envelope, raw_message)
-        .await
-        .map_err(|e| {
-            log::error!("SMTP send failed: {}", e);
-            crate::error::Error::Other(format!("SMTP send failed: {}", e))
-        })?;
-
-    log::info!("send_raw_smtp: message sent successfully");
-    Ok(())
+        from,
+        &recipients,
+        &[],
+        &[],
+        raw_message,
+    )
+    .await
 }
 
 /// Send meeting invite emails to attendees for a calendar event.
@@ -1917,8 +1876,14 @@ pub async fn send_invites(
         }
 
         if account.calendar_protocol_str() == "jmap" {
+            let envelope = crate::mail::jmap::JmapSubmissionEnvelope::new(
+                &account.email,
+                std::slice::from_ref(attendee_email),
+                &[],
+                &[],
+            )?;
             let (jmap_config, conn_jmap) = state.providers.jmap_client(&account).await?;
-            conn_jmap.send_email(&jmap_config, &raw).await?;
+            conn_jmap.send_email(&jmap_config, &raw, &envelope).await?;
         } else {
             let credentials = state
                 .providers
@@ -2168,20 +2133,20 @@ fn build_invite_message(
     body_text: &str,
     ical_data: &str,
 ) -> Vec<u8> {
-    use lettre::message::{header::ContentType, Mailbox, MultiPart, SinglePart};
+    use lettre::message::{header::ContentType, MultiPart, SinglePart};
     use lettre::Message;
 
-    let from_mailbox: Mailbox = match from.parse() {
+    let from_mailbox = match crate::mail::smtp::parse_mailbox(from) {
         Ok(m) => m,
-        Err(e) => {
-            log::error!("build_invite_message: invalid from '{}': {}", from, e);
+        Err(_) => {
+            log::error!("build_invite_message: invalid sender");
             return Vec::new();
         }
     };
-    let to_mailbox: Mailbox = match to.parse() {
+    let to_mailbox = match crate::mail::smtp::parse_mailbox(to) {
         Ok(m) => m,
-        Err(e) => {
-            log::error!("build_invite_message: invalid to '{}': {}", to, e);
+        Err(_) => {
+            log::error!("build_invite_message: invalid recipient");
             return Vec::new();
         }
     };

--- a/src-tauri/src/commands/compose.rs
+++ b/src-tauri/src/commands/compose.rs
@@ -1,11 +1,67 @@
 use serde::Deserialize;
-use tauri::{Emitter, State};
+use tauri::{Emitter, Manager, State};
 
 use crate::db;
 use crate::error::{Error, Result};
 use crate::mail::smtp;
 use crate::message::normalize_message_id;
+use crate::ops::offline::SendRetryDisposition;
 use crate::state::AppState;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum SendRoute {
+    Jmap,
+    SmtpOnly,
+    SmtpWithImapSent,
+}
+
+impl SendRoute {
+    fn appends_to_imap_sent(self) -> bool {
+        matches!(self, Self::SmtpWithImapSent)
+    }
+}
+
+fn resolve_send_route(account_id: &str, protocol: &str) -> Result<SendRoute> {
+    match protocol {
+        "" => Err(Error::Other(format!(
+            "Account {account_id} has no enabled mail binding"
+        ))),
+        "jmap" => Ok(SendRoute::Jmap),
+        "graph" => Ok(SendRoute::SmtpOnly),
+        // Match the backend registry's legacy fallback: every unknown,
+        // non-empty mail protocol resolves to IMAP.
+        _ => Ok(SendRoute::SmtpWithImapSent),
+    }
+}
+
+async fn acquire_send_account_guard(
+    coordinator: &crate::state::AccountLifecycleCoordinator,
+    account_id: &str,
+) -> tokio::sync::OwnedMutexGuard<()> {
+    coordinator.acquire(account_id).lock_owned().await
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum SendFailureEvents {
+    Suppress,
+    FailureOnly,
+    FailureAndQueueChanged,
+}
+
+fn retry_failure_events(transition: &Result<SendRetryDisposition>) -> SendFailureEvents {
+    match transition {
+        Ok(SendRetryDisposition::Pending) => SendFailureEvents::FailureOnly,
+        Ok(SendRetryDisposition::Dead) => SendFailureEvents::FailureAndQueueChanged,
+        Ok(SendRetryDisposition::MissingClaim) | Err(_) => SendFailureEvents::Suppress,
+    }
+}
+
+fn quarantine_failure_events(transition: &Result<bool>) -> SendFailureEvents {
+    match transition {
+        Ok(true) => SendFailureEvents::FailureAndQueueChanged,
+        Ok(false) | Err(_) => SendFailureEvents::Suppress,
+    }
+}
 
 #[derive(Debug, Deserialize)]
 pub struct ComposeMessage {
@@ -94,10 +150,12 @@ pub async fn send_message(
         message.subject
     );
 
+    let account_guard = acquire_send_account_guard(&state.account_lifecycle, &account_id).await;
     let account = {
         let conn = state.db.reader();
         db::accounts::get_account_full(&conn, &account_id)?
     };
+    let send_route = resolve_send_route(&account_id, account.mail_protocol_str())?;
     // --- Synchronous part: validate, read attachments, build message ---
     // This is fast (local I/O only) so the compose window waits for it.
     // We *peek* tokens for the build so a failure here (e.g. file
@@ -209,16 +267,15 @@ pub async fn send_message(
     let raw_message: std::sync::Arc<[u8]> = raw_message.into();
 
     // Resolve SMTP credentials now because OAuth refresh needs keyring access.
-    let smtp_creds = if account.mail_protocol_str() != "jmap" {
-        Some(
+    let smtp_creds = match send_route {
+        SendRoute::Jmap => None,
+        SendRoute::SmtpOnly | SendRoute::SmtpWithImapSent => Some(
             state
                 .providers
                 .credentials()
                 .mail_credentials(&account)
                 .await?,
-        )
-    } else {
-        None
+        ),
     };
 
     let subject_display = if message.subject.is_empty() {
@@ -283,10 +340,6 @@ pub async fn send_message(
     let subject_bg = subject_display.clone();
     let db_bg = state.db.clone();
     let providers_bg = state.providers.clone();
-    // Capture the worker's op-sender now so the spawn can enqueue a
-    // Sent-folder sync after a successful APPEND (#189). `state` is
-    // not `'static`, so the sender must be cloned out before the move.
-    let op_sender_bg = state.get_op_sender(&account_id, &app).await;
     let recipients: Vec<String> = message
         .to
         .iter()
@@ -295,25 +348,39 @@ pub async fn send_message(
         .collect();
 
     tokio::spawn(async move {
-        let result: std::result::Result<(), Error> = async {
-            if let Some(smtp_creds) = smtp_creds {
-                let smtp_username = account.username.clone();
-
+        let result: std::result::Result<(), Error> = match send_route {
+            SendRoute::Jmap => {
+                async {
+                    log::info!("Sending via JMAP for account {}", account.email);
+                    let envelope = crate::mail::jmap::JmapSubmissionEnvelope::new(
+                        &account.email,
+                        &message.to,
+                        &message.cc,
+                        &message.bcc,
+                    )?;
+                    let (jmap_config, conn_jmap) = providers_bg.jmap_client(&account).await?;
+                    conn_jmap
+                        .send_email(&jmap_config, &raw_message, &envelope)
+                        .await
+                }
+                .await
+            }
+            SendRoute::SmtpOnly | SendRoute::SmtpWithImapSent => {
+                let smtp_creds = smtp_creds
+                    .as_ref()
+                    .expect("SMTP send route must have credentials");
                 log::info!(
                     "Sending via SMTP {}:{} as {}",
                     account.smtp_host,
                     account.smtp_port,
                     account.email
                 );
-                // Send the already-built `raw_message` bytes verbatim.
-                // PGP/MIME wrapping (when pgp_sign/pgp_encrypt is set) is
-                // applied to those bytes upstream; rebuilding the message
-                // from structured fields here would discard the wrapping
-                // and leak the cleartext on the wire.
+                // Send the already-built bytes verbatim. Sent-folder
+                // maintenance runs only after delivery is durable locally.
                 smtp::send_raw(
                     &account.smtp_host,
                     account.smtp_port,
-                    &smtp_username,
+                    &account.username,
                     &smtp_creds.secret,
                     account.use_tls,
                     smtp_creds.use_xoauth2,
@@ -323,116 +390,136 @@ pub async fn send_message(
                     &message.bcc,
                     &raw_message,
                 )
-                .await?;
-
-                // Best-effort: APPEND the sent message to the IMAP Sent
-                // folder (#189). SMTP submission alone never writes to
-                // Sent for plain IMAP+SMTP or O365 SMTP+XOAUTH2. The JMAP
-                // branch below handles Sent server-side and skips this
-                // hook. Failures here MUST NOT propagate — the message has
-                // been delivered, and a retried send would duplicate it.
-                // Read-only lookup — use the pool's reader so we don't
-                // serialize on the single-writer mutex.
-                let sent_folder_path = {
-                    let conn = db_bg.reader();
-                    crate::db::folders::folder_path_by_type(&conn, &account_id_bg, "sent")
-                        .ok()
-                        .flatten()
-                };
-                let imap_config = crate::mail::imap::ImapConfig {
-                    host: account.imap_host.clone(),
-                    port: account.imap_port,
-                    username: smtp_username.clone(),
-                    password: smtp_creds.secret.clone(),
-                    use_tls: account.use_tls,
-                    use_xoauth2: smtp_creds.use_xoauth2,
-                };
-                // `Arc::clone` of `Arc<[u8]>` is a refcount bump — does
-                // not duplicate the inlined-attachment bytes (which can
-                // be many MB on a send with large attachments).
-                let raw_for_append = std::sync::Arc::clone(&raw_message);
-                let account_id_append = account_id_bg.clone();
-                let append_result = tokio::task::spawn_blocking(move || {
-                    crate::mail::imap::append_message_to_sent(
-                        &imap_config,
-                        sent_folder_path.as_deref(),
-                        &raw_for_append,
-                    )
-                })
-                .await;
-                match append_result {
-                    Ok(Ok(sent_folder)) => {
-                        log::info!(
-                            "APPENDed sent message to '{}' for account {}",
-                            sent_folder,
-                            account_id_append
-                        );
-                        // Nudge a targeted sync so the freshly-APPENDed
-                        // message shows up in the UI immediately instead
-                        // of waiting for the next scheduled sync.
-                        let send_res = op_sender_bg
-                            .send(crate::ops::queue::OpEntry {
-                                op: crate::ops::queue::MailOp::SyncFolder {
-                                    folder_path: sent_folder,
-                                },
-                                priority: crate::ops::queue::OpPriority::User,
-                            })
-                            .await;
-                        if let Err(e) = send_res {
-                            log::warn!(
-                                "Failed to queue Sent-folder sync for account {}: {}",
-                                account_id_append,
-                                e
-                            );
-                        }
-                    }
-                    Ok(Err(e)) => log::warn!(
-                        "Sent delivered but APPEND to Sent failed for account {}: {}",
-                        account_id_append,
-                        e
-                    ),
-                    Err(e) => {
-                        let kind = if e.is_panic() {
-                            "panicked"
-                        } else if e.is_cancelled() {
-                            "cancelled"
-                        } else {
-                            "failed"
-                        };
-                        log::warn!(
-                            "APPEND-to-Sent task {} for account {}: {}",
-                            kind,
-                            account_id_append,
-                            e
-                        );
-                    }
-                }
-            } else {
-                log::info!("Sending via JMAP for account {}", account.email);
-                let envelope = crate::mail::jmap::JmapSubmissionEnvelope::new(
-                    &account.email,
-                    &message.to,
-                    &message.cc,
-                    &message.bcc,
-                )?;
-                let (jmap_config, conn_jmap) = providers_bg.jmap_client(&account).await?;
-                conn_jmap
-                    .send_email(&jmap_config, &raw_message, &envelope)
-                    .await?;
+                .await
             }
-            Ok(())
-        }
-        .await;
+        };
 
         match result {
             Ok(()) => {
-                log::info!("Message sent successfully for account {}", account_id_bg);
-                let completion = {
-                    let conn = db_bg.writer().await;
-                    crate::ops::offline::complete_sending_send(&conn, outbox_id)
-                };
+                let app_complete = app_bg.clone();
+                let account_id_complete = account_id_bg.clone();
+                let subject_complete = subject_bg.clone();
+                let db_postprocess = db_bg.clone();
+                let completion = crate::ops::offline::complete_send_before(
+                    &db_bg,
+                    outbox_id,
+                    move || async move {
+                        // Account mutation only needs to wait through the
+                        // durable transition, not best-effort maintenance.
+                        drop(account_guard);
+                        app_complete
+                            .emit(
+                                "send-complete",
+                                serde_json::json!({
+                                    "account_id": account_id_complete,
+                                    "subject": subject_complete,
+                                    "outbox_id": outbox_id,
+                                }),
+                            )
+                            .ok();
+
+                        if send_route.appends_to_imap_sent() {
+                            let smtp_creds = smtp_creds
+                                .expect("IMAP Sent postprocess must have SMTP credentials");
+                            // SMTP delivery is already durable locally. A
+                            // failed APPEND can lose the Sent copy but must
+                            // never put the message back in the send queue.
+                            let sent_folder_path = {
+                                let conn = db_postprocess.reader();
+                                crate::db::folders::folder_path_by_type(
+                                    &conn,
+                                    &account_id_complete,
+                                    "sent",
+                                )
+                                .ok()
+                                .flatten()
+                            };
+                            let imap_config = crate::mail::imap::ImapConfig {
+                                host: account.imap_host.clone(),
+                                port: account.imap_port,
+                                username: account.username.clone(),
+                                password: smtp_creds.secret,
+                                use_tls: account.use_tls,
+                                use_xoauth2: smtp_creds.use_xoauth2,
+                            };
+                            let raw_for_append = std::sync::Arc::clone(&raw_message);
+                            let append_result = tokio::task::spawn_blocking(move || {
+                                crate::mail::imap::append_message_to_sent(
+                                    &imap_config,
+                                    sent_folder_path.as_deref(),
+                                    &raw_for_append,
+                                )
+                            })
+                            .await;
+                            match append_result {
+                                Ok(Ok(sent_folder)) => {
+                                    log::info!(
+                                        "APPENDed sent message to '{}' for account {}",
+                                        sent_folder,
+                                        account_id_complete
+                                    );
+                                    let op_sender = app_complete
+                                        .state::<AppState>()
+                                        .get_op_sender(&account_id_complete, &app_complete)
+                                        .await;
+                                    let send_res = op_sender
+                                        .send(crate::ops::queue::OpEntry {
+                                            op: crate::ops::queue::MailOp::SyncFolder {
+                                                folder_path: sent_folder,
+                                            },
+                                            priority: crate::ops::queue::OpPriority::User,
+                                        })
+                                        .await;
+                                    if let Err(e) = send_res {
+                                        log::warn!(
+                                            "Failed to queue Sent-folder sync for account {}: {}",
+                                            account_id_complete,
+                                            e
+                                        );
+                                    }
+                                }
+                                Ok(Err(e)) => log::warn!(
+                                    "Sent delivered but APPEND to Sent failed for account {}: {}",
+                                    account_id_complete,
+                                    e
+                                ),
+                                Err(e) => {
+                                    let kind = if e.is_panic() {
+                                        "panicked"
+                                    } else if e.is_cancelled() {
+                                        "cancelled"
+                                    } else {
+                                        "failed"
+                                    };
+                                    log::warn!(
+                                        "APPEND-to-Sent task {} for account {}: {}",
+                                        kind,
+                                        account_id_complete,
+                                        e
+                                    );
+                                }
+                            }
+                        }
+
+                        let conn = db_postprocess.writer().await;
+                        for addr in &recipients {
+                            if let Err(e) = db::contacts::collect_contact(
+                                &conn,
+                                &account_id_complete,
+                                addr,
+                                None,
+                            ) {
+                                log::warn!("Failed to collect contact '{}': {}", addr, e);
+                            }
+                        }
+                    },
+                )
+                .await;
                 match completion {
-                    Ok(true) => {}
+                    Ok(true) => log::info!(
+                        "Message sent successfully for account {}",
+                        account_id_bg
+                    ),
                     Ok(false) => log::error!(
                         "Send {} succeeded but its sending claim was missing",
                         outbox_id
@@ -443,28 +530,6 @@ pub async fn send_message(
                         error
                     ),
                 }
-                app_bg
-                    .emit(
-                        "send-complete",
-                        serde_json::json!({
-                            "account_id": account_id_bg,
-                            "subject": subject_bg,
-                            "outbox_id": outbox_id,
-                        }),
-                    )
-                    .ok();
-
-                // Auto-collect recipients to "Collected Contacts"
-                {
-                    let conn = db_bg.writer().await;
-                    for addr in &recipients {
-                        if let Err(e) =
-                            db::contacts::collect_contact(&conn, &account_id_bg, addr, None)
-                        {
-                            log::warn!("Failed to collect contact '{}': {}", addr, e);
-                        }
-                    }
-                }
             }
             Err(e) => {
                 log::error!("Send failed for account {}: {}", account_id_bg, e);
@@ -474,51 +539,83 @@ pub async fn send_message(
                 } else {
                     e.to_string()
                 };
-                let transition = {
-                    let conn = db_bg.writer().await;
-                    if indeterminate {
+                let event_decision = if indeterminate {
+                    let transition = {
+                        let conn = db_bg.writer().await;
                         crate::ops::offline::quarantine_sending_send(
                             &conn,
                             outbox_id,
                             &error_message,
                         )
-                    } else {
-                        crate::ops::offline::retry_sending_send(&conn, outbox_id, &error_message)
+                    };
+                    let decision = quarantine_failure_events(&transition);
+                    drop(account_guard);
+                    match transition {
+                        Ok(true) => {}
+                        Ok(false) => log::error!(
+                            "Send {} failed but its sending claim was missing",
+                            outbox_id
+                        ),
+                        Err(db_error) => log::error!(
+                            "Failed to quarantine indeterminate send {}; row remains sending: {}",
+                            outbox_id,
+                            db_error
+                        ),
                     }
-                };
-                match transition {
-                    Ok(true) => {}
-                    Ok(false) => log::error!(
-                        "Send {} failed but its sending claim was missing",
-                        outbox_id
-                    ),
-                    Err(db_error) if indeterminate => log::error!(
-                        "Failed to quarantine indeterminate send {}; row remains sending: {}",
-                        outbox_id,
-                        db_error
-                    ),
-                    Err(db_error) => log::error!(
-                        "Failed to persist retry for send {}; row remains sending: {}",
-                        outbox_id,
-                        db_error
-                    ),
-                }
-                let event_name = if indeterminate {
-                    "send-unknown"
+                    decision
                 } else {
-                    "send-failed"
+                    let transition = {
+                        let conn = db_bg.writer().await;
+                        crate::ops::offline::retry_sending_send(&conn, outbox_id, &error_message)
+                    };
+                    let decision = retry_failure_events(&transition);
+                    drop(account_guard);
+                    match transition {
+                        Ok(SendRetryDisposition::Pending | SendRetryDisposition::Dead) => {}
+                        Ok(SendRetryDisposition::MissingClaim) => {
+                            log::error!(
+                                "Send {} failed but its sending claim was missing",
+                                outbox_id
+                            )
+                        }
+                        Err(db_error) => log::error!(
+                            "Failed to persist retry for send {}; row remains sending: {}",
+                            outbox_id,
+                            db_error
+                        ),
+                    }
+                    decision
                 };
-                app_bg
-                    .emit(
-                        event_name,
-                        serde_json::json!({
-                            "account_id": account_id_bg,
-                            "subject": subject_bg,
-                            "outbox_id": outbox_id,
-                            "error": error_message,
-                        }),
-                    )
-                    .ok();
+                if event_decision != SendFailureEvents::Suppress {
+                    let event_name = if indeterminate {
+                        "send-unknown"
+                    } else {
+                        "send-failed"
+                    };
+                    app_bg
+                        .emit(
+                            event_name,
+                            serde_json::json!({
+                                "account_id": account_id_bg,
+                                "subject": subject_bg,
+                                "outbox_id": outbox_id,
+                                "error": error_message,
+                            }),
+                        )
+                        .ok();
+                }
+                if event_decision == SendFailureEvents::FailureAndQueueChanged {
+                    app_bg
+                        .emit(
+                            "offline-queue-changed",
+                            serde_json::json!({
+                                "account_id": account_id_bg,
+                                "dead_op_id": outbox_id,
+                                "action_type": "send",
+                            }),
+                        )
+                        .ok();
+                }
             }
         }
     });
@@ -1369,6 +1466,99 @@ pub async fn pgp_check_recipients(
         out.push(status);
     }
     Ok(out)
+}
+
+#[cfg(test)]
+mod send_safety_tests {
+    use super::{
+        acquire_send_account_guard, quarantine_failure_events, resolve_send_route,
+        retry_failure_events, SendFailureEvents, SendRoute,
+    };
+    use crate::error::{Error, Result};
+    use crate::ops::offline::SendRetryDisposition;
+    use crate::state::AccountLifecycleCoordinator;
+
+    #[test]
+    fn send_route_rejects_an_empty_or_disabled_mail_binding() {
+        let error = resolve_send_route("account", "").unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "Account account has no enabled mail binding"
+        );
+    }
+
+    #[test]
+    fn send_route_matches_backend_fallback_and_sent_behavior() {
+        assert_eq!(
+            resolve_send_route("account", "jmap").unwrap(),
+            SendRoute::Jmap
+        );
+        assert_eq!(
+            resolve_send_route("account", "graph").unwrap(),
+            SendRoute::SmtpOnly
+        );
+        assert_eq!(
+            resolve_send_route("account", "imap").unwrap(),
+            SendRoute::SmtpWithImapSent
+        );
+        assert_eq!(
+            resolve_send_route("account", "legacy-unknown").unwrap(),
+            SendRoute::SmtpWithImapSent
+        );
+    }
+
+    #[tokio::test]
+    async fn owned_send_guard_excludes_account_mutation_until_dropped() {
+        let coordinator = AccountLifecycleCoordinator::default();
+        let send_guard = acquire_send_account_guard(&coordinator, "account").await;
+        let mutation_lock = coordinator.acquire("account");
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+        let send_task = tokio::spawn(async move {
+            release_rx.await.unwrap();
+            drop(send_guard);
+        });
+
+        assert!(mutation_lock.clone().try_lock_owned().is_err());
+        release_tx.send(()).unwrap();
+        send_task.await.unwrap();
+        assert!(mutation_lock.try_lock_owned().is_ok());
+    }
+
+    #[test]
+    fn failure_events_require_a_persisted_transition() {
+        assert_eq!(
+            retry_failure_events(&Ok(SendRetryDisposition::Pending)),
+            SendFailureEvents::FailureOnly
+        );
+        assert_eq!(
+            retry_failure_events(&Ok(SendRetryDisposition::Dead)),
+            SendFailureEvents::FailureAndQueueChanged
+        );
+        assert_eq!(
+            retry_failure_events(&Ok(SendRetryDisposition::MissingClaim)),
+            SendFailureEvents::Suppress
+        );
+        let retry_error: Result<SendRetryDisposition> = Err(Error::Other("database".into()));
+        assert_eq!(
+            retry_failure_events(&retry_error),
+            SendFailureEvents::Suppress
+        );
+
+        assert_eq!(
+            quarantine_failure_events(&Ok(true)),
+            SendFailureEvents::FailureAndQueueChanged
+        );
+        assert_eq!(
+            quarantine_failure_events(&Ok(false)),
+            SendFailureEvents::Suppress
+        );
+        let quarantine_error: Result<bool> = Err(Error::Other("database".into()));
+        assert_eq!(
+            quarantine_failure_events(&quarantine_error),
+            SendFailureEvents::Suppress
+        );
+    }
 }
 
 #[cfg(test)]

--- a/src-tauri/src/commands/compose.rs
+++ b/src-tauri/src/commands/compose.rs
@@ -77,8 +77,8 @@ pub struct FileAttachment {
 
 /// Send an email. Validates and reads attachments synchronously, then spawns
 /// the actual network send in the background so the compose window can close
-/// immediately. Emits `send-started`, `send-complete`, or `send-failed` events
-/// to the main window for status tracking.
+/// immediately. Emits `send-started`, `send-complete`, `send-failed`, or
+/// `send-unknown` events to the main window for status tracking.
 #[tauri::command]
 pub async fn send_message(
     app: tauri::AppHandle,
@@ -221,26 +221,18 @@ pub async fn send_message(
         None
     };
 
-    // Notify main window that send is starting
     let subject_display = if message.subject.is_empty() {
         "(no subject)".to_string()
     } else {
         message.subject.clone()
     };
-    app.emit(
-        "send-started",
-        serde_json::json!({
-            "account_id": account_id,
-            "subject": subject_display,
-        }),
-    )
-    .ok();
 
     // --- Persist to outbox before spawning background send ---
     // The row is inserted with status 'sending' so the worker's replay
     // loop won't pick it up while the first attempt is still in flight.
-    // On success the row is deleted; on failure it flips to 'pending'
-    // and the next post-sync drain replays it via the worker.
+    // On success the row is deleted. A definite failure flips to
+    // 'pending' for worker replay; an indeterminate delivery is kept as
+    // 'dead' so only an explicit manual retry can resend it.
     let raw_message_b64 = {
         use base64::Engine;
         base64::engine::general_purpose::STANDARD.encode(&raw_message)
@@ -268,6 +260,15 @@ pub async fn send_message(
         outbox_id,
         account_id
     );
+    app.emit(
+        "send-started",
+        serde_json::json!({
+            "account_id": account_id,
+            "subject": subject_display,
+            "outbox_id": outbox_id,
+        }),
+    )
+    .ok();
 
     // From here on the outbox owns the payload — the attachment bytes
     // are already inlined in raw_message. Releasing tokens is safe even
@@ -408,8 +409,16 @@ pub async fn send_message(
                 }
             } else {
                 log::info!("Sending via JMAP for account {}", account.email);
+                let envelope = crate::mail::jmap::JmapSubmissionEnvelope::new(
+                    &account.email,
+                    &message.to,
+                    &message.cc,
+                    &message.bcc,
+                )?;
                 let (jmap_config, conn_jmap) = providers_bg.jmap_client(&account).await?;
-                conn_jmap.send_email(&jmap_config, &raw_message).await?;
+                conn_jmap
+                    .send_email(&jmap_config, &raw_message, &envelope)
+                    .await?;
             }
             Ok(())
         }
@@ -418,14 +427,21 @@ pub async fn send_message(
         match result {
             Ok(()) => {
                 log::info!("Message sent successfully for account {}", account_id_bg);
-                // Each writer acquire is scoped: shadowing the previous
-                // `conn` would NOT drop the old guard before the new
-                // `lock().await`, self-deadlocking on the same mutex.
-                {
+                let completion = {
                     let conn = db_bg.writer().await;
-                    if let Err(e) = crate::ops::offline::mark_completed(&conn, outbox_id) {
-                        log::warn!("Failed to remove sent message from outbox: {}", e);
-                    }
+                    crate::ops::offline::complete_sending_send(&conn, outbox_id)
+                };
+                match completion {
+                    Ok(true) => {}
+                    Ok(false) => log::error!(
+                        "Send {} succeeded but its sending claim was missing",
+                        outbox_id
+                    ),
+                    Err(error) => log::error!(
+                        "Send {} succeeded but completion persistence failed; row remains sending: {}",
+                        outbox_id,
+                        error
+                    ),
                 }
                 app_bg
                     .emit(
@@ -433,6 +449,7 @@ pub async fn send_message(
                         serde_json::json!({
                             "account_id": account_id_bg,
                             "subject": subject_bg,
+                            "outbox_id": outbox_id,
                         }),
                     )
                     .ok();
@@ -451,18 +468,54 @@ pub async fn send_message(
             }
             Err(e) => {
                 log::error!("Send failed for account {}: {}", account_id_bg, e);
-                // Flip the row from 'sending' back to 'pending' and record
-                // the error so the worker replays it on the next sync.
-                let conn = db_bg.writer().await;
-                let _ = crate::ops::offline::mark_failed(&conn, outbox_id, &e.to_string());
-                let _ = crate::ops::offline::mark_pending(&conn, outbox_id);
+                let indeterminate = e.is_indeterminate_delivery();
+                let error_message = if indeterminate {
+                    crate::ops::offline::INDETERMINATE_DELIVERY_ERROR_MESSAGE.to_string()
+                } else {
+                    e.to_string()
+                };
+                let transition = {
+                    let conn = db_bg.writer().await;
+                    if indeterminate {
+                        crate::ops::offline::quarantine_sending_send(
+                            &conn,
+                            outbox_id,
+                            &error_message,
+                        )
+                    } else {
+                        crate::ops::offline::retry_sending_send(&conn, outbox_id, &error_message)
+                    }
+                };
+                match transition {
+                    Ok(true) => {}
+                    Ok(false) => log::error!(
+                        "Send {} failed but its sending claim was missing",
+                        outbox_id
+                    ),
+                    Err(db_error) if indeterminate => log::error!(
+                        "Failed to quarantine indeterminate send {}; row remains sending: {}",
+                        outbox_id,
+                        db_error
+                    ),
+                    Err(db_error) => log::error!(
+                        "Failed to persist retry for send {}; row remains sending: {}",
+                        outbox_id,
+                        db_error
+                    ),
+                }
+                let event_name = if indeterminate {
+                    "send-unknown"
+                } else {
+                    "send-failed"
+                };
                 app_bg
                     .emit(
-                        "send-failed",
+                        event_name,
                         serde_json::json!({
                             "account_id": account_id_bg,
                             "subject": subject_bg,
-                            "error": e.to_string(),
+                            "outbox_id": outbox_id,
+                            "error": error_message,
                         }),
                     )
                     .ok();

--- a/src-tauri/src/commands/mail.rs
+++ b/src-tauri/src/commands/mail.rs
@@ -707,6 +707,7 @@ pub async fn create_folder(
             &jmap_config,
             state.providers.transports.jmap_discovery_http.clone(),
             state.providers.transports.jmap_api_http.clone(),
+            state.providers.transports.jmap_submission_http.clone(),
         )
         .await?;
         // For JMAP, folder_path is "parentId/name" (built by the frontend).
@@ -828,6 +829,7 @@ pub async fn delete_folder(
             &jmap_config,
             state.providers.transports.jmap_discovery_http.clone(),
             state.providers.transports.jmap_api_http.clone(),
+            state.providers.transports.jmap_submission_http.clone(),
         )
         .await?;
         conn_jmap

--- a/src-tauri/src/commands/outbox.rs
+++ b/src-tauri/src/commands/outbox.rs
@@ -75,13 +75,14 @@ fn row_from_payload(
     }
 }
 
-fn retry_dead_row(conn: &rusqlite::Connection, outbox_id: i64) -> Result<()> {
+fn retry_dead_row(conn: &rusqlite::Connection, account_id: &str, outbox_id: i64) -> Result<()> {
     let changed = conn
         .execute(
             "UPDATE outbox
              SET status = 'pending', retry_count = 0, error_message = NULL
-             WHERE id = ?1 AND action_type = 'send' AND status = 'dead'",
-            rusqlite::params![outbox_id],
+             WHERE id = ?1 AND account_id = ?2
+               AND action_type = 'send' AND status = 'dead'",
+            rusqlite::params![outbox_id, account_id],
         )
         .map_err(Error::Database)?;
     if changed != 1 {
@@ -93,13 +94,17 @@ fn retry_dead_row(conn: &rusqlite::Connection, outbox_id: i64) -> Result<()> {
     Ok(())
 }
 
-fn discard_inactive_row(conn: &rusqlite::Connection, outbox_id: i64) -> Result<()> {
+fn discard_inactive_row(
+    conn: &rusqlite::Connection,
+    account_id: &str,
+    outbox_id: i64,
+) -> Result<()> {
     let changed = conn
         .execute(
             "DELETE FROM outbox
-             WHERE id = ?1 AND action_type = 'send'
+             WHERE id = ?1 AND account_id = ?2 AND action_type = 'send'
                AND status IN ('pending', 'dead')",
-            rusqlite::params![outbox_id],
+            rusqlite::params![outbox_id, account_id],
         )
         .map_err(Error::Database)?;
     if changed != 1 {
@@ -148,18 +153,26 @@ pub async fn list_outbox(state: State<'_, AppState>, account_id: String) -> Resu
 /// Flip a dead row back to 'pending' with retry_count reset so the next sync
 /// drain will replay it. Pending and actively sending rows are not mutable.
 #[tauri::command]
-pub async fn retry_outbox_op(state: State<'_, AppState>, outbox_id: i64) -> Result<()> {
+pub async fn retry_outbox_op(
+    state: State<'_, AppState>,
+    account_id: String,
+    outbox_id: i64,
+) -> Result<()> {
     let conn = state.db.writer().await;
-    retry_dead_row(&conn, outbox_id)?;
+    retry_dead_row(&conn, &account_id, outbox_id)?;
     log::info!("Outbox row {} requeued for retry", outbox_id);
     Ok(())
 }
 
 /// Permanently delete an inactive outbox row. A sending row retains its claim.
 #[tauri::command]
-pub async fn discard_outbox_op(state: State<'_, AppState>, outbox_id: i64) -> Result<()> {
+pub async fn discard_outbox_op(
+    state: State<'_, AppState>,
+    account_id: String,
+    outbox_id: i64,
+) -> Result<()> {
     let conn = state.db.writer().await;
-    discard_inactive_row(&conn, outbox_id)?;
+    discard_inactive_row(&conn, &account_id, outbox_id)?;
     log::info!("Outbox row {} discarded", outbox_id);
     Ok(())
 }
@@ -185,12 +198,12 @@ mod tests {
         conn
     }
 
-    fn insert_row(conn: &rusqlite::Connection, status: &str) -> i64 {
+    fn insert_row(conn: &rusqlite::Connection, account_id: &str, status: &str) -> i64 {
         conn.execute(
             "INSERT INTO outbox
              (account_id, action_type, payload_json, status, retry_count, error_message)
-             VALUES ('acc1', 'send', '{}', ?1, 3, 'old error')",
-            rusqlite::params![status],
+             VALUES (?1, 'send', '{}', ?2, 3, 'old error')",
+            rusqlite::params![account_id, status],
         )
         .unwrap();
         conn.last_insert_rowid()
@@ -208,33 +221,45 @@ mod tests {
     #[test]
     fn manual_retry_only_transitions_dead_to_pending() {
         let conn = setup_db();
-        let dead = insert_row(&conn, "dead");
-        let pending = insert_row(&conn, "pending");
-        let sending = insert_row(&conn, "sending");
+        let dead = insert_row(&conn, "acc1", "dead");
+        let pending = insert_row(&conn, "acc1", "pending");
+        let sending = insert_row(&conn, "acc1", "sending");
 
-        retry_dead_row(&conn, dead).unwrap();
+        retry_dead_row(&conn, "acc1", dead).unwrap();
         assert_eq!(row_state(&conn, dead), Some(("pending".into(), 0, None)));
-        assert!(retry_dead_row(&conn, dead).is_err());
-        assert!(retry_dead_row(&conn, pending).is_err());
-        assert!(retry_dead_row(&conn, sending).is_err());
-        assert!(retry_dead_row(&conn, i64::MAX).is_err());
+        assert!(retry_dead_row(&conn, "acc1", dead).is_err());
+        assert!(retry_dead_row(&conn, "acc1", pending).is_err());
+        assert!(retry_dead_row(&conn, "acc1", sending).is_err());
+        assert!(retry_dead_row(&conn, "acc1", i64::MAX).is_err());
         assert_eq!(row_state(&conn, sending).unwrap().0, "sending");
     }
 
     #[test]
     fn discard_only_deletes_pending_or_dead_rows() {
         let conn = setup_db();
-        let dead = insert_row(&conn, "dead");
-        let pending = insert_row(&conn, "pending");
-        let sending = insert_row(&conn, "sending");
+        let dead = insert_row(&conn, "acc1", "dead");
+        let pending = insert_row(&conn, "acc1", "pending");
+        let sending = insert_row(&conn, "acc1", "sending");
 
-        discard_inactive_row(&conn, dead).unwrap();
-        discard_inactive_row(&conn, pending).unwrap();
+        discard_inactive_row(&conn, "acc1", dead).unwrap();
+        discard_inactive_row(&conn, "acc1", pending).unwrap();
         assert!(row_state(&conn, dead).is_none());
         assert!(row_state(&conn, pending).is_none());
-        assert!(discard_inactive_row(&conn, sending).is_err());
-        assert!(discard_inactive_row(&conn, i64::MAX).is_err());
+        assert!(discard_inactive_row(&conn, "acc1", sending).is_err());
+        assert!(discard_inactive_row(&conn, "acc1", i64::MAX).is_err());
         assert_eq!(row_state(&conn, sending).unwrap().0, "sending");
+    }
+
+    #[test]
+    fn manual_actions_reject_rows_from_another_account() {
+        let conn = setup_db();
+        let retry_row = insert_row(&conn, "acc1", "dead");
+        let discard_row = insert_row(&conn, "acc1", "pending");
+
+        assert!(retry_dead_row(&conn, "acc2", retry_row).is_err());
+        assert!(discard_inactive_row(&conn, "acc2", discard_row).is_err());
+        assert_eq!(row_state(&conn, retry_row).unwrap().0, "dead");
+        assert_eq!(row_state(&conn, discard_row).unwrap().0, "pending");
     }
 
     #[test]

--- a/src-tauri/src/commands/outbox.rs
+++ b/src-tauri/src/commands/outbox.rs
@@ -20,6 +20,7 @@ pub struct OutboxRow {
     pub status: String,
     pub retry_count: i32,
     pub error_message: Option<String>,
+    pub delivery_outcome_unknown: bool,
     pub subject: Option<String>,
     pub to: Vec<String>,
     pub cc: Vec<String>,
@@ -56,6 +57,9 @@ fn row_from_payload(
     let to = parse_string_array(&payload, "to");
     let cc = parse_string_array(&payload, "cc");
     let bcc = parse_string_array(&payload, "bcc");
+    let delivery_outcome_unknown = error_message
+        .as_deref()
+        .is_some_and(crate::ops::offline::is_indeterminate_delivery_error_message);
     OutboxRow {
         id,
         account_id,
@@ -63,11 +67,48 @@ fn row_from_payload(
         status,
         retry_count,
         error_message,
+        delivery_outcome_unknown,
         subject,
         to,
         cc,
         bcc,
     }
+}
+
+fn retry_dead_row(conn: &rusqlite::Connection, outbox_id: i64) -> Result<()> {
+    let changed = conn
+        .execute(
+            "UPDATE outbox
+             SET status = 'pending', retry_count = 0, error_message = NULL
+             WHERE id = ?1 AND action_type = 'send' AND status = 'dead'",
+            rusqlite::params![outbox_id],
+        )
+        .map_err(Error::Database)?;
+    if changed != 1 {
+        return Err(Error::Other(format!(
+            "Outbox row {} is not eligible for manual retry",
+            outbox_id
+        )));
+    }
+    Ok(())
+}
+
+fn discard_inactive_row(conn: &rusqlite::Connection, outbox_id: i64) -> Result<()> {
+    let changed = conn
+        .execute(
+            "DELETE FROM outbox
+             WHERE id = ?1 AND action_type = 'send'
+               AND status IN ('pending', 'dead')",
+            rusqlite::params![outbox_id],
+        )
+        .map_err(Error::Database)?;
+    if changed != 1 {
+        return Err(Error::Other(format!(
+            "Outbox row {} is not eligible for discard",
+            outbox_id
+        )));
+    }
+    Ok(())
 }
 
 /// List all outbox rows for an account that are visible to the user:
@@ -80,7 +121,8 @@ pub async fn list_outbox(state: State<'_, AppState>, account_id: String) -> Resu
         .prepare(
             "SELECT id, account_id, action_type, status, retry_count, error_message, payload_json
              FROM outbox
-             WHERE account_id = ?1 AND status IN ('pending', 'sending', 'dead')
+             WHERE account_id = ?1 AND action_type = 'send'
+               AND status IN ('pending', 'sending', 'dead')
              ORDER BY id DESC",
         )
         .map_err(Error::Database)?;
@@ -103,30 +145,120 @@ pub async fn list_outbox(state: State<'_, AppState>, account_id: String) -> Resu
     Ok(rows)
 }
 
-/// Flip a dead or pending row back to 'pending' with retry_count reset
-/// so the next sync drain will replay it.
+/// Flip a dead row back to 'pending' with retry_count reset so the next sync
+/// drain will replay it. Pending and actively sending rows are not mutable.
 #[tauri::command]
 pub async fn retry_outbox_op(state: State<'_, AppState>, outbox_id: i64) -> Result<()> {
     let conn = state.db.writer().await;
-    conn.execute(
-        "UPDATE outbox SET status = 'pending', retry_count = 0, error_message = NULL
-         WHERE id = ?1",
-        rusqlite::params![outbox_id],
-    )
-    .map_err(Error::Database)?;
+    retry_dead_row(&conn, outbox_id)?;
     log::info!("Outbox row {} requeued for retry", outbox_id);
     Ok(())
 }
 
-/// Permanently delete an outbox row.
+/// Permanently delete an inactive outbox row. A sending row retains its claim.
 #[tauri::command]
 pub async fn discard_outbox_op(state: State<'_, AppState>, outbox_id: i64) -> Result<()> {
     let conn = state.db.writer().await;
-    conn.execute(
-        "DELETE FROM outbox WHERE id = ?1",
-        rusqlite::params![outbox_id],
-    )
-    .map_err(Error::Database)?;
+    discard_inactive_row(&conn, outbox_id)?;
     log::info!("Outbox row {} discarded", outbox_id);
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn setup_db() -> rusqlite::Connection {
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE outbox (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                account_id TEXT NOT NULL,
+                action_type TEXT NOT NULL,
+                payload_json TEXT NOT NULL,
+                status TEXT NOT NULL,
+                retry_count INTEGER NOT NULL,
+                error_message TEXT
+            );",
+        )
+        .unwrap();
+        conn
+    }
+
+    fn insert_row(conn: &rusqlite::Connection, status: &str) -> i64 {
+        conn.execute(
+            "INSERT INTO outbox
+             (account_id, action_type, payload_json, status, retry_count, error_message)
+             VALUES ('acc1', 'send', '{}', ?1, 3, 'old error')",
+            rusqlite::params![status],
+        )
+        .unwrap();
+        conn.last_insert_rowid()
+    }
+
+    fn row_state(conn: &rusqlite::Connection, id: i64) -> Option<(String, i32, Option<String>)> {
+        conn.query_row(
+            "SELECT status, retry_count, error_message FROM outbox WHERE id = ?1",
+            rusqlite::params![id],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .ok()
+    }
+
+    #[test]
+    fn manual_retry_only_transitions_dead_to_pending() {
+        let conn = setup_db();
+        let dead = insert_row(&conn, "dead");
+        let pending = insert_row(&conn, "pending");
+        let sending = insert_row(&conn, "sending");
+
+        retry_dead_row(&conn, dead).unwrap();
+        assert_eq!(row_state(&conn, dead), Some(("pending".into(), 0, None)));
+        assert!(retry_dead_row(&conn, dead).is_err());
+        assert!(retry_dead_row(&conn, pending).is_err());
+        assert!(retry_dead_row(&conn, sending).is_err());
+        assert!(retry_dead_row(&conn, i64::MAX).is_err());
+        assert_eq!(row_state(&conn, sending).unwrap().0, "sending");
+    }
+
+    #[test]
+    fn discard_only_deletes_pending_or_dead_rows() {
+        let conn = setup_db();
+        let dead = insert_row(&conn, "dead");
+        let pending = insert_row(&conn, "pending");
+        let sending = insert_row(&conn, "sending");
+
+        discard_inactive_row(&conn, dead).unwrap();
+        discard_inactive_row(&conn, pending).unwrap();
+        assert!(row_state(&conn, dead).is_none());
+        assert!(row_state(&conn, pending).is_none());
+        assert!(discard_inactive_row(&conn, sending).is_err());
+        assert!(discard_inactive_row(&conn, i64::MAX).is_err());
+        assert_eq!(row_state(&conn, sending).unwrap().0, "sending");
+    }
+
+    #[test]
+    fn renderer_row_distinguishes_unknown_delivery_from_failure() {
+        let unknown = row_from_payload(
+            1,
+            "acc1".into(),
+            "send".into(),
+            "dead".into(),
+            0,
+            Some(crate::ops::offline::INDETERMINATE_DELIVERY_ERROR_MESSAGE.into()),
+            r#"{"subject":"test"}"#,
+        );
+        assert!(unknown.delivery_outcome_unknown);
+
+        let failed = row_from_payload(
+            2,
+            "acc1".into(),
+            "send".into(),
+            "dead".into(),
+            5,
+            Some("SMTP server rejected the message".into()),
+            "{}",
+        );
+        assert!(!failed.delivery_outcome_unknown);
+    }
 }

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -44,8 +44,20 @@ pub enum Error {
         capability: &'static str,
     },
 
+    /// A delivery attempt ended without a definitive rejection or success.
+    /// Keep this variant payload-free so user-facing formatting cannot leak
+    /// envelope recipients or transport internals.
+    #[error("Delivery outcome is unknown")]
+    IndeterminateDelivery,
+
     #[error("{0}")]
     Other(String),
+}
+
+impl Error {
+    pub fn is_indeterminate_delivery(&self) -> bool {
+        matches!(self, Self::IndeterminateDelivery)
+    }
 }
 
 impl Serialize for Error {
@@ -58,3 +70,21 @@ impl Serialize for Error {
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
+
+#[cfg(test)]
+mod tests {
+    use super::Error;
+
+    #[test]
+    fn indeterminate_delivery_has_safe_typed_classification() {
+        let error = Error::IndeterminateDelivery;
+
+        assert!(error.is_indeterminate_delivery());
+        assert_eq!(error.to_string(), "Delivery outcome is unknown");
+        assert_eq!(
+            serde_json::to_string(&error).unwrap(),
+            r#""Delivery outcome is unknown""#
+        );
+        assert!(!Error::Other("ordinary failure".into()).is_indeterminate_delivery());
+    }
+}

--- a/src-tauri/src/mail/jmap/identities.rs
+++ b/src-tauri/src/mail/jmap/identities.rs
@@ -23,7 +23,7 @@ impl JmapConnection {
             ]
         });
         let resp = self.api_request(&request, config).await?;
-        let (method, body) = identity_method_response(&resp)?;
+        let (method, body) = identity_method_response(&resp, &self.account_id)?;
         if method == "error" {
             return Err(Error::Other(format!(
                 "JMAP Identity/get failed (type={})",
@@ -43,7 +43,10 @@ impl JmapConnection {
     }
 }
 
-fn identity_method_response(response: &serde_json::Value) -> Result<(&str, &serde_json::Value)> {
+fn identity_method_response<'a>(
+    response: &'a serde_json::Value,
+    expected_account_id: &str,
+) -> Result<(&'a str, &'a serde_json::Value)> {
     let responses = response
         .get("methodResponses")
         .and_then(serde_json::Value::as_array)
@@ -65,6 +68,16 @@ fn identity_method_response(response: &serde_json::Value) -> Result<(&str, &serd
     let method = tuple[0]
         .as_str()
         .ok_or_else(|| Error::Other("Malformed JMAP Identity/get method".into()))?;
+    if method == "Identity/get"
+        && tuple[1]
+            .get("accountId")
+            .and_then(serde_json::Value::as_str)
+            != Some(expected_account_id)
+    {
+        return Err(Error::Other(
+            "JMAP Identity/get returned an unexpected account id".into(),
+        ));
+    }
     Ok((method, &tuple[1]))
 }
 
@@ -170,6 +183,14 @@ mod tests {
 
     #[test]
     fn identity_response_requires_one_correctly_correlated_tuple() {
+        let valid = serde_json::json!({
+            "methodResponses": [["Identity/get", {
+                "accountId": "account-1",
+                "list": []
+            }, "id1"]]
+        });
+        assert!(identity_method_response(&valid, "account-1").is_ok());
+
         for response in [
             serde_json::json!({ "methodResponses": [] }),
             serde_json::json!({
@@ -182,7 +203,27 @@ mod tests {
                 ]
             }),
         ] {
-            assert!(identity_method_response(&response).is_err());
+            assert!(identity_method_response(&response, "account-1").is_err());
+        }
+    }
+
+    #[test]
+    fn identity_response_requires_the_expected_account_id() {
+        for account_id in [
+            None,
+            Some(serde_json::Value::Null),
+            Some(serde_json::json!(7)),
+            Some(serde_json::json!("other-account")),
+        ] {
+            let mut body = serde_json::json!({ "list": [] });
+            if let Some(account_id) = account_id {
+                body["accountId"] = account_id;
+            }
+            let response = serde_json::json!({
+                "methodResponses": [["Identity/get", body, "id1"]]
+            });
+
+            assert!(identity_method_response(&response, "account-1").is_err());
         }
     }
 }

--- a/src-tauri/src/mail/jmap/identities.rs
+++ b/src-tauri/src/mail/jmap/identities.rs
@@ -2,27 +2,187 @@
 
 use crate::error::{Error, Result};
 
-use super::{JmapConfig, JmapConnection};
+use super::mail::{parse_rfc5321_addr_spec, ParsedMailbox};
+use super::{JmapConfig, JmapConnection, JmapSubmissionEnvelope};
 
 impl JmapConnection {
-    /// Find the identity ID for email submission.
-    pub(super) async fn find_identity_id(&self, config: &JmapConfig) -> Result<String> {
+    /// Find the first exact sender identity, falling back to the first
+    /// RFC 8621 `*@same-domain` identity only when no exact match exists.
+    pub(super) async fn find_identity_id(
+        &self,
+        config: &JmapConfig,
+        envelope: &JmapSubmissionEnvelope,
+    ) -> Result<String> {
         let request = serde_json::json!({
             "using": ["urn:ietf:params:jmap:core", "urn:ietf:params:jmap:submission"],
             "methodCalls": [
                 ["Identity/get", {
-                    "accountId": self.account_id
+                    "accountId": self.account_id,
+                    "properties": ["id", "email"]
                 }, "id1"]
             ]
         });
         let resp = self.api_request(&request, config).await?;
-        if let Some(identities) = resp["methodResponses"][0][1]["list"].as_array() {
-            if let Some(first) = identities.first() {
-                if let Some(id) = first["id"].as_str() {
-                    return Ok(id.to_string());
-                }
-            }
+        let (method, body) = identity_method_response(&resp)?;
+        if method == "error" {
+            return Err(Error::Other(format!(
+                "JMAP Identity/get failed (type={})",
+                super::safe_jmap_error_type(body)
+            )));
         }
-        Err(Error::Other("No JMAP identity found for submission".into()))
+        if method != "Identity/get" {
+            return Err(Error::Other(
+                "JMAP Identity/get returned an unexpected method".into(),
+            ));
+        }
+        let identities = body
+            .get("list")
+            .and_then(serde_json::Value::as_array)
+            .ok_or_else(|| Error::Other("Malformed JMAP Identity/get response".into()))?;
+        select_identity_id(identities, envelope.mail_from_mailbox())
+    }
+}
+
+fn identity_method_response(response: &serde_json::Value) -> Result<(&str, &serde_json::Value)> {
+    let responses = response
+        .get("methodResponses")
+        .and_then(serde_json::Value::as_array)
+        .ok_or_else(|| Error::Other("Malformed JMAP Identity/get response".into()))?;
+    if responses.len() != 1 {
+        return Err(Error::Other(
+            "Malformed JMAP Identity/get response count".into(),
+        ));
+    }
+    let tuple = responses[0]
+        .as_array()
+        .filter(|tuple| tuple.len() == 3)
+        .ok_or_else(|| Error::Other("Malformed JMAP Identity/get response tuple".into()))?;
+    if tuple[2].as_str() != Some("id1") {
+        return Err(Error::Other(
+            "Mismatched JMAP Identity/get response call id".into(),
+        ));
+    }
+    let method = tuple[0]
+        .as_str()
+        .ok_or_else(|| Error::Other("Malformed JMAP Identity/get method".into()))?;
+    Ok((method, &tuple[1]))
+}
+
+fn select_identity_id(
+    identities: &[serde_json::Value],
+    mail_from: &ParsedMailbox,
+) -> Result<String> {
+    let mut wildcard_id = None;
+    for identity in identities {
+        let Some(id) = identity
+            .get("id")
+            .and_then(serde_json::Value::as_str)
+            .filter(|id| !id.is_empty())
+        else {
+            continue;
+        };
+        let Some(email) = identity
+            .get("email")
+            .and_then(serde_json::Value::as_str)
+            .and_then(parse_rfc5321_addr_spec)
+        else {
+            continue;
+        };
+        if email.matches(mail_from) {
+            return Ok(id.to_string());
+        }
+        if wildcard_id.is_none() && email.is_wildcard_for(mail_from) {
+            wildcard_id = Some(id.to_string());
+        }
+    }
+    wildcard_id.ok_or_else(|| {
+        Error::Other("No JMAP identity permits the submission mail-from address".into())
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{identity_method_response, select_identity_id};
+    use crate::mail::jmap::JmapSubmissionEnvelope;
+
+    fn sender(mail_from: &str) -> JmapSubmissionEnvelope {
+        JmapSubmissionEnvelope::new(mail_from, &["recipient@example.test".into()], &[], &[])
+            .unwrap()
+    }
+
+    #[test]
+    fn exact_identity_outranks_wildcard_and_preserves_first_exact() {
+        let envelope = sender("Alice@Example.test");
+        let identities = serde_json::json!([
+            { "id": "wildcard", "email": "*@example.test" },
+            { "id": "exact-first", "email": "\"Ali\\ce\"@EXAMPLE.test" },
+            { "id": "exact-second", "email": "Alice@example.test" }
+        ]);
+
+        assert_eq!(
+            select_identity_id(identities.as_array().unwrap(), envelope.mail_from_mailbox())
+                .unwrap(),
+            "exact-first"
+        );
+    }
+
+    #[test]
+    fn same_domain_wildcard_is_accepted_without_exact_match() {
+        let envelope = sender("alias@Example.test");
+        let identities = serde_json::json!([
+            { "id": "wrong", "email": "*@other.test" },
+            { "id": "wildcard", "email": "*@EXAMPLE.test" }
+        ]);
+
+        assert_eq!(
+            select_identity_id(identities.as_array().unwrap(), envelope.mail_from_mailbox())
+                .unwrap(),
+            "wildcard"
+        );
+    }
+
+    #[test]
+    fn wrong_domain_wildcard_is_rejected() {
+        let envelope = sender("alias@example.test");
+        let identities = serde_json::json!([
+            { "id": "wrong", "email": "*@other.test" },
+            { "id": "also-wrong", "email": "alias@other.test" }
+        ]);
+
+        assert!(
+            select_identity_id(identities.as_array().unwrap(), envelope.mail_from_mailbox())
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn local_part_case_must_match_exactly() {
+        let envelope = sender("Alice@example.test");
+        let identities = serde_json::json!([
+            { "id": "wrong-case", "email": "alice@example.test" }
+        ]);
+
+        assert!(
+            select_identity_id(identities.as_array().unwrap(), envelope.mail_from_mailbox())
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn identity_response_requires_one_correctly_correlated_tuple() {
+        for response in [
+            serde_json::json!({ "methodResponses": [] }),
+            serde_json::json!({
+                "methodResponses": [["Identity/get", { "list": [] }, "wrong"]]
+            }),
+            serde_json::json!({
+                "methodResponses": [
+                    ["Identity/get", { "list": [] }, "id1"],
+                    ["Identity/get", { "list": [] }, "extra"]
+                ]
+            }),
+        ] {
+            assert!(identity_method_response(&response).is_err());
+        }
     }
 }

--- a/src-tauri/src/mail/jmap/mail.rs
+++ b/src-tauri/src/mail/jmap/mail.rs
@@ -4,6 +4,7 @@ use crate::error::{Error, Result};
 use crate::mail::search::build_jmap_filter;
 use crate::message::{normalize_message_id, SearchHit, SearchQuery};
 use serde::Serialize;
+use std::collections::{BTreeMap, HashSet};
 
 use super::{JmapConfig, JmapConnection};
 
@@ -43,6 +44,253 @@ pub struct JmapEmail {
     /// sync path to filter `Email/changes` results, since that method
     /// returns changes for the whole account, not a single mailbox.
     pub mailbox_ids: Vec<String>,
+}
+
+/// Explicit RFC 8621 submission envelope built from authoritative send data.
+///
+/// The fields are private so every value passes through [`Self::new`]: there
+/// is always one valid RFC 5321 reverse-path and at least one valid forward-
+/// path. Display names are discarded because JMAP submission envelopes carry
+/// addr-specs only.
+#[derive(Serialize)]
+pub struct JmapSubmissionEnvelope {
+    #[serde(rename = "mailFrom")]
+    mail_from: JmapEnvelopeAddress,
+    #[serde(rename = "rcptTo")]
+    rcpt_to: Vec<JmapEnvelopeAddress>,
+    #[serde(skip)]
+    mail_from_mailbox: ParsedMailbox,
+}
+
+#[derive(Serialize)]
+struct JmapEnvelopeAddress {
+    email: String,
+    parameters: Option<BTreeMap<String, Option<String>>>,
+}
+
+pub(super) struct ParsedMailbox {
+    addr_spec: String,
+    key: MailboxKey,
+    unquoted_wildcard: bool,
+}
+
+#[derive(PartialEq, Eq, Hash)]
+struct MailboxKey {
+    local: String,
+    domain: String,
+}
+
+impl ParsedMailbox {
+    pub(super) fn matches(&self, other: &Self) -> bool {
+        self.key == other.key
+    }
+
+    pub(super) fn is_wildcard_for(&self, other: &Self) -> bool {
+        self.unquoted_wildcard && self.key.domain == other.key.domain
+    }
+}
+
+impl JmapSubmissionEnvelope {
+    /// Build an envelope from one sender and the complete To + Cc + Bcc list.
+    ///
+    /// RFC 5321 section 2.4 requires local-part comparisons to preserve case,
+    /// while domains are case-insensitive. Duplicate recipients therefore use
+    /// a semantic quoted local-part and canonical IDNA domain key; the first
+    /// parsed addr-spec's spelling is retained in the emitted envelope.
+    pub fn new(mail_from: &str, to: &[String], cc: &[String], bcc: &[String]) -> Result<Self> {
+        let mail_from = parse_rfc5321_addr_spec(mail_from)
+            .ok_or_else(|| Error::Other("Invalid JMAP submission mail-from address".into()))?;
+
+        let mut requires_smtputf8 = !mail_from.addr_spec.is_ascii();
+        let mut seen = HashSet::new();
+        let mut rcpt_to = Vec::with_capacity(to.len() + cc.len() + bcc.len());
+        for (index, value) in to.iter().chain(cc).chain(bcc).enumerate() {
+            let address = parse_rfc5321_addr_spec(value).ok_or_else(|| {
+                // Do not include the value: errors are logged by callers and
+                // this position may belong to a confidential Bcc recipient.
+                Error::Other(format!(
+                    "Invalid JMAP submission recipient at position {}",
+                    index + 1
+                ))
+            })?;
+            if seen.insert(address.key) {
+                requires_smtputf8 |= !address.addr_spec.is_ascii();
+                rcpt_to.push(JmapEnvelopeAddress {
+                    email: address.addr_spec,
+                    parameters: None,
+                });
+            }
+        }
+
+        if rcpt_to.is_empty() {
+            return Err(Error::Other(
+                "JMAP submission envelope has no recipients".into(),
+            ));
+        }
+
+        let parameters = requires_smtputf8.then(|| {
+            let mut parameters = BTreeMap::new();
+            parameters.insert("SMTPUTF8".into(), None);
+            parameters
+        });
+        Ok(Self {
+            mail_from: JmapEnvelopeAddress {
+                email: mail_from.addr_spec.clone(),
+                parameters,
+            },
+            rcpt_to,
+            mail_from_mailbox: mail_from,
+        })
+    }
+
+    fn requires_smtputf8(&self) -> bool {
+        self.mail_from.parameters.is_some()
+    }
+
+    fn requires_smtputf8_for_message(&self, raw_message: &[u8]) -> bool {
+        self.requires_smtputf8() || raw_headers_contain_non_ascii(raw_message)
+    }
+
+    fn wire_value(&self, raw_message: &[u8]) -> Result<serde_json::Value> {
+        let mut value = serde_json::to_value(self)
+            .map_err(|_| Error::Other("Failed to serialize JMAP submission envelope".into()))?;
+        if self.requires_smtputf8_for_message(raw_message) {
+            value["mailFrom"]["parameters"] = serde_json::json!({ "SMTPUTF8": null });
+        }
+        Ok(value)
+    }
+
+    pub(super) fn mail_from_mailbox(&self) -> &ParsedMailbox {
+        &self.mail_from_mailbox
+    }
+}
+
+fn raw_headers_contain_non_ascii(raw_message: &[u8]) -> bool {
+    let header_end = raw_message
+        .windows(4)
+        .position(|window| window == b"\r\n\r\n")
+        .or_else(|| raw_message.windows(2).position(|window| window == b"\n\n"))
+        .unwrap_or(raw_message.len());
+    !raw_message[..header_end].is_ascii()
+}
+
+/// Parse either a bare addr-spec or one display-name mailbox into the exact
+/// addr-spec used for RFC 5321 submission. `mailparse` handles mailbox syntax
+/// (including quoted display names and quoted local parts inside angle
+/// brackets); lettre performs final addr-spec validation and exposes the
+/// parsed local/domain components used for standards-compliant deduplication.
+pub(super) fn parse_rfc5321_addr_spec(value: &str) -> Option<ParsedMailbox> {
+    let value = value.trim();
+    if value.is_empty() {
+        return None;
+    }
+
+    let addr_spec = match value.parse::<lettre::Address>() {
+        Ok(address) => address.to_string(),
+        Err(_) => mailparse::addrparse(value)
+            .ok()
+            .and_then(|addresses| addresses.extract_single_info())
+            .map(|mailbox| mailbox.addr.trim().to_string())
+            .unwrap_or_else(|| value.to_string()),
+    };
+    let (local, domain) = validated_addr_spec_parts(&addr_spec)?;
+    Some(ParsedMailbox {
+        addr_spec,
+        key: MailboxKey {
+            local: semantic_local_part(&local)?,
+            domain,
+        },
+        unquoted_wildcard: local == "*",
+    })
+}
+
+fn validated_addr_spec_parts(addr_spec: &str) -> Option<(String, String)> {
+    if let Ok(address) = addr_spec.parse::<lettre::Address>() {
+        return Some((
+            address.user().to_string(),
+            canonical_domain(address.domain())?,
+        ));
+    }
+
+    // lettre accepts IPv6 literals without RFC 5321's required `IPv6:` tag.
+    // Validate the tagged form by substituting lettre's accepted spelling,
+    // but retain the caller's RFC spelling in the serialized envelope.
+    let (local, domain) = addr_spec.rsplit_once('@')?;
+    let literal = domain.strip_prefix('[')?.strip_suffix(']')?;
+    let (tag, address) = literal.split_once(':')?;
+    if !tag.eq_ignore_ascii_case("IPv6") {
+        return None;
+    }
+    let address = address.parse::<std::net::Ipv6Addr>().ok()?;
+    lettre::Address::new(local, format!("[{address}]")).ok()?;
+    Some((local.to_string(), canonical_domain(domain)?))
+}
+
+fn semantic_local_part(local: &str) -> Option<String> {
+    let Some(inner) = local.strip_prefix('"').and_then(|s| s.strip_suffix('"')) else {
+        return Some(local.to_string());
+    };
+    let mut semantic = String::with_capacity(inner.len());
+    let mut chars = inner.chars();
+    while let Some(ch) = chars.next() {
+        if ch == '\\' {
+            semantic.push(chars.next()?);
+        } else {
+            semantic.push(ch);
+        }
+    }
+    Some(semantic)
+}
+
+fn canonical_domain(domain: &str) -> Option<String> {
+    if domain.ends_with('.') {
+        return None;
+    }
+
+    if let Some(literal) = domain
+        .strip_prefix('[')
+        .and_then(|value| value.strip_suffix(']'))
+    {
+        if let Ok(address) = literal.parse::<std::net::Ipv4Addr>() {
+            return Some(format!("[{address}]"));
+        }
+        let (tag, address) = literal.split_once(':')?;
+        if tag.eq_ignore_ascii_case("IPv6") {
+            let address = address.parse::<std::net::Ipv6Addr>().ok()?;
+            return Some(format!("[ipv6:{address}]"));
+        }
+        return None;
+    }
+
+    match url::Host::parse(domain).ok()? {
+        url::Host::Domain(domain) if valid_ascii_dns_domain(&domain) => {
+            Some(domain.to_ascii_lowercase())
+        }
+        // A dotted-quad without brackets is a domain spelling, not an SMTP
+        // address literal, so keep its key distinct from `[192.0.2.1]`.
+        url::Host::Ipv4(address) => Some(address.to_string()),
+        _ => None,
+    }
+}
+
+fn valid_ascii_dns_domain(domain: &str) -> bool {
+    !domain.is_empty()
+        && domain.len() <= 253
+        && domain.split('.').all(|label| {
+            !label.is_empty()
+                && label.len() <= 63
+                && label
+                    .bytes()
+                    .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
+                && label
+                    .as_bytes()
+                    .first()
+                    .is_some_and(u8::is_ascii_alphanumeric)
+                && label
+                    .as_bytes()
+                    .last()
+                    .is_some_and(u8::is_ascii_alphanumeric)
+        })
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -702,11 +950,7 @@ impl JmapConnection {
 
         if !resp.status().is_success() {
             let status = resp.status();
-            let body = resp.text().await.unwrap_or_default();
-            return Err(Error::Other(format!(
-                "JMAP upload error {}: {}",
-                status, body
-            )));
+            return Err(Error::Other(format!("JMAP upload error: {}", status)));
         }
 
         let upload_resp: serde_json::Value = resp
@@ -747,14 +991,77 @@ impl JmapConnection {
         Ok(())
     }
 
-    pub async fn send_email(&self, config: &JmapConfig, raw_message: &[u8]) -> Result<()> {
+    async fn submission_api_request(
+        &self,
+        request: &serde_json::Value,
+        config: &JmapConfig,
+    ) -> Result<serde_json::Value> {
+        let response = config
+            .apply_auth(self.http.post(&self.api_url))
+            .json(request)
+            .send()
+            .await
+            .map_err(|error| {
+                if error.is_builder() || error.is_connect() || error.is_redirect() {
+                    Error::Other("JMAP submission request failed before execution".into())
+                } else {
+                    Error::IndeterminateDelivery
+                }
+            })?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            if status.is_client_error() {
+                return Err(Error::Other(format!(
+                    "JMAP submission request rejected with HTTP status {status}"
+                )));
+            }
+            // A gateway/server error can be generated after an upstream JMAP
+            // server accepted the request, so it cannot prove non-delivery.
+            return Err(Error::IndeterminateDelivery);
+        }
+
+        response
+            .json()
+            .await
+            .map_err(|_| Error::IndeterminateDelivery)
+    }
+
+    pub async fn send_email(
+        &self,
+        config: &JmapConfig,
+        raw_message: &[u8],
+        envelope: &JmapSubmissionEnvelope,
+    ) -> Result<()> {
         log::info!("JMAP sending email ({} bytes)", raw_message.len());
 
-        // Step 1: Upload the raw message as a blob
+        let wire_envelope = envelope.wire_value(raw_message)?;
+        if envelope.requires_smtputf8_for_message(raw_message)
+            && !self.supports_submission_extension("SMTPUTF8")
+        {
+            return Err(Error::Other(
+                "JMAP submission requires unsupported SMTPUTF8 extension".into(),
+            ));
+        }
+
+        // Resolve all server-side prerequisites before upload so an alias or
+        // mailbox configuration error cannot leave an orphaned blob.
+        let identity_id = self.find_identity_id(config, envelope).await?;
+        log::debug!("JMAP selected an identity for submission");
+
+        let sent_mailbox_id = match self.find_mailbox_by_role(config, "sent").await? {
+            Some(mailbox_id) => mailbox_id,
+            None => self
+                .find_mailbox_by_role(config, "inbox")
+                .await?
+                .ok_or_else(|| Error::Other("No Sent or Inbox mailbox found".into()))?,
+        };
+        log::debug!("JMAP selected a mailbox for sent email");
+
+        // Upload the raw message as a blob only after validation and lookup.
         let upload_url = self
             .upload_url_template
             .replace("{accountId}", &self.account_id);
-        log::debug!("JMAP uploading blob to {}", upload_url);
 
         let resp = config
             .apply_auth(self.http.post(&upload_url))
@@ -766,11 +1073,7 @@ impl JmapConnection {
 
         if !resp.status().is_success() {
             let status = resp.status();
-            let body = resp.text().await.unwrap_or_default();
-            return Err(Error::Other(format!(
-                "JMAP upload error {}: {}",
-                status, body
-            )));
+            return Err(Error::Other(format!("JMAP upload error: {}", status)));
         }
 
         let upload_resp: serde_json::Value = resp
@@ -783,19 +1086,7 @@ impl JmapConnection {
             .to_string();
         log::debug!("JMAP blob uploaded: {}", blob_id);
 
-        // Step 2: Find the Sent mailbox (or Inbox as fallback) to store the email
-        let sent_mailbox_id = self
-            .find_mailbox_by_role(config, "sent")
-            .await?
-            .or(self.find_mailbox_by_role(config, "inbox").await?)
-            .ok_or_else(|| Error::Other("No Sent or Inbox mailbox found".into()))?;
-        log::debug!("JMAP using mailbox {} for sent email", sent_mailbox_id);
-
-        // Step 3: Get the identity ID for submission
-        let identity_id = self.find_identity_id(config).await?;
-        log::debug!("JMAP using identity {} for submission", identity_id);
-
-        // Step 4: Import the email into the Sent folder and submit it
+        // Import the email into the Sent folder and submit it.
         let request = serde_json::json!({
             "using": [
                 "urn:ietf:params:jmap:core",
@@ -818,73 +1109,18 @@ impl JmapConnection {
                     "create": {
                         "sub1": {
                             "emailId": "#draft",
-                            "identityId": identity_id
-                        }
-                    },
-                    "onSuccessUpdateEmail": {
-                        "#sub1": {
-                            "keywords/$draft": null,
-                            "keywords/$seen": true
+                            "identityId": identity_id,
+                            "envelope": wire_envelope
                         }
                     }
                 }, "s1"]
             ]
         });
 
-        let resp = self.api_request(&request, config).await?;
-        log::debug!(
-            "JMAP send response: {}",
-            serde_json::to_string_pretty(&resp).unwrap_or_default()
-        );
-
-        // Check for import errors
-        if let Some(err) = resp["methodResponses"][0][1]["notCreated"]["draft"].as_object() {
-            let desc = err
-                .get("description")
-                .and_then(|d| d.as_str())
-                .unwrap_or("Unknown error");
-            return Err(Error::Other(format!("JMAP email import failed: {}", desc)));
-        }
-
-        // Get the imported email ID for cleanup if submission fails
-        let imported_id = resp["methodResponses"][0][1]["created"]["draft"]["id"]
-            .as_str()
-            .map(|s| s.to_string());
-
-        // Check for submission errors — clean up imported email on failure
-        let submission_failed = if resp["methodResponses"]
-            .as_array()
-            .map(|a| a.len())
-            .unwrap_or(0)
-            > 1
-        {
-            if resp["methodResponses"][1][0].as_str() == Some("error") {
-                let desc = resp["methodResponses"][1][1]["description"]
-                    .as_str()
-                    .unwrap_or("Unknown error");
-                Some(format!("JMAP submission failed: {}", desc))
-            } else if let Some(err) =
-                resp["methodResponses"][1][1]["notCreated"]["sub1"].as_object()
-            {
-                let desc = err
-                    .get("description")
-                    .and_then(|d| d.as_str())
-                    .unwrap_or("Unknown error");
-                Some(format!("JMAP submission failed: {}", desc))
-            } else {
-                None
-            }
-        } else {
-            None
-        };
-
-        if let Some(error_msg) = submission_failed {
-            // Clean up the imported email that wasn't submitted
-            if let Some(ref email_id) = imported_id {
-                log::warn!(
-                    "JMAP cleaning up imported email {} after submission failure",
-                    email_id
-                );
+        let resp = self.submission_api_request(&request, config).await?;
+        if let Err(failure) = validate_submission_response(&resp) {
+            if let Some(email_id) = failure.imported_email_id {
+                log::warn!("JMAP cleaning up imported email after explicit submission rejection");
                 let cleanup = serde_json::json!({
                     "using": ["urn:ietf:params:jmap:core", "urn:ietf:params:jmap:mail"],
                     "methodCalls": [
@@ -896,7 +1132,7 @@ impl JmapConnection {
                 });
                 let _ = self.api_request(&cleanup, config).await;
             }
-            return Err(Error::Other(error_msg));
+            return Err(failure.error);
         }
 
         log::info!("JMAP email sent successfully");
@@ -922,11 +1158,7 @@ impl JmapConnection {
 
         if !resp.status().is_success() {
             let status = resp.status();
-            let body = resp.text().await.unwrap_or_default();
-            return Err(Error::Other(format!(
-                "JMAP draft upload error {}: {}",
-                status, body
-            )));
+            return Err(Error::Other(format!("JMAP draft upload error: {}", status)));
         }
 
         let upload_resp: serde_json::Value = resp
@@ -963,17 +1195,160 @@ impl JmapConnection {
 
         let resp = self.api_request(&request, config).await?;
 
-        if let Some(err) = resp["methodResponses"][0][1]["notImported"]["draft"].as_object() {
-            let desc = err
-                .get("description")
-                .and_then(|d| d.as_str())
-                .unwrap_or("Unknown error");
-            return Err(Error::Other(format!("JMAP draft import failed: {}", desc)));
+        if let Some(error) = resp["methodResponses"][0][1]["notImported"].get("draft") {
+            return Err(Error::Other(format!(
+                "JMAP draft import failed (type={})",
+                super::safe_jmap_error_type(error)
+            )));
         }
 
         log::info!("JMAP draft saved successfully");
         Ok(())
     }
+}
+
+struct SubmissionResponseFailure {
+    imported_email_id: Option<String>,
+    error: Error,
+}
+
+enum CreationOutcome<T> {
+    Created(T),
+    Rejected(Error),
+    Indeterminate,
+}
+
+fn validate_submission_response(
+    response: &serde_json::Value,
+) -> std::result::Result<(), SubmissionResponseFailure> {
+    let imported = classify_import_response(response);
+    let submitted = classify_email_submission_response(response);
+
+    match (imported, submitted) {
+        (CreationOutcome::Created(_), CreationOutcome::Created(())) => Ok(()),
+        (CreationOutcome::Created(email_id), CreationOutcome::Rejected(error)) => {
+            Err(SubmissionResponseFailure {
+                imported_email_id: Some(email_id),
+                error,
+            })
+        }
+        (CreationOutcome::Rejected(error), CreationOutcome::Rejected(_))
+        | (CreationOutcome::Rejected(error), CreationOutcome::Indeterminate) => {
+            // A submission using `#draft` cannot be created when the import
+            // creation itself was explicitly rejected.
+            Err(SubmissionResponseFailure {
+                imported_email_id: None,
+                error,
+            })
+        }
+        (CreationOutcome::Indeterminate, CreationOutcome::Rejected(error)) => {
+            // The submission was explicitly rejected, so delivery did not
+            // occur even though the import response cannot be trusted.
+            Err(SubmissionResponseFailure {
+                imported_email_id: None,
+                error,
+            })
+        }
+        _ => Err(SubmissionResponseFailure {
+            // Never destroy the imported Email unless submission rejection is
+            // positively known. Deleting it cannot cancel accepted delivery.
+            imported_email_id: None,
+            error: Error::IndeterminateDelivery,
+        }),
+    }
+}
+
+fn classify_import_response(response: &serde_json::Value) -> CreationOutcome<String> {
+    let Some((method, body)) = matching_method_response(response, "i1") else {
+        return CreationOutcome::Indeterminate;
+    };
+    if method == "error" {
+        return classify_method_error("JMAP Email/import failed", body);
+    }
+    if method != "Email/import" {
+        return CreationOutcome::Indeterminate;
+    }
+    let created = body
+        .pointer("/created/draft/id")
+        .and_then(serde_json::Value::as_str)
+        .filter(|id| !id.is_empty())
+        .map(str::to_string);
+    let rejected = body.pointer("/notCreated/draft");
+    match (created, rejected) {
+        (Some(email_id), None) => CreationOutcome::Created(email_id),
+        (None, Some(error)) => bounded_rejection("JMAP Email/import rejected draft", error)
+            .map(CreationOutcome::Rejected)
+            .unwrap_or(CreationOutcome::Indeterminate),
+        _ => CreationOutcome::Indeterminate,
+    }
+}
+
+fn classify_email_submission_response(response: &serde_json::Value) -> CreationOutcome<()> {
+    let Some((method, body)) = matching_method_response(response, "s1") else {
+        return CreationOutcome::Indeterminate;
+    };
+    if method == "error" {
+        return classify_method_error("JMAP EmailSubmission/set failed", body);
+    }
+    if method != "EmailSubmission/set" {
+        return CreationOutcome::Indeterminate;
+    }
+    let created = body
+        .pointer("/created/sub1/id")
+        .and_then(serde_json::Value::as_str)
+        .filter(|id| !id.is_empty())
+        .is_some();
+    let rejected = body.pointer("/notCreated/sub1");
+    match (created, rejected) {
+        (true, None) => CreationOutcome::Created(()),
+        (false, Some(error)) => {
+            bounded_rejection("JMAP EmailSubmission/set rejected submission", error)
+                .map(CreationOutcome::Rejected)
+                .unwrap_or(CreationOutcome::Indeterminate)
+        }
+        _ => CreationOutcome::Indeterminate,
+    }
+}
+
+fn bounded_rejection(context: &str, error: &serde_json::Value) -> Option<Error> {
+    let error_type = super::bounded_jmap_error_type(error)?;
+    Some(Error::Other(format!("{context} (type={error_type})")))
+}
+
+fn classify_method_error<T>(context: &str, error: &serde_json::Value) -> CreationOutcome<T> {
+    let Some(error_type) = super::bounded_jmap_error_type(error) else {
+        return CreationOutcome::Indeterminate;
+    };
+    // RFC 8620 section 3.6.2 permits a serverPartialFail response after
+    // some requested changes have occurred, so it never proves rejection.
+    if error_type == "serverPartialFail" {
+        return CreationOutcome::Indeterminate;
+    }
+    CreationOutcome::Rejected(Error::Other(format!("{context} (type={error_type})")))
+}
+
+fn matching_method_response<'a>(
+    response: &'a serde_json::Value,
+    call_id: &str,
+) -> Option<(&'a str, &'a serde_json::Value)> {
+    let responses = response
+        .get("methodResponses")
+        .and_then(serde_json::Value::as_array)?;
+    let mut matched = None;
+    for response in responses {
+        let Some(tuple) = response.as_array() else {
+            continue;
+        };
+        if tuple.get(2).and_then(serde_json::Value::as_str) != Some(call_id) {
+            continue;
+        }
+        if tuple.len() != 3 || matched.is_some() {
+            return None;
+        }
+        let method = tuple.first().and_then(serde_json::Value::as_str)?;
+        matched = Some((method, &tuple[1]));
+    }
+    matched
 }
 
 fn copy_updates(
@@ -1270,6 +1645,549 @@ fn parse_jmap_search_hit(account_id: &str, e: &serde_json::Value) -> SearchHit {
         from_email,
         date,
         snippet,
+    }
+}
+
+#[cfg(test)]
+mod submission_envelope_tests {
+    use super::{JmapConnection, JmapSubmissionEnvelope};
+    use crate::mail::jmap::JmapConfig;
+
+    fn envelope_json(
+        mail_from: &str,
+        to: &[String],
+        cc: &[String],
+        bcc: &[String],
+    ) -> serde_json::Value {
+        serde_json::to_value(JmapSubmissionEnvelope::new(mail_from, to, cc, bcc).unwrap()).unwrap()
+    }
+
+    #[test]
+    fn display_names_and_quoted_local_parts_become_addr_specs() {
+        let to = vec![r#""Recipient, Bob" <bob@example.com>"#.into()];
+        let cc = vec![r#"Quoted Local <"quoted local"@Example.COM>"#.into()];
+        let envelope = envelope_json(r#""Sender, Alice" <Sender@EXAMPLE.com>"#, &to, &cc, &[]);
+
+        assert_eq!(
+            envelope,
+            serde_json::json!({
+                "mailFrom": {
+                    "email": "Sender@EXAMPLE.com",
+                    "parameters": null
+                },
+                "rcptTo": [
+                    { "email": "bob@example.com", "parameters": null },
+                    {
+                        "email": "\"quoted local\"@Example.COM",
+                        "parameters": null
+                    }
+                ]
+            })
+        );
+    }
+
+    #[test]
+    fn duplicate_domains_ignore_case_and_keep_first_spelling() {
+        let to = vec!["Alice <alice@EXAMPLE.com>".into()];
+        let cc = vec!["alice@example.com".into()];
+        let bcc = vec!["alice@Example.Com".into()];
+        let envelope = envelope_json("sender@example.com", &to, &cc, &bcc);
+
+        assert_eq!(
+            envelope["rcptTo"],
+            serde_json::json!([{
+                "email": "alice@EXAMPLE.com",
+                "parameters": null
+            }])
+        );
+    }
+
+    #[test]
+    fn quoted_and_escaped_equivalents_dedupe_without_rewriting_first() {
+        let to = vec![r#""ali\ce"@EXAMPLE.com"#.into()];
+        let cc = vec!["alice@example.com".into(), r#""alice"@example.com"#.into()];
+        let envelope = envelope_json("sender@example.com", &to, &cc, &[]);
+
+        assert_eq!(
+            envelope["rcptTo"],
+            serde_json::json!([{
+                "email": "\"ali\\ce\"@EXAMPLE.com",
+                "parameters": null
+            }])
+        );
+    }
+
+    #[test]
+    fn idna_equivalent_domains_dedupe_and_smtputf8_is_mail_from_only() {
+        let to = vec!["alice@bücher.example".into()];
+        let cc = vec!["alice@xn--bcher-kva.example".into()];
+        let envelope = envelope_json("sender@example.com", &to, &cc, &[]);
+
+        assert_eq!(
+            envelope,
+            serde_json::json!({
+                "mailFrom": {
+                    "email": "sender@example.com",
+                    "parameters": { "SMTPUTF8": null }
+                },
+                "rcptTo": [{
+                    "email": "alice@bücher.example",
+                    "parameters": null
+                }]
+            })
+        );
+    }
+
+    #[test]
+    fn discarded_unicode_duplicate_does_not_require_smtputf8() {
+        let to = vec!["alice@xn--bcher-kva.example".into()];
+        let bcc = vec!["alice@bücher.example".into()];
+        let envelope = envelope_json("sender@example.com", &to, &[], &bcc);
+
+        assert_eq!(envelope["mailFrom"]["parameters"], serde_json::Value::Null);
+        assert_eq!(
+            envelope["rcptTo"],
+            serde_json::json!([{
+                "email": "alice@xn--bcher-kva.example",
+                "parameters": null
+            }])
+        );
+    }
+
+    #[test]
+    fn utf8_headers_require_smtputf8_but_utf8_body_does_not() {
+        let envelope = JmapSubmissionEnvelope::new(
+            "sender@example.com",
+            &["recipient@example.com".into()],
+            &[],
+            &[],
+        )
+        .unwrap();
+
+        let utf8_header = envelope
+            .wire_value("To: álïce@example.com\r\n\r\nbody".as_bytes())
+            .unwrap();
+        assert_eq!(
+            utf8_header["mailFrom"]["parameters"],
+            serde_json::json!({ "SMTPUTF8": null })
+        );
+
+        let utf8_body = envelope
+            .wire_value("To: alice@example.com\r\n\r\nálïce".as_bytes())
+            .unwrap();
+        assert_eq!(utf8_body["mailFrom"]["parameters"], serde_json::Value::Null);
+    }
+
+    #[test]
+    fn rfc_address_literals_are_valid_and_untagged_ipv6_is_rejected() {
+        let to = vec!["ipv4@[192.0.2.1]".into(), "ipv6@[IPv6:2001:db8::1]".into()];
+        let envelope = envelope_json("sender@example.com", &to, &[], &[]);
+
+        assert_eq!(
+            envelope["rcptTo"],
+            serde_json::json!([
+                { "email": "ipv4@[192.0.2.1]", "parameters": null },
+                {
+                    "email": "ipv6@[IPv6:2001:db8::1]",
+                    "parameters": null
+                }
+            ])
+        );
+
+        assert!(JmapSubmissionEnvelope::new(
+            "sender@example.com",
+            &["ipv6@[2001:db8::1]".into()],
+            &[],
+            &[],
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn local_part_case_variants_remain_distinct() {
+        let to = vec!["Alice@example.com".into(), "alice@EXAMPLE.com".into()];
+        let envelope = envelope_json("sender@example.com", &to, &[], &[]);
+
+        assert_eq!(
+            envelope["rcptTo"],
+            serde_json::json!([
+                { "email": "Alice@example.com", "parameters": null },
+                { "email": "alice@EXAMPLE.com", "parameters": null }
+            ])
+        );
+    }
+
+    #[test]
+    fn invalid_or_empty_envelopes_fail_before_upload_without_exposing_recipient() {
+        // `send_email` requires this private-field type, so a constructor
+        // failure occurs before its first operation (the blob upload).
+        assert!(JmapSubmissionEnvelope::new(
+            "invalid sender",
+            &["recipient@example.com".into()],
+            &[],
+            &[]
+        )
+        .is_err());
+
+        let confidential = "confidential bcc is invalid";
+        let error = match JmapSubmissionEnvelope::new(
+            "sender@example.com",
+            &[],
+            &[],
+            &[confidential.into()],
+        ) {
+            Ok(_) => panic!("invalid recipient must be rejected"),
+            Err(error) => error.to_string(),
+        };
+        assert!(!error.contains(confidential));
+
+        assert!(JmapSubmissionEnvelope::new("sender@example.com", &[], &[], &[]).is_err());
+    }
+
+    #[tokio::test]
+    async fn unsupported_smtputf8_fails_before_any_upload() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let base_url = format!("http://{}", listener.local_addr().unwrap());
+        let http = reqwest::Client::builder()
+            .no_proxy()
+            .timeout(std::time::Duration::from_secs(1))
+            .build()
+            .unwrap();
+        let connection = JmapConnection {
+            http,
+            api_url: format!("{base_url}/api"),
+            download_url_template: format!("{base_url}/download/{{blobId}}"),
+            upload_url_template: format!("{base_url}/upload/{{accountId}}"),
+            event_source_url_template: None,
+            account_id: "account-1".into(),
+            max_objects_in_set: 500,
+            submission_extensions: std::collections::HashMap::new(),
+        };
+        let config = JmapConfig {
+            jmap_url: base_url,
+            email: "sender@example.com".into(),
+            username: "sender".into(),
+            password: "password".into(),
+            access_token: None,
+            auth_method: "basic".into(),
+            oidc_token_endpoint: String::new(),
+            oidc_client_id: String::new(),
+        };
+        let envelope = JmapSubmissionEnvelope::new(
+            "sender@example.com",
+            &["recipient@bücher.example".into()],
+            &[],
+            &[],
+        )
+        .unwrap();
+
+        let error = connection
+            .send_email(&config, b"opaque MIME bytes", &envelope)
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("SMTPUTF8"));
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(100), listener.accept())
+                .await
+                .is_err(),
+            "SMTPUTF8 rejection must occur before any network request"
+        );
+    }
+}
+
+#[cfg(test)]
+mod submission_response_tests {
+    use super::validate_submission_response;
+
+    fn successful_response() -> serde_json::Value {
+        serde_json::json!({
+            "methodResponses": [
+                ["Email/import", {
+                    "created": { "draft": { "id": "email-1" } }
+                }, "i1"],
+                ["EmailSubmission/set", {
+                    "created": { "sub1": { "id": "submission-1" } }
+                }, "s1"]
+            ]
+        })
+    }
+
+    #[test]
+    fn requires_positive_import_and_submission_creation() {
+        assert!(validate_submission_response(&successful_response()).is_ok());
+
+        for response in [
+            serde_json::json!({
+                "methodResponses": [["Email/import", {
+                    "created": { "draft": { "id": "email-1" } }
+                }, "i1"]]
+            }),
+            serde_json::json!({
+                "methodResponses": [
+                    ["Email/import", {
+                        "created": { "draft": { "id": "email-1" } }
+                    }, "i1"],
+                    ["EmailSubmission/set", {
+                        "created": { "sub1": {} }
+                    }, "s1"]
+                ]
+            }),
+            serde_json::json!({
+                "methodResponses": [
+                    ["Email/import", {
+                        "created": { "draft": { "id": "email-1" } }
+                    }, "i1"],
+                    ["Email/set", {
+                        "created": { "sub1": { "id": "submission-1" } }
+                    }, "s1"]
+                ]
+            }),
+            serde_json::json!({
+                "methodResponses": [
+                    ["Email/import", {
+                        "created": { "draft": { "id": "email-1" } }
+                    }, "i1"],
+                    ["EmailSubmission/set", {
+                        "created": { "sub1": { "id": "submission-1" } }
+                    }, "wrong-call-id"]
+                ]
+            }),
+        ] {
+            let failure = validate_submission_response(&response).unwrap_err();
+            assert!(failure.imported_email_id.is_none());
+            assert!(failure.error.is_indeterminate_delivery());
+        }
+    }
+
+    #[test]
+    fn unrelated_extra_response_does_not_erase_proven_success() {
+        let mut response = successful_response();
+        response["methodResponses"]
+            .as_array_mut()
+            .unwrap()
+            .push(serde_json::json!(["Core/echo", {}, "extra"]));
+
+        assert!(validate_submission_response(&response).is_ok());
+    }
+
+    #[test]
+    fn explicit_submission_rejection_allows_import_cleanup() {
+        let response = serde_json::json!({
+            "methodResponses": [
+                ["Email/import", {
+                    "created": { "draft": { "id": "email-1" } }
+                }, "i1"],
+                ["EmailSubmission/set", {
+                    "notCreated": {
+                        "sub1": { "type": "forbiddenToSend" }
+                    }
+                }, "s1"]
+            ]
+        });
+
+        let failure = validate_submission_response(&response).unwrap_err();
+        assert_eq!(failure.imported_email_id.as_deref(), Some("email-1"));
+        assert!(!failure.error.is_indeterminate_delivery());
+    }
+
+    #[test]
+    fn contradictory_or_malformed_rejection_is_indeterminate() {
+        for rejected in [
+            serde_json::json!({ "type": "forbiddenToSend" }),
+            serde_json::json!({ "description": "missing type" }),
+        ] {
+            let mut response = successful_response();
+            response["methodResponses"][1][1]["notCreated"]["sub1"] = rejected;
+
+            let failure = validate_submission_response(&response).unwrap_err();
+            assert!(failure.imported_email_id.is_none());
+            assert!(failure.error.is_indeterminate_delivery());
+        }
+    }
+
+    #[test]
+    fn server_partial_fail_never_permits_cleanup_or_retry() {
+        let response = serde_json::json!({
+            "methodResponses": [
+                ["Email/import", {
+                    "created": { "draft": { "id": "email-1" } }
+                }, "i1"],
+                ["error", { "type": "serverPartialFail" }, "s1"]
+            ]
+        });
+
+        let failure = validate_submission_response(&response).unwrap_err();
+        assert!(failure.imported_email_id.is_none());
+        assert!(failure.error.is_indeterminate_delivery());
+    }
+
+    #[test]
+    fn import_failure_does_not_claim_an_email_for_cleanup() {
+        let response = serde_json::json!({
+            "methodResponses": [
+                ["Email/import", {
+                    "notCreated": {
+                        "draft": {
+                            "type": "invalidEmail",
+                            "description": "contains private message data"
+                        }
+                    }
+                }, "i1"],
+                ["EmailSubmission/set", {}, "s1"]
+            ]
+        });
+
+        let failure = validate_submission_response(&response).unwrap_err();
+        assert!(failure.imported_email_id.is_none());
+        let error = failure.error.to_string();
+        assert!(error.contains("invalidEmail"));
+        assert!(!error.contains("private message data"));
+    }
+
+    #[test]
+    fn invalid_recipients_error_is_bounded_and_redacted() {
+        let secret = "hidden-recipient@example.test";
+        let response = serde_json::json!({
+            "methodResponses": [
+                ["Email/import", {
+                    "created": { "draft": { "id": "email-1" } }
+                }, "i1"],
+                ["EmailSubmission/set", {
+                    "notCreated": {
+                        "sub1": {
+                            "type": "invalidRecipients",
+                            "description": format!("recipient rejected: {secret}"),
+                            "invalidRecipients": [secret]
+                        }
+                    }
+                }, "s1"]
+            ]
+        });
+
+        let failure = validate_submission_response(&response).unwrap_err();
+        assert_eq!(failure.imported_email_id.as_deref(), Some("email-1"));
+        let error = failure.error.to_string();
+        assert!(error.contains("type=invalidRecipients"));
+        assert!(!error.contains(secret));
+        assert!(error.len() < 160);
+    }
+}
+
+#[cfg(test)]
+mod submission_request_tests {
+    use super::{JmapConfig, JmapConnection};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    fn connection(api_url: String) -> JmapConnection {
+        JmapConnection {
+            http: reqwest::Client::builder()
+                .no_proxy()
+                .timeout(std::time::Duration::from_secs(1))
+                .build()
+                .unwrap(),
+            api_url,
+            download_url_template: String::new(),
+            upload_url_template: String::new(),
+            event_source_url_template: None,
+            account_id: "account-1".into(),
+            max_objects_in_set: 500,
+            submission_extensions: std::collections::HashMap::new(),
+        }
+    }
+
+    fn config() -> JmapConfig {
+        JmapConfig {
+            jmap_url: String::new(),
+            email: "sender@example.test".into(),
+            username: "sender".into(),
+            password: "password".into(),
+            access_token: None,
+            auth_method: "basic".into(),
+            oidc_token_endpoint: String::new(),
+            oidc_client_id: String::new(),
+        }
+    }
+
+    async fn serve_once(status: &str, body: &str) -> String {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!("http://{}/api", listener.local_addr().unwrap());
+        let status = status.to_string();
+        let body = body.to_string();
+        tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut request = Vec::new();
+            let mut chunk = [0_u8; 4096];
+            loop {
+                let read = stream.read(&mut chunk).await.unwrap();
+                assert!(read > 0, "request ended before its body was complete");
+                request.extend_from_slice(&chunk[..read]);
+                let Some(header_end) = request.windows(4).position(|part| part == b"\r\n\r\n")
+                else {
+                    continue;
+                };
+                let headers = std::str::from_utf8(&request[..header_end]).unwrap();
+                let content_length = headers
+                    .lines()
+                    .find_map(|line| {
+                        let (name, value) = line.split_once(':')?;
+                        name.eq_ignore_ascii_case("content-length")
+                            .then(|| value.trim().parse::<usize>().unwrap())
+                    })
+                    .unwrap_or(0);
+                if request.len() >= header_end + 4 + content_length {
+                    break;
+                }
+            }
+            let response = format!(
+                "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            stream.write_all(response.as_bytes()).await.unwrap();
+        });
+        url
+    }
+
+    #[tokio::test]
+    async fn http_rejection_is_definite_but_invalid_success_body_is_indeterminate() {
+        let request = serde_json::json!({ "methodCalls": [] });
+
+        let rejected_url = serve_once("401 Unauthorized", "private response").await;
+        let rejected = connection(rejected_url)
+            .submission_api_request(&request, &config())
+            .await
+            .unwrap_err();
+        assert!(!rejected.is_indeterminate_delivery());
+        assert_eq!(
+            rejected.to_string(),
+            "JMAP submission request rejected with HTTP status 401 Unauthorized"
+        );
+        assert!(!rejected.to_string().contains("private response"));
+
+        let malformed_url = serve_once("200 OK", "private non-json response").await;
+        let malformed = connection(malformed_url)
+            .submission_api_request(&request, &config())
+            .await
+            .unwrap_err();
+        assert!(malformed.is_indeterminate_delivery());
+        assert!(!malformed.to_string().contains("private non-json response"));
+
+        let gateway_url = serve_once("502 Bad Gateway", "private gateway response").await;
+        let gateway = connection(gateway_url)
+            .submission_api_request(&request, &config())
+            .await
+            .unwrap_err();
+        assert!(gateway.is_indeterminate_delivery());
+        assert!(!gateway.to_string().contains("private gateway response"));
+    }
+
+    #[tokio::test]
+    async fn request_builder_failure_is_definite() {
+        let error = connection("://invalid submission URL".into())
+            .submission_api_request(&serde_json::json!({ "methodCalls": [] }), &config())
+            .await
+            .unwrap_err();
+        assert!(!error.is_indeterminate_delivery());
     }
 }
 

--- a/src-tauri/src/mail/jmap/mail.rs
+++ b/src-tauri/src/mail/jmap/mail.rs
@@ -996,13 +996,17 @@ impl JmapConnection {
         request: &serde_json::Value,
         config: &JmapConfig,
     ) -> Result<serde_json::Value> {
-        let response = config
-            .apply_auth(self.http.post(&self.api_url))
+        let request = config
+            .apply_auth(self.submission_http.post(&self.api_url))
             .json(request)
-            .send()
+            .build()
+            .map_err(|_| Error::Other("JMAP submission request failed before execution".into()))?;
+        let response = self
+            .submission_http
+            .execute(request)
             .await
             .map_err(|error| {
-                if error.is_builder() || error.is_connect() || error.is_redirect() {
+                if error.is_connect() {
                     Error::Other("JMAP submission request failed before execution".into())
                 } else {
                     Error::IndeterminateDelivery
@@ -1016,8 +1020,9 @@ impl JmapConnection {
                     "JMAP submission request rejected with HTTP status {status}"
                 )));
             }
-            // A gateway/server error can be generated after an upstream JMAP
-            // server accepted the request, so it cannot prove non-delivery.
+            // A redirect proves the original endpoint received the POST, and
+            // a gateway/server error can follow upstream acceptance. Neither
+            // response class proves non-delivery.
             return Err(Error::IndeterminateDelivery);
         }
 
@@ -1080,10 +1085,7 @@ impl JmapConnection {
             .json()
             .await
             .map_err(|e| Error::Other(format!("JMAP upload response parse error: {}", e)))?;
-        let blob_id = upload_resp["blobId"]
-            .as_str()
-            .ok_or_else(|| Error::Other("No blobId in upload response".into()))?
-            .to_string();
+        let blob_id = submission_upload_blob_id(&upload_resp, &self.account_id)?;
         log::debug!("JMAP blob uploaded: {}", blob_id);
 
         // Import the email into the Sent folder and submit it.
@@ -1118,7 +1120,7 @@ impl JmapConnection {
         });
 
         let resp = self.submission_api_request(&request, config).await?;
-        if let Err(failure) = validate_submission_response(&resp) {
+        if let Err(failure) = validate_submission_response(&resp, &self.account_id) {
             if let Some(email_id) = failure.imported_email_id {
                 log::warn!("JMAP cleaning up imported email after explicit submission rejection");
                 let cleanup = serde_json::json!({
@@ -1165,10 +1167,7 @@ impl JmapConnection {
             .json()
             .await
             .map_err(|e| Error::Other(format!("JMAP draft upload parse error: {}", e)))?;
-        let blob_id = upload_resp["blobId"]
-            .as_str()
-            .ok_or_else(|| Error::Other("No blobId in draft upload response".into()))?
-            .to_string();
+        let blob_id = submission_upload_blob_id(&upload_resp, &self.account_id)?;
 
         // Find the Drafts mailbox
         let drafts_mailbox_id = self
@@ -1194,16 +1193,44 @@ impl JmapConnection {
         });
 
         let resp = self.api_request(&request, config).await?;
-
-        if let Some(error) = resp["methodResponses"][0][1]["notImported"].get("draft") {
-            return Err(Error::Other(format!(
-                "JMAP draft import failed (type={})",
-                super::safe_jmap_error_type(error)
-            )));
-        }
+        validate_draft_import_response(&resp, &self.account_id)?;
 
         log::info!("JMAP draft saved successfully");
         Ok(())
+    }
+}
+
+fn submission_upload_blob_id(
+    response: &serde_json::Value,
+    expected_account_id: &str,
+) -> Result<String> {
+    if response
+        .get("accountId")
+        .and_then(serde_json::Value::as_str)
+        != Some(expected_account_id)
+    {
+        return Err(Error::Other(
+            "JMAP upload response did not match the requested account".into(),
+        ));
+    }
+    response
+        .get("blobId")
+        .and_then(serde_json::Value::as_str)
+        .filter(|blob_id| !blob_id.is_empty())
+        .map(str::to_string)
+        .ok_or_else(|| Error::Other("No blobId in upload response".into()))
+}
+
+fn validate_draft_import_response(
+    response: &serde_json::Value,
+    expected_account_id: &str,
+) -> Result<()> {
+    match classify_import_response(response, expected_account_id) {
+        CreationOutcome::Created(_) => Ok(()),
+        CreationOutcome::Rejected(error) => Err(error),
+        CreationOutcome::Indeterminate => {
+            Err(Error::Other("Malformed JMAP draft import response".into()))
+        }
     }
 }
 
@@ -1220,9 +1247,10 @@ enum CreationOutcome<T> {
 
 fn validate_submission_response(
     response: &serde_json::Value,
+    expected_account_id: &str,
 ) -> std::result::Result<(), SubmissionResponseFailure> {
-    let imported = classify_import_response(response);
-    let submitted = classify_email_submission_response(response);
+    let imported = classify_import_response(response, expected_account_id);
+    let submitted = classify_email_submission_response(response, expected_account_id);
 
     match (imported, submitted) {
         (CreationOutcome::Created(_), CreationOutcome::Created(())) => Ok(()),
@@ -1258,7 +1286,10 @@ fn validate_submission_response(
     }
 }
 
-fn classify_import_response(response: &serde_json::Value) -> CreationOutcome<String> {
+fn classify_import_response(
+    response: &serde_json::Value,
+    expected_account_id: &str,
+) -> CreationOutcome<String> {
     let Some((method, body)) = matching_method_response(response, "i1") else {
         return CreationOutcome::Indeterminate;
     };
@@ -1266,6 +1297,9 @@ fn classify_import_response(response: &serde_json::Value) -> CreationOutcome<Str
         return classify_method_error("JMAP Email/import failed", body);
     }
     if method != "Email/import" {
+        return CreationOutcome::Indeterminate;
+    }
+    if !has_expected_account_id(body, expected_account_id) {
         return CreationOutcome::Indeterminate;
     }
     let created = body
@@ -1283,7 +1317,10 @@ fn classify_import_response(response: &serde_json::Value) -> CreationOutcome<Str
     }
 }
 
-fn classify_email_submission_response(response: &serde_json::Value) -> CreationOutcome<()> {
+fn classify_email_submission_response(
+    response: &serde_json::Value,
+    expected_account_id: &str,
+) -> CreationOutcome<()> {
     let Some((method, body)) = matching_method_response(response, "s1") else {
         return CreationOutcome::Indeterminate;
     };
@@ -1291,6 +1328,9 @@ fn classify_email_submission_response(response: &serde_json::Value) -> CreationO
         return classify_method_error("JMAP EmailSubmission/set failed", body);
     }
     if method != "EmailSubmission/set" {
+        return CreationOutcome::Indeterminate;
+    }
+    if !has_expected_account_id(body, expected_account_id) {
         return CreationOutcome::Indeterminate;
     }
     let created = body
@@ -1308,6 +1348,10 @@ fn classify_email_submission_response(response: &serde_json::Value) -> CreationO
         }
         _ => CreationOutcome::Indeterminate,
     }
+}
+
+fn has_expected_account_id(body: &serde_json::Value, expected_account_id: &str) -> bool {
+    body.get("accountId").and_then(serde_json::Value::as_str) == Some(expected_account_id)
 }
 
 fn bounded_rejection(context: &str, error: &serde_json::Value) -> Option<Error> {
@@ -1853,8 +1897,10 @@ mod submission_envelope_tests {
             .timeout(std::time::Duration::from_secs(1))
             .build()
             .unwrap();
+        let submission_http = http.clone();
         let connection = JmapConnection {
             http,
+            submission_http,
             api_url: format!("{base_url}/api"),
             download_url_template: format!("{base_url}/download/{{blobId}}"),
             upload_url_template: format!("{base_url}/upload/{{accountId}}"),
@@ -1900,13 +1946,17 @@ mod submission_envelope_tests {
 mod submission_response_tests {
     use super::validate_submission_response;
 
+    const ACCOUNT_ID: &str = "account-1";
+
     fn successful_response() -> serde_json::Value {
         serde_json::json!({
             "methodResponses": [
                 ["Email/import", {
+                    "accountId": ACCOUNT_ID,
                     "created": { "draft": { "id": "email-1" } }
                 }, "i1"],
                 ["EmailSubmission/set", {
+                    "accountId": ACCOUNT_ID,
                     "created": { "sub1": { "id": "submission-1" } }
                 }, "s1"]
             ]
@@ -1915,20 +1965,23 @@ mod submission_response_tests {
 
     #[test]
     fn requires_positive_import_and_submission_creation() {
-        assert!(validate_submission_response(&successful_response()).is_ok());
+        assert!(validate_submission_response(&successful_response(), ACCOUNT_ID).is_ok());
 
         for response in [
             serde_json::json!({
                 "methodResponses": [["Email/import", {
+                    "accountId": ACCOUNT_ID,
                     "created": { "draft": { "id": "email-1" } }
                 }, "i1"]]
             }),
             serde_json::json!({
                 "methodResponses": [
                     ["Email/import", {
+                        "accountId": ACCOUNT_ID,
                         "created": { "draft": { "id": "email-1" } }
                     }, "i1"],
                     ["EmailSubmission/set", {
+                        "accountId": ACCOUNT_ID,
                         "created": { "sub1": {} }
                     }, "s1"]
                 ]
@@ -1936,9 +1989,11 @@ mod submission_response_tests {
             serde_json::json!({
                 "methodResponses": [
                     ["Email/import", {
+                        "accountId": ACCOUNT_ID,
                         "created": { "draft": { "id": "email-1" } }
                     }, "i1"],
                     ["Email/set", {
+                        "accountId": ACCOUNT_ID,
                         "created": { "sub1": { "id": "submission-1" } }
                     }, "s1"]
                 ]
@@ -1946,15 +2001,17 @@ mod submission_response_tests {
             serde_json::json!({
                 "methodResponses": [
                     ["Email/import", {
+                        "accountId": ACCOUNT_ID,
                         "created": { "draft": { "id": "email-1" } }
                     }, "i1"],
                     ["EmailSubmission/set", {
+                        "accountId": ACCOUNT_ID,
                         "created": { "sub1": { "id": "submission-1" } }
                     }, "wrong-call-id"]
                 ]
             }),
         ] {
-            let failure = validate_submission_response(&response).unwrap_err();
+            let failure = validate_submission_response(&response, ACCOUNT_ID).unwrap_err();
             assert!(failure.imported_email_id.is_none());
             assert!(failure.error.is_indeterminate_delivery());
         }
@@ -1968,7 +2025,33 @@ mod submission_response_tests {
             .unwrap()
             .push(serde_json::json!(["Core/echo", {}, "extra"]));
 
-        assert!(validate_submission_response(&response).is_ok());
+        assert!(validate_submission_response(&response, ACCOUNT_ID).is_ok());
+    }
+
+    #[test]
+    fn successful_responses_require_the_expected_account_id() {
+        for method_index in [0, 1] {
+            for account_id in [
+                None,
+                Some(serde_json::Value::Null),
+                Some(serde_json::json!(7)),
+                Some(serde_json::json!("other-account")),
+            ] {
+                let mut response = successful_response();
+                let body = response["methodResponses"][method_index][1]
+                    .as_object_mut()
+                    .unwrap();
+                if let Some(account_id) = account_id {
+                    body.insert("accountId".into(), account_id);
+                } else {
+                    body.remove("accountId");
+                }
+
+                let failure = validate_submission_response(&response, ACCOUNT_ID).unwrap_err();
+                assert!(failure.imported_email_id.is_none());
+                assert!(failure.error.is_indeterminate_delivery());
+            }
+        }
     }
 
     #[test]
@@ -1976,9 +2059,11 @@ mod submission_response_tests {
         let response = serde_json::json!({
             "methodResponses": [
                 ["Email/import", {
+                    "accountId": ACCOUNT_ID,
                     "created": { "draft": { "id": "email-1" } }
                 }, "i1"],
                 ["EmailSubmission/set", {
+                    "accountId": ACCOUNT_ID,
                     "notCreated": {
                         "sub1": { "type": "forbiddenToSend" }
                     }
@@ -1986,9 +2071,31 @@ mod submission_response_tests {
             ]
         });
 
-        let failure = validate_submission_response(&response).unwrap_err();
+        let failure = validate_submission_response(&response, ACCOUNT_ID).unwrap_err();
         assert_eq!(failure.imported_email_id.as_deref(), Some("email-1"));
         assert!(!failure.error.is_indeterminate_delivery());
+    }
+
+    #[test]
+    fn mismatched_rejection_account_is_indeterminate_without_cleanup() {
+        let response = serde_json::json!({
+            "methodResponses": [
+                ["Email/import", {
+                    "accountId": ACCOUNT_ID,
+                    "created": { "draft": { "id": "email-1" } }
+                }, "i1"],
+                ["EmailSubmission/set", {
+                    "accountId": "other-account",
+                    "notCreated": {
+                        "sub1": { "type": "forbiddenToSend" }
+                    }
+                }, "s1"]
+            ]
+        });
+
+        let failure = validate_submission_response(&response, ACCOUNT_ID).unwrap_err();
+        assert!(failure.imported_email_id.is_none());
+        assert!(failure.error.is_indeterminate_delivery());
     }
 
     #[test]
@@ -2000,7 +2107,7 @@ mod submission_response_tests {
             let mut response = successful_response();
             response["methodResponses"][1][1]["notCreated"]["sub1"] = rejected;
 
-            let failure = validate_submission_response(&response).unwrap_err();
+            let failure = validate_submission_response(&response, ACCOUNT_ID).unwrap_err();
             assert!(failure.imported_email_id.is_none());
             assert!(failure.error.is_indeterminate_delivery());
         }
@@ -2011,13 +2118,14 @@ mod submission_response_tests {
         let response = serde_json::json!({
             "methodResponses": [
                 ["Email/import", {
+                    "accountId": ACCOUNT_ID,
                     "created": { "draft": { "id": "email-1" } }
                 }, "i1"],
                 ["error", { "type": "serverPartialFail" }, "s1"]
             ]
         });
 
-        let failure = validate_submission_response(&response).unwrap_err();
+        let failure = validate_submission_response(&response, ACCOUNT_ID).unwrap_err();
         assert!(failure.imported_email_id.is_none());
         assert!(failure.error.is_indeterminate_delivery());
     }
@@ -2027,6 +2135,7 @@ mod submission_response_tests {
         let response = serde_json::json!({
             "methodResponses": [
                 ["Email/import", {
+                    "accountId": ACCOUNT_ID,
                     "notCreated": {
                         "draft": {
                             "type": "invalidEmail",
@@ -2034,11 +2143,11 @@ mod submission_response_tests {
                         }
                     }
                 }, "i1"],
-                ["EmailSubmission/set", {}, "s1"]
+                ["EmailSubmission/set", { "accountId": ACCOUNT_ID }, "s1"]
             ]
         });
 
-        let failure = validate_submission_response(&response).unwrap_err();
+        let failure = validate_submission_response(&response, ACCOUNT_ID).unwrap_err();
         assert!(failure.imported_email_id.is_none());
         let error = failure.error.to_string();
         assert!(error.contains("invalidEmail"));
@@ -2051,9 +2160,11 @@ mod submission_response_tests {
         let response = serde_json::json!({
             "methodResponses": [
                 ["Email/import", {
+                    "accountId": ACCOUNT_ID,
                     "created": { "draft": { "id": "email-1" } }
                 }, "i1"],
                 ["EmailSubmission/set", {
+                    "accountId": ACCOUNT_ID,
                     "notCreated": {
                         "sub1": {
                             "type": "invalidRecipients",
@@ -2065,7 +2176,7 @@ mod submission_response_tests {
             ]
         });
 
-        let failure = validate_submission_response(&response).unwrap_err();
+        let failure = validate_submission_response(&response, ACCOUNT_ID).unwrap_err();
         assert_eq!(failure.imported_email_id.as_deref(), Some("email-1"));
         let error = failure.error.to_string();
         assert!(error.contains("type=invalidRecipients"));
@@ -2075,17 +2186,175 @@ mod submission_response_tests {
 }
 
 #[cfg(test)]
+mod upload_and_draft_response_tests {
+    use super::{submission_upload_blob_id, validate_draft_import_response};
+
+    const ACCOUNT_ID: &str = "account-1";
+
+    #[test]
+    fn submission_upload_requires_the_expected_account_id() {
+        let valid = serde_json::json!({
+            "accountId": ACCOUNT_ID,
+            "blobId": "blob-1"
+        });
+        assert_eq!(
+            submission_upload_blob_id(&valid, ACCOUNT_ID).unwrap(),
+            "blob-1"
+        );
+
+        for response in [
+            serde_json::json!({ "blobId": "private-blob" }),
+            serde_json::json!({ "accountId": null, "blobId": "private-blob" }),
+            serde_json::json!({ "accountId": 7, "blobId": "private-blob" }),
+            serde_json::json!({
+                "accountId": "other-account",
+                "blobId": "private-blob"
+            }),
+        ] {
+            let error = submission_upload_blob_id(&response, ACCOUNT_ID)
+                .unwrap_err()
+                .to_string();
+            assert!(!error.contains("private-blob"));
+            assert!(error.len() < 160);
+        }
+    }
+
+    #[test]
+    fn submission_upload_requires_a_nonempty_blob_id() {
+        for response in [
+            serde_json::json!({ "accountId": ACCOUNT_ID }),
+            serde_json::json!({ "accountId": ACCOUNT_ID, "blobId": null }),
+            serde_json::json!({ "accountId": ACCOUNT_ID, "blobId": "" }),
+        ] {
+            assert!(submission_upload_blob_id(&response, ACCOUNT_ID).is_err());
+        }
+    }
+
+    #[test]
+    fn draft_import_requires_correlated_creation_for_the_expected_account() {
+        let valid = serde_json::json!({
+            "methodResponses": [["Email/import", {
+                "accountId": ACCOUNT_ID,
+                "created": { "draft": { "id": "email-1" } }
+            }, "i1"]]
+        });
+        assert!(validate_draft_import_response(&valid, ACCOUNT_ID).is_ok());
+
+        let secret = "private draft response";
+        for response in [
+            serde_json::json!({}),
+            serde_json::json!({
+                "methodResponses": [["Email/import", {
+                    "accountId": ACCOUNT_ID,
+                    "created": { "draft": { "id": "email-1" } }
+                }, "wrong"]]
+            }),
+            serde_json::json!({
+                "methodResponses": [["Email/get", {
+                    "accountId": ACCOUNT_ID,
+                    "created": { "draft": { "id": "email-1" } }
+                }, "i1"]]
+            }),
+            serde_json::json!({
+                "methodResponses": [["Email/import", {
+                    "created": { "draft": { "id": "email-1" } }
+                }, "i1"]]
+            }),
+            serde_json::json!({
+                "methodResponses": [["Email/import", {
+                    "accountId": null,
+                    "created": { "draft": { "id": "email-1" } }
+                }, "i1"]]
+            }),
+            serde_json::json!({
+                "methodResponses": [["Email/import", {
+                    "accountId": "other-account",
+                    "created": { "draft": { "id": "email-1" } }
+                }, "i1"]]
+            }),
+            serde_json::json!({
+                "methodResponses": [["Email/import", {
+                    "accountId": ACCOUNT_ID,
+                    "created": { "draft": {} }
+                }, "i1"]]
+            }),
+            serde_json::json!({
+                "methodResponses": [["Email/import", {
+                    "accountId": ACCOUNT_ID,
+                    "notImported": {
+                        "draft": {
+                            "type": "invalidEmail",
+                            "description": secret
+                        }
+                    }
+                }, "i1"]]
+            }),
+        ] {
+            let error = validate_draft_import_response(&response, ACCOUNT_ID)
+                .unwrap_err()
+                .to_string();
+            assert!(!error.contains(secret));
+            assert!(error.len() < 160);
+        }
+    }
+
+    #[test]
+    fn draft_import_rejection_and_method_error_are_bounded_and_redacted() {
+        let secret = "private draft response";
+        for response in [
+            serde_json::json!({
+                "methodResponses": [["Email/import", {
+                    "accountId": ACCOUNT_ID,
+                    "notCreated": {
+                        "draft": {
+                            "type": "invalidEmail",
+                            "description": secret
+                        }
+                    }
+                }, "i1"]]
+            }),
+            serde_json::json!({
+                "methodResponses": [["error", {
+                    "type": "serverFail",
+                    "description": secret
+                }, "i1"]]
+            }),
+        ] {
+            let error = validate_draft_import_response(&response, ACCOUNT_ID)
+                .unwrap_err()
+                .to_string();
+            assert!(!error.contains(secret));
+            assert!(error.len() < 160);
+        }
+    }
+}
+
+#[cfg(test)]
 mod submission_request_tests {
     use super::{JmapConfig, JmapConnection};
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
     fn connection(api_url: String) -> JmapConnection {
+        let submission_http = reqwest::Client::builder()
+            .no_proxy()
+            .redirect(reqwest::redirect::Policy::none())
+            .timeout(std::time::Duration::from_secs(1))
+            .build()
+            .unwrap();
+        connection_with_submission_http(api_url, submission_http)
+    }
+
+    fn connection_with_submission_http(
+        api_url: String,
+        submission_http: reqwest::Client,
+    ) -> JmapConnection {
         JmapConnection {
             http: reqwest::Client::builder()
                 .no_proxy()
                 .timeout(std::time::Duration::from_secs(1))
                 .build()
                 .unwrap(),
+            submission_http,
             api_url,
             download_url_template: String::new(),
             upload_url_template: String::new(),
@@ -2110,9 +2379,14 @@ mod submission_request_tests {
     }
 
     async fn serve_once(status: &str, body: &str) -> String {
+        serve_once_with_headers(status, "", body).await
+    }
+
+    async fn serve_once_with_headers(status: &str, headers: &str, body: &str) -> String {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let url = format!("http://{}/api", listener.local_addr().unwrap());
         let status = status.to_string();
+        let headers = headers.to_string();
         let body = body.to_string();
         tokio::spawn(async move {
             let (mut stream, _) = listener.accept().await.unwrap();
@@ -2140,12 +2414,21 @@ mod submission_request_tests {
                 }
             }
             let response = format!(
-                "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                "HTTP/1.1 {status}\r\n{headers}Content-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
                 body.len()
             );
             stream.write_all(response.as_bytes()).await.unwrap();
         });
         url
+    }
+
+    async fn serve_redirect_once(status: u16, location: &str) -> String {
+        serve_once_with_headers(
+            &format!("{status} Redirect"),
+            &format!("Location: {location}\r\n"),
+            "",
+        )
+        .await
     }
 
     #[tokio::test]
@@ -2188,6 +2471,71 @@ mod submission_request_tests {
             .await
             .unwrap_err();
         assert!(!error.is_indeterminate_delivery());
+    }
+
+    #[tokio::test]
+    async fn connection_failure_is_definite() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!("http://{}/api", listener.local_addr().unwrap());
+        drop(listener);
+
+        let error = connection(url)
+            .submission_api_request(&serde_json::json!({ "methodCalls": [] }), &config())
+            .await
+            .unwrap_err();
+        assert!(!error.is_indeterminate_delivery());
+    }
+
+    #[tokio::test]
+    async fn submission_redirects_are_indeterminate_and_not_followed() {
+        let request = serde_json::json!({ "methodCalls": [] });
+        for status in [301, 302, 303, 307, 308] {
+            let target = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let target_url = format!("http://{}/redirected", target.local_addr().unwrap());
+            let origin_url = serve_redirect_once(status, &target_url).await;
+
+            let error = connection(origin_url)
+                .submission_api_request(&request, &config())
+                .await
+                .unwrap_err();
+            assert!(error.is_indeterminate_delivery(), "HTTP {status}");
+            assert!(
+                tokio::time::timeout(std::time::Duration::from_millis(100), target.accept())
+                    .await
+                    .is_err(),
+                "HTTP {status} submission redirect was followed"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn every_http_3xx_submission_response_is_indeterminate() {
+        let request = serde_json::json!({ "methodCalls": [] });
+        for status in 300..=399 {
+            let url = serve_once(&format!("{status} Redirect"), "").await;
+            let error = connection(url)
+                .submission_api_request(&request, &config())
+                .await
+                .unwrap_err();
+            assert!(error.is_indeterminate_delivery(), "HTTP {status}");
+        }
+    }
+
+    #[tokio::test]
+    async fn redirect_error_after_dispatch_is_indeterminate() {
+        let submission_http = reqwest::Client::builder()
+            .no_proxy()
+            .redirect(reqwest::redirect::Policy::limited(0))
+            .timeout(std::time::Duration::from_secs(1))
+            .build()
+            .unwrap();
+        let url = serve_redirect_once(307, "http://127.0.0.1:9/redirected").await;
+
+        let error = connection_with_submission_http(url, submission_http)
+            .submission_api_request(&serde_json::json!({ "methodCalls": [] }), &config())
+            .await
+            .unwrap_err();
+        assert!(error.is_indeterminate_delivery());
     }
 }
 

--- a/src-tauri/src/mail/jmap/mailboxes.rs
+++ b/src-tauri/src/mail/jmap/mailboxes.rs
@@ -70,14 +70,7 @@ impl JmapConnection {
             ]
         });
         let resp = self.api_request(&request, config).await?;
-        if let Some(mailboxes) = resp["methodResponses"][0][1]["list"].as_array() {
-            for mb in mailboxes {
-                if mb["role"].as_str() == Some(role) {
-                    return Ok(mb["id"].as_str().map(|s| s.to_string()));
-                }
-            }
-        }
-        Ok(None)
+        mailbox_id_by_role(&resp, role)
     }
 
     /// Create a new mailbox on the JMAP server.
@@ -171,5 +164,123 @@ impl JmapConnection {
         }
         log::info!("JMAP mailbox destroyed: {}", mailbox_id);
         Ok(())
+    }
+}
+
+fn mailbox_id_by_role(response: &serde_json::Value, role: &str) -> Result<Option<String>> {
+    let responses = response
+        .get("methodResponses")
+        .and_then(serde_json::Value::as_array)
+        .filter(|responses| responses.len() == 1)
+        .ok_or_else(|| Error::Other("Malformed JMAP Mailbox/get response count".into()))?;
+    let tuple = responses[0]
+        .as_array()
+        .filter(|tuple| tuple.len() == 3)
+        .ok_or_else(|| Error::Other("Malformed JMAP Mailbox/get response tuple".into()))?;
+    if tuple[2].as_str() != Some("r1") {
+        return Err(Error::Other(
+            "JMAP Mailbox/get returned an unexpected call id".into(),
+        ));
+    }
+
+    let method = tuple[0]
+        .as_str()
+        .ok_or_else(|| Error::Other("Malformed JMAP Mailbox/get method".into()))?;
+    if method == "error" {
+        return Err(Error::Other(format!(
+            "JMAP Mailbox/get failed (type={})",
+            super::safe_jmap_error_type(&tuple[1])
+        )));
+    }
+    if method != "Mailbox/get" {
+        return Err(Error::Other(
+            "JMAP Mailbox/get returned an unexpected method".into(),
+        ));
+    }
+
+    let mailboxes = tuple[1]
+        .get("list")
+        .and_then(serde_json::Value::as_array)
+        .ok_or_else(|| Error::Other("JMAP Mailbox/get returned no mailbox list".into()))?;
+    for mailbox in mailboxes {
+        let mailbox = mailbox
+            .as_object()
+            .ok_or_else(|| Error::Other("JMAP Mailbox/get returned a malformed mailbox".into()))?;
+        let id = mailbox
+            .get("id")
+            .and_then(serde_json::Value::as_str)
+            .filter(|id| !id.is_empty())
+            .ok_or_else(|| {
+                Error::Other("JMAP Mailbox/get returned a mailbox without an id".into())
+            })?;
+        let mailbox_role = mailbox
+            .get("role")
+            .ok_or_else(|| Error::Other("JMAP Mailbox/get omitted a requested role".into()))?;
+        if !mailbox_role.is_null() && !mailbox_role.is_string() {
+            return Err(Error::Other(
+                "JMAP Mailbox/get returned a malformed role".into(),
+            ));
+        }
+        if mailbox_role.as_str() == Some(role) {
+            return Ok(Some(id.to_string()));
+        }
+    }
+    Ok(None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::mailbox_id_by_role;
+
+    #[test]
+    fn role_lookup_requires_a_correlated_mailbox_get_result() {
+        let valid = serde_json::json!({
+            "methodResponses": [["Mailbox/get", {
+                "list": [
+                    { "id": "archive-id", "role": null },
+                    { "id": "sent-id", "role": "sent" }
+                ]
+            }, "r1"]]
+        });
+        assert_eq!(
+            mailbox_id_by_role(&valid, "sent").unwrap().as_deref(),
+            Some("sent-id")
+        );
+
+        for invalid in [
+            serde_json::json!({
+                "methodResponses": [["error", { "type": "serverFail" }, "r1"]]
+            }),
+            serde_json::json!({
+                "methodResponses": [["Mailbox/get", { "list": [] }, "wrong"]]
+            }),
+            serde_json::json!({
+                "methodResponses": [["Mailbox/get", {}, "r1"]]
+            }),
+            serde_json::json!({
+                "methodResponses": [["Mailbox/get", {
+                    "list": [{ "id": "sent-id" }]
+                }, "r1"]]
+            }),
+        ] {
+            assert!(mailbox_id_by_role(&invalid, "sent").is_err());
+        }
+    }
+
+    #[test]
+    fn role_lookup_redacts_method_error_descriptions() {
+        let secret = "private mailbox detail";
+        let response = serde_json::json!({
+            "methodResponses": [["error", {
+                "type": "serverFail",
+                "description": secret
+            }, "r1"]]
+        });
+
+        let error = mailbox_id_by_role(&response, "sent")
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("serverFail"));
+        assert!(!error.contains(secret));
     }
 }

--- a/src-tauri/src/mail/jmap/mailboxes.rs
+++ b/src-tauri/src/mail/jmap/mailboxes.rs
@@ -21,9 +21,10 @@ impl JmapConnection {
         });
 
         let resp = self.api_request(&request, config).await?;
-
-        let mailboxes = resp["methodResponses"][0][1]["list"]
-            .as_array()
+        let body = mailbox_get_body(&resp, "m1", &self.account_id)?;
+        let mailboxes = body
+            .get("list")
+            .and_then(serde_json::Value::as_array)
             .ok_or_else(|| Error::Other("Invalid Mailbox/get response".into()))?;
 
         let mut folders = Vec::new();
@@ -70,7 +71,7 @@ impl JmapConnection {
             ]
         });
         let resp = self.api_request(&request, config).await?;
-        mailbox_id_by_role(&resp, role)
+        mailbox_id_by_role(&resp, role, &self.account_id)
     }
 
     /// Create a new mailbox on the JMAP server.
@@ -167,7 +168,11 @@ impl JmapConnection {
     }
 }
 
-fn mailbox_id_by_role(response: &serde_json::Value, role: &str) -> Result<Option<String>> {
+fn mailbox_get_body<'a>(
+    response: &'a serde_json::Value,
+    call_id: &str,
+    expected_account_id: &str,
+) -> Result<&'a serde_json::Value> {
     let responses = response
         .get("methodResponses")
         .and_then(serde_json::Value::as_array)
@@ -177,7 +182,7 @@ fn mailbox_id_by_role(response: &serde_json::Value, role: &str) -> Result<Option
         .as_array()
         .filter(|tuple| tuple.len() == 3)
         .ok_or_else(|| Error::Other("Malformed JMAP Mailbox/get response tuple".into()))?;
-    if tuple[2].as_str() != Some("r1") {
+    if tuple[2].as_str() != Some(call_id) {
         return Err(Error::Other(
             "JMAP Mailbox/get returned an unexpected call id".into(),
         ));
@@ -197,8 +202,22 @@ fn mailbox_id_by_role(response: &serde_json::Value, role: &str) -> Result<Option
             "JMAP Mailbox/get returned an unexpected method".into(),
         ));
     }
+    let body = &tuple[1];
+    if body.get("accountId").and_then(serde_json::Value::as_str) != Some(expected_account_id) {
+        return Err(Error::Other(
+            "JMAP Mailbox/get returned an unexpected account id".into(),
+        ));
+    }
+    Ok(body)
+}
 
-    let mailboxes = tuple[1]
+fn mailbox_id_by_role(
+    response: &serde_json::Value,
+    role: &str,
+    expected_account_id: &str,
+) -> Result<Option<String>> {
+    let body = mailbox_get_body(response, "r1", expected_account_id)?;
+    let mailboxes = body
         .get("list")
         .and_then(serde_json::Value::as_array)
         .ok_or_else(|| Error::Other("JMAP Mailbox/get returned no mailbox list".into()))?;
@@ -236,6 +255,7 @@ mod tests {
     fn role_lookup_requires_a_correlated_mailbox_get_result() {
         let valid = serde_json::json!({
             "methodResponses": [["Mailbox/get", {
+                "accountId": "account-1",
                 "list": [
                     { "id": "archive-id", "role": null },
                     { "id": "sent-id", "role": "sent" }
@@ -243,7 +263,9 @@ mod tests {
             }, "r1"]]
         });
         assert_eq!(
-            mailbox_id_by_role(&valid, "sent").unwrap().as_deref(),
+            mailbox_id_by_role(&valid, "sent", "account-1")
+                .unwrap()
+                .as_deref(),
             Some("sent-id")
         );
 
@@ -255,15 +277,40 @@ mod tests {
                 "methodResponses": [["Mailbox/get", { "list": [] }, "wrong"]]
             }),
             serde_json::json!({
-                "methodResponses": [["Mailbox/get", {}, "r1"]]
+                "methodResponses": [["Mailbox/get", {
+                    "accountId": "account-1"
+                }, "r1"]]
             }),
             serde_json::json!({
                 "methodResponses": [["Mailbox/get", {
+                    "accountId": "account-1",
                     "list": [{ "id": "sent-id" }]
                 }, "r1"]]
             }),
         ] {
-            assert!(mailbox_id_by_role(&invalid, "sent").is_err());
+            assert!(mailbox_id_by_role(&invalid, "sent", "account-1").is_err());
+        }
+    }
+
+    #[test]
+    fn role_lookup_requires_the_expected_account_id() {
+        for account_id in [
+            None,
+            Some(serde_json::Value::Null),
+            Some(serde_json::json!(7)),
+            Some(serde_json::json!("other-account")),
+        ] {
+            let mut body = serde_json::json!({
+                "list": [{ "id": "sent-id", "role": "sent" }]
+            });
+            if let Some(account_id) = account_id {
+                body["accountId"] = account_id;
+            }
+            let response = serde_json::json!({
+                "methodResponses": [["Mailbox/get", body, "r1"]]
+            });
+
+            assert!(mailbox_id_by_role(&response, "sent", "account-1").is_err());
         }
     }
 
@@ -277,7 +324,7 @@ mod tests {
             }, "r1"]]
         });
 
-        let error = mailbox_id_by_role(&response, "sent")
+        let error = mailbox_id_by_role(&response, "sent", "account-1")
             .unwrap_err()
             .to_string();
         assert!(error.contains("serverFail"));

--- a/src-tauri/src/mail/jmap/mod.rs
+++ b/src-tauri/src/mail/jmap/mod.rs
@@ -18,6 +18,9 @@
 use crate::error::{Error, Result};
 use serde::Deserialize;
 
+const MAIL_CAPABILITY: &str = "urn:ietf:params:jmap:mail";
+const SUBMISSION_CAPABILITY: &str = "urn:ietf:params:jmap:submission";
+
 mod calendar;
 mod contacts;
 mod identities;
@@ -25,7 +28,7 @@ mod mail;
 mod mailboxes;
 
 pub use calendar::JmapCalendarEvent;
-pub use mail::{JmapEmail, JmapFetchResult};
+pub use mail::{JmapEmail, JmapFetchResult, JmapSubmissionEnvelope};
 
 #[derive(Clone)]
 pub struct JmapConfig {
@@ -62,7 +65,17 @@ mod connect_tests {
             "apiUrl": "http://127.0.0.1:9/jmap/api",
             "downloadUrl": "http://127.0.0.1:9/jmap/download/{blobId}",
             "uploadUrl": "http://127.0.0.1:9/jmap/upload/{accountId}",
-            "primaryAccounts": { "urn:ietf:params:jmap:mail": "account-1" }
+            "primaryAccounts": { "urn:ietf:params:jmap:mail": "account-1" },
+            "accounts": {
+                "account-1": {
+                    "accountCapabilities": {
+                        "urn:ietf:params:jmap:submission": {
+                            "maxDelayedSend": 0,
+                            "submissionExtensions": { "SMTPUTF8": [] }
+                        }
+                    }
+                }
+            }
         })
         .to_string();
 
@@ -115,13 +128,16 @@ mod connect_tests {
             oidc_client_id: String::new(),
         };
         let discovery_http = reqwest::Client::builder()
-            .proxy(reqwest::Proxy::all("http://127.0.0.1:9").unwrap())
+            .no_proxy()
+            .timeout(std::time::Duration::from_secs(2))
             .build()
             .unwrap();
         let mut headers = HeaderMap::new();
         headers.insert("x-injected-client", HeaderValue::from_static("jmap-test"));
         let api_http = reqwest::Client::builder()
             .default_headers(headers)
+            .no_proxy()
+            .timeout(std::time::Duration::from_secs(2))
             .build()
             .unwrap();
 
@@ -131,6 +147,7 @@ mod connect_tests {
         let request = request_rx.await.unwrap();
         assert_eq!(connection.account_id, "account-1");
         assert_eq!(connection.api_url, format!("{}/jmap/api", base_url));
+        assert!(connection.supports_submission_extension("SMTPUTF8"));
         assert!(request.starts_with("GET /.well-known/jmap HTTP/1.1\r\n"));
         assert_eq!(header(&request, "x-injected-client"), Some("jmap-test"));
         (connection, request)
@@ -415,6 +432,7 @@ pub struct JmapConnection {
     event_source_url_template: Option<String>,
     account_id: String,
     max_objects_in_set: usize,
+    submission_extensions: std::collections::HashMap<String, Vec<String>>,
 }
 
 #[derive(Deserialize)]
@@ -431,12 +449,26 @@ struct JmapSession {
     primary_accounts: std::collections::HashMap<String, String>,
     #[serde(default)]
     capabilities: std::collections::HashMap<String, JmapCoreCapability>,
+    #[serde(default)]
+    accounts: std::collections::HashMap<String, JmapAccount>,
 }
 
 #[derive(Deserialize, Default)]
 struct JmapCoreCapability {
     #[serde(rename = "maxObjectsInSet")]
     max_objects_in_set: Option<usize>,
+}
+
+#[derive(Deserialize, Default)]
+struct JmapAccount {
+    #[serde(rename = "accountCapabilities", default)]
+    account_capabilities: std::collections::HashMap<String, JmapSubmissionAccountCapability>,
+}
+
+#[derive(Deserialize, Default)]
+struct JmapSubmissionAccountCapability {
+    #[serde(rename = "submissionExtensions", default)]
+    submission_extensions: std::collections::HashMap<String, Vec<String>>,
 }
 
 impl JmapSession {
@@ -448,38 +480,96 @@ impl JmapSession {
             .filter(|limit| *limit > 0)
             .unwrap_or(DEFAULT_MAX_OBJECTS_IN_SET)
     }
+
+    fn submission_extensions(
+        &self,
+        account_id: &str,
+    ) -> std::collections::HashMap<String, Vec<String>> {
+        self.accounts
+            .get(account_id)
+            .and_then(|account| account.account_capabilities.get(SUBMISSION_CAPABILITY))
+            .map(|capability| capability.submission_extensions.clone())
+            .unwrap_or_default()
+    }
 }
 
 #[cfg(test)]
 mod session_limit_tests {
     use super::JmapSession;
 
-    fn session(capabilities: serde_json::Value) -> JmapSession {
+    fn session(
+        capabilities: serde_json::Value,
+        account_capabilities: serde_json::Value,
+    ) -> JmapSession {
         serde_json::from_value(serde_json::json!({
             "apiUrl": "https://example.test/api",
             "downloadUrl": "https://example.test/download/{blobId}",
             "uploadUrl": "https://example.test/upload/{accountId}",
             "primaryAccounts": { "urn:ietf:params:jmap:mail": "account" },
-            "capabilities": capabilities
+            "capabilities": capabilities,
+            "accounts": {
+                "account": { "accountCapabilities": account_capabilities },
+                "other": {
+                    "accountCapabilities": {
+                        "urn:ietf:params:jmap:submission": {
+                            "submissionExtensions": { "OTHER": [] }
+                        }
+                    }
+                }
+            }
         }))
         .unwrap()
     }
 
     #[test]
     fn reads_max_objects_in_set_from_core_capability() {
-        let session = session(serde_json::json!({
-            "urn:ietf:params:jmap:core": { "maxObjectsInSet": 37 }
-        }));
+        let session = session(
+            serde_json::json!({
+                "urn:ietf:params:jmap:core": { "maxObjectsInSet": 37 }
+            }),
+            serde_json::json!({}),
+        );
         assert_eq!(session.max_objects_in_set(), 37);
     }
 
     #[test]
     fn defaults_invalid_or_missing_set_limits() {
-        assert_eq!(session(serde_json::json!({})).max_objects_in_set(), 500);
-        let zero = session(serde_json::json!({
-            "urn:ietf:params:jmap:core": { "maxObjectsInSet": 0 }
-        }));
+        assert_eq!(
+            session(serde_json::json!({}), serde_json::json!({})).max_objects_in_set(),
+            500
+        );
+        let zero = session(
+            serde_json::json!({
+                "urn:ietf:params:jmap:core": { "maxObjectsInSet": 0 }
+            }),
+            serde_json::json!({}),
+        );
         assert_eq!(zero.max_objects_in_set(), 500);
+    }
+
+    #[test]
+    fn reads_submission_extensions_from_selected_account_capability() {
+        let session = session(
+            serde_json::json!({
+                "urn:ietf:params:jmap:submission": {
+                    "submissionExtensions": { "TOP_LEVEL_IS_WRONG": [] }
+                }
+            }),
+            serde_json::json!({
+                "urn:ietf:params:jmap:submission": {
+                    "submissionExtensions": {
+                        "SMTPUTF8": [],
+                        "SIZE": ["52428800"]
+                    }
+                }
+            }),
+        );
+
+        let extensions = session.submission_extensions("account");
+        assert_eq!(extensions.get("SMTPUTF8"), Some(&Vec::new()));
+        assert_eq!(extensions.get("SIZE"), Some(&vec!["52428800".into()]));
+        assert!(!extensions.contains_key("TOP_LEVEL_IS_WRONG"));
+        assert!(!extensions.contains_key("OTHER"));
     }
 }
 
@@ -548,8 +638,7 @@ impl JmapConnection {
 
         if !resp.status().is_success() {
             let status = resp.status();
-            let body = resp.text().await.unwrap_or_default();
-            return Err(Error::Other(format!("JMAP session: {} {}", status, body)));
+            return Err(Error::Other(format!("JMAP session error: {}", status)));
         }
 
         let session: JmapSession = resp
@@ -557,15 +646,14 @@ impl JmapConnection {
             .await
             .map_err(|e| Error::Other(format!("JMAP session parse failed: {}", e)))?;
 
-        let max_objects_in_set = session.max_objects_in_set();
-
         // Get the default account ID
         let account_id = session
             .primary_accounts
-            .values()
-            .next()
+            .get(MAIL_CAPABILITY)
             .cloned()
             .ok_or_else(|| Error::Other("No primary account in JMAP session".into()))?;
+        let max_objects_in_set = session.max_objects_in_set();
+        let submission_extensions = session.submission_extensions(&account_id);
 
         // Rewrite URLs to go through the HTTPS proxy instead of internal URLs.
         // e.g., "http://mail.example.com:8080/jmap/" → "https://mail.example.com/jmap/"
@@ -592,6 +680,7 @@ impl JmapConnection {
             event_source_url_template: event_source_url,
             account_id,
             max_objects_in_set,
+            submission_extensions,
         })
     }
 
@@ -643,6 +732,12 @@ impl JmapConnection {
         })
     }
 
+    fn supports_submission_extension(&self, extension: &str) -> bool {
+        self.submission_extensions
+            .keys()
+            .any(|advertised| advertised.eq_ignore_ascii_case(extension))
+    }
+
     /// Send a JMAP API request and return the response JSON.
     async fn api_request(
         &self,
@@ -658,14 +753,32 @@ impl JmapConnection {
 
         if !resp.status().is_success() {
             let status = resp.status();
-            let body = resp.text().await.unwrap_or_default();
-            return Err(Error::Other(format!("JMAP API error {}: {}", status, body)));
+            return Err(Error::Other(format!("JMAP API error: {}", status)));
         }
 
         resp.json()
             .await
             .map_err(|e| Error::Other(format!("JMAP response parse error: {}", e)))
     }
+}
+
+fn safe_jmap_error_type(value: &serde_json::Value) -> String {
+    bounded_jmap_error_type(value)
+        .unwrap_or("unknown")
+        .to_string()
+}
+
+fn bounded_jmap_error_type(value: &serde_json::Value) -> Option<&str> {
+    value
+        .get("type")
+        .and_then(serde_json::Value::as_str)
+        .filter(|error_type| {
+            !error_type.is_empty()
+                && error_type.len() <= 64
+                && error_type
+                    .bytes()
+                    .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.'))
+        })
 }
 
 /// Rewrite an internal URL to go through the HTTPS proxy.

--- a/src-tauri/src/mail/jmap/mod.rs
+++ b/src-tauri/src/mail/jmap/mod.rs
@@ -104,6 +104,26 @@ mod connect_tests {
         (format!("http://{}", addr), request_rx)
     }
 
+    async fn session_redirect_server(location: String) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut request = Vec::new();
+            let mut chunk = [0; 1024];
+            while !request.windows(4).any(|bytes| bytes == b"\r\n\r\n") {
+                let read = stream.read(&mut chunk).await.unwrap();
+                assert!(read > 0, "redirect request ended before its headers");
+                request.extend_from_slice(&chunk[..read]);
+            }
+            let response = format!(
+                "HTTP/1.1 307 Temporary Redirect\r\nLocation: {location}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+            );
+            stream.write_all(response.as_bytes()).await.unwrap();
+        });
+        format!("http://{addr}")
+    }
+
     fn header<'a>(request: &'a str, name: &str) -> Option<&'a str> {
         request.lines().find_map(|line| {
             let (key, value) = line.split_once(':')?;
@@ -140,10 +160,21 @@ mod connect_tests {
             .timeout(std::time::Duration::from_secs(2))
             .build()
             .unwrap();
-
-        let connection = JmapConnection::connect_with_clients(&config, discovery_http, api_http)
-            .await
+        let submission_http = reqwest::Client::builder()
+            .no_proxy()
+            .redirect(reqwest::redirect::Policy::none())
+            .timeout(std::time::Duration::from_secs(2))
+            .build()
             .unwrap();
+
+        let connection = JmapConnection::connect_with_clients(
+            &config,
+            discovery_http,
+            api_http,
+            submission_http,
+        )
+        .await
+        .unwrap();
         let request = request_rx.await.unwrap();
         assert_eq!(connection.account_id, "account-1");
         assert_eq!(connection.api_url, format!("{}/jmap/api", base_url));
@@ -170,6 +201,7 @@ mod connect_tests {
     async fn connect_rejects_http_url() {
         let msg = match JmapConnection::connect_with_clients(
             &http_config(),
+            reqwest::Client::new(),
             reqwest::Client::new(),
             reqwest::Client::new(),
         )
@@ -203,6 +235,7 @@ mod connect_tests {
         };
         let msg = match JmapConnection::connect_with_clients(
             &cfg,
+            reqwest::Client::new(),
             reqwest::Client::new(),
             reqwest::Client::new(),
         )
@@ -247,6 +280,47 @@ mod connect_tests {
     async fn configured_session_uses_injected_client_and_bearer_auth() {
         let (_, request) = connect_to_mock(Some("token-1")).await;
         assert_eq!(header(&request, "authorization"), Some("Bearer token-1"));
+    }
+
+    #[tokio::test]
+    async fn configured_session_still_follows_general_client_redirects() {
+        let (session_base, request_rx) = session_server().await;
+        let redirect_base =
+            session_redirect_server(format!("{session_base}/.well-known/jmap")).await;
+        let config = JmapConfig {
+            jmap_url: redirect_base,
+            email: "user@example.com".into(),
+            username: "user".into(),
+            password: "pass".into(),
+            access_token: None,
+            auth_method: "basic".into(),
+            oidc_token_endpoint: String::new(),
+            oidc_client_id: String::new(),
+        };
+        let general_http = reqwest::Client::builder()
+            .no_proxy()
+            .timeout(std::time::Duration::from_secs(2))
+            .build()
+            .unwrap();
+        let submission_http = reqwest::Client::builder()
+            .no_proxy()
+            .redirect(reqwest::redirect::Policy::none())
+            .timeout(std::time::Duration::from_secs(2))
+            .build()
+            .unwrap();
+
+        let connection = JmapConnection::connect_with_clients(
+            &config,
+            general_http.clone(),
+            general_http,
+            submission_http,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(connection.account_id, "account-1");
+        let request = request_rx.await.unwrap();
+        assert!(request.starts_with("GET /.well-known/jmap HTTP/1.1\r\n"));
     }
 }
 
@@ -426,6 +500,7 @@ mod from_mail_account_tests {
 /// session that aren't accessible externally (e.g., http://host:8080).
 pub struct JmapConnection {
     http: reqwest::Client,
+    submission_http: reqwest::Client,
     api_url: String,
     download_url_template: String,
     upload_url_template: String,
@@ -574,11 +649,13 @@ mod session_limit_tests {
 }
 
 impl JmapConnection {
-    /// Connect using caller-provided clients for discovery and JMAP API traffic.
+    /// Connect using caller-provided clients for discovery, general API, and
+    /// final submission traffic.
     pub async fn connect_with_clients(
         config: &JmapConfig,
         discovery_http: reqwest::Client,
         api_http: reqwest::Client,
+        submission_http: reqwest::Client,
     ) -> Result<Self> {
         // Fail fast if bearer/OIDC was selected but no access token
         // resolved. Without this guard, apply_auth() would silently fall
@@ -674,6 +751,7 @@ impl JmapConnection {
 
         Ok(Self {
             http: api_http,
+            submission_http,
             api_url,
             download_url_template: download_url,
             upload_url_template: upload_url,

--- a/src-tauri/src/mail/jmap_push.rs
+++ b/src-tauri/src/mail/jmap_push.rs
@@ -189,6 +189,7 @@ async fn connect_and_get_url(
         config,
         providers.transports.jmap_discovery_http.clone(),
         providers.transports.jmap_api_http.clone(),
+        providers.transports.jmap_submission_http.clone(),
     )
     .await
     .map_err(|e| format!("JMAP connect failed: {}", e))?;

--- a/src-tauri/src/mail/smtp.rs
+++ b/src-tauri/src/mail/smtp.rs
@@ -1,7 +1,9 @@
 use lettre::address::Envelope;
 use lettre::message::{header::ContentType, Attachment, Mailbox, MultiPart, SinglePart};
 use lettre::transport::smtp::authentication::{Credentials, Mechanism};
-use lettre::{Address, AsyncSmtpTransport, AsyncTransport, Message, Tokio1Executor};
+use lettre::transport::smtp::client::{AsyncSmtpConnection, TlsParameters};
+use lettre::transport::smtp::extension::ClientId;
+use lettre::{Address, Message};
 
 use crate::error::{Error, Result};
 
@@ -71,72 +73,215 @@ fn sender_message_id(from: &Mailbox) -> String {
     )
 }
 
-/// Build an SMTP transport from connection parameters.
+/// Establish and authenticate the exact SMTP connection used for submission.
 ///
 /// Port 587 forces STARTTLS regardless of `use_tls`; port 465 (or
 /// `use_tls=true` on any other port) uses implicit TLS; everything else
 /// falls back to STARTTLS on the requested port.
-fn build_transport(
+async fn connect_smtp(
     smtp_host: &str,
     smtp_port: u16,
     username: &str,
     password: &str,
     use_tls: bool,
     use_xoauth2: bool,
-) -> Result<AsyncSmtpTransport<Tokio1Executor>> {
+) -> Result<AsyncSmtpConnection> {
     let creds = Credentials::new(username.to_string(), password.to_string());
     let auth_mechanisms = if use_xoauth2 {
         vec![Mechanism::Xoauth2]
     } else {
         vec![Mechanism::Plain, Mechanism::Login]
     };
-
-    let transport = if smtp_port == 587 {
-        log::debug!("SMTP using STARTTLS on port 587 (xoauth2={})", use_xoauth2);
-        AsyncSmtpTransport::<Tokio1Executor>::starttls_relay(smtp_host)
-            .map_err(|e| Error::Other(format!("SMTP STARTTLS relay setup failed: {}", e)))?
-            .port(smtp_port)
-            .credentials(creds)
-            .authentication(auth_mechanisms)
-            .build()
-    } else if use_tls || smtp_port == 465 {
+    let hello_name = ClientId::default();
+    let tls_parameters = TlsParameters::new(smtp_host.to_string())
+        .map_err(|_| Error::Other("SMTP TLS configuration failed before submission".into()))?;
+    let implicit_tls = uses_implicit_tls(smtp_port, use_tls);
+    if implicit_tls {
         log::debug!("SMTP using implicit TLS on port {}", smtp_port);
-        AsyncSmtpTransport::<Tokio1Executor>::relay(smtp_host)
-            .map_err(|e| Error::Other(format!("SMTP TLS relay setup failed: {}", e)))?
-            .port(smtp_port)
-            .credentials(creds)
-            .authentication(auth_mechanisms)
-            .build()
     } else {
-        log::debug!("SMTP using STARTTLS (default) on port {}", smtp_port);
-        AsyncSmtpTransport::<Tokio1Executor>::starttls_relay(smtp_host)
-            .map_err(|e| Error::Other(format!("SMTP relay setup failed: {}", e)))?
-            .port(smtp_port)
-            .credentials(creds)
-            .authentication(auth_mechanisms)
-            .build()
-    };
-    Ok(transport)
+        log::debug!("SMTP using STARTTLS on port {}", smtp_port);
+    }
+
+    let mut connection = AsyncSmtpConnection::connect_tokio1(
+        (smtp_host, smtp_port),
+        Some(std::time::Duration::from_secs(60)),
+        &hello_name,
+        implicit_tls.then_some(tls_parameters.clone()),
+        None,
+    )
+    .await
+    .map_err(|error| definite_smtp_setup_error("connection", &error))?;
+
+    if !implicit_tls {
+        connection
+            .starttls(tls_parameters, &hello_name)
+            .await
+            .map_err(|error| definite_smtp_setup_error("STARTTLS", &error))?;
+    }
+    connection
+        .auth(&auth_mechanisms, &creds)
+        .await
+        .map_err(|error| definite_smtp_setup_error("authentication", &error))?;
+    Ok(connection)
 }
 
-/// Parse an address string ("user@host" or "Name <user@host>") into a
-/// lettre `Address` (just the addr-spec; display name is dropped because
-/// the envelope is only the addr-spec per RFC 5321 §3.6.1).
-fn parse_address(addr: &str) -> Result<Address> {
-    let trimmed = addr.trim();
-    // If it's in `Name <user@host>` form, extract the bracketed addr-spec.
-    let addr_spec = if let (Some(lt), Some(gt)) = (trimmed.find('<'), trimmed.rfind('>')) {
-        if lt < gt {
-            trimmed[lt + 1..gt].trim()
-        } else {
-            trimmed
+fn uses_implicit_tls(smtp_port: u16, use_tls: bool) -> bool {
+    smtp_port != 587 && (use_tls || smtp_port == 465)
+}
+
+fn definite_smtp_setup_error(stage: &str, error: &lettre::transport::smtp::Error) -> Error {
+    match error.status().map(u16::from) {
+        Some(code) => Error::Other(format!(
+            "SMTP {stage} rejected with status {code} before submission"
+        )),
+        None => Error::Other(format!("SMTP {stage} failed before submission")),
+    }
+}
+
+/// Parse one RFC 5322 mailbox. lettre's mailbox parser rejects some valid
+/// quoted local-parts, so mailparse provides the standards-aware fallback and
+/// lettre still performs final addr-spec validation.
+pub(crate) fn parse_mailbox(value: &str) -> Result<Mailbox> {
+    if let Ok(mailbox) = value.trim().parse::<Mailbox>() {
+        return Ok(mailbox);
+    }
+
+    if let Some((name, addr_spec)) = quoted_angle_mailbox(value) {
+        let email = validated_address(addr_spec)?;
+        return Ok(Mailbox::new(name, email));
+    }
+
+    if let Ok(email) = validated_address(value.trim()) {
+        return Ok(Mailbox::new(None, email));
+    }
+
+    let mailbox = mailparse::addrparse(value)
+        .ok()
+        .and_then(|addresses| addresses.extract_single_info())
+        .ok_or_else(|| Error::Other("Invalid mail address".into()))?;
+    let email = validated_address(&mailbox.addr)?;
+    Ok(Mailbox::new(mailbox.display_name, email))
+}
+
+fn validated_address(addr_spec: &str) -> Result<Address> {
+    if let Ok(address) = addr_spec.parse::<Address>() {
+        let domain = address.domain();
+        let untagged_ipv6 = domain
+            .strip_prefix('[')
+            .and_then(|domain| domain.strip_suffix(']'))
+            .is_some_and(|domain| domain.parse::<std::net::Ipv6Addr>().is_ok());
+        if !untagged_ipv6 {
+            return Ok(address);
         }
+        return Err(Error::Other("Invalid mail address".into()));
+    }
+
+    let (local, domain) = addr_spec
+        .rsplit_once('@')
+        .ok_or_else(|| Error::Other("Invalid mail address".into()))?;
+    let literal = domain
+        .strip_prefix('[')
+        .and_then(|domain| domain.strip_suffix(']'))
+        .ok_or_else(|| Error::Other("Invalid mail address".into()))?;
+    let (tag, address) = literal
+        .split_once(':')
+        .ok_or_else(|| Error::Other("Invalid mail address".into()))?;
+    if !tag.eq_ignore_ascii_case("IPv6") {
+        return Err(Error::Other("Invalid mail address".into()));
+    }
+    let address = address
+        .parse::<std::net::Ipv6Addr>()
+        .map_err(|_| Error::Other("Invalid mail address".into()))?;
+
+    // lettre can validate the same local part only with its non-standard
+    // untagged IPv6 spelling. After that validation, retain the RFC 5321/5322
+    // `IPv6:` tag in the safely constructed address.
+    Address::new(local, format!("[{address}]"))
+        .map_err(|_| Error::Other("Invalid mail address".into()))?;
+    Ok(Address::new_dangerous(local, domain))
+}
+
+fn quoted_angle_mailbox(value: &str) -> Option<(Option<String>, &str)> {
+    let mut quoted = false;
+    let mut escaped = false;
+    let mut left = None;
+    let mut right = None;
+
+    for (index, ch) in value.char_indices() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+        if quoted && ch == '\\' {
+            escaped = true;
+            continue;
+        }
+        if ch == '"' {
+            quoted = !quoted;
+            continue;
+        }
+        if quoted {
+            continue;
+        }
+        match (ch, left) {
+            ('<', None) => left = Some(index),
+            ('>', Some(_)) => {
+                right = Some(index);
+                break;
+            }
+            _ => {}
+        }
+    }
+
+    let (left, right) = (left?, right?);
+    if quoted || !value[right + 1..].trim().is_empty() {
+        return None;
+    }
+    let addr_spec = value[left + 1..right].trim();
+    if addr_spec.is_empty() {
+        return None;
+    }
+    let raw_name = value[..left].trim();
+    if raw_name.chars().any(char::is_control) {
+        return None;
+    }
+    let name = if raw_name.is_empty() {
+        None
+    } else if let Some(inner) = raw_name
+        .strip_prefix('"')
+        .and_then(|name| name.strip_suffix('"'))
+    {
+        let mut name = String::with_capacity(inner.len());
+        let mut chars = inner.chars();
+        while let Some(ch) = chars.next() {
+            name.push(if ch == '\\' { chars.next()? } else { ch });
+        }
+        Some(name)
     } else {
-        trimmed
+        Some(raw_name.to_string())
     };
-    addr_spec
-        .parse::<Address>()
-        .map_err(|e| Error::Other(format!("Invalid SMTP address '{}': {}", addr, e)))
+    Some((name, addr_spec))
+}
+
+/// Parse a mailbox into the addr-spec used by the SMTP envelope.
+fn parse_address(value: &str) -> Result<Address> {
+    parse_mailbox(value)
+        .map(|mailbox| mailbox.email)
+        .map_err(|error| Error::Other(format!("Invalid SMTP address '{value}': {error}")))
+}
+
+/// Lettre exposes an SMTP status only for a 4xx/5xx negative reply. Such a
+/// reply definitively rejects the attempt; any other error after entering
+/// `send_raw` can race with server acceptance and is therefore indeterminate.
+fn classify_send_error(status: Option<u16>, client_error: bool) -> Error {
+    match status.filter(|code| (400..600).contains(code)) {
+        Some(code) => Error::Other(format!(
+            "SMTP server rejected the message with status {}",
+            code
+        )),
+        None if client_error => Error::Other("SMTP rejected the message before submission".into()),
+        None => Error::IndeterminateDelivery,
+    }
 }
 
 /// Send a previously-built RFC 5322 message via SMTP.
@@ -162,8 +307,13 @@ pub async fn send_raw(
 ) -> Result<()> {
     let from_addr = parse_address(from)?;
     let mut recipients: Vec<Address> = Vec::with_capacity(to.len() + cc.len() + bcc.len());
-    for addr in to.iter().chain(cc.iter()).chain(bcc.iter()) {
-        recipients.push(parse_address(addr)?);
+    for (position, addr) in to.iter().chain(cc.iter()).chain(bcc.iter()).enumerate() {
+        recipients.push(parse_address(addr).map_err(|_| {
+            Error::Other(format!(
+                "Invalid SMTP envelope recipient at position {}",
+                position + 1
+            ))
+        })?);
     }
     if recipients.is_empty() {
         return Err(Error::Other(
@@ -182,27 +332,31 @@ pub async fn send_raw(
         smtp_port
     );
 
-    let transport = build_transport(
+    let mut connection = connect_smtp(
         smtp_host,
         smtp_port,
         username,
         password,
         use_tls,
         use_xoauth2,
-    )?;
-    let response = transport
-        .send_raw(&envelope, raw_message)
-        .await
-        .map_err(|e| {
-            log::error!("SMTP send_raw failed: {}", e);
-            Error::Other(format!("SMTP send_raw failed: {}", e))
-        })?;
+    )
+    .await?;
+    let response = connection.send(&envelope, raw_message).await.map_err(|e| {
+        let status = e.status().map(u16::from);
+        if let Some(code) = status {
+            log::error!("SMTP send_raw rejected with status {}", code);
+        } else if e.is_client() {
+            log::error!("SMTP send_raw rejected locally before submission");
+        } else {
+            log::error!(
+                "SMTP send_raw failed without a negative reply; delivery outcome is unknown"
+            );
+        }
+        classify_send_error(status, e.is_client())
+    })?;
 
-    log::info!(
-        "SMTP send_raw success: {} (code {})",
-        response.message().collect::<Vec<_>>().join(", "),
-        response.code()
-    );
+    let _ = connection.quit().await;
+    log::info!("SMTP send_raw success (code {})", response.code());
     Ok(())
 }
 
@@ -229,9 +383,8 @@ pub fn build_raw_message(
     in_reply_to: Option<&str>,
     references: &[String],
 ) -> Result<Vec<u8>> {
-    let from_mailbox: Mailbox = from
-        .parse()
-        .map_err(|e| Error::Other(format!("Invalid 'from' address '{}': {}", from, e)))?;
+    let from_mailbox =
+        parse_mailbox(from).map_err(|_| Error::Other("Invalid message From address".into()))?;
 
     // Always emit a Message-ID. Lettre's `build()` does NOT add one
     // automatically, so without this our outgoing replies have no
@@ -244,22 +397,31 @@ pub fn build_raw_message(
         .subject(subject)
         .message_id(Some(message_id));
 
-    for addr in to {
-        let mailbox: Mailbox = addr
-            .parse()
-            .map_err(|e| Error::Other(format!("Invalid 'to' address '{}': {}", addr, e)))?;
+    for (index, addr) in to.iter().enumerate() {
+        let mailbox = parse_mailbox(addr).map_err(|_| {
+            Error::Other(format!(
+                "Invalid message To address at position {}",
+                index + 1
+            ))
+        })?;
         builder = builder.to(mailbox);
     }
-    for addr in cc {
-        let mailbox: Mailbox = addr
-            .parse()
-            .map_err(|e| Error::Other(format!("Invalid 'cc' address '{}': {}", addr, e)))?;
+    for (index, addr) in cc.iter().enumerate() {
+        let mailbox = parse_mailbox(addr).map_err(|_| {
+            Error::Other(format!(
+                "Invalid message Cc address at position {}",
+                index + 1
+            ))
+        })?;
         builder = builder.cc(mailbox);
     }
-    for addr in bcc {
-        let mailbox: Mailbox = addr
-            .parse()
-            .map_err(|e| Error::Other(format!("Invalid 'bcc' address '{}': {}", addr, e)))?;
+    for (index, addr) in bcc.iter().enumerate() {
+        let mailbox = parse_mailbox(addr).map_err(|_| {
+            Error::Other(format!(
+                "Invalid message Bcc address at position {}",
+                index + 1
+            ))
+        })?;
         builder = builder.bcc(mailbox);
     }
 
@@ -682,6 +844,63 @@ pub fn insert_header_before_body(raw: &[u8], header_line: &str) -> Vec<u8> {
             out
         }
         None => raw.to_vec(),
+    }
+}
+
+#[cfg(test)]
+mod send_error_tests {
+    use super::*;
+
+    #[test]
+    fn negative_replies_are_definite_and_missing_status_is_indeterminate() {
+        for code in [421, 450, 500, 550] {
+            let error = classify_send_error(Some(code), false);
+            assert!(matches!(error, Error::Other(_)));
+            assert!(!error.is_indeterminate_delivery());
+            assert_eq!(
+                error.to_string(),
+                format!("SMTP server rejected the message with status {code}")
+            );
+        }
+
+        for status in [None, Some(250), Some(600)] {
+            let error = classify_send_error(status, false);
+            assert!(error.is_indeterminate_delivery());
+            assert_eq!(error.to_string(), "Delivery outcome is unknown");
+        }
+
+        let client_error = classify_send_error(None, true);
+        assert!(!client_error.is_indeterminate_delivery());
+        assert_eq!(
+            client_error.to_string(),
+            "SMTP rejected the message before submission"
+        );
+    }
+
+    #[test]
+    fn port_587_always_uses_starttls() {
+        assert!(!uses_implicit_tls(587, false));
+        assert!(!uses_implicit_tls(587, true));
+        assert!(uses_implicit_tls(465, false));
+        assert!(uses_implicit_tls(465, true));
+        assert!(!uses_implicit_tls(25, false));
+        assert!(uses_implicit_tls(2525, true));
+    }
+
+    #[test]
+    fn mailbox_parser_accepts_quoted_local_parts_and_address_literals() {
+        for value in [
+            r#""Recipient, Bob" <bob@example.com>"#,
+            r#"Quoted Local <"quoted local"@example.com>"#,
+            r#"Angle <"a>b"@example.com>"#,
+            "literal@[192.0.2.1]",
+            "ipv6@[IPv6:2001:db8::1]",
+        ] {
+            parse_mailbox(value)
+                .unwrap_or_else(|error| panic!("valid mailbox {value:?} was rejected: {error}"));
+        }
+
+        assert!(parse_mailbox("ipv6@[2001:db8::1]").is_err());
     }
 }
 

--- a/src-tauri/src/mail/smtp.rs
+++ b/src-tauri/src/mail/smtp.rs
@@ -1,11 +1,18 @@
+use std::time::Duration;
+
 use lettre::address::Envelope;
 use lettre::message::{header::ContentType, Attachment, Mailbox, MultiPart, SinglePart};
 use lettre::transport::smtp::authentication::{Credentials, Mechanism};
 use lettre::transport::smtp::client::{AsyncSmtpConnection, TlsParameters};
 use lettre::transport::smtp::extension::ClientId;
+use lettre::transport::smtp::response::{Code, Response, Severity};
+use lettre::transport::smtp::Error as SmtpError;
 use lettre::{Address, Message};
 
 use crate::error::{Error, Result};
+
+const SMTP_SEND_TIMEOUT: Duration = Duration::from_secs(5 * 60);
+const SMTP_QUIT_TIMEOUT: Duration = Duration::from_secs(1);
 
 /// Attachment data ready to embed in a message.
 pub struct AttachmentData {
@@ -284,6 +291,68 @@ fn classify_send_error(status: Option<u16>, client_error: bool) -> Error {
     }
 }
 
+async fn await_smtp_send(
+    send: impl std::future::Future<Output = std::result::Result<Response, SmtpError>>,
+    max_wait: Duration,
+) -> Result<Response> {
+    match tokio::time::timeout(max_wait, send).await {
+        Ok(Ok(response)) => Ok(response),
+        Ok(Err(error)) => {
+            let status = error.status().map(u16::from);
+            if let Some(code) = status {
+                log::error!("SMTP send_raw rejected with status {}", code);
+            } else if error.is_client() {
+                log::error!("SMTP send_raw rejected locally before submission");
+            } else {
+                log::error!(
+                    "SMTP send_raw failed without a negative reply; delivery outcome is unknown"
+                );
+            }
+            Err(classify_send_error(status, error.is_client()))
+        }
+        Err(_) => {
+            log::error!(
+                "SMTP send_raw timed out after {} ms; delivery outcome is unknown",
+                max_wait.as_millis()
+            );
+            Err(Error::IndeterminateDelivery)
+        }
+    }
+}
+
+fn validate_smtp_completion(code: Code) -> Result<u16> {
+    let status = u16::from(code);
+    if code.severity != Severity::PositiveCompletion {
+        log::error!(
+            "SMTP send_raw returned status {}; delivery outcome is unknown",
+            status
+        );
+        return Err(Error::IndeterminateDelivery);
+    }
+    Ok(status)
+}
+
+async fn await_smtp_quit<F, T, E>(quit: F, max_wait: Duration) -> bool
+where
+    F: std::future::Future<Output = std::result::Result<T, E>>,
+    E: std::fmt::Display,
+{
+    match tokio::time::timeout(max_wait, quit).await {
+        Ok(Ok(_)) => true,
+        Ok(Err(error)) => {
+            log::warn!("SMTP QUIT failed after accepted delivery: {}", error);
+            false
+        }
+        Err(_) => {
+            log::warn!(
+                "SMTP QUIT timed out after accepted delivery ({} ms)",
+                max_wait.as_millis()
+            );
+            false
+        }
+    }
+}
+
 /// Send a previously-built RFC 5322 message via SMTP.
 ///
 /// `commands::compose::send_message` and outbox retries pass the final
@@ -341,22 +410,12 @@ pub async fn send_raw(
         use_xoauth2,
     )
     .await?;
-    let response = connection.send(&envelope, raw_message).await.map_err(|e| {
-        let status = e.status().map(u16::from);
-        if let Some(code) = status {
-            log::error!("SMTP send_raw rejected with status {}", code);
-        } else if e.is_client() {
-            log::error!("SMTP send_raw rejected locally before submission");
-        } else {
-            log::error!(
-                "SMTP send_raw failed without a negative reply; delivery outcome is unknown"
-            );
-        }
-        classify_send_error(status, e.is_client())
-    })?;
+    let response =
+        await_smtp_send(connection.send(&envelope, raw_message), SMTP_SEND_TIMEOUT).await?;
 
-    let _ = connection.quit().await;
-    log::info!("SMTP send_raw success (code {})", response.code());
+    let status = validate_smtp_completion(response.code())?;
+    await_smtp_quit(connection.quit(), SMTP_QUIT_TIMEOUT).await;
+    log::info!("SMTP send_raw success (code {})", status);
     Ok(())
 }
 
@@ -850,6 +909,7 @@ pub fn insert_header_before_body(raw: &[u8], header_line: &str) -> Vec<u8> {
 #[cfg(test)]
 mod send_error_tests {
     use super::*;
+    use lettre::transport::smtp::response::{Category, Detail};
 
     #[test]
     fn negative_replies_are_definite_and_missing_status_is_indeterminate() {
@@ -875,6 +935,60 @@ mod send_error_tests {
             client_error.to_string(),
             "SMTP rejected the message before submission"
         );
+    }
+
+    #[test]
+    fn positive_completion_is_accepted() {
+        let code = Code::new(
+            Severity::PositiveCompletion,
+            Category::MailSystem,
+            Detail::Zero,
+        );
+
+        assert_eq!(validate_smtp_completion(code).unwrap(), 250);
+    }
+
+    #[test]
+    fn positive_intermediate_is_indeterminate() {
+        let code = Code::new(
+            Severity::PositiveIntermediate,
+            Category::MailSystem,
+            Detail::Four,
+        );
+
+        let error = validate_smtp_completion(code).unwrap_err();
+        assert!(error.is_indeterminate_delivery());
+    }
+
+    #[tokio::test]
+    async fn smtp_send_is_bounded_and_timeout_is_indeterminate() {
+        assert_eq!(SMTP_SEND_TIMEOUT, Duration::from_secs(5 * 60));
+
+        let result = tokio::time::timeout(
+            Duration::from_secs(1),
+            await_smtp_send(
+                std::future::pending::<std::result::Result<Response, SmtpError>>(),
+                Duration::ZERO,
+            ),
+        )
+        .await
+        .expect("SMTP send timeout helper did not return within its bound");
+
+        let error = result.unwrap_err();
+        assert!(error.is_indeterminate_delivery());
+    }
+
+    #[tokio::test]
+    async fn smtp_quit_is_bounded() {
+        assert_eq!(SMTP_QUIT_TIMEOUT, Duration::from_secs(1));
+
+        let completed = await_smtp_quit(
+            std::future::pending::<std::result::Result<(), &'static str>>(),
+            Duration::ZERO,
+        )
+        .await;
+
+        assert!(!completed);
     }
 
     #[test]

--- a/src-tauri/src/ops/offline.rs
+++ b/src-tauri/src/ops/offline.rs
@@ -5,6 +5,18 @@ use crate::message::BackendMessageRef;
 use crate::ops::flags::{remove_deleted_refs, subtract_flag_mutation, FlagMutation, FlagTarget};
 use crate::ops::queue::MailOp;
 
+pub const INDETERMINATE_DELIVERY_ERROR_MESSAGE: &str =
+    "Delivery outcome is unknown; automatic retry disabled to avoid duplicate delivery. Verify delivery before retrying manually.";
+
+const STUCK_SENDING_ERROR_MESSAGE: &str =
+    "Delivery outcome is unknown after app restart; automatic retry disabled to avoid duplicate delivery. Verify delivery before retrying manually.";
+
+const MAX_SEND_ERROR_MESSAGE_BYTES: usize = 256;
+
+pub fn is_indeterminate_delivery_error_message(message: &str) -> bool {
+    message == INDETERMINATE_DELIVERY_ERROR_MESSAGE || message == STUCK_SENDING_ERROR_MESSAGE
+}
+
 /// Replay order matching operation dependencies:
 /// flags (0) -> copies (1) -> moves (2) -> deletes (3).
 /// Copies precede moves because moving an IMAP message invalidates its source UID.
@@ -83,29 +95,101 @@ pub fn queue_dead_op(
     Ok(conn.last_insert_rowid())
 }
 
-/// Flip a 'sending' row back to 'pending' so the worker will retry it
-/// on the next sync.
-pub fn mark_pending(conn: &Connection, outbox_id: i64) -> Result<()> {
-    conn.execute(
-        "UPDATE outbox SET status = 'pending' WHERE id = ?1",
-        rusqlite::params![outbox_id],
-    )
-    .map_err(Error::Database)?;
-    Ok(())
+/// Atomically claim a pending send before replaying it. A false result means
+/// the snapshot is stale or another actor already claimed or removed the row.
+pub fn claim_pending_send(
+    conn: &Connection,
+    outbox_id: i64,
+    expected_retry_count: i32,
+) -> Result<bool> {
+    let changed = conn
+        .execute(
+            "UPDATE outbox SET status = 'sending'
+             WHERE id = ?1 AND action_type = 'send' AND status = 'pending'
+               AND retry_count = ?2",
+            rusqlite::params![outbox_id, expected_retry_count],
+        )
+        .map_err(Error::Database)?;
+    Ok(changed == 1)
 }
 
-/// On app startup, revive any rows left as 'sending' from a previous run.
-/// The owning task is gone, so the message would otherwise be invisible
-/// to both the user and the worker. Returns how many rows were revived.
-pub fn revive_stuck_sending(conn: &Connection) -> Result<usize> {
+/// Delete a successfully delivered send only while its claim is still held.
+pub fn complete_sending_send(conn: &Connection, outbox_id: i64) -> Result<bool> {
+    let changed = conn
+        .execute(
+            "DELETE FROM outbox
+             WHERE id = ?1 AND action_type = 'send' AND status = 'sending'",
+            rusqlite::params![outbox_id],
+        )
+        .map_err(Error::Database)?;
+    Ok(changed == 1)
+}
+
+/// Record a definite send failure and atomically release its claim for replay.
+pub fn retry_sending_send(conn: &Connection, outbox_id: i64, error: &str) -> Result<bool> {
+    let error = bounded_send_error(error);
+    let changed = conn
+        .execute(
+            "UPDATE outbox
+             SET status = 'pending', retry_count = retry_count + 1,
+                 error_message = ?1
+             WHERE id = ?2 AND action_type = 'send' AND status = 'sending'",
+            rusqlite::params![error, outbox_id],
+        )
+        .map_err(Error::Database)?;
+    Ok(changed == 1)
+}
+
+/// Quarantine a claimed send after an ambiguous outcome. The explanation is
+/// byte-bounded before persistence and the row can only move from sending.
+pub fn quarantine_sending_send(conn: &Connection, outbox_id: i64, error: &str) -> Result<bool> {
+    quarantine_send_from_status(conn, outbox_id, "sending", error)
+}
+
+/// Quarantine an unclaimed send without disturbing a concurrently claimed
+/// row. Used for retry exhaustion and invalid persisted payloads.
+pub fn quarantine_pending_send(conn: &Connection, outbox_id: i64, error: &str) -> Result<bool> {
+    quarantine_send_from_status(conn, outbox_id, "pending", error)
+}
+
+fn quarantine_send_from_status(
+    conn: &Connection,
+    outbox_id: i64,
+    expected_status: &str,
+    error: &str,
+) -> Result<bool> {
+    let error = bounded_send_error(error);
+    let changed = conn
+        .execute(
+            "UPDATE outbox SET status = 'dead', error_message = ?1
+             WHERE id = ?2 AND action_type = 'send' AND status = ?3",
+            rusqlite::params![error, outbox_id, expected_status],
+        )
+        .map_err(Error::Database)?;
+    Ok(changed == 1)
+}
+
+fn bounded_send_error(error: &str) -> &str {
+    let mut end = error.len().min(MAX_SEND_ERROR_MESSAGE_BYTES);
+    while !error.is_char_boundary(end) {
+        end -= 1;
+    }
+    &error[..end]
+}
+
+/// On app startup, quarantine rows left as 'sending' by a previous run.
+/// The owning task is gone and delivery may already have occurred, so an
+/// automatic retry could create a duplicate. Returns the quarantined count.
+pub fn quarantine_stuck_sending(conn: &Connection) -> Result<usize> {
     let count = conn
         .execute(
-            "UPDATE outbox SET status = 'pending' WHERE status = 'sending'",
-            [],
+            "UPDATE outbox SET status = 'dead', error_message = ?1
+             WHERE action_type = 'send' AND status = 'sending'",
+            rusqlite::params![STUCK_SENDING_ERROR_MESSAGE],
         )
         .map_err(Error::Database)?;
     if count > 0 {
-        log::info!("Revived {} outbox row(s) stuck in 'sending'", count);
+        log::warn!("Quarantined {} outbox row(s) stuck in 'sending'", count);
     }
     Ok(count)
 }
@@ -145,41 +229,43 @@ pub fn get_pending_ops(conn: &Connection, account_id: &str) -> Result<Vec<Outbox
     Ok(entries)
 }
 
-/// Mark an outbox entry as completed (will be deleted).
+/// Mark a non-send outbox entry as completed (will be deleted).
 pub fn mark_completed(conn: &Connection, outbox_id: i64) -> Result<()> {
     conn.execute(
-        "DELETE FROM outbox WHERE id = ?1",
+        "DELETE FROM outbox WHERE id = ?1 AND action_type != 'send'",
         rusqlite::params![outbox_id],
     )
     .map_err(Error::Database)?;
     Ok(())
 }
 
-/// Mark an outbox entry as failed, incrementing retry count.
+/// Mark a non-send outbox entry as failed, incrementing retry count.
 pub fn mark_failed(conn: &Connection, outbox_id: i64, error: &str) -> Result<()> {
     conn.execute(
         "UPDATE outbox SET retry_count = retry_count + 1, error_message = ?1
-         WHERE id = ?2",
+         WHERE id = ?2 AND action_type != 'send'",
         rusqlite::params![error, outbox_id],
     )
     .map_err(Error::Database)?;
     Ok(())
 }
 
-/// Mark an outbox entry as dead (too many retries).
+/// Mark a non-send outbox entry as dead (too many retries).
 pub fn mark_dead(conn: &Connection, outbox_id: i64) -> Result<()> {
     conn.execute(
-        "UPDATE outbox SET status = 'dead' WHERE id = ?1",
+        "UPDATE outbox SET status = 'dead'
+         WHERE id = ?1 AND action_type != 'send'",
         rusqlite::params![outbox_id],
     )
     .map_err(Error::Database)?;
     Ok(())
 }
 
-/// Mark an operation with an unrecoverable payload as dead.
-pub fn mark_invalid(conn: &Connection, outbox_id: i64, error: &str) -> Result<()> {
+/// Mark a non-send operation dead with a user-visible explanation.
+pub fn mark_dead_with_error(conn: &Connection, outbox_id: i64, error: &str) -> Result<()> {
     conn.execute(
-        "UPDATE outbox SET status = 'dead', error_message = ?1 WHERE id = ?2",
+        "UPDATE outbox SET status = 'dead', error_message = ?1
+         WHERE id = ?2 AND action_type != 'send'",
         rusqlite::params![error, outbox_id],
     )
     .map_err(Error::Database)?;
@@ -889,13 +975,13 @@ mod tests {
         conn
     }
 
-    fn row_state(conn: &Connection, id: i64) -> (String, i32, Option<String>) {
+    fn row_state(conn: &Connection, id: i64) -> Option<(String, i32, Option<String>)> {
         conn.query_row(
             "SELECT status, retry_count, error_message FROM outbox WHERE id = ?1",
             rusqlite::params![id],
             |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
         )
-        .unwrap()
+        .ok()
     }
 
     #[test]
@@ -970,11 +1056,11 @@ mod tests {
     fn invalid_payload_is_marked_dead_with_an_error() {
         let conn = setup_db();
         let id = queue_offline_op(&conn, "acc1", "delete", &serde_json::json!({})).unwrap();
-        mark_invalid(&conn, id, "invalid delete payload").unwrap();
+        mark_dead_with_error(&conn, id, "invalid delete payload").unwrap();
 
         assert_eq!(
             row_state(&conn, id),
-            ("dead".into(), 0, Some("invalid delete payload".into()))
+            Some(("dead".into(), 0, Some("invalid delete payload".into())))
         );
     }
 
@@ -993,8 +1079,172 @@ mod tests {
         assert!(get_pending_ops(&conn, "acc1").unwrap().is_empty());
         assert_eq!(
             row_state(&conn, id),
-            ("dead".into(), 0, Some("ambiguous copy outcome".into()))
+            Some(("dead".into(), 0, Some("ambiguous copy outcome".into())))
         );
+    }
+
+    #[test]
+    fn send_claim_rejects_stale_and_non_send_rows() {
+        let conn = setup_db();
+        let send_id = queue_offline_op(&conn, "acc1", "send", &serde_json::json!({})).unwrap();
+        let dead_id =
+            queue_offline_op_with_status(&conn, "acc1", "send", &serde_json::json!({}), "dead")
+                .unwrap();
+        let non_send_id = queue_offline_op(&conn, "acc1", "move", &serde_json::json!({})).unwrap();
+        let discarded_id = queue_offline_op(&conn, "acc1", "send", &serde_json::json!({})).unwrap();
+        let changed_retry_id =
+            queue_offline_op(&conn, "acc1", "send", &serde_json::json!({})).unwrap();
+        mark_failed(&conn, changed_retry_id, "legacy helper cannot change send").unwrap();
+        conn.execute(
+            "UPDATE outbox SET retry_count = 1 WHERE id = ?1",
+            rusqlite::params![changed_retry_id],
+        )
+        .unwrap();
+        conn.execute(
+            "DELETE FROM outbox WHERE id = ?1 AND status = 'pending'",
+            rusqlite::params![discarded_id],
+        )
+        .unwrap();
+
+        assert!(claim_pending_send(&conn, send_id, 0).unwrap());
+        assert_eq!(row_state(&conn, send_id).unwrap().0, "sending");
+        assert!(!claim_pending_send(&conn, send_id, 0).unwrap());
+        assert!(!claim_pending_send(&conn, dead_id, 0).unwrap());
+        assert!(!claim_pending_send(&conn, non_send_id, 0).unwrap());
+        assert!(!claim_pending_send(&conn, discarded_id, 0).unwrap());
+        assert!(!claim_pending_send(&conn, changed_retry_id, 0).unwrap());
+        assert!(claim_pending_send(&conn, changed_retry_id, 1).unwrap());
+    }
+
+    #[test]
+    fn legacy_non_send_transitions_cannot_mutate_send_rows() {
+        let conn = setup_db();
+        let id = queue_offline_op(&conn, "acc1", "send", &serde_json::json!({})).unwrap();
+
+        mark_completed(&conn, id).unwrap();
+        mark_failed(&conn, id, "failure").unwrap();
+        mark_dead(&conn, id).unwrap();
+        mark_dead_with_error(&conn, id, "dead").unwrap();
+
+        assert_eq!(row_state(&conn, id), Some(("pending".into(), 0, None)));
+    }
+
+    #[test]
+    fn pending_send_quarantine_does_not_override_a_claim() {
+        let conn = setup_db();
+        let pending = queue_offline_op(&conn, "acc1", "send", &serde_json::json!({})).unwrap();
+        let claimed = queue_offline_op(&conn, "acc1", "send", &serde_json::json!({})).unwrap();
+        assert!(claim_pending_send(&conn, claimed, 0).unwrap());
+
+        assert!(quarantine_pending_send(&conn, pending, "invalid payload").unwrap());
+        assert!(!quarantine_pending_send(&conn, claimed, "stale snapshot").unwrap());
+        assert_eq!(row_state(&conn, pending).unwrap().0, "dead");
+        assert_eq!(row_state(&conn, claimed).unwrap().0, "sending");
+    }
+
+    #[test]
+    fn send_completion_deletes_only_a_claimed_send() {
+        let conn = setup_db();
+        let send_id = queue_offline_op(&conn, "acc1", "send", &serde_json::json!({})).unwrap();
+        let non_send_id =
+            queue_offline_op_with_status(&conn, "acc1", "move", &serde_json::json!({}), "sending")
+                .unwrap();
+
+        assert!(!complete_sending_send(&conn, send_id).unwrap());
+        assert!(claim_pending_send(&conn, send_id, 0).unwrap());
+        assert!(complete_sending_send(&conn, send_id).unwrap());
+        assert!(row_state(&conn, send_id).is_none());
+        assert!(!complete_sending_send(&conn, send_id).unwrap());
+        assert!(!complete_sending_send(&conn, non_send_id).unwrap());
+        assert_eq!(row_state(&conn, non_send_id).unwrap().0, "sending");
+    }
+
+    #[test]
+    fn definite_send_failure_atomically_releases_claim_and_increments_retry() {
+        let conn = setup_db();
+        let id = queue_offline_op(&conn, "acc1", "send", &serde_json::json!({})).unwrap();
+
+        assert!(!retry_sending_send(&conn, id, "definite rejection").unwrap());
+        assert!(claim_pending_send(&conn, id, 0).unwrap());
+        assert!(retry_sending_send(&conn, id, "definite rejection").unwrap());
+        assert_eq!(
+            row_state(&conn, id),
+            Some(("pending".into(), 1, Some("definite rejection".into())))
+        );
+        assert!(!retry_sending_send(&conn, id, "second failure").unwrap());
+        assert_eq!(row_state(&conn, id).unwrap().1, 1);
+    }
+
+    #[test]
+    fn indeterminate_send_atomically_quarantines_with_bounded_error() {
+        let conn = setup_db();
+        let id = queue_offline_op(&conn, "acc1", "send", &serde_json::json!({})).unwrap();
+        assert!(claim_pending_send(&conn, id, 0).unwrap());
+
+        let long_error = format!("Delivery outcome is unknown: {}", "é".repeat(512));
+        assert!(quarantine_sending_send(&conn, id, &long_error).unwrap());
+        let state = row_state(&conn, id).unwrap();
+        assert_eq!(state.0, "dead");
+        let stored = state.2.unwrap();
+        assert!(stored.starts_with("Delivery outcome is unknown"));
+        assert!(stored.len() <= MAX_SEND_ERROR_MESSAGE_BYTES);
+        assert!(!quarantine_sending_send(&conn, id, "again").unwrap());
+    }
+
+    #[test]
+    fn failed_send_transition_leaves_the_claim_held() {
+        let conn = setup_db();
+        let id = queue_offline_op(&conn, "acc1", "send", &serde_json::json!({})).unwrap();
+        assert!(claim_pending_send(&conn, id, 0).unwrap());
+        conn.execute_batch(
+            "CREATE TRIGGER reject_send_transition
+             BEFORE UPDATE OF status ON outbox
+             WHEN OLD.status = 'sending'
+             BEGIN
+                 SELECT RAISE(ABORT, 'injected transition failure');
+             END;",
+        )
+        .unwrap();
+
+        assert!(retry_sending_send(&conn, id, "definite rejection").is_err());
+        assert!(quarantine_sending_send(&conn, id, "unknown").is_err());
+        assert_eq!(row_state(&conn, id), Some(("sending".into(), 0, None)));
+
+        conn.execute_batch(
+            "DROP TRIGGER reject_send_transition;
+             CREATE TRIGGER reject_send_completion
+             BEFORE DELETE ON outbox
+             WHEN OLD.status = 'sending'
+             BEGIN
+                 SELECT RAISE(ABORT, 'injected completion failure');
+             END;",
+        )
+        .unwrap();
+        assert!(complete_sending_send(&conn, id).is_err());
+        assert_eq!(row_state(&conn, id), Some(("sending".into(), 0, None)));
+    }
+
+    #[test]
+    fn stuck_sending_rows_are_quarantined_as_dead() {
+        let conn = setup_db();
+        let sending_id =
+            queue_offline_op_with_status(&conn, "acc1", "send", &serde_json::json!({}), "sending")
+                .unwrap();
+        let pending_id = queue_offline_op(&conn, "acc1", "send", &serde_json::json!({})).unwrap();
+
+        assert_eq!(quarantine_stuck_sending(&conn).unwrap(), 1);
+        assert_eq!(quarantine_stuck_sending(&conn).unwrap(), 0);
+
+        assert_eq!(
+            row_state(&conn, sending_id),
+            Some(("dead".into(), 0, Some(STUCK_SENDING_ERROR_MESSAGE.into())))
+        );
+        assert!(STUCK_SENDING_ERROR_MESSAGE.len() <= 256);
+        assert!(INDETERMINATE_DELIVERY_ERROR_MESSAGE.len() <= 256);
+
+        let pending = get_pending_ops(&conn, "acc1").unwrap();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].id, pending_id);
     }
 
     #[test]
@@ -1006,7 +1256,7 @@ mod tests {
 
         assert_eq!(
             row_state(&conn, id),
-            ("pending".into(), 2, Some("network error".into()))
+            Some(("pending".into(), 2, Some("network error".into())))
         );
     }
 
@@ -1023,7 +1273,7 @@ mod tests {
         mark_dead(&conn, id).unwrap();
         assert_eq!(
             row_state(&conn, id),
-            ("dead".into(), 5, Some("timeout".into()))
+            Some(("dead".into(), 5, Some("timeout".into())))
         );
         // Should no longer be in pending
         let pending = get_pending_ops(&conn, "acc1").unwrap();

--- a/src-tauri/src/ops/offline.rs
+++ b/src-tauri/src/ops/offline.rs
@@ -12,6 +12,7 @@ const STUCK_SENDING_ERROR_MESSAGE: &str =
     "Delivery outcome is unknown after app restart; automatic retry disabled to avoid duplicate delivery. Verify delivery before retrying manually.";
 
 const MAX_SEND_ERROR_MESSAGE_BYTES: usize = 256;
+const MAX_RETRIES: i32 = 5;
 
 pub fn is_indeterminate_delivery_error_message(message: &str) -> bool {
     message == INDETERMINATE_DELIVERY_ERROR_MESSAGE || message == STUCK_SENDING_ERROR_MESSAGE
@@ -125,19 +126,65 @@ pub fn complete_sending_send(conn: &Connection, outbox_id: i64) -> Result<bool> 
     Ok(changed == 1)
 }
 
-/// Record a definite send failure and atomically release its claim for replay.
-pub fn retry_sending_send(conn: &Connection, outbox_id: i64, error: &str) -> Result<bool> {
+/// Complete a delivered send before running any best-effort follow-up work.
+pub async fn complete_send_before<T, F, Fut>(
+    db: &crate::db::pool::DbPool,
+    outbox_id: i64,
+    after_completion: F,
+) -> Result<bool>
+where
+    F: FnOnce() -> Fut,
+    Fut: std::future::Future<Output = T>,
+{
+    let completed = {
+        let conn = db.writer().await;
+        complete_sending_send(&conn, outbox_id)?
+    };
+    if completed {
+        let _ = after_completion().await;
+    }
+    Ok(completed)
+}
+
+/// Durable disposition after recording a definite send failure.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SendRetryDisposition {
+    Pending,
+    Dead,
+    MissingClaim,
+}
+
+/// Record a definite send failure and atomically release or exhaust its claim.
+pub fn retry_sending_send(
+    conn: &Connection,
+    outbox_id: i64,
+    error: &str,
+) -> Result<SendRetryDisposition> {
     let error = bounded_send_error(error);
-    let changed = conn
-        .execute(
-            "UPDATE outbox
-             SET status = 'pending', retry_count = retry_count + 1,
-                 error_message = ?1
-             WHERE id = ?2 AND action_type = 'send' AND status = 'sending'",
-            rusqlite::params![error, outbox_id],
-        )
-        .map_err(Error::Database)?;
-    Ok(changed == 1)
+    let status = match conn.query_row(
+        "UPDATE outbox
+             SET retry_count = retry_count + 1,
+                 status = CASE
+                     WHEN retry_count + 1 >= ?1 THEN 'dead'
+                     ELSE 'pending'
+                 END,
+                 error_message = ?2
+             WHERE id = ?3 AND action_type = 'send' AND status = 'sending'
+             RETURNING status",
+        rusqlite::params![MAX_RETRIES, error, outbox_id],
+        |row| row.get::<_, String>(0),
+    ) {
+        Ok(status) => status,
+        Err(rusqlite::Error::QueryReturnedNoRows) => return Ok(SendRetryDisposition::MissingClaim),
+        Err(error) => return Err(Error::Database(error)),
+    };
+    match status.as_str() {
+        "pending" => Ok(SendRetryDisposition::Pending),
+        "dead" => Ok(SendRetryDisposition::Dead),
+        _ => Err(Error::Other(format!(
+            "Unexpected send retry disposition '{status}'"
+        ))),
+    }
 }
 
 /// Quarantine a claimed send after an ambiguous outcome. The explanation is
@@ -150,6 +197,26 @@ pub fn quarantine_sending_send(conn: &Connection, outbox_id: i64, error: &str) -
 /// row. Used for retry exhaustion and invalid persisted payloads.
 pub fn quarantine_pending_send(conn: &Connection, outbox_id: i64, error: &str) -> Result<bool> {
     quarantine_send_from_status(conn, outbox_id, "pending", error)
+}
+
+/// Mark a legacy pending send at the retry limit dead without replacing its
+/// last transport error. The fallback is used only if no error was persisted.
+pub fn exhaust_pending_send(
+    conn: &Connection,
+    outbox_id: i64,
+    fallback_error: &str,
+) -> Result<bool> {
+    let fallback_error = bounded_send_error(fallback_error);
+    let changed = conn
+        .execute(
+            "UPDATE outbox
+             SET status = 'dead', error_message = COALESCE(error_message, ?1)
+             WHERE id = ?2 AND action_type = 'send' AND status = 'pending'
+               AND retry_count >= ?3",
+            rusqlite::params![fallback_error, outbox_id, MAX_RETRIES],
+        )
+        .map_err(Error::Database)?;
+    Ok(changed == 1)
 }
 
 fn quarantine_send_from_status(
@@ -946,8 +1013,6 @@ pub fn outbox_to_mail_op(entry: &OutboxEntry) -> Option<MailOp> {
     }
 }
 
-const MAX_RETRIES: i32 = 5;
-
 /// Check if an entry has exceeded the retry limit.
 pub fn is_dead(entry: &OutboxEntry) -> bool {
     entry.retry_count >= MAX_RETRIES
@@ -957,6 +1022,7 @@ pub fn is_dead(entry: &OutboxEntry) -> bool {
 mod tests {
     use super::*;
     use crate::message::BackendMessageRef;
+    use std::sync::atomic::{AtomicBool, Ordering};
     fn setup_db() -> Connection {
         let conn = Connection::open_in_memory().unwrap();
         conn.execute_batch(
@@ -1159,20 +1225,131 @@ mod tests {
         assert_eq!(row_state(&conn, non_send_id).unwrap().0, "sending");
     }
 
+    #[tokio::test]
+    async fn completion_precedes_and_survives_failed_postprocess() {
+        let temp = tempfile::tempdir().unwrap();
+        let pool = crate::db::pool::DbPool::new(&temp.path().join("outbox.db"), 1).unwrap();
+        {
+            let conn = pool.writer().await;
+            conn.execute_batch(
+                "CREATE TABLE outbox (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    account_id TEXT NOT NULL,
+                    action_type TEXT NOT NULL,
+                    payload_json TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    retry_count INTEGER NOT NULL,
+                    error_message TEXT
+                );",
+            )
+            .unwrap();
+        }
+        let id = {
+            let conn = pool.writer().await;
+            queue_offline_op_with_status(&conn, "acc1", "send", &serde_json::json!({}), "sending")
+                .unwrap()
+        };
+        let postprocess_ran = AtomicBool::new(false);
+
+        let completed = complete_send_before(&pool, id, || async {
+            let conn = pool.reader();
+            let count: i64 = conn
+                .query_row(
+                    "SELECT COUNT(*) FROM outbox WHERE id = ?1",
+                    rusqlite::params![id],
+                    |row| row.get(0),
+                )
+                .unwrap();
+            assert_eq!(count, 0, "delivery must complete before postprocess");
+            postprocess_ran.store(true, Ordering::SeqCst);
+            Err::<(), &str>("injected Sent append failure")
+        })
+        .await
+        .unwrap();
+
+        assert!(completed);
+        assert!(postprocess_ran.load(Ordering::SeqCst));
+        let conn = pool.reader();
+        assert_eq!(
+            conn.query_row(
+                "SELECT COUNT(*) FROM outbox WHERE id = ?1",
+                rusqlite::params![id],
+                |row| row.get::<_, i64>(0),
+            )
+            .unwrap(),
+            0
+        );
+    }
+
     #[test]
     fn definite_send_failure_atomically_releases_claim_and_increments_retry() {
         let conn = setup_db();
         let id = queue_offline_op(&conn, "acc1", "send", &serde_json::json!({})).unwrap();
 
-        assert!(!retry_sending_send(&conn, id, "definite rejection").unwrap());
+        assert_eq!(
+            retry_sending_send(&conn, id, "definite rejection").unwrap(),
+            SendRetryDisposition::MissingClaim
+        );
         assert!(claim_pending_send(&conn, id, 0).unwrap());
-        assert!(retry_sending_send(&conn, id, "definite rejection").unwrap());
+        assert_eq!(
+            retry_sending_send(&conn, id, "definite rejection").unwrap(),
+            SendRetryDisposition::Pending
+        );
         assert_eq!(
             row_state(&conn, id),
             Some(("pending".into(), 1, Some("definite rejection".into())))
         );
-        assert!(!retry_sending_send(&conn, id, "second failure").unwrap());
+        assert_eq!(
+            retry_sending_send(&conn, id, "second failure").unwrap(),
+            SendRetryDisposition::MissingClaim
+        );
         assert_eq!(row_state(&conn, id).unwrap().1, 1);
+    }
+
+    #[test]
+    fn definite_send_failure_at_limit_is_dead_with_last_bounded_error() {
+        let conn = setup_db();
+        let id = queue_offline_op(&conn, "acc1", "send", &serde_json::json!({})).unwrap();
+        conn.execute(
+            "UPDATE outbox SET retry_count = ?1 WHERE id = ?2",
+            rusqlite::params![MAX_RETRIES - 1, id],
+        )
+        .unwrap();
+        assert!(claim_pending_send(&conn, id, MAX_RETRIES - 1).unwrap());
+
+        let error = format!("last transport error: {}", "é".repeat(512));
+        assert_eq!(
+            retry_sending_send(&conn, id, &error).unwrap(),
+            SendRetryDisposition::Dead
+        );
+        let state = row_state(&conn, id).unwrap();
+        assert_eq!(state.0, "dead");
+        assert_eq!(state.1, MAX_RETRIES);
+        let stored = state.2.unwrap();
+        assert!(stored.starts_with("last transport error:"));
+        assert!(stored.len() <= MAX_SEND_ERROR_MESSAGE_BYTES);
+    }
+
+    #[test]
+    fn legacy_pending_send_at_limit_preserves_existing_error() {
+        let conn = setup_db();
+        let id = queue_offline_op(&conn, "acc1", "send", &serde_json::json!({})).unwrap();
+        conn.execute(
+            "UPDATE outbox SET retry_count = ?1, error_message = 'last SMTP rejection'
+             WHERE id = ?2",
+            rusqlite::params![MAX_RETRIES, id],
+        )
+        .unwrap();
+
+        assert!(exhaust_pending_send(&conn, id, "retry limit reached").unwrap());
+        assert_eq!(
+            row_state(&conn, id),
+            Some((
+                "dead".into(),
+                MAX_RETRIES,
+                Some("last SMTP rejection".into())
+            ))
+        );
     }
 
     #[test]

--- a/src-tauri/src/ops/worker.rs
+++ b/src-tauri/src/ops/worker.rs
@@ -6,11 +6,41 @@ use tokio_util::sync::CancellationToken;
 
 use crate::backend::mail::{MailBackend, MailOpExecutor, MailSyncCtx};
 use crate::db::pool::DbPool;
-use crate::error::Result;
+use crate::error::{Error, Result};
 
 use super::coalesce::coalesce;
 use super::lifecycle::{SpawnedWorker, WorkerTaskExit};
 use super::queue::{MailOp, OpEntry};
+
+const AMBIGUOUS_OPERATION_ERROR_MESSAGE: &str =
+    "Operation outcome may be ambiguous; automatic retry disabled to avoid duplicate effects. Verify remote state before retrying manually.";
+
+const SEND_RETRY_LIMIT_ERROR_MESSAGE: &str =
+    "Automatic send retry limit reached; retry manually after reviewing the last failure.";
+
+fn automatic_retry_allowed(statically_retry_safe: bool, error: &Error) -> bool {
+    statically_retry_safe && !error.is_indeterminate_delivery()
+}
+
+fn automatic_retry_disabled_message(error: &Error) -> &'static str {
+    if error.is_indeterminate_delivery() {
+        super::offline::INDETERMINATE_DELIVERY_ERROR_MESSAGE
+    } else {
+        AMBIGUOUS_OPERATION_ERROR_MESSAGE
+    }
+}
+
+fn outbox_subject(payload_json: &str) -> String {
+    serde_json::from_str::<serde_json::Value>(payload_json)
+        .ok()
+        .and_then(|value| {
+            value
+                .get("subject")
+                .and_then(|subject| subject.as_str())
+                .map(String::from)
+        })
+        .unwrap_or_default()
+}
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum WorkerExit {
@@ -260,9 +290,36 @@ impl AccountWorker {
         );
 
         for entry in &pending {
+            let is_send = entry.action_type == "send";
             if super::offline::is_dead(entry) {
-                let conn = self.db.writer().await;
-                let _ = super::offline::mark_dead(&conn, entry.id);
+                if is_send {
+                    let transition = {
+                        let conn = self.db.writer().await;
+                        super::offline::quarantine_pending_send(
+                            &conn,
+                            entry.id,
+                            SEND_RETRY_LIMIT_ERROR_MESSAGE,
+                        )
+                    };
+                    match transition {
+                        Ok(true) => {}
+                        Ok(false) => {
+                            log::info!("Skipping stale exhausted send snapshot {}", entry.id);
+                            continue;
+                        }
+                        Err(error) => {
+                            log::error!(
+                                "Failed to quarantine exhausted send {}: {}",
+                                entry.id,
+                                error
+                            );
+                            break;
+                        }
+                    }
+                } else {
+                    let conn = self.db.writer().await;
+                    let _ = super::offline::mark_dead(&conn, entry.id);
+                }
                 log::warn!(
                     "Offline op {} ({}) exceeded max retries, marking dead",
                     entry.id,
@@ -291,16 +348,39 @@ impl AccountWorker {
                     entry.id,
                     entry.action_type
                 );
-                let conn = self.db.writer().await;
-                if let Err(mark_error) = super::offline::mark_invalid(&conn, entry.id, &error) {
-                    log::error!(
-                        "Failed to mark invalid offline op {} dead: {}",
-                        entry.id,
-                        mark_error
-                    );
-                    break;
+                if is_send {
+                    let transition = {
+                        let conn = self.db.writer().await;
+                        super::offline::quarantine_pending_send(&conn, entry.id, &error)
+                    };
+                    match transition {
+                        Ok(true) => {}
+                        Ok(false) => {
+                            log::info!("Skipping stale invalid send snapshot {}", entry.id);
+                            continue;
+                        }
+                        Err(mark_error) => {
+                            log::error!(
+                                "Failed to mark invalid send {} dead: {}",
+                                entry.id,
+                                mark_error
+                            );
+                            break;
+                        }
+                    }
+                } else {
+                    let conn = self.db.writer().await;
+                    if let Err(mark_error) =
+                        super::offline::mark_dead_with_error(&conn, entry.id, &error)
+                    {
+                        log::error!(
+                            "Failed to mark invalid offline op {} dead: {}",
+                            entry.id,
+                            mark_error
+                        );
+                        break;
+                    }
                 }
-                drop(conn);
                 self.app
                     .emit(
                         "offline-queue-changed",
@@ -313,7 +393,46 @@ impl AccountWorker {
                     .ok();
                 continue;
             };
-            let retry_safe = op.can_retry_after_execution_failure();
+            let statically_retry_safe = op.can_retry_after_execution_failure();
+
+            if is_send {
+                let claim = {
+                    let conn = self.db.writer().await;
+                    super::offline::claim_pending_send(&conn, entry.id, entry.retry_count)
+                };
+                match claim {
+                    Ok(true) => {
+                        self.app
+                            .emit(
+                                "send-started",
+                                serde_json::json!({
+                                    "account_id": self.account_id,
+                                    "subject": outbox_subject(&entry.payload_json),
+                                    "outbox_id": entry.id,
+                                    "via": "outbox-replay",
+                                }),
+                            )
+                            .ok();
+                    }
+                    Ok(false) => {
+                        log::info!(
+                            "Skipping stale send replay snapshot {} for account {}",
+                            entry.id,
+                            self.account_id
+                        );
+                        continue;
+                    }
+                    Err(error) => {
+                        log::error!(
+                            "Failed to claim send {} for account {}; replay stopped before transport: {}",
+                            entry.id,
+                            self.account_id,
+                            error
+                        );
+                        break;
+                    }
+                }
+            }
 
             // Execute the replayed op directly (not through execute() to avoid
             // re-queuing to outbox on failure — we handle retries here)
@@ -321,6 +440,49 @@ impl AccountWorker {
 
             match result {
                 Ok(()) => {
+                    if is_send {
+                        let completion = {
+                            let conn = self.db.writer().await;
+                            super::offline::complete_sending_send(&conn, entry.id)
+                        };
+                        let completed = match completion {
+                            Ok(true) => {
+                                log::info!("Replayed offline send {} successfully", entry.id);
+                                true
+                            }
+                            Ok(false) => {
+                                log::error!(
+                                    "Send {} succeeded but its sending claim was missing; replay stopped",
+                                    entry.id
+                                );
+                                false
+                            }
+                            Err(error) => {
+                                log::error!(
+                                    "Send {} succeeded but completion persistence failed; row remains sending: {}",
+                                    entry.id,
+                                    error
+                                );
+                                false
+                            }
+                        };
+                        self.app
+                            .emit(
+                                "send-complete",
+                                serde_json::json!({
+                                    "account_id": self.account_id,
+                                    "subject": outbox_subject(&entry.payload_json),
+                                    "outbox_id": entry.id,
+                                    "via": "outbox-replay",
+                                }),
+                            )
+                            .ok();
+                        if completed {
+                            continue;
+                        }
+                        break;
+                    }
+
                     let conn = self.db.writer().await;
                     let _ = super::offline::mark_completed(&conn, entry.id);
                     log::info!(
@@ -329,38 +491,72 @@ impl AccountWorker {
                         entry.action_type
                     );
                     drop(conn);
-                    if entry.action_type == "send" {
-                        let subject =
-                            serde_json::from_str::<serde_json::Value>(&entry.payload_json)
-                                .ok()
-                                .and_then(|v| {
-                                    v.get("subject").and_then(|s| s.as_str()).map(String::from)
-                                })
-                                .unwrap_or_default();
-                        self.app
-                            .emit(
-                                "send-complete",
-                                serde_json::json!({
-                                    "account_id": self.account_id,
-                                    "subject": subject,
-                                    "via": "outbox-replay",
-                                }),
-                            )
-                            .ok();
-                    }
                 }
                 Err(e) => {
-                    if !retry_safe {
-                        let error = format!(
-                            "Copy outcome may be ambiguous; automatic retry disabled to avoid duplicates: {}",
-                            e
-                        );
+                    if !automatic_retry_allowed(statically_retry_safe, &e) {
+                        let error = automatic_retry_disabled_message(&e);
+
+                        if is_send {
+                            let quarantine = {
+                                let conn = self.db.writer().await;
+                                super::offline::quarantine_sending_send(&conn, entry.id, error)
+                            };
+                            let quarantined = match quarantine {
+                                Ok(true) => true,
+                                Ok(false) => {
+                                    log::error!(
+                                        "Indeterminate send {} lost its sending claim; replay stopped",
+                                        entry.id
+                                    );
+                                    false
+                                }
+                                Err(mark_error) => {
+                                    log::error!(
+                                        "Failed to quarantine indeterminate send {}; row remains sending: {}",
+                                        entry.id,
+                                        mark_error
+                                    );
+                                    false
+                                }
+                            };
+                            self.app
+                                .emit(
+                                    "send-unknown",
+                                    serde_json::json!({
+                                        "account_id": self.account_id,
+                                        "subject": outbox_subject(&entry.payload_json),
+                                        "outbox_id": entry.id,
+                                        "error": error,
+                                    }),
+                                )
+                                .ok();
+                            if !quarantined {
+                                break;
+                            }
+                            log::warn!(
+                                "Replay of send {} has an unknown outcome; marked dead without automatic retry: {}",
+                                entry.id,
+                                e
+                            );
+                            self.app
+                                .emit(
+                                    "offline-queue-changed",
+                                    serde_json::json!({
+                                        "account_id": self.account_id,
+                                        "dead_op_id": entry.id,
+                                        "action_type": entry.action_type,
+                                    }),
+                                )
+                                .ok();
+                            continue;
+                        }
+
                         let conn = self.db.writer().await;
                         if let Err(mark_error) =
-                            super::offline::mark_invalid(&conn, entry.id, &error)
+                            super::offline::mark_dead_with_error(&conn, entry.id, error)
                         {
                             log::error!(
-                                "Failed to mark ambiguous copy op {} dead: {}",
+                                "Failed to mark ambiguous offline op {} dead: {}",
                                 entry.id,
                                 mark_error
                             );
@@ -368,7 +564,8 @@ impl AccountWorker {
                         }
                         drop(conn);
                         log::warn!(
-                            "Replay of copy op {} failed; marked dead without automatic retry: {}",
+                            "Replay of {} op {} failed; marked dead without automatic retry: {}",
+                            entry.action_type,
                             entry.id,
                             e
                         );
@@ -384,6 +581,56 @@ impl AccountWorker {
                             .ok();
                         continue;
                     }
+
+                    if is_send {
+                        let retry = {
+                            let conn = self.db.writer().await;
+                            super::offline::retry_sending_send(&conn, entry.id, &e.to_string())
+                        };
+                        let persisted = match retry {
+                            Ok(true) => {
+                                log::warn!(
+                                    "Replay of send {} failed definitely (attempt {}): {}",
+                                    entry.id,
+                                    entry.retry_count + 1,
+                                    e
+                                );
+                                true
+                            }
+                            Ok(false) => {
+                                log::error!(
+                                    "Failed send {} lost its sending claim; replay stopped",
+                                    entry.id
+                                );
+                                false
+                            }
+                            Err(error) => {
+                                log::error!(
+                                    "Failed to persist retry for send {}; row remains sending: {}",
+                                    entry.id,
+                                    error
+                                );
+                                false
+                            }
+                        };
+                        self.app
+                            .emit(
+                                "send-failed",
+                                serde_json::json!({
+                                    "account_id": self.account_id,
+                                    "subject": outbox_subject(&entry.payload_json),
+                                    "outbox_id": entry.id,
+                                    "error": e.to_string(),
+                                    "via": "outbox-replay",
+                                }),
+                            )
+                            .ok();
+                        if persisted {
+                            continue;
+                        }
+                        break;
+                    }
+
                     let conn = self.db.writer().await;
                     let _ = super::offline::mark_failed(&conn, entry.id, &e.to_string());
                     log::warn!(
@@ -393,14 +640,9 @@ impl AccountWorker {
                         entry.retry_count + 1,
                         e
                     );
-                    // For send ops we keep going: a retryable transient
-                    // (timeout, transient SMTP 4xx, etc.) on one message
-                    // shouldn't stall the other replays in this drain.
-                    // For other ops a failure usually indicates the
-                    // connection is broken, so break as before.
-                    if entry.action_type != "send" {
-                        break;
-                    }
+                    // A non-send failure usually indicates the connection is
+                    // broken, so stop this drain as before.
+                    break;
                 }
             }
         }
@@ -422,12 +664,13 @@ impl AccountWorker {
         }
     }
 
-    /// Run a user op through the executor; on failure, queue it to the
-    /// offline outbox for replay after the next successful sync.
+    /// Run a user op through the executor. Retryable failures become pending
+    /// outbox rows; ambiguous outcomes are retained as dead rows for manual
+    /// review rather than automatic replay.
     async fn execute_user_op(&mut self, op: MailOp) -> Result<()> {
         // Serialize the op for outbox before executing (we move op into the executor)
         let outbox_data = super::offline::mail_op_to_outbox(&op).map(|(t, p)| (t.to_string(), p));
-        let retry_safe = op.can_retry_after_execution_failure();
+        let statically_retry_safe = op.can_retry_after_execution_failure();
 
         let preflight = match &op {
             MailOp::SetFlags { mutations } => {
@@ -453,13 +696,11 @@ impl AccountWorker {
         if let Err(ref e) = result {
             if let Some((action_type, payload)) = outbox_data {
                 let conn = self.db.writer().await;
+                let retry_safe = automatic_retry_allowed(statically_retry_safe, e);
                 let error = if retry_safe {
                     format!("{} (will retry)", e)
                 } else {
-                    format!(
-                        "Copy outcome may be ambiguous; automatic retry disabled to avoid duplicates: {}",
-                        e
-                    )
+                    automatic_retry_disabled_message(e).to_string()
                 };
                 let queued = if retry_safe {
                     super::offline::queue_offline_op(
@@ -571,4 +812,21 @@ pub(crate) fn emit_op_failed(app: &AppHandle, account_id: &str, op_type: &str, e
         }),
     )
     .ok();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::automatic_retry_allowed;
+    use crate::error::Error;
+
+    #[test]
+    fn retry_decision_combines_static_safety_and_dynamic_outcome() {
+        let ordinary = Error::Other("definite failure".into());
+        let indeterminate = Error::IndeterminateDelivery;
+
+        assert!(automatic_retry_allowed(true, &ordinary));
+        assert!(!automatic_retry_allowed(false, &ordinary));
+        assert!(!automatic_retry_allowed(true, &indeterminate));
+        assert!(!automatic_retry_allowed(false, &indeterminate));
+    }
 }

--- a/src-tauri/src/ops/worker.rs
+++ b/src-tauri/src/ops/worker.rs
@@ -26,7 +26,7 @@ pub enum WorkerExit {
 /// - Prioritises user ops (move/copy/delete/flag) over background sync
 /// - Executes ops through the account's [`MailOpExecutor`] (the IMAP
 ///   executor maintains a persistent connection and reconnects when it
-///   goes stale; JMAP/Graph executors are stateless HTTP)
+///   goes stale; JMAP/Graph executors are stateless)
 /// - Routes sync ops through the account's [`MailBackend`]
 pub struct AccountWorker {
     pub account_id: String,

--- a/src-tauri/src/ops/worker.rs
+++ b/src-tauri/src/ops/worker.rs
@@ -4,12 +4,13 @@ use tauri::{AppHandle, Emitter, Manager};
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
-use crate::backend::mail::{MailBackend, MailOpExecutor, MailSyncCtx};
+use crate::backend::mail::{MailBackend, MailOpExecutor, MailSyncCtx, SendPostprocess};
 use crate::db::pool::DbPool;
 use crate::error::{Error, Result};
 
 use super::coalesce::coalesce;
 use super::lifecycle::{SpawnedWorker, WorkerTaskExit};
+use super::offline::SendRetryDisposition;
 use super::queue::{MailOp, OpEntry};
 
 const AMBIGUOUS_OPERATION_ERROR_MESSAGE: &str =
@@ -40,6 +41,14 @@ fn outbox_subject(payload_json: &str) -> String {
                 .map(String::from)
         })
         .unwrap_or_default()
+}
+
+fn missing_executor_error(account_id: &str) -> Error {
+    Error::Other(format!("Account {account_id} has no enabled mail binding"))
+}
+
+fn send_unknown_events_allowed(transition: &Result<bool>) -> bool {
+    matches!(transition, Ok(true))
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -250,19 +259,24 @@ impl AccountWorker {
         Ok(())
     }
 
-    /// Run `op` through the account's executor. `Ok(())` when the
-    /// account has no mail backend (nothing to execute against).
+    /// Run `op` through the account's executor.
     async fn execute_op(&mut self, op: MailOp) -> Result<()> {
         let ctx = self.ctx.as_ref().expect("worker initialized");
         match self.executor.as_mut() {
             Some(executor) => executor.execute(ctx, &self.account_id, op).await,
-            None => {
-                log::warn!(
-                    "Worker: no mail backend for account {}, dropping op",
-                    self.account_id
-                );
-                Ok(())
+            None => Err(missing_executor_error(&self.account_id)),
+        }
+    }
+
+    async fn execute_replayed_send(&mut self, op: MailOp) -> Result<SendPostprocess> {
+        let ctx = self.ctx.as_ref().expect("worker initialized");
+        match self.executor.as_mut() {
+            Some(executor) => {
+                executor
+                    .execute_replayed_send(ctx, &self.account_id, op)
+                    .await
             }
+            None => Err(missing_executor_error(&self.account_id)),
         }
     }
 
@@ -295,7 +309,7 @@ impl AccountWorker {
                 if is_send {
                     let transition = {
                         let conn = self.db.writer().await;
-                        super::offline::quarantine_pending_send(
+                        super::offline::exhaust_pending_send(
                             &conn,
                             entry.id,
                             SEND_RETRY_LIMIT_ERROR_MESSAGE,
@@ -436,26 +450,47 @@ impl AccountWorker {
 
             // Execute the replayed op directly (not through execute() to avoid
             // re-queuing to outbox on failure — we handle retries here)
-            let result = self.execute_op(op).await;
+            let result = if is_send {
+                self.execute_replayed_send(op).await
+            } else {
+                self.execute_op(op).await.map(|_| SendPostprocess::None)
+            };
 
             match result {
-                Ok(()) => {
+                Ok(postprocess) => {
                     if is_send {
-                        let completion = {
-                            let conn = self.db.writer().await;
-                            super::offline::complete_sending_send(&conn, entry.id)
-                        };
-                        let completed = match completion {
+                        let app = self.app.clone();
+                        let account_id = self.account_id.clone();
+                        let subject = outbox_subject(&entry.payload_json);
+                        let ctx = self.ctx.as_ref().expect("worker initialized").clone();
+                        let completion = super::offline::complete_send_before(
+                            &self.db,
+                            entry.id,
+                            move || async move {
+                                app.emit(
+                                    "send-complete",
+                                    serde_json::json!({
+                                        "account_id": account_id,
+                                        "subject": subject,
+                                        "outbox_id": entry.id,
+                                        "via": "outbox-replay",
+                                    }),
+                                )
+                                .ok();
+                                postprocess.run_best_effort(&ctx, &account_id).await;
+                            },
+                        )
+                        .await;
+                        match completion {
                             Ok(true) => {
                                 log::info!("Replayed offline send {} successfully", entry.id);
-                                true
                             }
                             Ok(false) => {
                                 log::error!(
                                     "Send {} succeeded but its sending claim was missing; replay stopped",
                                     entry.id
                                 );
-                                false
+                                break;
                             }
                             Err(error) => {
                                 log::error!(
@@ -463,24 +498,10 @@ impl AccountWorker {
                                     entry.id,
                                     error
                                 );
-                                false
+                                break;
                             }
-                        };
-                        self.app
-                            .emit(
-                                "send-complete",
-                                serde_json::json!({
-                                    "account_id": self.account_id,
-                                    "subject": outbox_subject(&entry.payload_json),
-                                    "outbox_id": entry.id,
-                                    "via": "outbox-replay",
-                                }),
-                            )
-                            .ok();
-                        if completed {
-                            continue;
                         }
-                        break;
+                        continue;
                     }
 
                     let conn = self.db.writer().await;
@@ -501,14 +522,14 @@ impl AccountWorker {
                                 let conn = self.db.writer().await;
                                 super::offline::quarantine_sending_send(&conn, entry.id, error)
                             };
-                            let quarantined = match quarantine {
-                                Ok(true) => true,
+                            let quarantined = send_unknown_events_allowed(&quarantine);
+                            match quarantine {
+                                Ok(true) => {}
                                 Ok(false) => {
                                     log::error!(
                                         "Indeterminate send {} lost its sending claim; replay stopped",
                                         entry.id
                                     );
-                                    false
                                 }
                                 Err(mark_error) => {
                                     log::error!(
@@ -516,9 +537,11 @@ impl AccountWorker {
                                         entry.id,
                                         mark_error
                                     );
-                                    false
                                 }
-                            };
+                            }
+                            if !quarantined {
+                                break;
+                            }
                             self.app
                                 .emit(
                                     "send-unknown",
@@ -530,9 +553,6 @@ impl AccountWorker {
                                     }),
                                 )
                                 .ok();
-                            if !quarantined {
-                                break;
-                            }
                             log::warn!(
                                 "Replay of send {} has an unknown outcome; marked dead without automatic retry: {}",
                                 entry.id,
@@ -583,26 +603,70 @@ impl AccountWorker {
                     }
 
                     if is_send {
+                        let error_message = e.to_string();
                         let retry = {
                             let conn = self.db.writer().await;
-                            super::offline::retry_sending_send(&conn, entry.id, &e.to_string())
+                            super::offline::retry_sending_send(&conn, entry.id, &error_message)
                         };
-                        let persisted = match retry {
-                            Ok(true) => {
+                        match retry {
+                            Ok(SendRetryDisposition::Pending) => {
                                 log::warn!(
                                     "Replay of send {} failed definitely (attempt {}): {}",
                                     entry.id,
                                     entry.retry_count + 1,
                                     e
                                 );
-                                true
+                                self.app
+                                    .emit(
+                                        "send-failed",
+                                        serde_json::json!({
+                                            "account_id": self.account_id,
+                                            "subject": outbox_subject(&entry.payload_json),
+                                            "outbox_id": entry.id,
+                                            "error": error_message,
+                                            "via": "outbox-replay",
+                                        }),
+                                    )
+                                    .ok();
+                                continue;
                             }
-                            Ok(false) => {
+                            Ok(SendRetryDisposition::Dead) => {
+                                log::warn!(
+                                    "Replay of send {} failed definitely at retry limit (attempt {}): {}",
+                                    entry.id,
+                                    entry.retry_count + 1,
+                                    e
+                                );
+                                self.app
+                                    .emit(
+                                        "send-failed",
+                                        serde_json::json!({
+                                            "account_id": self.account_id,
+                                            "subject": outbox_subject(&entry.payload_json),
+                                            "outbox_id": entry.id,
+                                            "error": error_message,
+                                            "via": "outbox-replay",
+                                        }),
+                                    )
+                                    .ok();
+                                self.app
+                                    .emit(
+                                        "offline-queue-changed",
+                                        serde_json::json!({
+                                            "account_id": self.account_id,
+                                            "dead_op_id": entry.id,
+                                            "action_type": entry.action_type,
+                                        }),
+                                    )
+                                    .ok();
+                                continue;
+                            }
+                            Ok(SendRetryDisposition::MissingClaim) => {
                                 log::error!(
                                     "Failed send {} lost its sending claim; replay stopped",
                                     entry.id
                                 );
-                                false
+                                break;
                             }
                             Err(error) => {
                                 log::error!(
@@ -610,25 +674,9 @@ impl AccountWorker {
                                     entry.id,
                                     error
                                 );
-                                false
+                                break;
                             }
-                        };
-                        self.app
-                            .emit(
-                                "send-failed",
-                                serde_json::json!({
-                                    "account_id": self.account_id,
-                                    "subject": outbox_subject(&entry.payload_json),
-                                    "outbox_id": entry.id,
-                                    "error": e.to_string(),
-                                    "via": "outbox-replay",
-                                }),
-                            )
-                            .ok();
-                        if persisted {
-                            continue;
                         }
-                        break;
                     }
 
                     let conn = self.db.writer().await;
@@ -816,8 +864,8 @@ pub(crate) fn emit_op_failed(app: &AppHandle, account_id: &str, op_type: &str, e
 
 #[cfg(test)]
 mod tests {
-    use super::automatic_retry_allowed;
-    use crate::error::Error;
+    use super::{automatic_retry_allowed, missing_executor_error, send_unknown_events_allowed};
+    use crate::error::{Error, Result};
 
     #[test]
     fn retry_decision_combines_static_safety_and_dynamic_outcome() {
@@ -828,5 +876,24 @@ mod tests {
         assert!(!automatic_retry_allowed(false, &ordinary));
         assert!(!automatic_retry_allowed(true, &indeterminate));
         assert!(!automatic_retry_allowed(false, &indeterminate));
+    }
+
+    #[test]
+    fn missing_executor_is_a_definite_failure() {
+        let error = missing_executor_error("account");
+
+        assert!(!error.is_indeterminate_delivery());
+        assert_eq!(
+            error.to_string(),
+            "Account account has no enabled mail binding"
+        );
+    }
+
+    #[test]
+    fn send_unknown_events_require_a_persisted_quarantine() {
+        assert!(send_unknown_events_allowed(&Ok(true)));
+        assert!(!send_unknown_events_allowed(&Ok(false)));
+        let persistence_error: Result<bool> = Err(Error::Other("database".into()));
+        assert!(!send_unknown_events_allowed(&persistence_error));
     }
 }

--- a/src-tauri/src/provider.rs
+++ b/src-tauri/src/provider.rs
@@ -415,6 +415,7 @@ pub struct ProviderTransports {
     pub google_endpoints: crate::mail::google::GoogleEndpoints,
     pub jmap_discovery_http: reqwest::Client,
     pub jmap_api_http: reqwest::Client,
+    pub jmap_submission_http: reqwest::Client,
     pub jmap_sse_http: reqwest::Client,
     pub oidc_http: reqwest::Client,
     pub oidc_poll_http: reqwest::Client,
@@ -435,6 +436,11 @@ impl ProviderTransports {
             .timeout(std::time::Duration::from_secs(30))
             .build()
             .map_err(|error| Error::Other(error.to_string()))?;
+        let jmap_submission_http = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(30))
+            .redirect(reqwest::redirect::Policy::none())
+            .build()
+            .map_err(|error| Error::Other(error.to_string()))?;
 
         Ok(Self {
             graph_http: reqwest::Client::new(),
@@ -443,6 +449,7 @@ impl ProviderTransports {
             google_endpoints: crate::mail::google::GoogleEndpoints::default(),
             jmap_discovery_http,
             jmap_api_http,
+            jmap_submission_http,
             // No overall timeout: EventSource responses are long-lived and
             // enforce a per-chunk read timeout in the push loop.
             jmap_sse_http: reqwest::Client::builder()
@@ -592,6 +599,7 @@ impl ProviderServices {
             &config,
             self.transports.jmap_discovery_http.clone(),
             self.transports.jmap_api_http.clone(),
+            self.transports.jmap_submission_http.clone(),
         )
         .await?;
         Ok((config, connection))

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -268,13 +268,13 @@ impl AppState {
         // Create pool: 1 writer + 4 readers (matches MAX_PARALLEL_CONNECTIONS)
         let pool = DbPool::new(&db_path, 4)?;
 
-        // Revive any outbox rows left in 'sending' from a previous run.
-        // The spawn task that owned them is dead; without this the rows
-        // would never be retried and would be invisible to the user.
+        // Quarantine outbox rows left in 'sending' by a previous run. Their
+        // delivery outcome is unknowable after the owning task disappears,
+        // so only a deliberate manual retry may send them again.
         {
-            let revive_conn = rusqlite::Connection::open(&db_path)?;
-            if let Err(e) = crate::ops::offline::revive_stuck_sending(&revive_conn) {
-                log::warn!("Failed to revive stuck 'sending' outbox rows: {}", e);
+            let quarantine_conn = rusqlite::Connection::open(&db_path)?;
+            if let Err(e) = crate::ops::offline::quarantine_stuck_sending(&quarantine_conn) {
+                log::warn!("Failed to quarantine stuck 'sending' outbox rows: {}", e);
             }
         }
 

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::fs::{File, OpenOptions, TryLockError};
 use std::net::{Shutdown, TcpStream};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -7,7 +8,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::db;
 use crate::db::pool::DbPool;
-use crate::error::Result;
+use crate::error::{Error, Result};
 use crate::ops::lifecycle::WorkerRegistry;
 use crate::ops::queue::OpEntry;
 use crate::ops::worker::AccountWorker;
@@ -176,6 +177,7 @@ pub struct AppState {
     /// join handles. Workers are spawned lazily on first use.
     op_workers: WorkerRegistry<OpEntry>,
     pub data_dir: PathBuf,
+    _data_dir_lock: File,
     /// Token -> canonical file path for attachments picked via the native
     /// dialog. The renderer only ever sees the token, so a compromised
     /// renderer cannot ask the backend to read arbitrary files.
@@ -258,6 +260,24 @@ pub struct ZoomOAuthSession {
 impl AppState {
     pub fn new(data_dir: PathBuf) -> Result<Self> {
         std::fs::create_dir_all(&data_dir)?;
+        let lock_path = data_dir.join(".chithi.lock");
+        let data_dir_lock = OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(false)
+            .open(&lock_path)?;
+        match data_dir_lock.try_lock() {
+            Ok(()) => {}
+            Err(TryLockError::WouldBlock) => {
+                return Err(Error::Other(format!(
+                    "Cannot start Chithi: data directory '{}' is already in use by another Chithi instance (lock file '{}')",
+                    data_dir.display(),
+                    lock_path.display()
+                )));
+            }
+            Err(TryLockError::Error(error)) => return Err(error.into()),
+        }
         let db_path = data_dir.join("chithi.db");
 
         // Initialize schema on a temporary connection
@@ -293,6 +313,7 @@ impl AppState {
             calendar_sync_in_progress: std::sync::Mutex::new(HashMap::new()),
             op_workers: WorkerRegistry::new(256),
             data_dir,
+            _data_dir_lock: data_dir_lock,
             attachments: std::sync::Mutex::new(HashMap::new()),
             talk_login_sessions: std::sync::Mutex::new(HashMap::new()),
             matrix_sso_listeners: std::sync::Mutex::new(HashMap::new()),
@@ -381,11 +402,84 @@ impl AppState {
 
 #[cfg(test)]
 mod tests {
-    use super::{AccountLifecycleCoordinator, IdleControl, MeetLifecycleCoordinator};
+    use super::{AccountLifecycleCoordinator, AppState, IdleControl, MeetLifecycleCoordinator};
     use std::io::Read;
     use std::net::{TcpListener, TcpStream};
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::Arc;
+
+    #[test]
+    fn second_app_state_cannot_run_startup_quarantine() {
+        let temp = tempfile::tempdir().unwrap();
+        let data_dir = temp.path().to_path_buf();
+        let first_state = AppState::new(data_dir.clone()).unwrap();
+        let db_path = data_dir.join("chithi.db");
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conn.execute(
+            "INSERT INTO accounts (id, display_name, email, username)
+             VALUES ('lock-test', 'Lock Test', 'lock@example.com', 'lock-test')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO outbox (account_id, action_type, payload_json, status)
+             VALUES ('lock-test', 'send', '{}', 'sending')",
+            [],
+        )
+        .unwrap();
+        let outbox_id = conn.last_insert_rowid();
+        drop(conn);
+
+        let error = match AppState::new(data_dir.clone()) {
+            Ok(state) => {
+                drop(state);
+                panic!("a second AppState acquired the same data directory lock");
+            }
+            Err(error) => error,
+        };
+        let message = error.to_string();
+        assert!(
+            message.contains("already in use by another Chithi instance"),
+            "unexpected startup error: {message}"
+        );
+        assert!(message.contains(".chithi.lock"));
+
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        let status: String = conn
+            .query_row(
+                "SELECT status FROM outbox WHERE id = ?1",
+                [outbox_id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(status, "sending");
+        drop(conn);
+        drop(first_state);
+    }
+
+    #[test]
+    fn dropping_app_state_releases_data_dir_lock() {
+        let temp = tempfile::tempdir().unwrap();
+        let data_dir = temp.path().to_path_buf();
+        let first_state = AppState::new(data_dir.clone()).unwrap();
+        drop(first_state);
+
+        let later_state = AppState::new(data_dir.clone()).unwrap();
+        assert_eq!(later_state.data_dir, data_dir);
+        drop(later_state);
+    }
+
+    #[test]
+    fn app_states_for_different_data_dirs_can_coexist() {
+        let first_temp = tempfile::tempdir().unwrap();
+        let second_temp = tempfile::tempdir().unwrap();
+        let first_state = AppState::new(first_temp.path().to_path_buf()).unwrap();
+        let second_state = AppState::new(second_temp.path().to_path_buf()).unwrap();
+
+        assert_ne!(first_state.data_dir, second_state.data_dir);
+        drop(second_state);
+        drop(first_state);
+    }
 
     #[test]
     fn idle_control_interrupts_registered_socket() {

--- a/src/App.vue
+++ b/src/App.vue
@@ -6,13 +6,11 @@ import MobileShell from "@/components/shell/MobileShell.vue";
 import ToastContainer from "@/components/common/ToastContainer.vue";
 import PassphraseDialog from "@/components/pgp/PassphraseDialog.vue";
 import PinDialog from "@/components/pgp/PinDialog.vue";
-import { useActivityStore } from "@/stores/activity";
 import { useAccountsStore } from "@/stores/accounts";
 import { useUiStore } from "@/stores/ui";
 import { usePlatformStore } from "@/stores/platform";
 import { usePgpPromptsStore } from "@/stores/pgp-prompts";
 
-const activityStore = useActivityStore();
 const accountsStore = useAccountsStore();
 const uiStore = useUiStore();
 const platformStore = usePlatformStore();
@@ -25,7 +23,6 @@ onMounted(async () => {
   uiStore.initTheme();
   uiStore.initDecorations();
   await uiStore.initTimezone();
-  activityStore.initEventListeners();
   await accountsStore.fetchAccounts();
   // Subscribe globally so any view that triggers a sign/decrypt can
   // receive its prompt.

--- a/src/__tests__/activity-send.test.ts
+++ b/src/__tests__/activity-send.test.ts
@@ -1,15 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createPinia, setActivePinia } from "pinia";
+import { flushPromises } from "@vue/test-utils";
 
-const handlers = new Map<string, (event: { payload: unknown }) => void>();
+const { handlers, listenEvent } = vi.hoisted(() => ({
+  handlers: new Map<string, (event: { payload: unknown }) => void>(),
+  listenEvent: vi.fn(),
+}));
 
 vi.mock("@tauri-apps/api/event", () => ({
-  listen: vi.fn(
-    (name: string, handler: (event: { payload: unknown }) => void) => {
-      handlers.set(name, handler);
-      return Promise.resolve(() => {});
-    },
-  ),
+  listen: listenEvent,
 }));
 
 vi.mock("@/lib/toast", () => ({
@@ -18,12 +17,23 @@ vi.mock("@/lib/toast", () => ({
 }));
 
 import { dismissToast, showToast } from "@/lib/toast";
-import { useActivityStore } from "@/stores/activity";
+import {
+  initializeActivityListenersWithRetry,
+  useActivityStore,
+} from "@/stores/activity";
 
 function emit(name: string, payload: unknown) {
   const handler = handlers.get(name);
   if (!handler) throw new Error(`no listener registered for "${name}"`);
   handler({ payload });
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
 }
 
 describe("activity store send listeners", () => {
@@ -32,6 +42,12 @@ describe("activity store send listeners", () => {
   beforeEach(() => {
     setActivePinia(createPinia());
     handlers.clear();
+    listenEvent.mockReset().mockImplementation(
+      (name: string, handler: (event: { payload: unknown }) => void) => {
+        handlers.set(name, handler);
+        return Promise.resolve(() => {});
+      },
+    );
     vi.mocked(showToast).mockReset();
     vi.mocked(showToast)
       .mockReturnValueOnce(101)
@@ -122,6 +138,255 @@ describe("activity store send listeners", () => {
       expect.stringContaining("Send failed"),
       expect.anything(),
       expect.anything(),
+    );
+  });
+
+  it("shares one initialization while every listener registration is pending", async () => {
+    const registration = deferred<() => void>();
+    listenEvent.mockImplementation(
+      (name: string, handler: (event: { payload: unknown }) => void) => {
+        handlers.set(name, handler);
+        return registration.promise;
+      },
+    );
+    store = useActivityStore();
+
+    const first = store.initEventListeners();
+    const second = store.initEventListeners();
+
+    expect(listenEvent).toHaveBeenCalledTimes(13);
+
+    registration.resolve(() => {});
+    await Promise.all([first, second]);
+    expect(listenEvent).toHaveBeenCalledTimes(13);
+  });
+
+  it("ignores events from listeners until the whole attempt commits", async () => {
+    const finalRegistration = deferred<() => void>();
+    listenEvent.mockImplementation(
+      (name: string, handler: (event: { payload: unknown }) => void) => {
+        handlers.set(name, handler);
+        return name === "send-unknown"
+          ? finalRegistration.promise
+          : Promise.resolve(() => {});
+      },
+    );
+    store = useActivityStore();
+    const initialization = store.initEventListeners();
+
+    emit("send-started", {
+      account_id: "account-1",
+      subject: "Too early",
+      outbox_id: 90,
+    });
+    expect(store.operations.size).toBe(0);
+    expect(showToast).not.toHaveBeenCalled();
+
+    finalRegistration.resolve(() => {});
+    await initialization;
+    emit("send-started", {
+      account_id: "account-1",
+      subject: "Committed",
+      outbox_id: 91,
+    });
+    expect(store.operations.get("send-91")?.status).toBe("running");
+    expect(showToast).toHaveBeenCalledWith(
+      'Sending "Committed"...',
+      "info",
+      0,
+    );
+  });
+
+  it("cleans up a partial failure and permits initialization retry", async () => {
+    let failRegistration = true;
+    const firstAttemptUnlisteners: ReturnType<typeof vi.fn>[] = [];
+    listenEvent.mockImplementation(
+      (name: string, handler: (event: { payload: unknown }) => void) => {
+        handlers.set(name, handler);
+        if (failRegistration && name === "send-failed") {
+          return Promise.reject(new Error("listen failed"));
+        }
+        const unlisten = vi.fn();
+        if (failRegistration) firstAttemptUnlisteners.push(unlisten);
+        return Promise.resolve(unlisten);
+      },
+    );
+    store = useActivityStore();
+
+    const initialization = store.initEventListeners();
+    emit("send-started", {
+      account_id: "account-1",
+      subject: "Partial",
+      outbox_id: 92,
+    });
+    expect(store.operations.size).toBe(0);
+    expect(showToast).not.toHaveBeenCalled();
+
+    await expect(initialization).rejects.toThrow("listen failed");
+    expect(firstAttemptUnlisteners).toHaveLength(12);
+    for (const unlisten of firstAttemptUnlisteners) {
+      expect(unlisten).toHaveBeenCalledOnce();
+    }
+
+    failRegistration = false;
+    await expect(store.initEventListeners()).resolves.toBeUndefined();
+    expect(listenEvent).toHaveBeenCalledTimes(26);
+  });
+
+  it("cleans listeners that finish after the store is disposed", async () => {
+    const registration = deferred<() => void>();
+    const unlisten = vi.fn();
+    listenEvent.mockImplementation(
+      (name: string, handler: (event: { payload: unknown }) => void) => {
+        handlers.set(name, handler);
+        return registration.promise;
+      },
+    );
+    store = useActivityStore();
+    const activity = store;
+    const initialization = activity.initEventListeners();
+
+    emit("send-started", {
+      account_id: "account-1",
+      subject: "Disposed",
+      outbox_id: 93,
+    });
+    activity.$dispose();
+    store = undefined;
+    registration.resolve(unlisten);
+    await initialization;
+
+    expect(activity.operations.size).toBe(0);
+    expect(showToast).not.toHaveBeenCalled();
+    expect(unlisten).toHaveBeenCalledTimes(13);
+  });
+
+  it("recovers from a transient startup initialization failure", async () => {
+    const initialize = vi
+      .fn<() => Promise<void>>()
+      .mockRejectedValueOnce(new Error("transient"))
+      .mockResolvedValueOnce(undefined);
+
+    const error = await initializeActivityListenersWithRetry(
+      initialize,
+      2,
+      0,
+      100,
+    );
+
+    expect(error).toBeNull();
+    expect(initialize).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns a persistent startup failure after bounded attempts", async () => {
+    const failure = new Error("persistent");
+    const initialize = vi
+      .fn<() => Promise<void>>()
+      .mockRejectedValue(failure);
+
+    const error = await initializeActivityListenersWithRetry(
+      initialize,
+      2,
+      0,
+      100,
+    );
+
+    expect(error).toBe(failure);
+    expect(initialize).toHaveBeenCalledTimes(2);
+  });
+
+  it("bounds a startup attempt whose listener registration never settles", async () => {
+    const initialize = vi.fn<() => Promise<void>>(
+      () => new Promise<void>(() => {}),
+    );
+
+    const error = await initializeActivityListenersWithRetry(
+      initialize,
+      1,
+      0,
+      5,
+    );
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain("timed out");
+    expect(initialize).toHaveBeenCalledOnce();
+  });
+
+  it("cancels a timed-out store attempt before a fresh retry commits", async () => {
+    const lateRegistration = deferred<() => void>();
+    const lateUnlisten = vi.fn();
+    const firstAttemptUnlisteners: ReturnType<typeof vi.fn>[] = [];
+    const secondAttemptUnlisteners: ReturnType<typeof vi.fn>[] = [];
+    const staleHandlers = new Map<
+      string,
+      (event: { payload: unknown }) => void
+    >();
+    let registrationCount = 0;
+    listenEvent.mockImplementation(
+      (name: string, handler: (event: { payload: unknown }) => void) => {
+        registrationCount += 1;
+        const attempt = Math.ceil(registrationCount / 13);
+        handlers.set(name, handler);
+        if (attempt === 1) staleHandlers.set(name, handler);
+        if (attempt === 1 && name === "send-unknown") {
+          return lateRegistration.promise;
+        }
+        const unlisten = vi.fn();
+        if (attempt === 1) {
+          firstAttemptUnlisteners.push(unlisten);
+        } else {
+          secondAttemptUnlisteners.push(unlisten);
+        }
+        return Promise.resolve(unlisten);
+      },
+    );
+    const activity = useActivityStore();
+    store = activity;
+
+    const error = await initializeActivityListenersWithRetry(
+      (signal) => activity.initEventListeners(signal),
+      2,
+      0,
+      10,
+    );
+
+    expect(error).toBeNull();
+    expect(listenEvent).toHaveBeenCalledTimes(26);
+    expect(firstAttemptUnlisteners).toHaveLength(12);
+    for (const unlisten of firstAttemptUnlisteners) {
+      expect(unlisten).toHaveBeenCalledOnce();
+    }
+    expect(secondAttemptUnlisteners).toHaveLength(13);
+    for (const unlisten of secondAttemptUnlisteners) {
+      expect(unlisten).not.toHaveBeenCalled();
+    }
+
+    emit("send-started", {
+      account_id: "account-1",
+      subject: "Fresh attempt",
+      outbox_id: 94,
+    });
+    expect(activity.operations.get("send-94")?.status).toBe("running");
+
+    lateRegistration.resolve(lateUnlisten);
+    await flushPromises();
+    expect(lateUnlisten).toHaveBeenCalledOnce();
+    for (const unlisten of secondAttemptUnlisteners) {
+      expect(unlisten).not.toHaveBeenCalled();
+    }
+
+    staleHandlers.get("send-started")?.({
+      payload: {
+        account_id: "account-1",
+        subject: "Stale attempt",
+        outbox_id: 95,
+      },
+    });
+    expect(activity.operations.has("send-95")).toBe(false);
+    expect(showToast).not.toHaveBeenCalledWith(
+      'Sending "Stale attempt"...',
+      "info",
+      0,
     );
   });
 });

--- a/src/__tests__/activity-send.test.ts
+++ b/src/__tests__/activity-send.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createPinia, setActivePinia } from "pinia";
+
+const handlers = new Map<string, (event: { payload: unknown }) => void>();
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn(
+    (name: string, handler: (event: { payload: unknown }) => void) => {
+      handlers.set(name, handler);
+      return Promise.resolve(() => {});
+    },
+  ),
+}));
+
+vi.mock("@/lib/toast", () => ({
+  showToast: vi.fn(),
+  dismissToast: vi.fn(),
+}));
+
+import { dismissToast, showToast } from "@/lib/toast";
+import { useActivityStore } from "@/stores/activity";
+
+function emit(name: string, payload: unknown) {
+  const handler = handlers.get(name);
+  if (!handler) throw new Error(`no listener registered for "${name}"`);
+  handler({ payload });
+}
+
+describe("activity store send listeners", () => {
+  let store: ReturnType<typeof useActivityStore> | undefined;
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    handlers.clear();
+    vi.mocked(showToast).mockReset();
+    vi.mocked(showToast)
+      .mockReturnValueOnce(101)
+      .mockReturnValueOnce(102)
+      .mockReturnValue(103);
+    vi.mocked(dismissToast).mockReset();
+    store = undefined;
+  });
+
+  afterEach(() => {
+    store?.$dispose();
+  });
+
+  it("correlates concurrent sends from one account by outbox id", async () => {
+    store = useActivityStore();
+    await store.initEventListeners();
+
+    emit("send-started", {
+      account_id: "account-1",
+      subject: "First",
+      outbox_id: 41,
+    });
+    emit("send-started", {
+      account_id: "account-1",
+      subject: "Second",
+      outbox_id: 42,
+    });
+
+    emit("send-complete", {
+      account_id: "account-1",
+      subject: "First",
+      outbox_id: 41,
+    });
+
+    expect(store.operations.get("send-41")?.status).toBe("done");
+    expect(store.operations.get("send-42")?.status).toBe("running");
+    expect(dismissToast).toHaveBeenCalledWith(101);
+    expect(dismissToast).not.toHaveBeenCalledWith(102);
+
+    emit("send-failed", {
+      account_id: "account-1",
+      subject: "Second",
+      outbox_id: 42,
+      error: "server rejected message",
+    });
+
+    expect(store.operations.get("send-41")?.status).toBe("done");
+    expect(store.operations.get("send-42")?.status).toBe("error");
+    expect(store.operations.get("send-42")?.error).toBe(
+      "server rejected message",
+    );
+    expect(dismissToast).toHaveBeenCalledWith(102);
+    expect(showToast).toHaveBeenCalledWith(
+      "Send failed: server rejected message",
+      "error",
+      10000,
+    );
+  });
+
+  it("reports an unknown delivery outcome distinctly", async () => {
+    store = useActivityStore();
+    await store.initEventListeners();
+
+    emit("send-started", {
+      account_id: "account-1",
+      subject: "Possibly sent",
+      outbox_id: 77,
+    });
+    emit("send-unknown", {
+      account_id: "account-1",
+      subject: "Possibly sent",
+      outbox_id: 77,
+      error: "connection lost after upload",
+    });
+
+    const operation = store.operations.get("send-77");
+    expect(operation?.status).toBe("error");
+    expect(operation?.error).toBe(
+      "Delivery status unknown: connection lost after upload",
+    );
+    expect(dismissToast).toHaveBeenCalledWith(101);
+    expect(showToast).toHaveBeenCalledWith(
+      'Delivery status unknown for "Possibly sent": connection lost after upload',
+      "error",
+      10000,
+    );
+    expect(showToast).not.toHaveBeenCalledWith(
+      expect.stringContaining("Send failed"),
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+});

--- a/src/__tests__/outbox-list.test.ts
+++ b/src/__tests__/outbox-list.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { flushPromises, mount, type VueWrapper } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+import type { OutboxRow } from "@/lib/types";
+
+const {
+  handlers,
+  listOutbox,
+  retryOutboxOp,
+  discardOutboxOp,
+  showToast,
+} = vi.hoisted(() => ({
+  handlers: new Map<string, (event: { payload: unknown }) => void>(),
+  listOutbox: vi.fn(),
+  retryOutboxOp: vi.fn(),
+  discardOutboxOp: vi.fn(),
+  showToast: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn(
+    (name: string, handler: (event: { payload: unknown }) => void) => {
+      handlers.set(name, handler);
+      return Promise.resolve(() => {});
+    },
+  ),
+}));
+
+vi.mock("@/lib/tauri", () => ({
+  listOutbox,
+  retryOutboxOp,
+  discardOutboxOp,
+}));
+
+vi.mock("@/lib/toast", () => ({ showToast }));
+
+import OutboxList from "@/components/mail/OutboxList.vue";
+import { useAccountsStore } from "@/stores/accounts";
+
+function makeRow(overrides: Partial<OutboxRow> = {}): OutboxRow {
+  return {
+    id: 1,
+    account_id: "account-1",
+    action_type: "send",
+    status: "dead",
+    delivery_outcome_unknown: false,
+    retry_count: 3,
+    error_message: "send failed",
+    subject: "Status report",
+    to: ["reader@example.com"],
+    cc: [],
+    bcc: [],
+    ...overrides,
+  };
+}
+
+describe("OutboxList indeterminate delivery", () => {
+  let wrapper: VueWrapper | undefined;
+  const confirm = vi.fn();
+
+  async function mountList(rows: OutboxRow[]) {
+    listOutbox.mockResolvedValue(rows);
+    wrapper = mount(OutboxList);
+    await flushPromises();
+    return wrapper;
+  }
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    useAccountsStore().activeAccountId = "account-1";
+    handlers.clear();
+    listOutbox.mockReset();
+    retryOutboxOp.mockReset().mockResolvedValue(undefined);
+    discardOutboxOp.mockReset().mockResolvedValue(undefined);
+    showToast.mockReset();
+    confirm.mockReset();
+    vi.stubGlobal("confirm", confirm);
+    wrapper = undefined;
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    vi.unstubAllGlobals();
+  });
+
+  it("labels unknown dead rows without changing definite failures", async () => {
+    const view = await mountList([
+      makeRow({ id: 1, delivery_outcome_unknown: true }),
+      makeRow({ id: 2, subject: "Definite failure" }),
+    ]);
+
+    const unknown = view.get('[data-testid="outbox-item-1"]');
+    expect(unknown.text()).toContain("Delivery status unknown");
+    expect(unknown.text()).not.toContain("Failed");
+    expect(view.get('[data-testid="outbox-item-2"]').text()).toContain(
+      "Failed (3 attempts)",
+    );
+  });
+
+  it("warns about duplicate delivery before retrying", async () => {
+    const row = makeRow({ delivery_outcome_unknown: true });
+    const view = await mountList([row]);
+    confirm.mockReturnValue(false);
+
+    await view.get('[data-testid="outbox-retry-1"]').trigger("click");
+
+    expect(confirm).toHaveBeenCalledWith(
+      expect.stringMatching(/may already have occurred.*duplicate.*Retry anyway/),
+    );
+    expect(retryOutboxOp).not.toHaveBeenCalled();
+
+    confirm.mockReturnValue(true);
+    await view.get('[data-testid="outbox-retry-1"]').trigger("click");
+    await flushPromises();
+    expect(retryOutboxOp).toHaveBeenCalledWith(1);
+  });
+
+  it("explains that discarding cannot cancel delivery", async () => {
+    const view = await mountList([
+      makeRow({ delivery_outcome_unknown: true }),
+    ]);
+    confirm.mockReturnValue(false);
+
+    await view.get('[data-testid="outbox-discard-1"]').trigger("click");
+
+    expect(confirm).toHaveBeenCalledWith(
+      expect.stringMatching(/only removes the local record.*cannot cancel delivery/),
+    );
+    expect(discardOutboxOp).not.toHaveBeenCalled();
+  });
+
+  it("disables retry and discard while the row is sending", async () => {
+    const view = await mountList([makeRow({ status: "sending" })]);
+
+    expect(view.get('[data-testid="outbox-retry-1"]').attributes("disabled"))
+      .toBeDefined();
+    expect(view.get('[data-testid="outbox-discard-1"]').attributes("disabled"))
+      .toBeDefined();
+  });
+
+  it("reloads the active account when a send becomes unknown", async () => {
+    await mountList([makeRow()]);
+    listOutbox.mockClear();
+
+    const handler = handlers.get("send-unknown");
+    expect(handler).toBeDefined();
+    handler?.({ payload: { account_id: "account-1" } });
+    await flushPromises();
+
+    expect(listOutbox).toHaveBeenCalledOnce();
+    expect(listOutbox).toHaveBeenCalledWith("account-1");
+  });
+});

--- a/src/__tests__/outbox-list.test.ts
+++ b/src/__tests__/outbox-list.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { flushPromises, mount, type VueWrapper } from "@vue/test-utils";
 import { createPinia, setActivePinia } from "pinia";
+import { nextTick } from "vue";
 import type { OutboxRow } from "@/lib/types";
 
 const {
@@ -9,22 +10,27 @@ const {
   retryOutboxOp,
   discardOutboxOp,
   showToast,
+  listenEvent,
 } = vi.hoisted(() => ({
   handlers: new Map<string, (event: { payload: unknown }) => void>(),
   listOutbox: vi.fn(),
   retryOutboxOp: vi.fn(),
   discardOutboxOp: vi.fn(),
   showToast: vi.fn(),
+  listenEvent: vi.fn(),
 }));
 
 vi.mock("@tauri-apps/api/event", () => ({
-  listen: vi.fn(
-    (name: string, handler: (event: { payload: unknown }) => void) => {
-      handlers.set(name, handler);
-      return Promise.resolve(() => {});
-    },
-  ),
+  listen: listenEvent,
 }));
+
+function defaultListen(
+  name: string,
+  handler: (event: { payload: unknown }) => void,
+) {
+  handlers.set(name, handler);
+  return Promise.resolve(() => {});
+}
 
 vi.mock("@/lib/tauri", () => ({
   listOutbox,
@@ -54,6 +60,16 @@ function makeRow(overrides: Partial<OutboxRow> = {}): OutboxRow {
   };
 }
 
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
 describe("OutboxList indeterminate delivery", () => {
   let wrapper: VueWrapper | undefined;
   const confirm = vi.fn();
@@ -69,6 +85,7 @@ describe("OutboxList indeterminate delivery", () => {
     setActivePinia(createPinia());
     useAccountsStore().activeAccountId = "account-1";
     handlers.clear();
+    listenEvent.mockReset().mockImplementation(defaultListen);
     listOutbox.mockReset();
     retryOutboxOp.mockReset().mockResolvedValue(undefined);
     discardOutboxOp.mockReset().mockResolvedValue(undefined);
@@ -92,6 +109,10 @@ describe("OutboxList indeterminate delivery", () => {
     const unknown = view.get('[data-testid="outbox-item-1"]');
     expect(unknown.text()).toContain("Delivery status unknown");
     expect(unknown.text()).not.toContain("Failed");
+    expect(unknown.get(".outbox-status").attributes("role")).toBe("alert");
+    expect(
+      unknown.get('[data-testid="outbox-retry-1"]').attributes("aria-label"),
+    ).toBe("Retry message: Status report");
     expect(view.get('[data-testid="outbox-item-2"]').text()).toContain(
       "Failed (3 attempts)",
     );
@@ -112,7 +133,7 @@ describe("OutboxList indeterminate delivery", () => {
     confirm.mockReturnValue(true);
     await view.get('[data-testid="outbox-retry-1"]').trigger("click");
     await flushPromises();
-    expect(retryOutboxOp).toHaveBeenCalledWith(1);
+    expect(retryOutboxOp).toHaveBeenCalledWith("account-1", 1);
   });
 
   it("explains that discarding cannot cancel delivery", async () => {
@@ -136,6 +157,187 @@ describe("OutboxList indeterminate delivery", () => {
       .toBeDefined();
     expect(view.get('[data-testid="outbox-discard-1"]').attributes("disabled"))
       .toBeDefined();
+  });
+
+  it("keeps retry disabled for pending rows", async () => {
+    const view = await mountList([makeRow({ status: "pending" })]);
+
+    expect(view.get('[data-testid="outbox-retry-1"]').attributes("disabled"))
+      .toBeDefined();
+    expect(view.get('[data-testid="outbox-discard-1"]').attributes("disabled"))
+      .toBeUndefined();
+  });
+
+  it("reloads after a successful account-scoped discard", async () => {
+    const view = await mountList([makeRow()]);
+    listOutbox.mockResolvedValue([]);
+    confirm.mockReturnValue(true);
+
+    await view.get('[data-testid="outbox-discard-1"]').trigger("click");
+    await flushPromises();
+
+    expect(discardOutboxOp).toHaveBeenCalledWith("account-1", 1);
+    expect(view.find('[data-testid="outbox-item-1"]').exists()).toBe(false);
+  });
+
+  it("allows only one row action at a time", async () => {
+    const view = await mountList([makeRow()]);
+    const mutation = deferred<void>();
+    retryOutboxOp.mockReturnValueOnce(mutation.promise);
+    confirm.mockReturnValue(true);
+
+    await view.get('[data-testid="outbox-retry-1"]').trigger("click");
+    expect(view.get('[data-testid="outbox-retry-1"]').attributes("disabled"))
+      .toBeDefined();
+    await view.get('[data-testid="outbox-retry-1"]').trigger("click");
+
+    expect(retryOutboxOp).toHaveBeenCalledOnce();
+    mutation.resolve(undefined);
+    await flushPromises();
+  });
+
+  it("clears old rows and ignores stale account errors and loading", async () => {
+    const view = await mountList([makeRow()]);
+    const staleAccount = deferred<OutboxRow[]>();
+    const currentAccount = deferred<OutboxRow[]>();
+    listOutbox.mockReset();
+    listOutbox
+      .mockReturnValueOnce(staleAccount.promise)
+      .mockReturnValueOnce(currentAccount.promise);
+
+    await view.get('[data-testid="outbox-refresh-btn"]').trigger("click");
+    useAccountsStore().activeAccountId = "account-2";
+    await nextTick();
+
+    expect(view.find('[data-testid="outbox-item-1"]').exists()).toBe(false);
+    expect(view.get('[data-testid="outbox-list"]').attributes("aria-busy")).toBe(
+      "true",
+    );
+
+    currentAccount.resolve([
+      makeRow({ id: 2, account_id: "account-2", subject: "Current" }),
+    ]);
+    await flushPromises();
+    staleAccount.reject(new Error("stale account failed"));
+    await flushPromises();
+
+    expect(view.get('[data-testid="outbox-item-2"]').text()).toContain("Current");
+    expect(view.find('[data-testid="outbox-error"]').exists()).toBe(false);
+    expect(view.get('[data-testid="outbox-list"]').attributes("aria-busy")).toBe(
+      "false",
+    );
+  });
+
+  it("does not act on a row after the active account changes", async () => {
+    const view = await mountList([makeRow()]);
+    listOutbox.mockResolvedValue([]);
+    useAccountsStore().activeAccountId = "account-2";
+
+    await view.get('[data-testid="outbox-retry-1"]').trigger("click");
+    await flushPromises();
+
+    expect(confirm).not.toHaveBeenCalled();
+    expect(retryOutboxOp).not.toHaveBeenCalled();
+    expect(showToast).toHaveBeenCalledWith(
+      "The Outbox account changed. Refresh and try again.",
+      "error",
+      5000,
+    );
+  });
+
+  it("keeps the newest event reload when responses finish out of order", async () => {
+    const view = await mountList([makeRow()]);
+    const started = deferred<OutboxRow[]>();
+    const unknown = deferred<OutboxRow[]>();
+    listOutbox.mockReset();
+    listOutbox.mockReturnValueOnce(started.promise).mockReturnValueOnce(unknown.promise);
+
+    handlers.get("send-started")?.({ payload: { account_id: "account-1" } });
+    handlers.get("send-unknown")?.({ payload: { account_id: "account-1" } });
+
+    unknown.resolve([
+      makeRow({ delivery_outcome_unknown: true, error_message: "unknown" }),
+    ]);
+    await flushPromises();
+    started.resolve([makeRow({ status: "sending" })]);
+    await flushPromises();
+
+    expect(view.get('[data-testid="outbox-item-1"]').text()).toContain(
+      "Delivery status unknown",
+    );
+    expect(view.get('[data-testid="outbox-list"]').attributes("aria-busy")).toBe(
+      "false",
+    );
+  });
+
+  it("cleans partial listeners and still loads with manual refresh", async () => {
+    const unlisteners: ReturnType<typeof vi.fn>[] = [];
+    listenEvent.mockImplementation(
+      (name: string, handler: (event: { payload: unknown }) => void) => {
+        handlers.set(name, handler);
+        if (name === "send-failed") {
+          return Promise.reject(new Error("event API unavailable"));
+        }
+        const unlisten = vi.fn();
+        unlisteners.push(unlisten);
+        return Promise.resolve(unlisten);
+      },
+    );
+    listOutbox.mockResolvedValue([makeRow()]);
+
+    wrapper = mount(OutboxList);
+    handlers.get("send-started")?.({ payload: { account_id: "account-1" } });
+    await flushPromises();
+
+    expect(listOutbox).toHaveBeenCalledOnce();
+    expect(wrapper.find('[data-testid="outbox-item-1"]').exists()).toBe(true);
+    expect(wrapper.get('[data-testid="outbox-listener-error"]').text()).toContain(
+      "Automatic Outbox updates are unavailable",
+    );
+    for (const unlisten of unlisteners) {
+      expect(unlisten).toHaveBeenCalledOnce();
+    }
+    expect(
+      wrapper.get('[data-testid="outbox-refresh-btn"]').attributes("disabled"),
+    ).toBeUndefined();
+
+    handlers.get("send-started")?.({ payload: { account_id: "account-1" } });
+    await flushPromises();
+    expect(listOutbox).toHaveBeenCalledOnce();
+
+    await wrapper.get('[data-testid="outbox-refresh-btn"]').trigger("click");
+    await flushPromises();
+    expect(listOutbox).toHaveBeenCalledTimes(2);
+  });
+
+  it("cleans fulfilled and late listeners when unmounted during setup", async () => {
+    const lateRegistration = deferred<() => void>();
+    const fulfilledUnlisteners: ReturnType<typeof vi.fn>[] = [];
+    const lateUnlisten = vi.fn();
+    listenEvent.mockImplementation(
+      (name: string, handler: (event: { payload: unknown }) => void) => {
+        handlers.set(name, handler);
+        if (name === "send-unknown") return lateRegistration.promise;
+        const unlisten = vi.fn();
+        fulfilledUnlisteners.push(unlisten);
+        return Promise.resolve(unlisten);
+      },
+    );
+    listOutbox.mockResolvedValue([makeRow()]);
+
+    wrapper = mount(OutboxList);
+    await flushPromises();
+    expect(wrapper.find('[data-testid="outbox-item-1"]').exists()).toBe(true);
+
+    wrapper.unmount();
+    wrapper = undefined;
+    for (const unlisten of fulfilledUnlisteners) {
+      expect(unlisten).toHaveBeenCalledOnce();
+    }
+
+    lateRegistration.resolve(lateUnlisten);
+    await flushPromises();
+    expect(lateUnlisten).toHaveBeenCalledOnce();
   });
 
   it("reloads the active account when a send becomes unknown", async () => {

--- a/src/__tests__/toast-container.test.ts
+++ b/src/__tests__/toast-container.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mount, type VueWrapper } from "@vue/test-utils";
+import { nextTick } from "vue";
+import ToastContainer from "@/components/common/ToastContainer.vue";
+import { dismissToast, showToast } from "@/lib/toast";
+
+describe("ToastContainer accessibility", () => {
+  let wrapper: VueWrapper;
+  const toastIds: number[] = [];
+
+  beforeEach(() => {
+    wrapper = mount(ToastContainer);
+  });
+
+  afterEach(() => {
+    for (const id of toastIds.splice(0)) dismissToast(id);
+    wrapper.unmount();
+  });
+
+  it("announces errors assertively and other messages as status", async () => {
+    toastIds.push(showToast("Delivery status unknown", "error", 0));
+    toastIds.push(showToast("Queued for retry", "info", 0));
+    await nextTick();
+
+    const errorToast = document.body.querySelector(".toast.error");
+    const infoToast = document.body.querySelector(".toast.info");
+    expect(errorToast?.getAttribute("role")).toBe("alert");
+    expect(errorToast?.getAttribute("aria-atomic")).toBe("true");
+    expect(infoToast?.getAttribute("role")).toBe("status");
+    expect(
+      errorToast?.querySelector(".toast-icon")?.getAttribute("aria-hidden"),
+    ).toBe("true");
+  });
+});

--- a/src/assets/styles/main.css
+++ b/src/assets/styles/main.css
@@ -51,6 +51,7 @@
   --color-danger-text: #e7000b;
   --color-success: #00a63e;
   --color-warning: #e17100;
+  --color-warning-text: #9a3c06;
   --color-email-body-bg: #ffffff;
   --color-email-body-text: #1a1a1a;
   --color-status-dot: #6ca04f;      /* sync green */
@@ -117,6 +118,7 @@
   --color-danger-text: #e7000b;
   --color-success: #00a63e;
   --color-warning: #e17100;
+  --color-warning-text: #f59e0b;
   --color-email-body-bg: #171717;
   --color-email-body-text: #e5e5e5;
   --color-status-dot: #00c950;

--- a/src/components/common/ToastContainer.vue
+++ b/src/components/common/ToastContainer.vue
@@ -13,8 +13,10 @@ const toasts = useToasts();
           :key="toast.id"
           class="toast"
           :class="toast.type"
+          :role="toast.type === 'error' ? 'alert' : 'status'"
+          aria-atomic="true"
         >
-          <span class="toast-icon">
+          <span class="toast-icon" aria-hidden="true">
             <svg v-if="toast.type === 'info'" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
               <circle cx="12" cy="12" r="10" /><polyline points="12 6 12 12 16 14" />
             </svg>
@@ -56,7 +58,9 @@ const toasts = useToasts();
   font-weight: 500;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
   pointer-events: auto;
-  white-space: nowrap;
+  max-width: min(640px, calc(100vw - 32px));
+  white-space: normal;
+  overflow-wrap: anywhere;
 }
 
 .toast.info {

--- a/src/components/mail/OutboxList.vue
+++ b/src/components/mail/OutboxList.vue
@@ -10,25 +10,63 @@ const accountsStore = useAccountsStore();
 const rows = ref<OutboxRow[]>([]);
 const loading = ref(false);
 const error = ref<string | null>(null);
+const listenerError = ref<string | null>(null);
+const actingRowId = ref<number | null>(null);
+let reloadGeneration = 0;
+let disposed = false;
+
+function isCurrentReload(generation: number, accountId: string): boolean {
+  return (
+    !disposed &&
+    generation === reloadGeneration &&
+    accountsStore.activeAccountId === accountId
+  );
+}
 
 async function reload() {
+  const generation = ++reloadGeneration;
+  if (disposed) return;
+
   const accountId = accountsStore.activeAccountId;
   if (!accountId) {
     rows.value = [];
+    error.value = null;
+    loading.value = false;
     return;
   }
   loading.value = true;
   error.value = null;
   try {
-    rows.value = await api.listOutbox(accountId);
+    const nextRows = await api.listOutbox(accountId);
+    if (isCurrentReload(generation, accountId)) {
+      rows.value = nextRows;
+    }
   } catch (e) {
-    error.value = e instanceof Error ? e.message : String(e);
+    if (isCurrentReload(generation, accountId)) {
+      error.value = e instanceof Error ? e.message : String(e);
+    }
   } finally {
-    loading.value = false;
+    if (isCurrentReload(generation, accountId)) {
+      loading.value = false;
+    }
   }
 }
 
+function activeAccountFor(row: OutboxRow): string | null {
+  const accountId = accountsStore.activeAccountId;
+  if (!accountId || row.account_id !== accountId) {
+    showToast("The Outbox account changed. Refresh and try again.", "error", 5000);
+    void reload();
+    return null;
+  }
+  return accountId;
+}
+
 async function retry(row: OutboxRow) {
+  if (actingRowId.value !== null) return;
+  const accountId = activeAccountFor(row);
+  if (!accountId) return;
+
   if (
     row.delivery_outcome_unknown &&
     !confirm(
@@ -37,82 +75,144 @@ async function retry(row: OutboxRow) {
   ) {
     return;
   }
+  actingRowId.value = row.id;
   try {
-    await api.retryOutboxOp(row.id);
+    await api.retryOutboxOp(accountId, row.id);
     showToast(`Queued "${row.subject ?? "(no subject)"}" for retry`, "info");
-    await reload();
   } catch (e) {
     showToast(`Retry failed: ${e instanceof Error ? e.message : String(e)}`, "error", 5000);
+  } finally {
+    await reload();
+    if (!disposed && actingRowId.value === row.id) {
+      actingRowId.value = null;
+    }
   }
 }
 
 async function discard(row: OutboxRow) {
+  if (actingRowId.value !== null) return;
+  const accountId = activeAccountFor(row);
+  if (!accountId) return;
+
   const message = row.delivery_outcome_unknown
     ? `Discard "${row.subject ?? "(no subject)"}"? This only removes the local record and cannot cancel delivery.`
     : `Discard "${row.subject ?? "(no subject)"}"? This cannot be undone.`;
   if (!confirm(message)) {
     return;
   }
+  actingRowId.value = row.id;
   try {
-    await api.discardOutboxOp(row.id);
-    rows.value = rows.value.filter((r) => r.id !== row.id);
+    await api.discardOutboxOp(accountId, row.id);
   } catch (e) {
     showToast(`Discard failed: ${e instanceof Error ? e.message : String(e)}`, "error", 5000);
+  } finally {
+    await reload();
+    if (!disposed && actingRowId.value === row.id) {
+      actingRowId.value = null;
+    }
   }
 }
 
 const unlistenFns: UnlistenFn[] = [];
+const pendingListenerCleanups = new Set<() => void>();
+const refreshEvents = [
+  "offline-queue-changed",
+  "send-started",
+  "send-complete",
+  "send-failed",
+  "send-unknown",
+] as const;
 
 onMounted(async () => {
+  let listenersCommitted = false;
+  let acceptingListeners = true;
+  const setupListeners = new Set<UnlistenFn>();
+  const cleanupSetup = () => {
+    acceptingListeners = false;
+    for (const unlisten of setupListeners) unlisten();
+    setupListeners.clear();
+    pendingListenerCleanups.delete(cleanupSetup);
+  };
+  pendingListenerCleanups.add(cleanupSetup);
+
+  const registrations = refreshEvents.map((name) => {
+    let registration: Promise<UnlistenFn>;
+    try {
+      registration = listen<{ account_id: string }>(name, (event) => {
+        if (
+          listenersCommitted &&
+          !disposed &&
+          event.payload.account_id === accountsStore.activeAccountId
+        ) {
+          void reload();
+        }
+      });
+    } catch (setupError) {
+      return Promise.reject(setupError);
+    }
+    return registration.then((unlisten) => {
+      if (!acceptingListeners || disposed) {
+        unlisten();
+      } else {
+        setupListeners.add(unlisten);
+      }
+      return unlisten;
+    });
+  });
+
+  // Do not make initial data visibility depend on event subscription. A
+  // second load after a successful commit reconciles transitions that occur
+  // while listeners are still gated.
+  const initialLoad = reload();
+  const results = await Promise.allSettled(registrations);
+  const listeners: UnlistenFn[] = [];
+  let setupFailed = false;
+  let setupFailure: unknown;
+  for (const result of results) {
+    if (result.status === "fulfilled") {
+      listeners.push(result.value);
+    } else if (!setupFailed) {
+      setupFailed = true;
+      setupFailure = result.reason;
+    }
+  }
+
+  if (disposed || setupFailed) {
+    cleanupSetup();
+    if (!disposed && setupFailed) {
+      const detail =
+        setupFailure instanceof Error ? setupFailure.message : String(setupFailure);
+      listenerError.value = `Automatic Outbox updates are unavailable: ${detail}. Use Refresh to update the list.`;
+    }
+    await initialLoad;
+    return;
+  }
+
+  pendingListenerCleanups.delete(cleanupSetup);
+  acceptingListeners = false;
+  setupListeners.clear();
+  unlistenFns.push(...listeners);
+  listenersCommitted = true;
+  await initialLoad;
   await reload();
-  // Refresh when the worker drains the outbox or marks something dead.
-  unlistenFns.push(
-    await listen<{ account_id: string }>("offline-queue-changed", (event) => {
-      if (event.payload.account_id === accountsStore.activeAccountId) {
-        reload();
-      }
-    }),
-  );
-  unlistenFns.push(
-    await listen<{ account_id: string }>("send-started", (event) => {
-      if (event.payload.account_id === accountsStore.activeAccountId) {
-        reload();
-      }
-    }),
-  );
-  unlistenFns.push(
-    await listen<{ account_id: string }>("send-complete", (event) => {
-      if (event.payload.account_id === accountsStore.activeAccountId) {
-        reload();
-      }
-    }),
-  );
-  unlistenFns.push(
-    await listen<{ account_id: string }>("send-failed", (event) => {
-      if (event.payload.account_id === accountsStore.activeAccountId) {
-        reload();
-      }
-    }),
-  );
-  unlistenFns.push(
-    await listen<{ account_id: string }>("send-unknown", (event) => {
-      if (event.payload.account_id === accountsStore.activeAccountId) {
-        reload();
-      }
-    }),
-  );
 });
 
 onUnmounted(() => {
+  disposed = true;
+  reloadGeneration += 1;
   for (const u of unlistenFns) {
     u();
   }
+  unlistenFns.length = 0;
+  for (const cleanup of [...pendingListenerCleanups]) cleanup();
 });
 
 watch(
   () => accountsStore.activeAccountId,
   () => {
-    reload();
+    rows.value = [];
+    error.value = null;
+    void reload();
   },
 );
 
@@ -135,23 +235,42 @@ function statusLabel(row: OutboxRow): string {
 </script>
 
 <template>
-  <div class="outbox-list" data-testid="outbox-list">
+  <div
+    class="outbox-list"
+    data-testid="outbox-list"
+    role="region"
+    aria-labelledby="outbox-heading"
+    :aria-busy="loading"
+  >
     <div class="outbox-header">
-      <h2>Outbox</h2>
+      <h2 id="outbox-heading">Outbox</h2>
       <button
         type="button"
         class="outbox-refresh"
         data-testid="outbox-refresh-btn"
-        :disabled="loading"
+        :disabled="loading || actingRowId !== null"
         @click="reload"
       >
         Refresh
       </button>
     </div>
 
-    <div v-if="loading && rows.length === 0" class="outbox-empty">Loading...</div>
-    <div v-else-if="error" class="outbox-error" data-testid="outbox-error">{{ error }}</div>
-    <div v-else-if="rows.length === 0" class="outbox-empty" data-testid="outbox-empty">
+    <div
+      v-if="listenerError"
+      class="outbox-listener-error"
+      data-testid="outbox-listener-error"
+      role="alert"
+    >
+      {{ listenerError }}
+    </div>
+
+    <div v-if="loading && rows.length === 0" class="outbox-empty" role="status">
+      Loading...
+    </div>
+    <div v-else-if="error" class="outbox-error" data-testid="outbox-error" role="alert">
+      {{ error }}
+    </div>
+    <div v-else-if="rows.length === 0" class="outbox-empty" data-testid="outbox-empty" role="status">
       No queued or failed sends.
     </div>
 
@@ -170,7 +289,11 @@ function statusLabel(row: OutboxRow): string {
         <div class="outbox-item-main">
           <div class="outbox-subject">{{ row.subject || "(no subject)" }}</div>
           <div class="outbox-recipients">{{ recipients(row) }}</div>
-          <div class="outbox-status">
+          <div
+            class="outbox-status"
+            :role="row.delivery_outcome_unknown ? 'alert' : 'status'"
+            aria-atomic="true"
+          >
             <span class="outbox-status-label">{{ statusLabel(row) }}</span>
             <span v-if="row.error_message" class="outbox-error-msg" :title="row.error_message">
               {{ row.error_message }}
@@ -182,7 +305,13 @@ function statusLabel(row: OutboxRow): string {
             type="button"
             class="outbox-btn outbox-btn-retry"
             :data-testid="`outbox-retry-${row.id}`"
-            :disabled="row.status !== 'dead'"
+            :aria-label="`Retry message: ${row.subject || '(no subject)'}`"
+            :disabled="
+              loading ||
+              actingRowId !== null ||
+              row.account_id !== accountsStore.activeAccountId ||
+              row.status !== 'dead'
+            "
             @click="retry(row)"
           >
             Retry
@@ -191,7 +320,13 @@ function statusLabel(row: OutboxRow): string {
             type="button"
             class="outbox-btn outbox-btn-discard"
             :data-testid="`outbox-discard-${row.id}`"
-            :disabled="row.status === 'sending'"
+            :aria-label="`Discard message: ${row.subject || '(no subject)'}`"
+            :disabled="
+              loading ||
+              actingRowId !== null ||
+              row.account_id !== accountsStore.activeAccountId ||
+              row.status === 'sending'
+            "
             @click="discard(row)"
           >
             Discard
@@ -250,6 +385,12 @@ function statusLabel(row: OutboxRow): string {
 
 .outbox-error {
   color: var(--color-danger-text);
+}
+
+.outbox-listener-error {
+  color: var(--color-warning-text);
+  font-size: 11px;
+  margin-bottom: 8px;
 }
 
 .outbox-items {
@@ -323,7 +464,7 @@ function statusLabel(row: OutboxRow): string {
 
 .outbox-item.unknown .outbox-status-label,
 .outbox-item.unknown .outbox-error-msg {
-  color: var(--color-warning);
+  color: var(--color-warning-text);
 }
 
 .outbox-error-msg {

--- a/src/components/mail/OutboxList.vue
+++ b/src/components/mail/OutboxList.vue
@@ -29,6 +29,14 @@ async function reload() {
 }
 
 async function retry(row: OutboxRow) {
+  if (
+    row.delivery_outcome_unknown &&
+    !confirm(
+      `Delivery of "${row.subject ?? "(no subject)"}" may already have occurred. Retrying can duplicate this message. Retry anyway?`,
+    )
+  ) {
+    return;
+  }
   try {
     await api.retryOutboxOp(row.id);
     showToast(`Queued "${row.subject ?? "(no subject)"}" for retry`, "info");
@@ -39,7 +47,10 @@ async function retry(row: OutboxRow) {
 }
 
 async function discard(row: OutboxRow) {
-  if (!confirm(`Discard "${row.subject ?? "(no subject)"}"? This cannot be undone.`)) {
+  const message = row.delivery_outcome_unknown
+    ? `Discard "${row.subject ?? "(no subject)"}"? This only removes the local record and cannot cancel delivery.`
+    : `Discard "${row.subject ?? "(no subject)"}"? This cannot be undone.`;
+  if (!confirm(message)) {
     return;
   }
   try {
@@ -63,6 +74,13 @@ onMounted(async () => {
     }),
   );
   unlistenFns.push(
+    await listen<{ account_id: string }>("send-started", (event) => {
+      if (event.payload.account_id === accountsStore.activeAccountId) {
+        reload();
+      }
+    }),
+  );
+  unlistenFns.push(
     await listen<{ account_id: string }>("send-complete", (event) => {
       if (event.payload.account_id === accountsStore.activeAccountId) {
         reload();
@@ -71,6 +89,13 @@ onMounted(async () => {
   );
   unlistenFns.push(
     await listen<{ account_id: string }>("send-failed", (event) => {
+      if (event.payload.account_id === accountsStore.activeAccountId) {
+        reload();
+      }
+    }),
+  );
+  unlistenFns.push(
+    await listen<{ account_id: string }>("send-unknown", (event) => {
       if (event.payload.account_id === accountsStore.activeAccountId) {
         reload();
       }
@@ -100,6 +125,9 @@ function recipients(row: OutboxRow): string {
 
 function statusLabel(row: OutboxRow): string {
   if (row.status === "sending") return "Sending...";
+  if (row.status === "dead" && row.delivery_outcome_unknown) {
+    return "Delivery status unknown";
+  }
   if (row.status === "dead") return `Failed (${row.retry_count} attempts)`;
   if (row.retry_count > 0) return `Queued for retry (${row.retry_count} so far)`;
   return "Queued";
@@ -132,7 +160,11 @@ function statusLabel(row: OutboxRow): string {
         v-for="row in rows"
         :key="row.id"
         class="outbox-item"
-        :class="{ dead: row.status === 'dead', sending: row.status === 'sending' }"
+        :class="{
+          dead: row.status === 'dead',
+          sending: row.status === 'sending',
+          unknown: row.delivery_outcome_unknown,
+        }"
         :data-testid="`outbox-item-${row.id}`"
       >
         <div class="outbox-item-main">
@@ -150,7 +182,7 @@ function statusLabel(row: OutboxRow): string {
             type="button"
             class="outbox-btn outbox-btn-retry"
             :data-testid="`outbox-retry-${row.id}`"
-            :disabled="row.status === 'sending'"
+            :disabled="row.status !== 'dead'"
             @click="retry(row)"
           >
             Retry
@@ -159,6 +191,7 @@ function statusLabel(row: OutboxRow): string {
             type="button"
             class="outbox-btn outbox-btn-discard"
             :data-testid="`outbox-discard-${row.id}`"
+            :disabled="row.status === 'sending'"
             @click="discard(row)"
           >
             Discard
@@ -240,6 +273,10 @@ function statusLabel(row: OutboxRow): string {
   border-color: var(--color-danger);
 }
 
+.outbox-item.unknown {
+  border-color: var(--color-warning);
+}
+
 .outbox-item.sending {
   opacity: 0.7;
 }
@@ -284,6 +321,11 @@ function statusLabel(row: OutboxRow): string {
   color: var(--color-danger-text);
 }
 
+.outbox-item.unknown .outbox-status-label,
+.outbox-item.unknown .outbox-error-msg {
+  color: var(--color-warning);
+}
+
 .outbox-error-msg {
   color: var(--color-danger-text);
   font-family: monospace;
@@ -324,7 +366,7 @@ function statusLabel(row: OutboxRow): string {
   color: var(--color-danger-text);
 }
 
-.outbox-btn-discard:hover {
+.outbox-btn-discard:hover:not(:disabled) {
   background: var(--color-danger);
   color: #fff;
   border-color: var(--color-danger);

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -803,12 +803,18 @@ export async function listOutbox(
   return invoke("list_outbox", { accountId });
 }
 
-export async function retryOutboxOp(outboxId: number): Promise<void> {
-  return invoke("retry_outbox_op", { outboxId });
+export async function retryOutboxOp(
+  accountId: string,
+  outboxId: number,
+): Promise<void> {
+  return invoke("retry_outbox_op", { accountId, outboxId });
 }
 
-export async function discardOutboxOp(outboxId: number): Promise<void> {
-  return invoke("discard_outbox_op", { outboxId });
+export async function discardOutboxOp(
+  accountId: string,
+  outboxId: number,
+): Promise<void> {
+  return invoke("discard_outbox_op", { accountId, outboxId });
 }
 
 // OpenPGP

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -504,6 +504,7 @@ export interface OutboxRow {
   account_id: string;
   action_type: string;
   status: "pending" | "sending" | "dead";
+  delivery_outcome_unknown: boolean;
   retry_count: number;
   error_message: string | null;
   subject: string | null;

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,12 +2,70 @@ import { createApp } from "vue";
 import { createPinia } from "pinia";
 import router from "./router";
 import App from "./App.vue";
+import {
+  initializeActivityListenersWithRetry,
+  useActivityStore,
+} from "./stores/activity";
 import { usePlatformStore } from "./stores/platform";
+import { dismissToast, showToast } from "./lib/toast";
 import "./assets/styles/main.css";
 
-const app = createApp(App);
-app.use(createPinia());
-app.use(router);
-app.mount("#app");
+const STARTUP_ATTEMPTS = 2;
+const STARTUP_RETRY_DELAY_MS = 50;
+const STARTUP_ATTEMPT_TIMEOUT_MS = 750;
+const BACKGROUND_RETRY_MAX_DELAY_MS = 30_000;
 
+const app = createApp(App);
+const pinia = createPinia();
+app.use(pinia);
+app.use(router);
+
+const activityStore = useActivityStore(pinia);
+const activityInitializationError =
+  await initializeActivityListenersWithRetry(
+    (signal) => activityStore.initEventListeners(signal),
+    STARTUP_ATTEMPTS,
+    STARTUP_RETRY_DELAY_MS,
+    STARTUP_ATTEMPT_TIMEOUT_MS,
+  );
+
+app.mount("#app");
 usePlatformStore().init();
+
+if (activityInitializationError !== null) {
+  console.error(
+    "Activity listeners unavailable during startup:",
+    activityInitializationError,
+  );
+  const unavailableToastId = showToast(
+    "Background activity updates are unavailable. Retrying...",
+    "error",
+    0,
+  );
+
+  const scheduleRetry = (delayMs: number) => {
+    window.setTimeout(() => {
+      void initializeActivityListenersWithRetry(
+        (signal) => activityStore.initEventListeners(signal),
+        1,
+        0,
+        STARTUP_ATTEMPT_TIMEOUT_MS,
+      )
+        .then((error) => {
+          if (error === null) {
+            dismissToast(unavailableToastId);
+            showToast("Background activity updates restored", "success");
+            return;
+          }
+          console.error("Activity listener retry failed:", error);
+          scheduleRetry(Math.min(delayMs * 2, BACKGROUND_RETRY_MAX_DELAY_MS));
+        })
+        .catch((error) => {
+          console.error("Unexpected activity listener retry failure:", error);
+          scheduleRetry(Math.min(delayMs * 2, BACKGROUND_RETRY_MAX_DELAY_MS));
+        });
+    }, delayMs);
+  };
+
+  scheduleRetry(1000);
+}

--- a/src/stores/activity.ts
+++ b/src/stores/activity.ts
@@ -233,13 +233,21 @@ export const useActivityStore = defineStore("activity", () => {
     // "Sending..." toast when the send completes or fails.
     const sendToastIds = new Map<string, number>();
 
+    function dismissSendToast(opId: string) {
+      const toastId = sendToastIds.get(opId);
+      if (toastId !== undefined) {
+        dismissToast(toastId);
+        sendToastIds.delete(opId);
+      }
+    }
+
     // --- Send events ---
     unlistenFns.push(
-      await listen<{ account_id: string; subject: string }>(
+      await listen<{ account_id: string; subject: string; outbox_id: number }>(
         "send-started",
         (event) => {
           const p = event.payload;
-          const opId = `send-${p.account_id}-${Date.now()}`;
+          const opId = `send-${p.outbox_id}`;
           startOperation(opId, "send", `Sending "${p.subject}"`, "Syncing...");
           const toastId = showToast(`Sending "${p.subject}"...`, "info", 0); // persistent until complete/failed
           sendToastIds.set(opId, toastId);
@@ -248,45 +256,54 @@ export const useActivityStore = defineStore("activity", () => {
     );
 
     unlistenFns.push(
-      await listen<{ account_id: string; subject: string }>(
+      await listen<{ account_id: string; subject: string; outbox_id: number }>(
         "send-complete",
         (event) => {
           const p = event.payload;
-          // Complete all running send operations for this account
-          for (const [id, op] of operations.value) {
-            if (op.type === "send" && op.status === "running" && id.startsWith(`send-${p.account_id}`)) {
-              completeOperation(id, "Sent");
-              const toastId = sendToastIds.get(id);
-              if (toastId !== undefined) {
-                dismissToast(toastId);
-                sendToastIds.delete(id);
-              }
-            }
-          }
+          const opId = `send-${p.outbox_id}`;
+          completeOperation(opId, "Sent");
+          dismissSendToast(opId);
           showToast(`"${p.subject}" sent`, "success");
         },
       ),
     );
 
     unlistenFns.push(
-      await listen<{ account_id: string; subject: string; error: string }>(
+      await listen<{
+        account_id: string;
+        subject: string;
+        outbox_id: number;
+        error: string;
+      }>(
         "send-failed",
         (event) => {
           const p = event.payload;
-          // Fail all running send operations for this account
-          for (const [id, op] of operations.value) {
-            if (op.type === "send" && op.status === "running" && id.startsWith(`send-${p.account_id}`)) {
-              failOperation(id, p.error);
-              const toastId = sendToastIds.get(id);
-              if (toastId !== undefined) {
-                dismissToast(toastId);
-                sendToastIds.delete(id);
-              }
-            }
-          }
+          const opId = `send-${p.outbox_id}`;
+          failOperation(opId, p.error);
+          dismissSendToast(opId);
           showToast(`Send failed: ${p.error}`, "error", 10000);
         },
       ),
+    );
+
+    unlistenFns.push(
+      await listen<{
+        account_id: string;
+        subject: string;
+        outbox_id: number;
+        error: string;
+      }>("send-unknown", (event) => {
+        const p = event.payload;
+        const opId = `send-${p.outbox_id}`;
+        const detail = `Delivery status unknown: ${p.error}`;
+        failOperation(opId, detail);
+        dismissSendToast(opId);
+        showToast(
+          `Delivery status unknown for "${p.subject}": ${p.error}`,
+          "error",
+          10000,
+        );
+      }),
     );
   }
 

--- a/src/stores/activity.ts
+++ b/src/stores/activity.ts
@@ -1,8 +1,60 @@
 import { defineStore } from "pinia";
 import { ref, computed, onScopeDispose } from "vue";
 import { listen } from "@tauri-apps/api/event";
-import type { UnlistenFn } from "@tauri-apps/api/event";
+import type { Event, UnlistenFn } from "@tauri-apps/api/event";
 import { showToast, dismissToast } from "@/lib/toast";
+
+async function wait(ms: number): Promise<void> {
+  if (ms <= 0) return;
+  await new Promise<void>((resolve) => setTimeout(resolve, ms));
+}
+
+async function initializeWithTimeout(
+  initialize: (signal: AbortSignal) => Promise<void>,
+  timeoutMs: number,
+): Promise<void> {
+  const controller = new AbortController();
+  if (timeoutMs <= 0) {
+    await initialize(controller.signal);
+    return;
+  }
+
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      initialize(controller.signal),
+      new Promise<never>((_, reject) => {
+        timeout = setTimeout(() => {
+          const error = new Error("Activity listener initialization timed out");
+          controller.abort(error);
+          reject(error);
+        }, timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeout !== undefined) clearTimeout(timeout);
+  }
+}
+
+export async function initializeActivityListenersWithRetry(
+  initialize: (signal: AbortSignal) => Promise<void>,
+  attempts = 2,
+  retryDelayMs = 50,
+  attemptTimeoutMs = 1000,
+): Promise<unknown | null> {
+  const attemptCount = Math.max(1, Math.floor(attempts));
+  let lastError: unknown;
+  for (let attempt = 0; attempt < attemptCount; attempt += 1) {
+    try {
+      await initializeWithTimeout(initialize, attemptTimeoutMs);
+      return null;
+    } catch (error) {
+      lastError = error;
+      if (attempt + 1 < attemptCount) await wait(retryDelayMs);
+    }
+  }
+  return lastError;
+}
 
 export interface Operation {
   id: string;
@@ -111,46 +163,95 @@ export const useActivityStore = defineStore("activity", () => {
   }
 
   const unlistenFns: UnlistenFn[] = [];
+  const sendToastIds = new Map<string, number>();
+  const pendingRegistrationCleanups = new Set<() => void>();
+  let initializationAttempt: { id: number; promise: Promise<void> } | null = null;
+  let nextInitializationAttemptId = 0;
+  let disposed = false;
 
-  async function initEventListeners() {
-    if (initialized.value) return;
-    initialized.value = true;
+  function dismissSendToast(opId: string) {
+    const toastId = sendToastIds.get(opId);
+    if (toastId !== undefined) {
+      dismissToast(toastId);
+      sendToastIds.delete(opId);
+    }
+  }
+
+  async function registerEventListeners(signal?: AbortSignal) {
+    const registrations: Promise<UnlistenFn>[] = [];
+    const attemptListeners = new Set<UnlistenFn>();
+    let acceptingListeners = true;
+    let committed = false;
+
+    const cleanupAttempt = () => {
+      acceptingListeners = false;
+      for (const unlisten of attemptListeners) unlisten();
+      attemptListeners.clear();
+      pendingRegistrationCleanups.delete(cleanupAttempt);
+    };
+    pendingRegistrationCleanups.add(cleanupAttempt);
+
+    let rejectCancellation!: (reason: unknown) => void;
+    const cancellation = new Promise<never>((_, reject) => {
+      rejectCancellation = reject;
+    });
+    const cancelAttempt = () => {
+      if (!acceptingListeners || committed) return;
+      const reason = signal?.reason ?? new Error("Activity listener initialization cancelled");
+      cleanupAttempt();
+      rejectCancellation(reason);
+    };
+    if (signal?.aborted) {
+      cancelAttempt();
+    } else {
+      signal?.addEventListener("abort", cancelAttempt, { once: true });
+    }
+
+    function whenCommitted<T>(handler: (event: Event<T>) => void) {
+      return (event: Event<T>) => {
+        if (!committed || disposed) return;
+        handler(event);
+      };
+    }
 
     // --- Mail sync events ---
-    unlistenFns.push(
-      await listen<{ account_id: string; account_name: string }>(
+    registrations.push(
+      listen<{ account_id: string; account_name: string }>(
         "sync-started",
-        (event) => {
+        whenCommitted((event) => {
           startOperation(
             `sync-${event.payload.account_id}`,
             "sync",
             `Syncing ${event.payload.account_name}`,
             "Syncing...",
           );
-        },
+        }),
       ),
     );
 
-    unlistenFns.push(
-      await listen<{
+    registrations.push(
+      listen<{
         account_id: string;
         folder: string;
         synced: number;
         total_folders: number;
         current_folder: number;
-      }>("sync-progress", (event) => {
-        const p = event.payload;
-        updateOperation(
-          `sync-${p.account_id}`,
-          `${p.folder} (${p.current_folder}/${p.total_folders})${p.synced > 0 ? ` - ${p.synced} new` : ""}`,
-        );
-      }),
+      }>(
+        "sync-progress",
+        whenCommitted((event) => {
+          const p = event.payload;
+          updateOperation(
+            `sync-${p.account_id}`,
+            `${p.folder} (${p.current_folder}/${p.total_folders})${p.synced > 0 ? ` - ${p.synced} new` : ""}`,
+          );
+        }),
+      ),
     );
 
-    unlistenFns.push(
-      await listen<{ account_id: string; total_synced: number }>(
+    registrations.push(
+      listen<{ account_id: string; total_synced: number }>(
         "sync-complete",
-        (event) => {
+        whenCommitted((event) => {
           const p = event.payload;
           completeOperation(
             `sync-${p.account_id}`,
@@ -158,16 +259,16 @@ export const useActivityStore = defineStore("activity", () => {
               ? `Done - ${p.total_synced} new messages`
               : "Up to date",
           );
-        },
+        }),
       ),
     );
 
-    unlistenFns.push(
-      await listen<{ account_id: string; error: string }>(
+    registrations.push(
+      listen<{ account_id: string; error: string }>(
         "sync-error",
-        (event) => {
+        whenCommitted((event) => {
           failOperation(`sync-${event.payload.account_id}`, event.payload.error);
-        },
+        }),
       ),
     );
 
@@ -177,140 +278,195 @@ export const useActivityStore = defineStore("activity", () => {
     // NOT listen for `calendar-changed`: that event also fires from invite
     // responses, push processing, and other non-sync mutations, so coupling
     // it to the spinner would complete the indicator prematurely.
-    unlistenFns.push(
-      await listen<string>("calendar-sync-started", (event) => {
-        startOperation(
-          `cal-sync-${event.payload}`,
-          "sync",
-          "Syncing calendars",
-          "Syncing...",
-        );
-      }),
+    registrations.push(
+      listen<string>(
+        "calendar-sync-started",
+        whenCommitted((event) => {
+          startOperation(
+            `cal-sync-${event.payload}`,
+            "sync",
+            "Syncing calendars",
+            "Syncing...",
+          );
+        }),
+      ),
     );
-    unlistenFns.push(
-      await listen<string>("calendar-sync-complete", (event) => {
-        completeOperation(`cal-sync-${event.payload}`, "Calendars updated");
-      }),
+    registrations.push(
+      listen<string>(
+        "calendar-sync-complete",
+        whenCommitted((event) => {
+          completeOperation(`cal-sync-${event.payload}`, "Calendars updated");
+        }),
+      ),
     );
-    unlistenFns.push(
-      await listen<{ account_id: string; error: string }>(
+    registrations.push(
+      listen<{ account_id: string; error: string }>(
         "calendar-sync-error",
-        (event) => {
+        whenCommitted((event) => {
           failOperation(
             `cal-sync-${event.payload.account_id}`,
             event.payload.error,
           );
-        },
+        }),
       ),
     );
 
     // --- Contacts sync events ---
-    unlistenFns.push(
-      await listen<string>("contacts-changed", (event) => {
-        completeOperation(
-          `contacts-sync-${event.payload}`,
-          "Contacts updated",
-        );
-      }),
+    registrations.push(
+      listen<string>(
+        "contacts-changed",
+        whenCommitted((event) => {
+          completeOperation(
+            `contacts-sync-${event.payload}`,
+            "Contacts updated",
+          );
+        }),
+      ),
     );
 
     // --- Background operation failures ---
-    unlistenFns.push(
-      await listen<{ account_id: string; op_type: string; error: string }>(
+    registrations.push(
+      listen<{ account_id: string; op_type: string; error: string }>(
         "op-failed",
-        (event) => {
+        whenCommitted((event) => {
           const p = event.payload;
           // Create and immediately fail an operation entry so it shows up in the
           // operations panel (failOperation is a no-op for unknown ids).
           const opId = `op-${p.account_id}-${Date.now()}`;
           startOperation(opId, "general", `${p.op_type} failed`, p.error);
           failOperation(opId, `${p.op_type}: ${p.error}`);
-        },
+        }),
       ),
     );
 
-    // Maps an operation id → toast id so we can dismiss the persistent
-    // "Sending..." toast when the send completes or fails.
-    const sendToastIds = new Map<string, number>();
-
-    function dismissSendToast(opId: string) {
-      const toastId = sendToastIds.get(opId);
-      if (toastId !== undefined) {
-        dismissToast(toastId);
-        sendToastIds.delete(opId);
-      }
-    }
-
     // --- Send events ---
-    unlistenFns.push(
-      await listen<{ account_id: string; subject: string; outbox_id: number }>(
+    registrations.push(
+      listen<{ account_id: string; subject: string; outbox_id: number }>(
         "send-started",
-        (event) => {
+        whenCommitted((event) => {
           const p = event.payload;
           const opId = `send-${p.outbox_id}`;
           startOperation(opId, "send", `Sending "${p.subject}"`, "Syncing...");
           const toastId = showToast(`Sending "${p.subject}"...`, "info", 0); // persistent until complete/failed
           sendToastIds.set(opId, toastId);
-        },
+        }),
       ),
     );
 
-    unlistenFns.push(
-      await listen<{ account_id: string; subject: string; outbox_id: number }>(
+    registrations.push(
+      listen<{ account_id: string; subject: string; outbox_id: number }>(
         "send-complete",
-        (event) => {
+        whenCommitted((event) => {
           const p = event.payload;
           const opId = `send-${p.outbox_id}`;
           completeOperation(opId, "Sent");
           dismissSendToast(opId);
           showToast(`"${p.subject}" sent`, "success");
-        },
+        }),
       ),
     );
 
-    unlistenFns.push(
-      await listen<{
+    registrations.push(
+      listen<{
         account_id: string;
         subject: string;
         outbox_id: number;
         error: string;
       }>(
         "send-failed",
-        (event) => {
+        whenCommitted((event) => {
           const p = event.payload;
           const opId = `send-${p.outbox_id}`;
           failOperation(opId, p.error);
           dismissSendToast(opId);
           showToast(`Send failed: ${p.error}`, "error", 10000);
-        },
+        }),
       ),
     );
 
-    unlistenFns.push(
-      await listen<{
+    registrations.push(
+      listen<{
         account_id: string;
         subject: string;
         outbox_id: number;
         error: string;
-      }>("send-unknown", (event) => {
-        const p = event.payload;
-        const opId = `send-${p.outbox_id}`;
-        const detail = `Delivery status unknown: ${p.error}`;
-        failOperation(opId, detail);
-        dismissSendToast(opId);
-        showToast(
-          `Delivery status unknown for "${p.subject}": ${p.error}`,
-          "error",
-          10000,
-        );
-      }),
+      }>(
+        "send-unknown",
+        whenCommitted((event) => {
+          const p = event.payload;
+          const opId = `send-${p.outbox_id}`;
+          const detail = `Delivery status unknown: ${p.error}`;
+          failOperation(opId, detail);
+          dismissSendToast(opId);
+          showToast(
+            `Delivery status unknown for "${p.subject}": ${p.error}`,
+            "error",
+            10000,
+          );
+        }),
+      ),
     );
+
+    let listeners: UnlistenFn[];
+    try {
+      listeners = await Promise.race([
+        Promise.all(
+          registrations.map((registration) =>
+            registration.then((unlisten) => {
+              if (!acceptingListeners || disposed) {
+                unlisten();
+              } else {
+                attemptListeners.add(unlisten);
+              }
+              return unlisten;
+            }),
+          ),
+        ),
+        cancellation,
+      ]);
+    } catch (error) {
+      cleanupAttempt();
+      throw error;
+    } finally {
+      signal?.removeEventListener("abort", cancelAttempt);
+    }
+
+    if (disposed) {
+      cleanupAttempt();
+      return;
+    }
+
+    pendingRegistrationCleanups.delete(cleanupAttempt);
+    acceptingListeners = false;
+    attemptListeners.clear();
+    unlistenFns.push(...listeners);
+    committed = true;
+    initialized.value = true;
+  }
+
+  function initEventListeners(signal?: AbortSignal): Promise<void> {
+    if (initialized.value) return Promise.resolve();
+    if (initializationAttempt) return initializationAttempt.promise;
+
+    const attemptId = ++nextInitializationAttemptId;
+    const promise = registerEventListeners(signal).finally(() => {
+      if (initializationAttempt?.id === attemptId) {
+        initializationAttempt = null;
+      }
+    });
+    initializationAttempt = { id: attemptId, promise };
+    return promise;
   }
 
   onScopeDispose(() => {
+    disposed = true;
     for (const unlisten of unlistenFns) {
       unlisten();
     }
+    unlistenFns.length = 0;
+    for (const cleanup of [...pendingRegistrationCleanups]) cleanup();
+    for (const toastId of sendToastIds.values()) dismissToast(toastId);
+    sendToastIds.clear();
     // Cancel any pending removal timers so they don't fire on a disposed
     // store and mutate state (or leak the handle).
     for (const handle of pendingRemovals.values()) {


### PR DESCRIPTION
## Summary

Make background mail delivery and Outbox replay duplicate-resistant across
IMAP, Microsoft Graph/O365, and JMAP accounts.

The central rule is that delivery is retried automatically only when failure
is known to have occurred before acceptance. Unknown outcomes are quarantined
for explicit user review.

## Changes

### Routing and recipient fidelity

- Replay Microsoft Graph/O365 sends through SMTP with the appropriate
  Microsoft IMAP/SMTP OAuth scope.
- Route Graph first attempts through SMTP without attempting IMAP Sent-folder
  handling.
- Preserve the explicit From, To, Cc, and Bcc envelope separately from the raw
  MIME.
- Keep Bcc recipients out of the transmitted MIME while delivering them
  through SMTP or the JMAP submission envelope.
- Submit the same persisted raw MIME bytes on first attempt and replay.
- Reject sends before persistence when no mail binding is enabled.

### Durable delivery state

- Persist first-attempt sends before starting transport.
- Atomically claim pending sends before replay.
- Distinguish definite failures from indeterminate delivery outcomes.
- Return definite failures to `pending`, becoming `dead` immediately at the
  retry limit while preserving the last transport error.
- Quarantine unknown outcomes as `dead` without automatic retry.
- Complete accepted delivery before best-effort IMAP Sent-folder work.
- Prevent account update or deletion while a first-attempt send is active.
- Treat missing mail executors as failures rather than successful delivery.
- Acquire an exclusive data-directory lock before startup recovery so another
  process cannot steal an active delivery claim.

### Protocol hardening

- Require a final SMTP 2xx completion response.
- Bound the complete SMTP send operation and post-acceptance `QUIT`.
- Classify SMTP timeout or loss of completion evidence as indeterminate.
- Use a dedicated no-redirect client for final JMAP submission POSTs.
- Treat all JMAP submission redirects and server/gateway failures as
  indeterminate.
- Correlate JMAP identity, mailbox, upload, import, and submission responses by
  method, call ID, and account ID.
- Validate JMAP draft import responses instead of accepting malformed or
  rejected imports.

### Outbox and activity UI

- Account-scope Retry and Discard operations in both IPC and SQL.
- Ignore stale and out-of-order Outbox responses after account changes.
- Prevent actions on rows belonging to another account.
- Surface queued, sending, failed, and unknown-delivery states distinctly.
- Require confirmation before manually retrying an unknown delivery.
- Make activity-listener initialization transactional, retryable, and safe
  against hung registrations.
- Always mount the application even when listener initialization fails.
- Improve status announcements, action labels, warning contrast, and toast
  wrapping for accessibility.

## Safety model

A successful transport response removes the claimed Outbox row before any
best-effort post-delivery work. This means a crash can omit an IMAP Sent-folder
copy, but cannot turn accepted delivery into an automatic recipient resend.

If transport completion cannot be proven, the row remains visible with
“Delivery status unknown”. Only an explicit manual retry can send it again.

## Validation

- `with-secret-service cargo test --locked --all-targets --all-features`
  - 775 passed, 1 ignored
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo rustc --locked --lib -- --force-warn dead_code`
  - zero dead-code diagnostics
- `npm test`
  - 509 passed
- `npm run build`
- `npx vue-tsc --noEmit`
- `cargo fmt --all -- --check`
- `git diff --check`

## Follow-ups

- Add exact in-process recovery for a panicked or forcibly cancelled detached
  send task; startup currently quarantines its row.
- Make IMAP Sent-folder repair durable without ever resubmitting recipients.
- Bring calendar invitation and RSVP delivery into the same durable Outbox
  state machine.
- Support a rare quoted-local-part JMAP address syntax currently rejected
  safely before submission.
